### PR TITLE
fix(publishers/ovt): data race on shared `_description`

### DIFF
--- a/src/projects/publishers/ovt/ovt_stream.cpp
+++ b/src/projects/publishers/ovt/ovt_stream.cpp
@@ -95,7 +95,7 @@ bool OvtStream::Stop()
 	return Stream::Stop();
 }
 
-bool OvtStream::GenerateDescription()
+bool OvtStream::GenerateDescription(Json::Value &out_description)
 {
 	Json::Value 	json_root;
 	Json::Value		json_stream;
@@ -196,8 +196,8 @@ bool OvtStream::GenerateDescription()
 	json_stream["playlists"] = json_playlists;
 	json_stream["tracks"] = json_tracks;
 	json_root["stream"] = json_stream;
-	
-	_description = json_root;
+
+	out_description = std::move(json_root);
 
 	return true;
 }
@@ -253,10 +253,7 @@ bool OvtStream::GetDescription(Json::Value &description)
 		return false;
 	}
 
-	GenerateDescription();
-	description = _description;
-
-	return true;
+	return GenerateDescription(description);
 }
 
 bool OvtStream::GetDescription(const ov::String &track_set_name, Json::Value &description)
@@ -274,8 +271,10 @@ bool OvtStream::GetDescription(const ov::String &track_set_name, Json::Value &de
 		return false;
 	}
 
-	GenerateDescription();
-	description = _description;
+	if (GenerateDescription(description) == false)
+	{
+		return false;
+	}
 
 	FilterDescriptionByTrackIds(description, allowed_track_ids);
 

--- a/src/projects/publishers/ovt/ovt_stream.h
+++ b/src/projects/publishers/ovt/ovt_stream.h
@@ -40,12 +40,11 @@ private:
 	bool Start() override;
 	bool Stop() override;
 
-	bool GenerateDescription();
+	bool GenerateDescription(Json::Value &out_description);
 	void FilterDescriptionByTrackIds(Json::Value &description, const std::set<uint32_t> &allowed_track_ids);
 
 	uint32_t							_worker_count = 0;
 
-	Json::Value							_description;
 	std::shared_mutex					_packetizer_lock;
 	std::shared_ptr<OvtPacketizer>		_packetizer;
 };


### PR DESCRIPTION
## Summary
- Concurrent `DESCRIBE` handlers race on the shared `_description` member: one thread reassigns it while another deep-copies it, freeing RB-tree nodes mid-traversal.
- Remove the member and have `GenerateDescription` write directly into a caller-owned `Json::Value`, so each request operates on its own object with no shared mutable state.

## Root cause
`OvtStream::GetDescription()` rebuilt the tree into `_description` (`_description = json_root` is copy-and-swap; the old map is destroyed in the temporary's destructor) and then copied it out into the caller's parameter.
With two parallel requests, the reader's `Rb_tree::_M_copy` could traverse nodes that the writer's swap had just freed, segfaulting deep in the JsonCpp deep-copy chain - see the recursive `_M_copy` / `dupPayload` stack frames in the crash log.

## Fix
- Drop the `_description` member.
- `GenerateDescription` now takes `Json::Value &out_description` and move-assigns the built tree into it.
- Both `GetDescription` overloads build directly into the caller's local - no shared state, no race, no extra synchronization required.

Incidentally removes one redundant deep copy per `DESCRIBE`. `DESCRIBE` is once-per-edge-connection and not on the media path, so omitting the cache is not expected to have a significant impact.