### PR TITLE
refactor: clean up constructors and remove unneeded retry

### DIFF
--- a/src/projects/base/info/managed_queue.h
+++ b/src/projects/base/info/managed_queue.h
@@ -311,8 +311,8 @@ namespace info
 		// Threshold value: count (CountBased) or milliseconds (TimeBased)
 		size_t _threshold_value = 0;
 
-		// threshold_exceeded_time increases from the point the queue is exceeded
-		int64_t _threshold_exceeded_time_ms = 0;
+		// threshold_exceeded_time increases from the point the queue is exceeded.
+		std::atomic<int64_t> _threshold_exceeded_time_ms{0};
 
 		// Buffering delay (milliseconds).
 		int _buffering_delay = 0;

--- a/src/projects/base/info/managed_queue.h
+++ b/src/projects/base/info/managed_queue.h
@@ -154,7 +154,7 @@ namespace info
 			  _threshold(threshold),
 			  _threshold_mode(ThresholdMode::CountBased),
 			  _threshold_value(threshold),
-			  _threshold_exceeded_time_in_us(0),
+			  _threshold_exceeded_time_ms(0),
 			  _buffering_delay(0),
 			  _input_message_count(0),
 			  _output_message_count(0),
@@ -251,7 +251,7 @@ namespace info
 
 		int64_t GetThresholdExceededTimeInUs() const
 		{
-			return _threshold_exceeded_time_in_us;
+			return _threshold_exceeded_time_ms;
 		}
 
 		void SetUrn(std::shared_ptr<URN> urn, const char* type_name)
@@ -312,7 +312,7 @@ namespace info
 		size_t _threshold_value = 0;
 
 		// threshold_exceeded_time increases from the point the queue is exceeded
-		int64_t _threshold_exceeded_time_in_us = 0;
+		int64_t _threshold_exceeded_time_ms = 0;
 
 		// Buffering delay (milliseconds).
 		int _buffering_delay = 0;

--- a/src/projects/mediarouter/mediarouter_stream.cpp
+++ b/src/projects/mediarouter/mediarouter_stream.cpp
@@ -47,6 +47,7 @@ MediaRouteStream::MediaRouteStream(const std::shared_ptr<info::Stream> &stream, 
 
 MediaRouteStream::~MediaRouteStream()
 {
+	_packets_queue.Stop();
 	_media_packet_stash.clear();
 	_packets_queue.Clear();
 }

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -641,8 +641,10 @@ namespace ov
 		mutable std::mutex _mutex;
 		std::condition_variable _condition;
 
-		// Stop flag
-		bool _stop;
+		// Stop flag. Atomic so IsStopped() can read it without holding _mutex.
+		// Writers (Stop()) still take _mutex before set + notify_all to avoid
+		// missed-wakeup races with condition_variable waiters.
+		std::atomic<bool> _stop;
 
 		// Set by InjectWakeup(), consumed by Dequeue(). A pending one-shot
 		// wakeup. Unlike _stop, the queue stays usable.
@@ -652,8 +654,9 @@ namespace ov
 		size_t _last_logged_peak = 0;
 
 		// Prevent exceed threshold. If true, the queue will not exceed the threshold
-		// Wait until the queue falls below the threshold
-		bool _exceed_threshold_and_wait_enabled = false;
+		// Wait until the queue falls below the threshold.
+		// Atomic so Set/IsExceedWaitEnable() can be called without holding _mutex.
+		std::atomic<bool> _exceed_threshold_and_wait_enabled{false};
 	};
 
 }  // namespace ov

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -93,8 +93,7 @@ namespace ov
 		// The effective item count is estimated as: input_message_per_second * time_ms / 1000.
 		void SetThresholdByTime(size_t time_ms)
 		{
-			const size_t validated_time_ms = (time_ms < 0) ? 0U : time_ms;
-			info::ManagedQueue::SetThresholdByTime(validated_time_ms);
+			info::ManagedQueue::SetThresholdByTime(time_ms);
 
 			MonitorInstance->OnQueueUpdated(*this);
 		}
@@ -291,7 +290,7 @@ namespace ov
 		}
 
 		// Returns true if the queue has been over its threshold for at least `duration`.
-		// Notes: exceeded time is updated only on each stats tick (MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC 100ms)
+		// Notes: exceeded time is updated only on each stats tick (MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC)
 		bool IsThresholdExceededFor(std::chrono::milliseconds duration) const
 		{
 			return _threshold_exceeded_time_ms >= static_cast<int64_t>(duration.count());

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -40,11 +40,8 @@ namespace ov
 			std::chrono::steady_clock::time_point _start;
 			bool _urgent = false;
 
-			ManagedQueueNode(const T& value, bool urgent, ManagedQueueNode* next_node = nullptr)
-				: data(value), next(next_node), _start(std::chrono::steady_clock::time_point::min()), _urgent(urgent)
-			{
-				_start = std::chrono::steady_clock::now();
-			}
+			ManagedQueueNode(T value, bool urgent, ManagedQueueNode *next_node = nullptr)
+				: data(std::move(value)), next(next_node), _start(std::chrono::steady_clock::now()), _urgent(urgent) {}
 		};
 
 	public:
@@ -61,16 +58,11 @@ namespace ov
 		{
 			info::ManagedQueue::SetUrn(urn, Demangle(typeid(T).name()).CStr());
 
-			// Register to the server metrics
-			// If the Unique id is duplicated or memory allocation failed, retry
-			while (true)
-			{
-				SetId(IssueUniqueQueueId());
+			SetId(IssueUniqueQueueId());
 
-				if (MonitorInstance->OnQueueCreated(*this) == true)
-				{
-					break;
-				}
+			if (MonitorInstance->OnQueueCreated(*this) == false)
+			{
+				logw(LOG_TAG, "Failed to register queue to monitor. id:%u", GetId());
 			}
 		}
 
@@ -104,21 +96,17 @@ namespace ov
 			info::ManagedQueue::SetThresholdByTime(validated_time_ms);
 
 			MonitorInstance->OnQueueUpdated(*this);
-		}				
-
-		// Urgent item will be inserted at the front of the queue
-		void Enqueue(const T& item, bool urgent = false, int timeout = Infinite)
-		{
-			auto node = new ManagedQueueNode(item, urgent);
-			EnqeuePos pos = urgent ? EnqeuePos::EnqueuFrontPos : EnqeuePos::EnqueuBackPos;
-
-			EnqueueInternal(node, timeout, pos);
 		}
 
 		// Urgent item will be inserted at the front of the queue
-		void Enqueue(T&& item, bool urgent = false, int timeout = Infinite)
+		void Enqueue(T item, bool urgent = false, int timeout = Infinite)
 		{
-			auto node = new ManagedQueueNode(item, urgent);
+			auto node = new ManagedQueueNode(std::move(item), urgent);
+			if(node == nullptr)
+			{
+				loge(LOG_TAG, "Failed to allocate memory for queue node.");
+				return;
+			}
 			EnqeuePos pos = urgent ? EnqeuePos::EnqueuFrontPos : EnqeuePos::EnqueuBackPos;
 
 			EnqueueInternal(node, timeout, pos);
@@ -280,11 +268,7 @@ namespace ov
 			_output_message_count++;
 
 			// Update statistics of waiting time (microseconds)
-			if (node->_start != std::chrono::steady_clock::time_point::max())
-			{
-				auto current = std::chrono::steady_clock::now();
-				_waiting_time_in_us = _waiting_time_in_us * 0.9 + std::chrono::duration_cast<std::chrono::microseconds>(current - node->_start).count() * 0.1;
-			}
+			_waiting_time_in_us = _waiting_time_in_us * 0.9 + std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - node->_start).count() * 0.1;
 
 			delete node;
 
@@ -309,7 +293,7 @@ namespace ov
 		// Notes: exceeded time is updated only on each stats tick (MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC 100ms)
 		bool IsThresholdExceededFor(std::chrono::milliseconds duration) const
 		{
-			return _threshold_exceeded_time_in_us >= static_cast<int64_t>(duration.count());
+			return _threshold_exceeded_time_ms >= static_cast<int64_t>(duration.count());
 		}
 
 		// Cleared all items in the queue
@@ -456,7 +440,7 @@ namespace ov
 			{
 				std::chrono::steady_clock::time_point expire = (timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 				auto result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
-					return (!IsThresholdExceeded());
+					return (!IsThresholdExceeded() || _stop);
 				});
 				if (!result || _stop)
 				{
@@ -545,7 +529,7 @@ namespace ov
 
 				if (IsThresholdExceeded())
 				{
-					_threshold_exceeded_time_in_us += elapsed_time;
+					_threshold_exceeded_time_ms += elapsed_time;
 
 					// Logging
 					_last_logging_time += elapsed_time;
@@ -561,7 +545,7 @@ namespace ov
 				}
 				else
 				{
-					_threshold_exceeded_time_in_us = 0;
+					_threshold_exceeded_time_ms = 0;
 #if DEBUG
 					logt(LOG_TAG, "Stable. %s", GetInfoString().CStr());
 #endif					
@@ -581,7 +565,7 @@ namespace ov
 
 			_last_input_message_count = 0;
 			_last_output_message_count = 0;
-			_threshold_exceeded_time_in_us = 0;
+			_threshold_exceeded_time_ms = 0;
 
 			_last_logging_time = 0;
 			_last_logged_peak = 0;

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -26,6 +26,10 @@
 
 namespace ov
 {
+	// Shutdown order: Stop() -> join consumer threads -> destroy the queue.
+	// Destroying the queue while a thread is still waiting in Dequeue/Front/
+	// Back is undefined behavior. The destructor calls Stop() defensively,
+	// but does not wait for waiters to exit.
 	template <typename T>
 	class ManagedQueue : public info::ManagedQueue
 	{
@@ -69,6 +73,11 @@ namespace ov
 
 		~ManagedQueue()
 		{
+			// Defensive: wake any remaining waiters so they can exit. The owner
+			// is still responsible for joining consumer threads BEFORE this
+			// runs (see lifecycle contract above) — Stop() only signals; it
+			// does not wait for waiters to leave the wait functions.
+			Stop();
 			Clear();
 
 			// Unregister to the server metrics

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -371,6 +371,13 @@ namespace ov
 		// Buffer keeps items for a certain amount of time
 		void SetBufferingDelay(int delay_ms)
 		{
+			auto unique_lock = std::unique_lock(_mutex);
+			if(delay_ms < 0)
+			{
+				logw(LOG_TAG, "Invalid buffering delay value: %d. Setting to 0.", delay_ms);
+				delay_ms = 0;
+			}
+
 			_buffering_delay = delay_ms;
 		}
 

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -12,6 +12,7 @@
 #include <monitoring/monitoring.h>
 
 #include <condition_variable>
+#include <new>
 #include <optional>
 #include <queue>
 #include <shared_mutex>
@@ -101,8 +102,8 @@ namespace ov
 		// Urgent item will be inserted at the front of the queue
 		void Enqueue(T item, bool urgent = false, int timeout = Infinite)
 		{
-			auto node = new ManagedQueueNode(std::move(item), urgent);
-			if(node == nullptr)
+			auto node = new(std::nothrow) ManagedQueueNode(std::move(item), urgent);
+			if (node == nullptr)
 			{
 				loge(LOG_TAG, "Failed to allocate memory for queue node.");
 				return;
@@ -424,13 +425,7 @@ namespace ov
 
 		void EnqueueInternal(ManagedQueueNode* node, int timeout, EnqeuePos push_method)
 		{
-			auto unique_lock = std::unique_lock(_mutex);			
-
-			if (!node)
-			{
-				logc(LOG_TAG, "Failed to allocate memory. id:%u", GetId());
-				return;
-			}
+			auto unique_lock = std::unique_lock(_mutex);
 
 			// Update statistics of input message count
 			_input_message_count++;

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -107,7 +107,7 @@ namespace ov
 				loge(LOG_TAG, "Failed to allocate memory for queue node.");
 				return;
 			}
-			EnqeuePos pos = urgent ? EnqeuePos::EnqueuFrontPos : EnqeuePos::EnqueuBackPos;
+			EnqueuePos pos = urgent ? EnqueuePos::EnqueueFrontPos : EnqueuePos::EnqueueBackPos;
 
 			EnqueueInternal(node, timeout, pos);
 		}
@@ -416,13 +416,13 @@ namespace ov
 		// If the queue is full, it waits until the queue is less than the threshold or the timeout expires.
 		// If the timeout expires, the message is dropped.
 		// This is to avoid dropping items when the queue size exceeds the threshold, if it exceeds it momentarily due to jitter.
-		enum EnqeuePos : int8_t
+		enum EnqueuePos : int8_t
 		{
-			EnqueuFrontPos = 0,
-			EnqueuBackPos
+			EnqueueFrontPos = 0,
+			EnqueueBackPos
 		};
 
-		void EnqueueInternal(ManagedQueueNode* node, int timeout, EnqeuePos push_method)
+		void EnqueueInternal(ManagedQueueNode* node, int timeout, EnqueuePos push_method)
 		{
 			auto unique_lock = std::unique_lock(_mutex);
 
@@ -444,7 +444,7 @@ namespace ov
 				}
 			}
 
-			if (push_method == EnqeuePos::EnqueuBackPos)
+			if (push_method == EnqueuePos::EnqueueBackPos)
 			{
 				PushBack(node);
 			}

--- a/src/projects/publishers/push/push_session.cpp
+++ b/src/projects/publishers/push/push_session.cpp
@@ -274,6 +274,11 @@ namespace pub
 	{
 		_sender_stop_flag = true;
 
+		// Wake the sender thread now to skip the Dequeue() timeout wait.
+		// Use InjectWakeup() (not Stop()) so the queue stays reusable
+		// across Start/StopSenderThread cycles.
+		_sender_packet_queue.InjectWakeup();
+
 		if (_sender_thread.joinable())
 		{
 			_sender_thread.join();


### PR DESCRIPTION
## Summary
Clean up `ManagedQueue`: drop a useless retry loop and merge duplicated overloads. No behavior change.

## Changes
- Removed the 10-try retry when registering a queue with the monitor. Queue IDs are unique by design (atomic counter) and `make_shared` throws on failure, so the retry never did anything.
- Merged the two `ManagedQueueNode` constructors into one pass-by-value version. Also fixes a hidden copy in the old `const T&` version that looked like a move.
- Merged the two `Enqueue()` overloads the same way. lvalue still copies, rvalue still moves, with half the code.
- Fixed `EnqueueInternal()` getting stuck when the queue is stopped while full. The wait predicate now also returns true on `_stop`, so `Stop()` reliably wakes blocked enqueuers; the existing `if (!result || _stop)` check then drops the pending item cleanly.
