### PR TITLE
fix: suppress repeated incomplete-frame error logs in jitter buffer

### DIFF
--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.cpp
@@ -167,9 +167,11 @@ bool RtpFrame::CheckCompleted()
 		_completed = true;
 		logtt("Frame completed: timestamp(%u) packets(%zu) need packets(%u)", _timestamp, _packets.size(), need_number_of_packets);
 	}
-	else
+	else if (_incomplete_logged == false)
 	{
-		logte("Invalid frame: timestamp(%u) %zu/%u", _timestamp, _packets.size(), need_number_of_packets);
+		// Marker arrived but packets are still missing. May recover via NACK; log once.
+		_incomplete_logged = true;
+		logtd("Incomplete frame after marker: timestamp(%u) %zu/%u", _timestamp, _packets.size(), need_number_of_packets);
 	}
 
 	return _completed;

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.h
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.h
@@ -33,6 +33,7 @@ private:
 	uint32_t	_marker_sequence_number = 0;
 	bool		_marked = false;
 	bool		_completed = false;
+	bool		_incomplete_logged = false;
 
 	uint16_t 	_first_sequence_number = 0;
 	bool		_first_packet = true;


### PR DESCRIPTION
## Problem
When RTP packets are lost, an incomplete frame stays at the front of the jitter buffer and `CheckCompleted()` runs on every subsequent packet arrival via `BurnOutExpiredFrames()`. Each call emits the same `Invalid frame` error, producing dozens of identical lines per lost frame.

## Solution
Demote the message to debug level and gate it behind a per-frame flag so it logs at most once per affected frame. The existing trace log in `BurnOutExpiredFrames()` still records actual frame discards.