### PR TITLE
fix(webrtc): improve Pacer startup smoothness and per-track buffering

### DIFF
--- a/src/projects/modules/pacer/adaptive_delay_controller.cpp
+++ b/src/projects/modules/pacer/adaptive_delay_controller.cpp
@@ -17,19 +17,21 @@ static constexpr auto kWindow = std::chrono::seconds(30);
 // Recompute is throttled to this interval (avoids re-sorting per-frame).
 static constexpr auto kRecomputeInterval = std::chrono::milliseconds(500);
 
-// Target percentile of recent lateness. The Pacer absorbs everything up to
-// this percentile; the remaining tail (here ~5%) passes straight through to
-// the receiver, where the player's own jitter buffer covers it. Trading
-// "perfect" pacing for lower sender-side latency.
-static constexpr double kTargetPercentile = 0.95;
+// Target percentile of recent lateness. The Pacer absorbs up to this; the
+// remaining tail passes through to the receiver's jitter buffer.
+static constexpr double kTargetPercentile = 0.99;
 
-// Below this many samples, percentile estimate is unreliable; skip recompute
-// (current_delay stays at Min until enough samples accumulate).
+// Below this many samples, percentile estimate is unreliable; skip recompute.
 static constexpr size_t kMinSamplesForRecompute = 30;
 
-// Small headroom added on top of the percentile so frames that fall in the
-// (p95, p95 + margin] band are still absorbed and aren't pushed to the tail.
-static constexpr int kMarginMs = 10;
+// Headroom added on top of the percentile.
+static constexpr int kMarginMs = 20;
+
+// EMA coefficient applied when the desired delay drops below the current one.
+// Increases are immediate (alpha=1) so a fresh jitter spike isn't lost;
+// decreases are eased so a shrinking buffer doesn't show up to the viewer
+// as variable playback rate.
+static constexpr double kRelaxAlpha = 0.1;
 
 // Warning rate limit (per warning type).
 static constexpr auto kWarnThrottle = std::chrono::seconds(1);
@@ -37,8 +39,9 @@ static constexpr auto kWarnThrottle = std::chrono::seconds(1);
 // Periodic per-track lateness statistics dump (for measurement / tuning).
 static constexpr auto kStatsLogInterval = std::chrono::seconds(5);
 
-AdaptiveDelayController::AdaptiveDelayController(int min_delay_ms, int max_delay_ms)
-	: _min_delay_ms(min_delay_ms),
+AdaptiveDelayController::AdaptiveDelayController(const ov::String &stream_id, int min_delay_ms, int max_delay_ms)
+	: _stream_id(stream_id),
+	  _min_delay_ms(min_delay_ms),
 	  _max_delay_ms(std::max(min_delay_ms, max_delay_ms)),
 	  _current_delay_ms(min_delay_ms)
 {
@@ -114,13 +117,15 @@ void AdaptiveDelayController::RecordSample(uint32_t track_id, int64_t lateness_m
 
 	if (warn_exceed_max)
 	{
-		logtw("Lateness %lldms exceeds configured Pacer Max %dms — Pacer cannot smooth this frame; receiver likely drops it. Consider raising Max or investigating source jitter.",
+		logtw("[%s] Lateness %lldms exceeds configured Pacer Max %dms — Pacer cannot smooth this frame; receiver likely drops it. Consider raising Max or investigating source jitter.",
+			  _stream_id.CStr(),
 			  static_cast<long long>(warn_late_value),
 			  warn_late_max);
 	}
 	if (warn_max_reached)
 	{
-		logtw("Adaptive delay reached configured Max %dms — Max may be too low for current conditions",
+		logtw("[%s] Adaptive delay reached configured Max %dms — Max may be too low for current conditions",
+			  _stream_id.CStr(),
 			  warn_max_value);
 	}
 }
@@ -138,30 +143,61 @@ void AdaptiveDelayController::Recompute()
 		return;
 	}
 
-	std::vector<int64_t> values;
-	values.reserve(_samples.size());
+	// Per-track percentile, take the max. Mixing tracks into one sorted window
+	// biases the percentile toward the higher-rate, lower-lateness track
+	// (typically audio), under-buffering the worse track. Per-track max keeps
+	// A/V sync (one shared delay) while letting any track's tail size it.
+	std::map<uint32_t, std::vector<int64_t>> per_track;
 	for (const auto &s : _samples)
 	{
-		values.push_back(s.lateness_ms);
+		per_track[s.track_id].push_back(s.lateness_ms);
 	}
-	std::sort(values.begin(), values.end());
 
-	size_t idx = static_cast<size_t>(kTargetPercentile * (values.size() - 1));
-	int64_t p_value = values[idx];
+	// Per-track minimum sample count to trust that track's percentile.
+	static constexpr size_t kMinPerTrack = 10;
 
-	// Negative percentile means anchor settled at a path slower than typical;
-	// no buffer needed beyond Min in that case. Floor at 0 so margin is the
-	// effective minimum buffer size when jitter is below the floor.
-	int desired_ms = static_cast<int>(std::max<int64_t>(p_value, 0)) + kMarginMs;
+	int64_t worst_pvalue = 0;
+	bool have_value		 = false;
+	for (auto &[tid, vals] : per_track)
+	{
+		if (vals.size() < kMinPerTrack)
+		{
+			continue;
+		}
+		std::sort(vals.begin(), vals.end());
+		size_t idx		= static_cast<size_t>(kTargetPercentile * (vals.size() - 1));
+		int64_t p_value = vals[idx];
+		if (!have_value || p_value > worst_pvalue)
+		{
+			worst_pvalue = p_value;
+			have_value	 = true;
+		}
+	}
+	if (!have_value)
+	{
+		return;
+	}
+
+	// Floor at 0: negative percentile means jitter is below the floor, in
+	// which case the margin defines the minimum buffer.
+	int desired_ms = static_cast<int>(std::max<int64_t>(worst_pvalue, 0)) + kMarginMs;
 	desired_ms	   = std::clamp(desired_ms, _min_delay_ms, _max_delay_ms);
 
-	_current_delay_ms = desired_ms;
+	if (desired_ms >= _current_delay_ms)
+	{
+		_current_delay_ms = desired_ms;
+	}
+	else
+	{
+		double smoothed	  = kRelaxAlpha * static_cast<double>(desired_ms) +
+							(1.0 - kRelaxAlpha) * static_cast<double>(_current_delay_ms);
+		_current_delay_ms = std::clamp(static_cast<int>(smoothed), _min_delay_ms, _max_delay_ms);
+	}
 }
 
 // Caller holds _mu.
 void AdaptiveDelayController::LogPerTrackStats()
 {
-	// Group samples by track_id.
 	std::map<uint32_t, std::vector<int64_t>> per_track;
 	for (const auto &s : _samples)
 	{
@@ -175,25 +211,20 @@ void AdaptiveDelayController::LogPerTrackStats()
 	};
 
 	ov::String msg;
-	msg.Format("[PacerStats] current_delay=%dms total_samples=%zu min=%dms max=%dms",
-			   _current_delay_ms, _samples.size(), _min_delay_ms, _max_delay_ms);
+	msg.Format("[%s] [PacerStats] current_delay=%dms total_samples=%zu min=%dms max=%dms",
+			   _stream_id.CStr(), _current_delay_ms, _samples.size(), _min_delay_ms, _max_delay_ms);
 
 	for (auto &[tid, vals] : per_track)
 	{
 		std::sort(vals.begin(), vals.end());
-		int64_t p5	= pct(vals, 0.05);
-		int64_t p50 = pct(vals, 0.50);
-		int64_t p95 = pct(vals, 0.95);
-		int64_t mn	= vals.front();
-		int64_t mx	= vals.back();
-
-		msg.AppendFormat("\n  track=%u count=%zu p5=%lldms p50=%lldms p95=%lldms min=%lldms max=%lldms",
+		msg.AppendFormat("\n  track=%u count=%zu p5=%lldms p50=%lldms p95=%lldms p99=%lldms min=%lldms max=%lldms",
 						 tid, vals.size(),
-						 static_cast<long long>(p5),
-						 static_cast<long long>(p50),
-						 static_cast<long long>(p95),
-						 static_cast<long long>(mn),
-						 static_cast<long long>(mx));
+						 static_cast<long long>(pct(vals, 0.05)),
+						 static_cast<long long>(pct(vals, 0.50)),
+						 static_cast<long long>(pct(vals, 0.95)),
+						 static_cast<long long>(pct(vals, 0.99)),
+						 static_cast<long long>(vals.front()),
+						 static_cast<long long>(vals.back()));
 	}
 
 	logtd("%s", msg.CStr());

--- a/src/projects/modules/pacer/adaptive_delay_controller.h
+++ b/src/projects/modules/pacer/adaptive_delay_controller.h
@@ -28,13 +28,17 @@
 class AdaptiveDelayController
 {
 public:
-	AdaptiveDelayController(int min_delay_ms, int max_delay_ms);
+	AdaptiveDelayController(const ov::String &stream_id, int min_delay_ms, int max_delay_ms);
 
 	// Record a per-frame lateness sample (in ms; can be negative).
 	void RecordSample(uint32_t track_id, int64_t lateness_ms);
 
 	// Current smoothing delay to apply (ms). Cheap to call per-frame.
 	int GetCurrentDelayMs();
+
+	// Configured ceiling. Used by callers to treat frames above this as
+	// outliers (e.g., to exclude them from anchor calibration).
+	int GetMaxDelayMs() const { return _max_delay_ms; }
 
 private:
 	void Recompute();
@@ -46,6 +50,7 @@ private:
 		uint32_t track_id;
 	};
 
+	ov::String _stream_id;
 	int _min_delay_ms;
 	int _max_delay_ms;
 

--- a/src/projects/modules/pacer/frame_pacer.cpp
+++ b/src/projects/modules/pacer/frame_pacer.cpp
@@ -5,22 +5,35 @@
 //==============================================================================
 #include "frame_pacer.h"
 
+#include <algorithm>
+#include <vector>
+
 #define OV_LOG_TAG "FramePacer"
 
-// Reset the anchor if no packet has been pushed for this duration. Avoids
-// scheduling far in the future when the source pauses then resumes.
-static constexpr auto kAnchorIdleResetThreshold = std::chrono::seconds(2);
+// Idle longer than this resets the anchor. Catches the WebRTC publisher
+// startup pattern where the first keyframe is followed by a brief idle
+// (Chrome BWE/pacer throttle) that bakes a baseline lateness offset.
+// Loose enough not to trigger on normal frame jitter at 30/60fps.
+static constexpr auto kAnchorIdleResetThreshold = std::chrono::milliseconds(500);
 
-// If a frame's computed dispatch time would be more than this many delays in
-// the future, the anchor is considered drifted (e.g., burst push of catch-up
-// packets, or PTS clock running faster than wall clock). Reset.
+// Treat anchor as drifted when target dispatch is this many delays in the
+// future (catch-up burst or PTS running faster than wall clock).
 static constexpr int kAnchorDriftMultiplier = 3;
+
+// Number of valid frames after each (re)anchor used to calibrate the
+// anchor onto the path-delay median.
+static constexpr size_t kCalibrationFrames = 30;
+
+// Force calibration after this many total frames even without enough
+// valid samples (bounds worst-case startup latency).
+static constexpr size_t kCalibrationMaxAttempts = 90;
 
 // Per-track warning rate limit.
 static constexpr auto kWarnThrottle = std::chrono::seconds(1);
 
-FramePacer::FramePacer(int64_t timebase_num, int64_t timebase_den, uint32_t fallback_delay_ms)
-	: _timebase_num(timebase_num),
+FramePacer::FramePacer(const ov::String &stream_id, int64_t timebase_num, int64_t timebase_den, uint32_t fallback_delay_ms)
+	: _stream_id(stream_id),
+	  _timebase_num(timebase_num),
 	  _timebase_den(timebase_den),
 	  _fallback_delay_ms(fallback_delay_ms)
 {
@@ -47,18 +60,25 @@ void FramePacer::Push(const std::shared_ptr<MediaPacket> &packet,
 
 	int after_ms = 0;
 
-	bool warn_drift				= false;
-	int64_t warn_drift_lateness = 0;
-	int64_t warn_drift_delta	= 0;
-	uint32_t warn_drift_delay	= 0;
-	uint32_t warn_drift_track	= 0;
+	bool warn_drift					= false;
+	bool warn_drift_was_calibrated	= false;
+	int64_t warn_drift_lateness		= 0;
+	int64_t warn_drift_delta		= 0;
+	uint32_t warn_drift_delay		= 0;
+	uint32_t warn_drift_track		= 0;
+
+	bool calibrated			   = false;
+	int64_t calib_shift_ms	   = 0;
+	size_t calib_sample_count  = 0;
+	uint32_t calib_track_id	   = 0;
 
 	{
 		std::lock_guard<std::mutex> lock(_mu);
 
 		auto now = arrival_time;
 
-		// Anchor reset on first push or after long idle
+		// Anchor reset on first push or after long idle. Uses current frame
+		// as a provisional anchor; calibration shifts it to the median.
 		if (!_anchor_set || (now - _last_push) > kAnchorIdleResetThreshold)
 		{
 			int64_t pts_us = (_timebase_den == 0)
@@ -66,9 +86,12 @@ void FramePacer::Push(const std::shared_ptr<MediaPacket> &packet,
 								 : static_cast<int64_t>(static_cast<double>(packet->GetPts()) *
 														static_cast<double>(_timebase_num) * 1000000.0 /
 														static_cast<double>(_timebase_den));
-			_anchor_pts_us	= pts_us;
-			_anchor_arrival = now;
-			_anchor_set		= true;
+			_anchor_pts_us			= pts_us;
+			_anchor_arrival			= now;
+			_anchor_set				= true;
+			_anchor_calibrated		= false;
+			_calibration_samples_ms.clear();
+			_calibration_attempts	= 0;
 		}
 		_last_push = now;
 
@@ -91,26 +114,74 @@ void FramePacer::Push(const std::shared_ptr<MediaPacket> &packet,
 
 		auto delta_ms = std::chrono::duration_cast<std::chrono::milliseconds>(target - now).count();
 
-		// Anchor drift safety: if target is too far in the future compared to the
-		// effective delay, the anchor has drifted (e.g., a burst of catch-up
-		// packets or source PTS running faster than wall clock). Reset.
+		// Anchor drift safety. Reset if target sits too far in the future.
 		if (effective_delay_ms > 0 &&
 			delta_ms > static_cast<int64_t>(effective_delay_ms) * kAnchorDriftMultiplier)
 		{
 			if ((now - _last_drift_warn) >= kWarnThrottle)
 			{
-				_last_drift_warn	 = now;
-				warn_drift			 = true;
-				warn_drift_lateness	 = lateness_ms;
-				warn_drift_delta	 = delta_ms;
-				warn_drift_delay	 = effective_delay_ms;
-				warn_drift_track	 = packet->GetTrackId();
+				_last_drift_warn			= now;
+				warn_drift					= true;
+				warn_drift_was_calibrated	= _anchor_calibrated;
+				warn_drift_lateness			= lateness_ms;
+				warn_drift_delta			= delta_ms;
+				warn_drift_delay			= effective_delay_ms;
+				warn_drift_track			= packet->GetTrackId();
 			}
 
-			_anchor_pts_us	= pts_us;
-			_anchor_arrival = now;
-			delta_ms		= effective_delay_ms;
-			lateness_ms		= 0;
+			_anchor_pts_us			= pts_us;
+			_anchor_arrival			= now;
+			delta_ms				= effective_delay_ms;
+			lateness_ms				= 0;
+			_anchor_calibrated		= false;
+			_calibration_samples_ms.clear();
+			_calibration_attempts	= 0;
+		}
+		else if (!_anchor_calibrated)
+		{
+			_calibration_attempts++;
+
+			// Outlier guard: drop positive spikes above the smoothing ceiling
+			// so they don't pull the median. Negatives stay (they're part of
+			// the burst pattern; runaways trigger drift reset above).
+			int64_t calib_outlier_max = _adaptive_controller
+											? static_cast<int64_t>(_adaptive_controller->GetMaxDelayMs())
+											: static_cast<int64_t>(_fallback_delay_ms);
+			if (lateness_ms <= calib_outlier_max)
+			{
+				_calibration_samples_ms.push_back(lateness_ms);
+			}
+
+			// Calibrate when enough valid samples, or when timeout fires
+			// (force-completes calibration so we don't spin forever on
+			// pervasively over-ceiling jitter).
+			bool enough  = _calibration_samples_ms.size() >= kCalibrationFrames;
+			bool timeout = _calibration_attempts >= kCalibrationMaxAttempts;
+			if (enough || timeout)
+			{
+				int64_t median_ms = 0;
+				if (!_calibration_samples_ms.empty())
+				{
+					auto mid = _calibration_samples_ms.begin() + _calibration_samples_ms.size() / 2;
+					std::nth_element(_calibration_samples_ms.begin(), mid, _calibration_samples_ms.end());
+					median_ms = *mid;
+
+					_anchor_arrival += std::chrono::milliseconds(median_ms);
+
+					// Re-evaluate the current frame against the calibrated anchor.
+					expected_arrival = _anchor_arrival + std::chrono::microseconds(pts_diff_us);
+					lateness_ms		 = std::chrono::duration_cast<std::chrono::milliseconds>(now - expected_arrival).count();
+					target			 = expected_arrival + std::chrono::milliseconds(effective_delay_ms);
+					delta_ms		 = std::chrono::duration_cast<std::chrono::milliseconds>(target - now).count();
+				}
+
+				_anchor_calibrated		   = true;
+				calibrated				   = true;
+				calib_shift_ms			   = median_ms;
+				calib_sample_count		   = _calibration_samples_ms.size();
+				calib_track_id			   = packet->GetTrackId();
+				_calibration_samples_ms.clear();
+			}
 		}
 
 		if (_adaptive_controller)
@@ -123,11 +194,45 @@ void FramePacer::Push(const std::shared_ptr<MediaPacket> &packet,
 
 	if (warn_drift)
 	{
-		logtw("Anchor drift reset on track %u (lateness=%lldms, computed delta=%lldms, current delay=%ums) — PTS clock may be running faster than wall clock or catch-up burst pushed",
-			  warn_drift_track,
-			  static_cast<long long>(warn_drift_lateness),
-			  static_cast<long long>(warn_drift_delta),
-			  warn_drift_delay);
+		// Startup-phase drift is the expected publisher backlog flush (info).
+		// Post-calibration drift is a genuine anomaly (warning).
+		if (warn_drift_was_calibrated)
+		{
+			logtw("[%s] Anchor drift reset on track %u (lateness=%lldms, computed delta=%lldms, current delay=%ums) — PTS clock may be running faster than wall clock or catch-up burst pushed",
+				  _stream_id.CStr(),
+				  warn_drift_track,
+				  static_cast<long long>(warn_drift_lateness),
+				  static_cast<long long>(warn_drift_delta),
+				  warn_drift_delay);
+		}
+		else
+		{
+			logti("[%s] Startup anchor drift reset on track %u (lateness=%lldms) — initial publisher backlog flush, will recalibrate",
+				  _stream_id.CStr(),
+				  warn_drift_track,
+				  static_cast<long long>(warn_drift_lateness));
+		}
+	}
+
+	if (calibrated)
+	{
+		if (calib_sample_count == 0)
+		{
+			logtw("[%s] Anchor calibration on track %u completed with no usable samples "
+				  "— all %zu initial frames exceeded Pacer Max. Source jitter "
+				  "exceeds Pacer's smoothing ceiling; provisional anchor kept.",
+				  _stream_id.CStr(),
+				  calib_track_id, kCalibrationMaxAttempts);
+		}
+		else
+		{
+			logti("[%s] Anchor calibrated on track %u by %lldms (%zu/%zu valid samples)",
+				  _stream_id.CStr(),
+				  calib_track_id,
+				  static_cast<long long>(calib_shift_ms),
+				  calib_sample_count,
+				  kCalibrationFrames);
+		}
 	}
 
 	// Capture by value so the lambda is independent of FramePacer lifetime.

--- a/src/projects/modules/pacer/frame_pacer.h
+++ b/src/projects/modules/pacer/frame_pacer.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <vector>
 
 #include "adaptive_delay_controller.h"
 
@@ -35,7 +36,7 @@ class FramePacer
 public:
 	using DispatchFn = std::function<void(const std::shared_ptr<MediaPacket> &)>;
 
-	FramePacer(int64_t timebase_num, int64_t timebase_den, uint32_t fallback_delay_ms);
+	FramePacer(const ov::String &stream_id, int64_t timebase_num, int64_t timebase_den, uint32_t fallback_delay_ms);
 
 	// Set the scheduler (shared DelayQueue) and the dispatcher callback that
 	// will be invoked by the scheduler thread at the target time.
@@ -57,6 +58,7 @@ public:
 			  std::chrono::steady_clock::time_point arrival_time);
 
 private:
+	ov::String _stream_id;
 	int64_t _timebase_num;
 	int64_t _timebase_den;
 	uint32_t _fallback_delay_ms;
@@ -72,4 +74,14 @@ private:
 	std::chrono::steady_clock::time_point _anchor_arrival;
 	std::chrono::steady_clock::time_point _last_push;
 	std::chrono::steady_clock::time_point _last_drift_warn;
+
+	// Anchor calibration. The provisional anchor (first frame after reset)
+	// may sit at an extreme of the path-delay distribution; calibration
+	// collects N frames and shifts the anchor by their median so baseline
+	// lateness centers on zero.
+	bool _anchor_calibrated = false;
+	std::vector<int64_t> _calibration_samples_ms;
+	// Total frames since last (re)anchor including outliers, used as a
+	// timeout when valid samples don't accumulate.
+	size_t _calibration_attempts = 0;
 };

--- a/src/projects/publishers/webrtc/rtc_stream.cpp
+++ b/src/projects/publishers/webrtc/rtc_stream.cpp
@@ -149,6 +149,7 @@ bool RtcStream::Start()
 		_pacer_scheduler->Start();
 
 		_adaptive_delay_controller = std::make_shared<AdaptiveDelayController>(
+			ov::String::FormatString("%s/%s", GetApplication()->GetVHostAppName().CStr(), GetName().CStr()),
 			kPacerMinMs, kPacerMaxMs);
 	}
 
@@ -213,6 +214,7 @@ bool RtcStream::Start()
 		if (_pacer_enabled && _pacer_scheduler && _adaptive_delay_controller)
 		{
 			auto pacer = std::make_shared<FramePacer>(
+				ov::String::FormatString("%s/%s", GetApplication()->GetVHostAppName().CStr(), GetName().CStr()),
 				track->GetTimeBase().GetNum(),
 				track->GetTimeBase().GetDen(),
 				kPacerMinMs);


### PR DESCRIPTION
## Problem

WebRTC publisher's Pacer absorbs source-side jitter well, but viewers see stutter right after startup. Three causes compound. First, the shared controller's percentile is dominated by audio (50pps near zero lateness), under-buffering video. Second, the first frame is taken as the anchor, and if it sits at an extreme of the publisher's startup burst it bakes a permanent baseline lateness offset. This can happen with any source, whether due to conservative BWE startup, first-keyframe paced burst, or encoder warm-up. Third, after a jitter spike `current_delay` contracts quickly, which the viewer perceives as variable playback rate.

## Solution

Anchor calibration combined with per-track percentile and asymmetric smoothing.

- **Per-track percentile, take max across tracks.** Mixing tracks into one sorted window biases the percentile toward audio. The controller now computes p99 per track and uses the max as \`current_delay\`. The single shared delay keeps A/V sync, while any track's tail can size the buffer.
- **Anchor calibration.** After each (re)anchor, the first 30 valid lateness samples are collected and \`anchor_arrival\` is shifted by their median. Baseline lateness then centers on zero, so the percentile rides on real source jitter rather than on a burst-induced offset.
- **Calibration outlier guard.** Frames whose lateness exceeds Pacer Max are excluded from the calibration set. Including such spikes would pull the anchor into the future, needlessly delaying dispatch of subsequent normal frames. The spikes themselves are handled by the controller (p99) and the player's jitter buffer.
- **Calibration timeout.** After 90 observed frames without enough valid samples, calibration force-completes with whatever exists (no-op shift if all were outliers). Bounds worst-case startup latency at low framerates or under extreme source jitter.
- **Idle reset 2s to 500ms.** After an idle, the first frame may be part of the publisher's resume burst, reducing anchor accuracy. Tightening the threshold catches shorter idles so the anchor is reset and calibration re-runs.
- **Asymmetric EMA on \`current_delay\`.** Rises apply immediately so jitter spikes aren't lost. Drops are smoothed (alpha=0.1) so a shrinking buffer doesn't show up to viewers as variable playback rate.
- **Percentile 0.95 to 0.99, margin 10ms to 20ms.** Remote source jitter typically has a long thin tail too frequent to leave to the receiver.
- **Drift reset logs split into info (startup phase) and warning (post-calibration)**, so operational logs only highlight genuine anomalies.