### PR TITLE
build: fix NVIDIA link failure when OME_BUILD_TESTS=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,6 @@ if(OME_BUILD_TESTS)
         PkgConfig::PKG_SPDLOG
         PkgConfig::PKG_WHISPER
         ${UUID_LIB}
-        pthread dl z stdc++fs
     )
 
     # Mirror the optional hardware-acceleration libs that
@@ -211,6 +210,14 @@ if(OME_BUILD_TESTS)
     if(OME_HWACCEL_NILOGAN AND XCODER_LOGAN_LIB)
         set_property(GLOBAL APPEND PROPERTY OME_COMMON_TEST_EXT_LIBS xcoder_logan)
     endif()
+
+    # System libraries must come last so that any static archive listed earlier
+    # (e.g. libcudart_static.a from OME_NVIDIA_LIBS) can resolve its references
+    # to pthread / dl / rt against them. Placing them last also keeps
+    # list(REMOVE_DUPLICATES) in ome_add_tests() from dropping a trailing copy.
+    set_property(GLOBAL APPEND PROPERTY OME_COMMON_TEST_EXT_LIBS
+        pthread dl z stdc++fs
+    )
 endif()
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,27 @@ if(OME_BUILD_TESTS)
         ${UUID_LIB}
         pthread dl z stdc++fs
     )
+
+    # Mirror the optional hardware-acceleration libs that
+    # src/projects/main/CMakeLists.txt links into the main executable so that
+    # test binaries linking the same static archives (e.g. libtranscoder.a)
+    # can resolve CUDA / XMA / NiLogan symbols.
+    if(OME_HWACCEL_NVIDIA)
+        set_property(GLOBAL APPEND PROPERTY OME_COMMON_TEST_EXT_LIBS
+            ${OME_NVIDIA_LIBS}
+            PkgConfig::PKG_FFNVCODEC
+        )
+    endif()
+    if(OME_HWACCEL_XMA AND PKG_LIBXMA2API_FOUND)
+        set_property(GLOBAL APPEND PROPERTY OME_COMMON_TEST_EXT_LIBS
+            PkgConfig::PKG_LIBXMA2API
+            PkgConfig::PKG_XVBM
+            PkgConfig::PKG_LIBXRM
+        )
+    endif()
+    if(OME_HWACCEL_NILOGAN AND XCODER_LOGAN_LIB)
+        set_property(GLOBAL APPEND PROPERTY OME_COMMON_TEST_EXT_LIBS xcoder_logan)
+    endif()
 endif()
 
 add_subdirectory(src)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -349,7 +349,11 @@ if(OME_HWACCEL_NVIDIA)
         include_directories(${CUDA_ROOT}/include)
         link_directories(${CUDA_ROOT}/lib64)
 
-        set(OME_NVIDIA_LIBS cuda nvidia-ml ${NV_CUDART_LIB} rt dl)
+        # Use absolute paths from find_library. Some systems install only the
+        # runtime SONAME (libnvidia-ml.so.1) without the linker symlink
+        # (libnvidia-ml.so), so -lnvidia-ml cannot be resolved through
+        # link_directories. The full path side-steps that.
+        set(OME_NVIDIA_LIBS ${NV_CUDA_LIB} ${NV_ML_LIB} ${NV_CUDART_LIB} rt dl)
     else()
         message(WARNING "[OME] OME_HWACCEL_NVIDIA=ON but required NVIDIA libraries/tools not found - disabled")
         set(OME_HWACCEL_NVIDIA OFF)


### PR DESCRIPTION
## Problem
Builds with `-DOME_HWACCEL_NVIDIA=ON -DOME_BUILD_TESTS=ON` fail to link the unit test executables because `OME_NVIDIA_LIBS` is wired only into the `OvenMediaEngine` executable, leaving every test that pulls in `libtranscoder.a` with unresolved CUDA driver symbols such as `cuDeviceGetCount`. The same definition uses link names (`cuda`, `nvidia-ml`), which also fail on systems that ship only `libnvidia-ml.so.1` without the `libnvidia-ml.so` symlink.

## Solution
Append `OME_NVIDIA_LIBS` (and the other optional hardware-acceleration libs) to `OME_COMMON_TEST_EXT_LIBS` so every unit test inherits the same hardware-acceleration link set as the main executable. Switch `OME_NVIDIA_LIBS` to use absolute paths returned by `find_library`, so resolution no longer depends on a linker symlink that may not be present.