### PR TITLE
build: validate NVIDIA toolchain and auto-select nvcc host compiler

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -314,7 +314,7 @@ endmacro()
 # ==============================================================================
 if(OME_HWACCEL_NVIDIA)
     set(CUDA_ROOT "/usr/local/cuda")
-    find_program(NV_NVCC           nvcc            HINTS ${CUDA_ROOT}/bin)
+    find_program(NV_NVCC           nvcc            HINTS ${CUDA_ROOT}/bin /usr/cuda/bin)
     # libnvidia-ml.so and libcuda.so are not included in Docker images like
     # `nvidia/cuda` base images, so also check the stubs directory.
     find_library(NV_ML_LIB         nvidia-ml       HINTS ${CUDA_ROOT}/lib64 ${CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -317,9 +317,9 @@ if(OME_HWACCEL_NVIDIA)
     find_program(NV_NVCC           nvcc            HINTS ${CUDA_ROOT}/bin /usr/cuda/bin)
     # libnvidia-ml.so and libcuda.so are not included in Docker images like
     # `nvidia/cuda` base images, so also check the stubs directory.
-    find_library(NV_ML_LIB         nvidia-ml       HINTS ${CUDA_ROOT}/lib64 ${CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)
-    find_library(NV_CUDA_LIB       cuda            HINTS ${CUDA_ROOT}/lib64 ${CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)
-    find_library(NV_CUDART_LIB     cudart_static   HINTS ${CUDA_ROOT}/lib64 /usr/lib/x86_64-linux-gnu)
+    find_library(NV_ML_LIB         nvidia-ml       HINTS ${CUDA_ROOT}/lib64 ${CUDA_ROOT}/lib64/stubs /usr/cuda/lib64 /usr/cuda/lib64/stubs /usr/lib/x86_64-linux-gnu)
+    find_library(NV_CUDA_LIB       cuda            HINTS ${CUDA_ROOT}/lib64 ${CUDA_ROOT}/lib64/stubs /usr/cuda/lib64 /usr/cuda/lib64/stubs /usr/lib/x86_64-linux-gnu)
+    find_library(NV_CUDART_LIB     cudart_static   HINTS ${CUDA_ROOT}/lib64 /usr/cuda/lib64 /usr/lib/x86_64-linux-gnu)
 
     if(NOT (NV_NVCC AND NV_CUDA_LIB AND NV_CUDART_LIB AND NV_ML_LIB))
         message(FATAL_ERROR

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -160,6 +160,9 @@ macro(ome_find_pkg var pkg version_var)
         set(_FP_HWACCEL_ARGS)
         if(OME_HWACCEL_NVIDIA)
             list(APPEND _FP_HWACCEL_ARGS -DOME_HWACCEL_NVIDIA=ON)
+            if(CMAKE_CUDA_HOST_COMPILER)
+                list(APPEND _FP_HWACCEL_ARGS "-DCMAKE_CUDA_HOST_COMPILER=${CMAKE_CUDA_HOST_COMPILER}")
+            endif()
         endif()
         if(OME_HWACCEL_QSV)
             list(APPEND _FP_HWACCEL_ARGS -DOME_HWACCEL_QSV=ON)
@@ -302,6 +305,37 @@ macro(ome_find_pkg var pkg version_var)
 endmacro()
 
 # ==============================================================================
+# NVIDIA toolchain validation (fail-fast)
+#
+# Must run BEFORE any ome_find_pkg() call below — those calls can trigger an
+# automatic reinstall of CUDA-dependent libraries (notably whisper.cpp), and a
+# missing CUDA Toolkit would then surface as an opaque nvcc error deep inside
+# the whisper build instead of a clear up-front message.
+# ==============================================================================
+if(OME_HWACCEL_NVIDIA)
+    set(CUDA_ROOT "/usr/local/cuda")
+    find_program(NV_NVCC           nvcc            HINTS ${CUDA_ROOT}/bin)
+    # libnvidia-ml.so and libcuda.so are not included in Docker images like
+    # `nvidia/cuda` base images, so also check the stubs directory.
+    find_library(NV_ML_LIB         nvidia-ml       HINTS ${CUDA_ROOT}/lib64 ${CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)
+    find_library(NV_CUDA_LIB       cuda            HINTS ${CUDA_ROOT}/lib64 ${CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)
+    find_library(NV_CUDART_LIB     cudart_static   HINTS ${CUDA_ROOT}/lib64 /usr/lib/x86_64-linux-gnu)
+
+    if(NOT (NV_NVCC AND NV_CUDA_LIB AND NV_CUDART_LIB AND NV_ML_LIB))
+        message(FATAL_ERROR
+            "[OME] OME_HWACCEL_NVIDIA=ON but CUDA Toolkit is missing or incomplete:\n"
+            "  nvcc:             ${NV_NVCC}\n"
+            "  libnvidia-ml:     ${NV_ML_LIB}\n"
+            "  libcuda:          ${NV_CUDA_LIB}\n"
+            "  libcudart_static: ${NV_CUDART_LIB}\n"
+            "Install CUDA Toolkit: https://developer.nvidia.com/cuda-downloads\n"
+            "Or disable NVIDIA support: rm -rf build && cmake -B build -DOME_HWACCEL_NVIDIA=OFF ..."
+        )
+    endif()
+
+endif()
+
+# ==============================================================================
 # Required dependencies  (exact version required; wrong/newer version → targeted reinstall)
 # ==============================================================================
 ome_find_pkg(PKG_OPENSSL        openssl         OME_VER_OPENSSL         REINSTALL_TARGET openssl)
@@ -331,29 +365,16 @@ ome_find_pkg(PKG_LIBAVUTIL      libavutil       OME_VER_LIBAVUTIL       REINSTAL
 # Optional / hardware-accelerated dependencies
 # ==============================================================================
 
-# NVIDIA CUDA/NVML 
+# NVIDIA CUDA/NVML — toolchain already validated up top
 if(OME_HWACCEL_NVIDIA)
     ome_find_pkg(PKG_FFNVCODEC  ffnvcodec       OME_VER_NVCC_HDR        REINSTALL_TARGET ffnvcodec)
 
-    set(CUDA_ROOT "/usr/local/cuda")
-    find_program(NV_NVCC           nvcc            HINTS ${CUDA_ROOT}/bin)
-    # libnvidia-ml.so and libcuda.so are not included in Docker images like
-    # `nvidia/cuda` base images, so also check the stubs directory.
-    find_library(NV_ML_LIB         nvidia-ml       HINTS ${CUDA_ROOT}/lib64 ${CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)
-    find_library(NV_CUDA_LIB       cuda            HINTS ${CUDA_ROOT}/lib64 ${CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)
-    find_library(NV_CUDART_LIB     cudart_static   HINTS ${CUDA_ROOT}/lib64 /usr/lib/x86_64-linux-gnu)
+    message(STATUS "[OME] NVIDIA hardware acceleration: ENABLED")
+    add_compile_definitions(HWACCELS_NVIDIA_ENABLED)
+    include_directories(${CUDA_ROOT}/include)
+    link_directories(${CUDA_ROOT}/lib64)
 
-    if(NV_CUDA_LIB AND NV_CUDART_LIB AND NV_ML_LIB AND NV_NVCC)
-        message(STATUS "[OME] NVIDIA hardware acceleration: ENABLED")
-        add_compile_definitions(HWACCELS_NVIDIA_ENABLED)
-        include_directories(${CUDA_ROOT}/include)
-        link_directories(${CUDA_ROOT}/lib64)
-
-        set(OME_NVIDIA_LIBS cuda nvidia-ml ${NV_CUDART_LIB} rt dl)
-    else()
-        message(WARNING "[OME] OME_HWACCEL_NVIDIA=ON but required NVIDIA libraries/tools not found - disabled")
-        set(OME_HWACCEL_NVIDIA OFF)
-    endif()
+    set(OME_NVIDIA_LIBS cuda nvidia-ml ${NV_CUDART_LIB} rt dl)
 
     unset(NV_CUDA_LIB CACHE)
     unset(NV_CUDART_LIB CACHE)

--- a/cmake/InstallPrerequisites.cmake
+++ b/cmake/InstallPrerequisites.cmake
@@ -358,14 +358,15 @@ if(OME_HWACCEL_NVIDIA)
     if(_OME_HOST_PICKED STREQUAL "NOTFOUND")
         execute_process(COMMAND ${_OME_NVCC} --version
             OUTPUT_VARIABLE _OME_NVCC_VER OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
-        execute_process(COMMAND gcc --version
+        execute_process(COMMAND g++ --version
             OUTPUT_VARIABLE _OME_HOST_VER OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
         message(FATAL_ERROR
-            "[OME Prerequisites] nvcc cannot compile with any available host compiler (tried default + g++-14/13/12/11).\n\n"
+            "[OME Prerequisites] nvcc could not compile a trivial CUDA file with any C++ host compiler tried (default + g++-14/13/12/11).\n\n"
             "Last nvcc error:\n${_OME_CUDA_TEST_ERR}\n"
             "nvcc:\n${_OME_NVCC_VER}\n\n"
-            "host gcc:\n${_OME_HOST_VER}\n\n"
-            "Install a gcc version compatible with your CUDA toolkit, for example:\n"
+            "system g++:\n${_OME_HOST_VER}\n\n"
+            "Most often this is a C++ host compiler incompatibility (each CUDA toolkit only supports up to a specific g++ version). Less commonly the same failure surfaces from a partially installed CUDA Toolkit (missing headers or libraries). Inspect the nvcc error above to tell which case applies.\n\n"
+            "If it is a host compiler issue, install a supported g++, for example:\n"
             "  sudo apt install -y gcc-14 g++-14"
         )
     elseif("${_OME_HOST_PICKED}" STREQUAL "default")

--- a/cmake/InstallPrerequisites.cmake
+++ b/cmake/InstallPrerequisites.cmake
@@ -287,9 +287,9 @@ endif()
 if(OME_HWACCEL_NVIDIA)
     set(_CUDA_ROOT "/usr/local/cuda")
     find_program(_OME_NVCC nvcc HINTS ${_CUDA_ROOT}/bin /usr/cuda/bin)
-    find_library(_OME_ML_LIB     nvidia-ml     HINTS ${_CUDA_ROOT}/lib64 ${_CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)
-    find_library(_OME_CUDA_LIB   cuda          HINTS ${_CUDA_ROOT}/lib64 ${_CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)
-    find_library(_OME_CUDART_LIB cudart_static HINTS ${_CUDA_ROOT}/lib64 /usr/lib/x86_64-linux-gnu)
+    find_library(_OME_ML_LIB     nvidia-ml     HINTS ${_CUDA_ROOT}/lib64 ${_CUDA_ROOT}/lib64/stubs /usr/cuda/lib64 /usr/cuda/lib64/stubs /usr/lib/x86_64-linux-gnu)
+    find_library(_OME_CUDA_LIB   cuda          HINTS ${_CUDA_ROOT}/lib64 ${_CUDA_ROOT}/lib64/stubs /usr/cuda/lib64 /usr/cuda/lib64/stubs /usr/lib/x86_64-linux-gnu)
+    find_library(_OME_CUDART_LIB cudart_static HINTS ${_CUDA_ROOT}/lib64 /usr/cuda/lib64 /usr/lib/x86_64-linux-gnu)
 
     if(NOT (_OME_NVCC AND _OME_CUDA_LIB AND _OME_CUDART_LIB AND _OME_ML_LIB))
         message(FATAL_ERROR

--- a/cmake/InstallPrerequisites.cmake
+++ b/cmake/InstallPrerequisites.cmake
@@ -277,6 +277,105 @@ else()
 endif()
 
 # ==============================================================================
+# NVIDIA toolchain validation (fail-fast)
+#
+# Catches missing CUDA Toolkit before any time is spent building dependencies.
+# Mirrors the same check in cmake/Dependencies.cmake so that both entry points
+# (direct `cmake -P InstallPrerequisites.cmake` and the auto-reinstall path
+# triggered from the main configure) fail at the earliest possible moment.
+# ==============================================================================
+if(OME_HWACCEL_NVIDIA)
+    set(_CUDA_ROOT "/usr/local/cuda")
+    find_program(_OME_NVCC nvcc HINTS ${_CUDA_ROOT}/bin /usr/cuda/bin)
+    find_library(_OME_ML_LIB     nvidia-ml     HINTS ${_CUDA_ROOT}/lib64 ${_CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)
+    find_library(_OME_CUDA_LIB   cuda          HINTS ${_CUDA_ROOT}/lib64 ${_CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)
+    find_library(_OME_CUDART_LIB cudart_static HINTS ${_CUDA_ROOT}/lib64 /usr/lib/x86_64-linux-gnu)
+
+    if(NOT (_OME_NVCC AND _OME_CUDA_LIB AND _OME_CUDART_LIB AND _OME_ML_LIB))
+        message(FATAL_ERROR
+            "[OME Prerequisites] OME_HWACCEL_NVIDIA=ON but CUDA Toolkit is missing or incomplete:\n"
+            "  nvcc:             ${_OME_NVCC}\n"
+            "  libnvidia-ml:     ${_OME_ML_LIB}\n"
+            "  libcuda:          ${_OME_CUDA_LIB}\n"
+            "  libcudart_static: ${_OME_CUDART_LIB}\n"
+            "Install CUDA Toolkit: https://developer.nvidia.com/cuda-downloads\n"
+            "Or disable NVIDIA support: re-run without -DOME_HWACCEL_NVIDIA=ON"
+        )
+    endif()
+    message(STATUS "[OME Prerequisites] CUDA Toolkit found - nvcc: ${_OME_NVCC}")
+
+    # nvcc <-> host compiler compatibility probe with auto-fallback.
+    # nvcc enforces the host compiler version (e.g. CUDA 12.x rejects gcc 15+).
+    # If CMAKE_CUDA_HOST_COMPILER is preset (user-supplied or forwarded from the
+    # parent configure) only that is probed. Otherwise try the system default,
+    # then walk g++-14 / g++-13 / g++-12 / g++-11 and pick the first one nvcc
+    # accepts. The selected compiler is exported via OME_NVCC_HOST_CXX so the
+    # whisper build inherits it as CMAKE_CUDA_HOST_COMPILER.
+    set(_OME_CUDA_TEST_DIR "${TEMP_PATH}/cuda_compat_test")
+    file(REMOVE_RECURSE "${_OME_CUDA_TEST_DIR}")
+    file(MAKE_DIRECTORY "${_OME_CUDA_TEST_DIR}")
+    file(WRITE "${_OME_CUDA_TEST_DIR}/test.cu" "#include <cuda_runtime.h>\nint main(){return 0;}\n")
+
+    if(CMAKE_CUDA_HOST_COMPILER)
+        set(_OME_HOST_CANDIDATES "${CMAKE_CUDA_HOST_COMPILER}")
+    else()
+        # Empty string means "system default" (no -ccbin passed to nvcc).
+        set(_OME_HOST_CANDIDATES "" g++-14 g++-13 g++-12 g++-11)
+    endif()
+
+    set(OME_NVCC_HOST_CXX "")
+    set(_OME_HOST_PICKED "NOTFOUND")
+    set(_OME_CUDA_TEST_ERR "")
+    foreach(_cxx IN LISTS _OME_HOST_CANDIDATES)
+        set(_cxx_args "")
+        if(NOT "${_cxx}" STREQUAL "")
+            unset(_OME_FOUND_CXX CACHE)
+            find_program(_OME_FOUND_CXX NAMES "${_cxx}")
+            if(NOT _OME_FOUND_CXX)
+                continue()
+            endif()
+            set(_cxx_args "-ccbin" "${_OME_FOUND_CXX}")
+        endif()
+        execute_process(
+            COMMAND ${_OME_NVCC} ${_cxx_args} -c "${_OME_CUDA_TEST_DIR}/test.cu" -o "${_OME_CUDA_TEST_DIR}/test.o"
+            RESULT_VARIABLE _OME_CUDA_TEST_RET
+            ERROR_VARIABLE _OME_CUDA_TEST_ERR
+            OUTPUT_QUIET
+        )
+        if(_OME_CUDA_TEST_RET EQUAL 0)
+            if("${_cxx}" STREQUAL "")
+                set(_OME_HOST_PICKED "default")
+            else()
+                set(_OME_HOST_PICKED "${_OME_FOUND_CXX}")
+                set(OME_NVCC_HOST_CXX "${_OME_FOUND_CXX}")
+            endif()
+            break()
+        endif()
+    endforeach()
+    unset(_OME_FOUND_CXX CACHE)
+    file(REMOVE_RECURSE "${_OME_CUDA_TEST_DIR}")
+
+    if(_OME_HOST_PICKED STREQUAL "NOTFOUND")
+        execute_process(COMMAND ${_OME_NVCC} --version
+            OUTPUT_VARIABLE _OME_NVCC_VER OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+        execute_process(COMMAND gcc --version
+            OUTPUT_VARIABLE _OME_HOST_VER OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+        message(FATAL_ERROR
+            "[OME Prerequisites] nvcc cannot compile with any available host compiler (tried default + g++-14/13/12/11).\n\n"
+            "Last nvcc error:\n${_OME_CUDA_TEST_ERR}\n"
+            "nvcc:\n${_OME_NVCC_VER}\n\n"
+            "host gcc:\n${_OME_HOST_VER}\n\n"
+            "Install a gcc version compatible with your CUDA toolkit, for example:\n"
+            "  sudo apt install -y gcc-14 g++-14"
+        )
+    elseif("${_OME_HOST_PICKED}" STREQUAL "default")
+        message(STATUS "[OME Prerequisites] nvcc host compiler: system default works")
+    else()
+        message(STATUS "[OME Prerequisites] nvcc host compiler: auto-selected ${_OME_HOST_PICKED}")
+    endif()
+endif()
+
+# ==============================================================================
 # Individual install functions (implemented as cmake variables holding shell code)
 # ==============================================================================
 
@@ -549,11 +648,10 @@ set(_WHISPER_CMAKE_ARGS
 )
 if(OME_HWACCEL_NVIDIA)
     list(APPEND _WHISPER_CMAKE_ARGS "\"-DCMAKE_CUDA_ARCHITECTURES=61-real\;70-real\;75-real\;80-real\;86-real\;89\"")
-    find_program(_OME_NVCC nvcc HINTS /usr/local/cuda/bin /usr/cuda/bin)
-    if(_OME_NVCC)
-        list(APPEND _WHISPER_CMAKE_ARGS "-DCMAKE_CUDA_COMPILER=${_OME_NVCC}")
-    else()
-        message(WARNING "[OME] nvcc not found - whisper CUDA build may fail. Install CUDA toolkit or add nvcc to PATH.")
+    # nvcc and OME_NVCC_HOST_CXX were resolved by the probe above.
+    list(APPEND _WHISPER_CMAKE_ARGS "-DCMAKE_CUDA_COMPILER=${_OME_NVCC}")
+    if(OME_NVCC_HOST_CXX)
+        list(APPEND _WHISPER_CMAKE_ARGS "-DCMAKE_CUDA_HOST_COMPILER=${OME_NVCC_HOST_CXX}")
     endif()
 endif()
 list(JOIN _WHISPER_CMAKE_ARGS " " _WHISPER_CMAKE_LINE)


### PR DESCRIPTION
## Motivation

When `OME_HWACCEL_NVIDIA=ON`, missing or partial CUDA Toolkit installs used to surface only after several minutes of dependency builds, with the actual `nvcc` error buried at the very end of the whisper reinstall. The situation worsens on systems with a newer host gcc that `nvcc` rejects (CUDA 12.x does not accept gcc 15+), where whisper failed even with the toolkit installed and the cause was not obvious from the build log.

## Solution

Add a single fail-fast NVIDIA toolchain validation block at the top of both `cmake/Dependencies.cmake` and `cmake/InstallPrerequisites.cmake`. It verifies that `nvcc` and the CUDA runtime libraries (`libcuda`, `libcudart_static`, `libnvidia-ml`) are present and reports which component is missing.

The prerequisites side also probes `nvcc` and host compiler compatibility with a trivial CUDA compile. If the system gcc is rejected by `nvcc`, it walks `g++-14` / `g++-13` / `g++-12` / `g++-11` and forwards the first accepted compiler to the whisper build as `CMAKE_CUDA_HOST_COMPILER`. A user-supplied `CMAKE_CUDA_HOST_COMPILER` is honored as-is and forwarded across the auto-reinstall path.

The legacy `WARNING + silent NVIDIA-OFF` fallback in the lower NVIDIA block is dropped because the validation up top already produces a `FATAL_ERROR` for the same conditions.