### PR TITLE
feat(logger): add <File enabled> toggle to disable file output

### DIFF
--- a/docs/logs-and-statistics.md
+++ b/docs/logs-and-statistics.md
@@ -15,6 +15,11 @@ You can set up Logger.xml as shown in the following example: OvenMediaEngine pri
 	<!-- Log file location -->
 	<Path>/var/log/ovenmediaengine</Path>
 
+	<!-- Optional: disable the per-line file sink. stdout/stderr is
+	     unaffected. Useful when logs are shipped via the container
+	     runtime's stdout capture. Default: enabled. -->
+	<!-- <File enabled="false"/> -->
+
 	<!-- Disable some SRT internal logs -->
 	<Tag name="SRT" level="critical" />
 	<Tag name="Monitor" level="critical" />
@@ -24,6 +29,12 @@ You can set up Logger.xml as shown in the following example: OvenMediaEngine pri
 </Logger>
 
 ```
+
+### Disabling the file sink
+
+Every log line is also written to stdout/stderr regardless of the file sink. If your deployment ships logs via your container runtime's stdout capture (e.g. Docker → Loki/Promtail/Alloy, journald, Kubernetes), the on-disk file is duplicate state — and OvenMediaEngine rotates its log file daily without ever deleting old rotations, so the directory grows unbounded.
+
+Set `<File enabled="false"/>` on the `<Logger>` element to skip the file sink entirely. With it disabled, OvenMediaEngine does not create the log directory and does not open or rotate any file; stdout/stderr behavior is unchanged. The setting defaults to `true` (the historical behavior) when the element is omitted.
 
 OvenMediaEngine generates log files. If you start OvenMediaEngine by `systemctl start ovenmediaengine`, the log file is generated to the following path.
 

--- a/misc/conf_examples/Logger.xml
+++ b/misc/conf_examples/Logger.xml
@@ -4,6 +4,11 @@
 	<!-- Log file location -->
 	<Path>/var/log/ovenmediaengine</Path>
 
+	<!-- Optional: disable the on-disk file sink. stdout/stderr is
+	     unaffected. Useful when logs are shipped via the container
+	     runtime's stdout capture. Default: enabled. -->
+	<!-- <File enabled="false"/> -->
+
 	<!-- Disable some SRT internal logs -->
 	<Tag name="SRT" level="critical" />
 	<Tag name="HTTP.Server" level="warn" />

--- a/src/projects/base/ovlibrary/log.cpp
+++ b/src/projects/base/ovlibrary/log.cpp
@@ -68,6 +68,11 @@ const char *ov_log_get_path()
 	return g_log_internal.GetLogPath();
 }
 
+void ov_log_set_file_enabled(bool enabled)
+{
+	g_log_internal.SetFileEnabled(enabled);
+}
+
 void ov_stat_log_internal(StatLogType type, OVLogLevel level, const char *tag, const char *file, int line, const char *method, const char *format, ...)
 {
 	// Getroot : Now, disable the temporarily created stat_log. (21-07-16)

--- a/src/projects/base/ovlibrary/log.h
+++ b/src/projects/base/ovlibrary/log.h
@@ -171,6 +171,12 @@ extern "C"
 	void ov_log_set_path(const char *log_path);
 	const char *ov_log_get_path();
 
+	/// Toggle the per-line file sink (the daily-rotated file in the log dir).
+	/// stdout/stderr output is unaffected. Useful when logs are shipped via
+	/// the container runtime's stdout capture and the on-disk file is just
+	/// duplicate state to manage. Default: enabled.
+	void ov_log_set_file_enabled(bool enabled);
+
 	void ov_stat_log_internal(StatLogType type, OVLogLevel level, const char *tag, const char *file, int line, const char *method, const char *format, ...);
 	void ov_stat_log_set_path(StatLogType type, const char *log_path);
 

--- a/src/projects/base/ovlibrary/log_internal.cpp
+++ b/src/projects/base/ovlibrary/log_internal.cpp
@@ -373,4 +373,14 @@ namespace ov
 
 		return _log_file.GetLogPath();
 	}
+
+	void LogInternal::SetFileEnabled(bool enabled)
+	{
+		if (_released)
+		{
+			return;
+		}
+
+		_log_file.SetEnabled(enabled);
+	}
 }  // namespace ov

--- a/src/projects/base/ovlibrary/log_internal.h
+++ b/src/projects/base/ovlibrary/log_internal.h
@@ -69,6 +69,8 @@ namespace ov
 		void SetLogPath(const char *log_path);
 		const char *GetLogPath() const;
 
+		void SetFileEnabled(bool enabled);
+
 	protected:
 		// This variable is used to avoid the problem of referencing incorrect heap if the log is written after LogInternal instance is released.
 		// This situation occurs when the LogInternal instance declared static is disabled just before the OME is terminated and then logs are written by another module.

--- a/src/projects/base/ovlibrary/log_write.cpp
+++ b/src/projects/base/ovlibrary/log_write.cpp
@@ -86,8 +86,18 @@ namespace ov
 		_start_service = start_service;
 	}
 
+	void LogWrite::SetEnabled(bool enabled)
+	{
+		_enabled = enabled;
+	}
+
 	void LogWrite::Write(const char *log, std::time_t time)
 	{
+		if (_enabled == false)
+		{
+			return;
+		}
+
 		if (time == 0)
 		{
 			time = std::time(nullptr);

--- a/src/projects/base/ovlibrary/log_write.h
+++ b/src/projects/base/ovlibrary/log_write.h
@@ -8,6 +8,7 @@
 //==============================================================================
 #pragma once
 
+#include <atomic>
 #include <fstream>
 #include <mutex>
 
@@ -25,6 +26,7 @@ namespace ov
 		void Write(const char *log, std::time_t time = 0);
 		void SetLogPath(const char *log_path);
 		const char *GetLogPath() const;
+		void SetEnabled(bool enabled);
 
 		static void SetAsService(bool start_service);
 
@@ -38,6 +40,7 @@ namespace ov
 		std::string _log_file_name;
 		std::string _log_file;
 		bool _include_date_in_filename = false;
+		std::atomic<bool> _enabled{true};
 		static bool _start_service;
 	};
 }  // namespace ov

--- a/src/projects/config/config_logger_loader.cpp
+++ b/src/projects/config/config_logger_loader.cpp
@@ -59,6 +59,10 @@ namespace cfg
 
 		_log_path = logger_node.child_value("Path");
 		_version  = logger_node.attribute("version").value();
+
+		// <File enabled="true|false"/> — toggle the on-disk file sink.
+		// Defaults to true (current behavior) when absent.
+		_file_enabled = logger_node.child("File").attribute("enabled").as_bool(true);
 	}
 
 	void ConfigLoggerLoader::Reset()
@@ -81,6 +85,11 @@ namespace cfg
 	ov::String ConfigLoggerLoader::GetVersion() const noexcept
 	{
 		return _version;
+	}
+
+	bool ConfigLoggerLoader::IsFileEnabled() const noexcept
+	{
+		return _file_enabled;
 	}
 
 	std::shared_ptr<LoggerTagInfo> ParseTag(pugi::xml_node tag_node)

--- a/src/projects/config/config_logger_loader.h
+++ b/src/projects/config/config_logger_loader.h
@@ -29,10 +29,12 @@ namespace cfg
 		std::vector<std::shared_ptr<LoggerTagInfo>> GetTags() const noexcept;
 		ov::String GetLogPath() const noexcept;
 		ov::String GetVersion() const noexcept;
+		bool IsFileEnabled() const noexcept;
 
 	private:
 		std::vector<std::shared_ptr<LoggerTagInfo>> _tags;
 		ov::String _log_path;
 		ov::String _version = "1.0";
+		bool _file_enabled = true;
 	};
 }  // namespace cfg

--- a/src/projects/config/config_manager.cpp
+++ b/src/projects/config/config_manager.cpp
@@ -222,6 +222,7 @@ namespace cfg
 
 		auto log_path = logger_loader->GetLogPath();
 		::ov_log_set_path(log_path.CStr());
+		::ov_log_set_file_enabled(logger_loader->IsFileEnabled());
 
 		// Init stat log
 		//TODO(Getroot): This is temporary code for testing. This will change to more elegant code in the future.


### PR DESCRIPTION
Note: the following is LLM (Claude Opus) written, except the Why section, and the whole thing lightly edited by me. 

The code is tested and simple but entirely from Claude, I'm no C programmer, certainly not on Airensoft's level!

## What

Adds a `<File enabled="true|false"/>` child element to `Logger.xml` that toggles the on-disk log file sink. Default is `true` (preserves current behavior when the element is omitted), so this is a purely additive, backwards-compatible change.

```xml
<Logger version="2">
    <Path>/var/log/ovenmediaengine</Path>
    <File enabled="false"/>    <!-- skip the file sink entirely -->
    <Tag name=".*" level="info" />
</Logger>
```

When disabled, `LogWrite::Write` early-returns before any `mkdir()` or `ofstream::open()` runs, so the log directory is never created and the daily rotation `rename()` never fires. `stdout`/`stderr` output is unaffected.

## Why

In production, we ran into endlessly growing log files in-container, and since we pipe logs to loki via `docker logs` and the docker logging engine, the files are just waste. 

There was no way to disable the written-to-disk log, so I asked Claude to whip up a simple PR. 

Of note, the log files appear to just pile up on any docker container endlessly. I would call that a bug, but figured I'd open this and maybe then we open a bug report after.


## Backward compatibility

- `_file_enabled` defaults to `true` in `ConfigLoggerLoader`, so configs without `<File>` behave exactly as before.
- The Logger.xml schema version is unchanged (still `version="2"`) — this is an additive child element, no breaking change.
- `<File enabled="true"/>` is identical to the historical (no-element) behavior.

## Test plan

Built with the project Dockerfile (`docker build --build-arg USE_LOCAL=true`) on Linux x86_64. Smoke-tested the resulting image with three Logger.xml shapes:

| Config | Result |
| --- | --- |
| no `<File>` element | `/var/log/ovenmediaengine/ovenmediaengine.log` written as before |
| `<File enabled="true"/>` | identical to above |
| `<File enabled="false"/>` | `/var/log/ovenmediaengine/` is not created; OME still emits all expected log lines on `stdout` (106 OME-formatted lines after boot, including the banner, version, module init, monitor start) |


## Changes

- `src/projects/base/ovlibrary/log_write.{h,cpp}` — `_enabled` (atomic bool) + `SetEnabled()`; `Write()` early-returns when disabled.
- `src/projects/base/ovlibrary/log_internal.{h,cpp}` — `SetFileEnabled()` forwarder.
- `src/projects/base/ovlibrary/log.{h,cpp}` — new `ov_log_set_file_enabled(bool)` C glue alongside `ov_log_set_path()`.
- `src/projects/config/config_logger_loader.{h,cpp}` — parses `<File enabled>` via `pugi::xml_attribute::as_bool(true)`.
- `src/projects/config/config_manager.cpp` — calls `ov_log_set_file_enabled()` next to `ov_log_set_path()` on initial load and hot reload.
- `docs/logs-and-statistics.md` — adds a "Disabling the file sink" section.
- `misc/conf_examples/Logger.xml` — adds a commented example of the new element.

64 insertions, 0 deletions across 11 files.

## Notes for reviewers

- Claude used an XML attribute (`<File enabled="false"/>`) to match the existing Logger.xml-internal style (its hand-rolled pugixml parser is the only place in the codebase that doesn't use `cfg::Item`/`Register<>`). 