### PR TITLE
fix: treat terminal SRT epoll errors as disconnects

### DIFF
--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -1676,6 +1676,15 @@ namespace ov
 				socket_error	 = SocketError::CreateError("Remote is disconnected");
 				*received_length = 0UL;
 
+				// NOTE: `SRT_ECONNLOST` is ambiguous - close as plain Disconnected.
+				//
+				// libsrt reports `SRT_ECONNLOST` for BOTH a real network break
+				// AND a graceful peer `srt_close()` - when the peer sends
+				// `UMSG_SHUTDOWN`, libsrt's `processCtrlShutdown()` sets the
+				// broken flag and calls `completeBrokenConnectionDependencies(SRT_ECONNLOST)`,
+				// so the receiver cannot tell the two cases apart at the API level.
+				// Close with `Disconnected` (same posture as TCP RST) instead of `Error`
+				// so downstream does not treat this as an unambiguous transport failure.
 				CloseWithState(SocketState::Disconnected);
 
 				return socket_error;

--- a/src/projects/base/ovsocket/socket_pool/socket_pool_worker.cpp
+++ b/src/projects/base/ovsocket/socket_pool/socket_pool_worker.cpp
@@ -695,7 +695,27 @@ namespace ov
 		{
 			event->events |= EPOLLOUT;
 		}
-		if (OV_CHECK_FLAG(srt_event.events, SRT_EPOLL_ERR))
+
+		// NOTE: Do not unconditionally translate `SRT_EPOLL_ERR` to `EPOLLERR`.
+		//
+		// libsrt raises `SRT_EPOLL_ERR` together with the terminal-state
+		// transitions (`SRTS_BROKEN` / `SRTS_CLOSED` / `SRTS_NONEXIST`), and
+		// those transitions fire for BOTH a real network break AND a graceful
+		// peer `srt_close()` (the `UMSG_SHUTDOWN` handler in libsrt sets
+		// `m_bBroken = true` and notifies the epoll listener with
+		// `SRT_EPOLL_ERR`). The two cases are indistinguishable at the
+		// socket layer.
+		//
+		// We treat `SRT_EPOLL_ERR` accompanying these terminal states as a
+		// disconnect signal only (the matching `case` below sets `EPOLLHUP`).
+		// For any other state we still raise `EPOLLERR` so genuine errors
+		// that occur outside of a clean state transition are not silenced.
+		const bool is_srt_terminal_state =
+			(status == SRTS_BROKEN) ||
+			(status == SRTS_CLOSED) ||
+			(status == SRTS_NONEXIST);
+
+		if (OV_CHECK_FLAG(srt_event.events, SRT_EPOLL_ERR) && (is_srt_terminal_state == false))
 		{
 			event->events |= EPOLLERR;
 		}
@@ -711,12 +731,20 @@ namespace ov
 				break;
 
 			case SRTS_BROKEN:
-				// The client is disconnected (unexpected)
+				// The client is disconnected - "unexpected" here means OME did not initiate the close,
+				// NOT that the peer's close was abnormal.
+				// libsrt transitions to `SRTS_BROKEN` for BOTH a real network break
+				// AND a graceful peer `srt_close()`
+				// (the `SHUTDOWN` message handler in libsrt sets `m_bBroken = true`).
+				// The two cases are indistinguishable at this level,
+				// so signal a plain disconnect(`EPOLLHUP`) instead of escalating to an error event.
 				event->events |= EPOLLHUP;
 				break;
 
 			case SRTS_CLOSED:
-				// The client is disconnected (expected)
+				// The client is disconnected - OME itself called `srt_close()`
+				// (graceful close initiated locally; `SRTS_CLOSED` only happens
+				// after a local `srt_close()` completes, never from a remote shutdown).
 				event->events |= EPOLLHUP;
 				break;
 

--- a/src/projects/base/ovsocket/socket_pool/socket_pool_worker.cpp
+++ b/src/projects/base/ovsocket/socket_pool/socket_pool_worker.cpp
@@ -737,7 +737,7 @@ namespace ov
 				// AND a graceful peer `srt_close()`
 				// (the `SHUTDOWN` message handler in libsrt sets `m_bBroken = true`).
 				// The two cases are indistinguishable at this level,
-				// so signal a plain disconnect(`EPOLLHUP`) instead of escalating to an error event.
+				// so signal a plain disconnect (`EPOLLHUP`) instead of escalating to an error event.
 				event->events |= EPOLLHUP;
 				break;
 


### PR DESCRIPTION
## Summary
- treat `SRT_EPOLL_ERR` as `EPOLLHUP` when the SRT socket is already in a terminal state
- keep raising `EPOLLERR` for non-terminal SRT states
- document why `SRT_ECONNLOST` / `SRT_EPOLL_ERR` are ambiguous in libsrt