### PR TITLE
fix(webrtc): cache certificates inserted before signalling/WHIP HTTPS servers exist

### DIFF
--- a/src/projects/modules/rtc_signalling/rtc_signalling_server.cpp
+++ b/src/projects/modules/rtc_signalling/rtc_signalling_server.cpp
@@ -236,6 +236,25 @@ bool RtcSignallingServer::Start(
 			_http_server_list = std::move(http_server_list);
 			_https_server_list = std::move(https_server_list);
 
+			// Replay any certificates that were inserted before `Start()` built the HTTPS
+			// server list (e.g., during the WebRTC provider's `OnCreateHost()` pass that
+			// runs after `RegisterModule()` but before `Bind()`).
+			// Without this replay those inserts would never reach a live server
+			// and `HttpsServer::OnConnected()` would refuse TLS handshakes with "there is no certificate".
+			// Best-effort: log and continue so one bad cert does not abort the whole module start.
+			for (const auto &[cert_name, cert] : _certificate_map)
+			{
+				for (auto &https_server : _https_server_list)
+				{
+					auto error = https_server->InsertCertificate(cert);
+					if (error != nullptr)
+					{
+						logte("Could not apply cached certificate '%s' to %p: %s",
+							  cert_name.CStr(), https_server.get(), error->What());
+					}
+				}
+			}
+
 			return true;
 		}
 
@@ -250,20 +269,27 @@ bool RtcSignallingServer::Start(
 
 bool RtcSignallingServer::InsertCertificate(const std::shared_ptr<const info::Certificate> &certificate)
 {
-	if (certificate != nullptr)
+	if (certificate == nullptr)
 	{
-		_http_server_list_mutex.lock();
-		auto https_server_list = _https_server_list;
-		_http_server_list_mutex.unlock();
+		return true;
+	}
 
-		for (auto &https_server : https_server_list)
+	// Cache update and live-server update share a single lock
+	// so the cache is always a superset of what live servers have applied.
+	// The cache replays in `Start()` if this is called before listeners exist.
+	//
+	// Lock order: this mutex (outer) -> `HttpsServer::_https_certificate_map_mutex` (inner).
+	std::lock_guard lock_guard{_http_server_list_mutex};
+
+	_certificate_map[certificate->GetName()] = certificate;
+
+	for (auto &https_server : _https_server_list)
+	{
+		auto error = https_server->InsertCertificate(certificate);
+		if (error != nullptr)
 		{
-			auto error = https_server->InsertCertificate(certificate);
-			if (error != nullptr)
-			{
-				logte("Could not append certificate to %p: %s", https_server.get(), error->What());
-				return false;
-			}
+			logte("Could not append certificate to %p: %s", https_server.get(), error->What());
+			return false;
 		}
 	}
 
@@ -272,20 +298,22 @@ bool RtcSignallingServer::InsertCertificate(const std::shared_ptr<const info::Ce
 
 bool RtcSignallingServer::RemoveCertificate(const std::shared_ptr<const info::Certificate> &certificate)
 {
-	if (certificate != nullptr)
+	if (certificate == nullptr)
 	{
-		_http_server_list_mutex.lock();
-		auto https_server_list = _https_server_list;
-		_http_server_list_mutex.unlock();
+		return true;
+	}
 
-		for (auto &https_server : https_server_list)
+	std::lock_guard lock_guard{_http_server_list_mutex};
+
+	_certificate_map.erase(certificate->GetName());
+
+	for (auto &https_server : _https_server_list)
+	{
+		auto error = https_server->RemoveCertificate(certificate);
+		if (error != nullptr)
 		{
-			auto error = https_server->RemoveCertificate(certificate);
-			if (error != nullptr)
-			{
-				logte("Could not remove certificate from %p: %s", https_server.get(), error->What());
-				return false;
-			}
+			logte("Could not remove certificate from %p: %s", https_server.get(), error->What());
+			return false;
 		}
 	}
 

--- a/src/projects/modules/rtc_signalling/rtc_signalling_server.h
+++ b/src/projects/modules/rtc_signalling/rtc_signalling_server.h
@@ -159,6 +159,15 @@ protected:
 	std::vector<std::shared_ptr<http::svr::HttpServer>> _http_server_list;
 	std::vector<std::shared_ptr<http::svr::HttpsServer>> _https_server_list;
 
+	// Cached certificates that must be applied to every HTTPS server in `_https_server_list`.
+	// `InsertCertificate()` can be called before `Start()` constructs the HTTPS servers
+	// (e.g., during the WebRTC provider's `OnCreateHost()` pass that runs between `RegisterModule()` and the later `Bind()`);
+	// without this cache those early inserts would be silently dropped against an empty server list.
+	// Protected by `_http_server_list_mutex`.
+	//
+	// Lock order: this mutex (outer) -> `HttpsServer::_https_certificate_map_mutex` (inner).
+	std::map<ov::String, std::shared_ptr<const info::Certificate>> _certificate_map;
+
 	std::vector<std::shared_ptr<RtcSignallingObserver>> _observers;
 
 	std::map<peer_id_t, std::shared_ptr<RtcSignallingInfo>> _client_list;

--- a/src/projects/modules/whip/whip_server.cpp
+++ b/src/projects/modules/whip/whip_server.cpp
@@ -203,6 +203,26 @@ bool WhipServer::Start(
 			_http_server_list = std::move(http_server_list);
 			_https_server_list = std::move(https_server_list);
 
+			// Replay any certificates that were inserted before `Start()` built the HTTPS
+			// server list (e.g., during the WebRTC provider's `OnCreateHost()` pass that
+			// runs after `RegisterModule()` but before `Bind()`).
+			// Without this replay those inserts would never reach a live server
+			// and `HttpsServer::OnConnected()` would refuse TLS handshakes with "there is no certificate".
+			// Best-effort: log and continue so one bad cert does not abort the whole module start.
+			for (const auto &[cert_name, cert] : _certificate_map)
+			{
+				for (auto &https_server : _https_server_list)
+				{
+					auto error = https_server->InsertCertificate(cert);
+
+					if (error != nullptr)
+					{
+						logte("Could not apply cached certificate '%s' to %p: %s",
+							  cert_name.CStr(), https_server.get(), error->What());
+					}
+				}
+			}
+
 			return true;
 		}
 
@@ -224,20 +244,27 @@ bool WhipServer::Stop()
 
 bool WhipServer::InsertCertificate(const std::shared_ptr<const info::Certificate> &certificate)
 {
-	if (certificate != nullptr)
+	if (certificate == nullptr)
 	{
-		_http_server_list_mutex.lock();
-		auto https_server_list = _https_server_list;
-		_http_server_list_mutex.unlock();
+		return true;
+	}
 
-		for (auto &https_server : https_server_list)
+	// Cache update and live-server update share a single lock
+	// so the cache is always a superset of what live servers have applied.
+	// The cache replays in `Start()` if this is called before listeners exist.
+	//
+	// Lock order: this mutex (outer) -> `HttpsServer::_https_certificate_map_mutex` (inner).
+	std::lock_guard lock_guard{_http_server_list_mutex};
+
+	_certificate_map[certificate->GetName()] = certificate;
+
+	for (auto &https_server : _https_server_list)
+	{
+		auto error = https_server->InsertCertificate(certificate);
+		if (error != nullptr)
 		{
-			auto error = https_server->InsertCertificate(certificate);
-			if (error != nullptr)
-			{
-				logte("Could not append certificate to %p: %s", https_server.get(), error->What());
-				return false;
-			}
+			logte("Could not append certificate to %p: %s", https_server.get(), error->What());
+			return false;
 		}
 	}
 
@@ -246,11 +273,16 @@ bool WhipServer::InsertCertificate(const std::shared_ptr<const info::Certificate
 
 bool WhipServer::RemoveCertificate(const std::shared_ptr<const info::Certificate> &certificate)
 {
-	_http_server_list_mutex.lock();
-	auto https_server_list = _https_server_list;
-	_http_server_list_mutex.unlock();
+	if (certificate == nullptr)
+	{
+		return true;
+	}
 
-	for (auto &https_server : https_server_list)
+	std::lock_guard lock_guard{_http_server_list_mutex};
+
+	_certificate_map.erase(certificate->GetName());
+
+	for (auto &https_server : _https_server_list)
 	{
 		auto error = https_server->RemoveCertificate(certificate);
 		if (error != nullptr)

--- a/src/projects/modules/whip/whip_server.h
+++ b/src/projects/modules/whip/whip_server.h
@@ -79,6 +79,15 @@ private:
 	std::vector<std::shared_ptr<http::svr::HttpServer>> _http_server_list;
 	std::vector<std::shared_ptr<http::svr::HttpsServer>> _https_server_list;
 
+	// Cached certificates that must be applied to every HTTPS server in `_https_server_list`.
+	// `InsertCertificate()` can be called before `Start()` constructs the HTTPS servers
+	// (e.g., during the `OnCreateHost()` notification pass between `RegisterModule()` and the provider's later `Bind()`);
+	// without this cache those early inserts would be silently dropped against an empty server list.
+	// Protected by `_http_server_list_mutex`.
+	//
+	// Lock order: this mutex (outer) -> `HttpsServer::_https_certificate_map_mutex` (inner).
+	std::map<ov::String, std::shared_ptr<const info::Certificate>> _certificate_map;
+
 	std::set<ov::String> _link_headers;
 	bool _tcp_force = false;
 	ov::String _default_transport{"UDPTCP"};


### PR DESCRIPTION
## Summary
- `WhipServer::InsertCertificate()` / `RtcSignallingServer::InsertCertificate()` no-op'd against an empty `_https_server_list`.
- After #2149, the WebRTC provider's `OnCreateHost()` runs before `Bind()` opens the listeners, so every cert insert was silently dropped and WHIP TLS handshakes failed with `there is no certificate`.
- Both servers now cache certificates by name and replay them under the same lock right after `Start()` populates `_https_server_list`. `Remove` keeps cache and live servers in sync.
- Lock order: outer `_http_server_list_mutex` -> inner `HttpsServer::_https_certificate_map_mutex` (`HttpsServer` never reaches back, so one-way).