### PR TITLE
feat(api): expose relay option in pull stream API

### DIFF
--- a/docs/rest-api/v1/virtualhost/application/stream/README.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/README.md
@@ -137,7 +137,8 @@ Content-Type: application/json
 		"persistent": false,
 		"noInputFailoverTimeoutMs": 3000,
 		"unusedStreamDeletionTimeoutMs": 60000,
-		"ignoreRtcpSRTimestamp": false
+		"ignoreRtcpSRTimestamp": false,
+		"relay": false
   	}
 }
 
@@ -157,6 +158,11 @@ Content-Type: application/json
 		the stream is deleted, but ignored if persistent is true
 	## ignoreRtcpSRTimestamp
 		No waits RTCP SR and start stream immediately
+	## relay
+		If true, the pulled stream is registered as a Relay (passthrough) 
+		instead of a transcoded Source. Useful for OVT upstreams that 
+		already expose multiple renditions, so tracks pass through without 
+		per-profile transcoding. Defaults to false.
 ```
 
 </details>

--- a/src/projects/api_server/controllers/v1/vhosts/apps/streams/streams_controller.cpp
+++ b/src/projects/api_server/controllers/v1/vhosts/apps/streams/streams_controller.cpp
@@ -101,17 +101,22 @@ namespace api
 							properties->EnableIgnoreRtcpSRTimestamp(jv_properties["ignoreRtcpSRTimestamp"].asBool());
 						}
 
+						if (jv_properties["relay"].isNull() == false && jv_properties["relay"].isBool())
+						{
+							properties->EnableRelay(jv_properties["relay"].asBool());
+						}
+
 						if (jv_properties["retryCount"].isNull() == false && jv_properties["retryCount"].isInt())
 						{
 							properties->SetRetryCount(jv_properties["retryCount"].asInt());
 						}
 						else
 						{
-							properties->SetRetryCount(0); 
+							properties->SetRetryCount(0);
 						}
 					}
 
-					logti("Request to pull stream: %s/%s - persistent(%s) noInputFailoverTimeoutMs(%d) unusedStreamDeletionTimeoutMs(%d) ignoreRtcpSRTimestamp(%s)", app->GetVHostAppName().CStr(), stream_name.CStr(), properties->IsPersistent() ? "true" : "false", properties->GetNoInputFailoverTimeout(), properties->GetUnusedStreamDeletionTimeout(), properties->IsRtcpSRTimestampIgnored() ? "true" : "false");
+					logti("Request to pull stream: %s/%s - persistent(%s) noInputFailoverTimeoutMs(%d) unusedStreamDeletionTimeoutMs(%d) ignoreRtcpSRTimestamp(%s) relay(%s)", app->GetVHostAppName().CStr(), stream_name.CStr(), properties->IsPersistent() ? "true" : "false", properties->GetNoInputFailoverTimeout(), properties->GetUnusedStreamDeletionTimeout(), properties->IsRtcpSRTimestampIgnored() ? "true" : "false", properties->IsRelay() ? "true" : "false");
 					for (auto &url : request_urls)
 					{
 						logti(" - %s", url.CStr());


### PR DESCRIPTION
## Summary

Honor the `relay` boolean in the `POST /v1/vhosts/<vhost>/apps/<app>/streams` body so a pull stream created via REST can be registered as a Relay stream (passthrough) instead of always being created as Source (transcoded).

## Why

The handler already parses `persistent`, `noInputFailoverTimeoutMs`, `unusedStreamDeletionTimeoutMs`, `ignoreRtcpSRTimestamp` and `retryCount`, but not `relay`. Because `relay` defaults to `false`, every stream created through this API is forced to `StreamRepresentationType::Source` in `pull_provider/stream.cpp` and runs through the Transcoder + OutputProfile pipeline. When the upstream is OVT and already exposes multiple renditions, this produces a cartesian product over input tracks x Encodes profiles and ends up transcoding most of them, defeating multi-rendition passthrough.

The same `RequestPullStreamWithUrls` path is already used by the OriginMapStore (Redis) flow in `base/publisher/publisher.cpp`, where `EnableRelay(true)` is forced for OVT URLs so the stream is created as a Relay. The REST API was the only caller missing the toggle, so this is a consistency fix more than a new feature.

## Change

- Add a `relay` boolean to the `properties` block of the pull-stream request, mirroring the existing optional flags.
- Include the resolved relay flag in the `Request to pull stream` log line.
- Default behavior is unchanged (`relay` omitted → `false`, same as today).

## Test plan

- [ ] POST a pull stream without `relay` → behaves as before (Source / transcoded).
- [ ] POST a pull stream with `"relay": true` for an OVT upstream → registered as Relay, multi-rendition tracks pass through without per-profile transcoding.
- [ ] Log line shows `relay(true|false)` matching the request.