### PR TITLE
fix(push): fill in error reason for failed packet writes (#2079)

### DIFF
--- a/src/projects/modules/ffmpeg/writer.cpp
+++ b/src/projects/modules/ffmpeg/writer.cpp
@@ -10,17 +10,19 @@
 #include <modules/rtmp/amf0/amf_document.h>
 
 #define OV_LOG_TAG "FFmpegWriter"
+#define OV_LOG_PREFIX_FORMAT "%s"
+#define OV_LOG_PREFIX_VALUE _log_prefix.CStr()
 
-#define _logti(target, fmt, ...) logti("%s" fmt, (target)->_log_prefix.CStr(), ##__VA_ARGS__)
-#define _logtd(target, fmt, ...) logtd("%s" fmt, (target)->_log_prefix.CStr(), ##__VA_ARGS__)
-#define _logtw(target, fmt, ...) logtw("%s" fmt, (target)->_log_prefix.CStr(), ##__VA_ARGS__)
-#define _logtt(target, fmt, ...) logtt("%s" fmt, (target)->_log_prefix.CStr(), ##__VA_ARGS__)
-#define _logte(target, fmt, ...)                                               \
-	do                                                                         \
-	{                                                                          \
-		auto _err_msg = ov::String::FormatString(fmt, ##__VA_ARGS__);          \
-		logte("%s%s", (target)->_log_prefix.CStr(), _err_msg.CStr());          \
-		(target)->SetErrorMessage(_err_msg);                                   \
+// Redefine 'logae" to include the log prefix and also store the formatted message on the Writer
+#ifdef logae
+#	undef logae
+#endif
+#define logae(target, fmt, ...)                                                           \
+	do                                                                                    \
+	{                                                                                     \
+		auto _err_msg = ov::String::FormatString(fmt, ##__VA_ARGS__);                     \
+		logte(OV_LOG_PREFIX_FORMAT "%s", (target)->OV_LOG_PREFIX_VALUE, _err_msg.CStr()); \
+		(target)->SetErrorMessage(_err_msg);                                              \
 	} while (0)
 
 namespace ffmpeg
@@ -76,7 +78,7 @@ namespace ffmpeg
 		auto elapsed = std::chrono::steady_clock::now() - writer->GetLastPacketSentTime();
 		if(writer->GetState() == WriterStateClosed)
 		{
-			_logte(writer, "Writer was closed before I/O operation completed.");
+			logae(writer, "Writer was closed before I/O operation completed.");
 			return 1;
 		}
 		else if(writer->GetState() == WriterStateConnecting)
@@ -84,7 +86,7 @@ namespace ffmpeg
 			int64_t elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
 			if(elapsed_ms > writer->GetConnectionTimeout())
 			{
-				_logte(writer, "Connection timeout occurred. %" PRId64 " milliseconds. ", elapsed_ms);
+				logae(writer, "Connection timeout occurred. %" PRId64 " milliseconds. ", elapsed_ms);
 				return 1;
 			}
 		}
@@ -93,7 +95,7 @@ namespace ffmpeg
 			int64_t elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
 			if(elapsed_ms > writer->GetSendTimeout())
 			{
-				_logte(writer, "Send timeout occurred. %" PRId64 " milliseconds. ", elapsed_ms);
+				logae(writer, "Send timeout occurred. %" PRId64 " milliseconds. ", elapsed_ms);
 				return 1;
 			}
 		}
@@ -109,7 +111,7 @@ namespace ffmpeg
 	{
 		if (!url || url.IsEmpty() == true)
 		{
-			_logte(this, "Destination url is empty");
+			logae(this, "Destination url is empty");
 			return false;
 		}
 
@@ -121,7 +123,7 @@ namespace ffmpeg
 		int error = avformat_alloc_output_context2(&av_format, nullptr, (_format != nullptr) ? _format.CStr() : nullptr, _url.CStr());
 		if (error < 0)
 		{
-			_logte(this, "Failed to allocate output context. %s", ffmpeg::compat::AVErrorToString(error).CStr());
+			logae(this, "Failed to allocate output context. %s", ffmpeg::compat::AVErrorToString(error).CStr());
 			return false;
 		}
 
@@ -150,28 +152,28 @@ namespace ffmpeg
 		auto av_format = GetAVFormatContext();
 		if (!av_format)
 		{
-			_logte(this, "Context is not available");
+			logae(this, "Context is not available");
 			return nullptr;
 		}
 
 		AVStream *new_stream = avformat_new_stream(av_format.get(), nullptr);
 		if (!new_stream)
 		{
-			_logte(this, "Could not allocate stream");
+			logae(this, "Could not allocate stream");
 			return nullptr;
 		}
 
 		std::shared_ptr<AVStream> av_stream(new_stream, [](AVStream *av_stream) {});
 		if (!av_stream)
 		{
-			_logte(this, "Could not create AVStream");
+			logae(this, "Could not create AVStream");
 			return nullptr;
 		}
 
 		// Convert MediaTrack to AVStream
 		if (ffmpeg::compat::ToAVStream(media_track, av_stream.get()) == false)
 		{
-			_logte(this, "Could not convert track info to AVStream");
+			logae(this, "Could not convert track info to AVStream");
 			return nullptr;
 		}
 
@@ -182,14 +184,14 @@ namespace ffmpeg
 	{
 		if (media_track == nullptr || av_stream == nullptr || av_stream->codecpar == nullptr)
 		{
-			_logte(this, "Could not add track. MediaTrack or AVStream is null");
+			logae(this, "Could not add track. MediaTrack or AVStream is null");
 			return false;
 		}
 
 		std::lock_guard<std::shared_mutex> mlock(_track_map_lock);
 		_av_track_map[media_track->GetId()] = std::make_pair(av_stream, media_track);
 
-		_logtt(this, "Added %s track. id(%d), codec(%s), format(%s)",
+		logat("Added %s track. id(%d), codec(%s), format(%s)",
 			  cmn::GetMediaTypeString(media_track->GetMediaType()),
 			  media_track->GetId(),
 			  ffmpeg::compat::GetCodecName(av_stream->codecpar->codec_id).CStr(),
@@ -202,14 +204,14 @@ namespace ffmpeg
 	{
 		if (media_track == nullptr || av_stream == nullptr || av_stream->codecpar == nullptr)
 		{
-			_logte(this, "Could not add event track. MediaTrack or AVStream is null");
+			logae(this, "Could not add event track. MediaTrack or AVStream is null");
 			return false;
 		}
 
 		std::lock_guard<std::shared_mutex> mlock(_track_map_lock);
 		_event_track_map[std::make_pair(media_track->GetId(), format)] = std::make_pair(av_stream, media_track);
 
-		_logtt(this, "Added %s track. id(%d), codec(%s), format(%s)",
+		logat("Added %s track. id(%d), codec(%s), format(%s)",
 			  cmn::GetMediaTypeString(media_track->GetMediaType()),
 			  media_track->GetId(),
 			  ffmpeg::compat::GetCodecName(av_stream->codecpar->codec_id).CStr(),
@@ -321,7 +323,7 @@ namespace ffmpeg
 		auto av_format = GetAVFormatContext();
 		if (av_format == nullptr)
 		{
-			_logte(this, "Context is not available");
+			logae(this, "Context is not available");
 			return false;
 		}
 
@@ -352,7 +354,7 @@ namespace ffmpeg
 			{
 				SetState(WriterStateError);
 
-				_logte(this, "Failed to open output url. %s", ffmpeg::compat::AVErrorToString(error).CStr());
+				logae(this, "Failed to open output url. %s", ffmpeg::compat::AVErrorToString(error).CStr());
 
 				return false;
 			}
@@ -370,7 +372,7 @@ namespace ffmpeg
 		if (avformat_write_header(av_format.get(), &format_options) < 0)
 		{
 			SetState(WriterStateError);
-			_logte(this, "Could not create header");
+			logae(this, "Could not create header");
 
 			return false;
 		}
@@ -419,7 +421,7 @@ namespace ffmpeg
 		// Writer is not connected, but it's not an error. Waiting for initialization.
 		if(GetState() != WriterStateConnected)
 		{
-			_logtd(this, "Writer is not initialized. state:%s", WriterStateToString(GetState()));
+			logad("Writer is not initialized. state:%s", WriterStateToString(GetState()));
 			return true;
 		}
 
@@ -429,7 +431,7 @@ namespace ffmpeg
 		// It is not considered a reason to stop the Writer.
 		if (!packet)
 		{
-			_logtw(this, "Invalid packet. packet is null. Dropping.");
+			logaw("Invalid packet. packet is null. Dropping.");
 			return true;
 		}
 
@@ -460,7 +462,7 @@ namespace ffmpeg
 		AVPacket av_packet = {0};
 		if (ToAVPacket(av_packet, av_stream, packet, media_track, start_time) == false)
 		{
-			_logte(this, "Failed to convert MediaPacket to AVPacket");
+			logae(this, "Failed to convert MediaPacket to AVPacket");
 			return false;
 		}
 
@@ -469,7 +471,7 @@ namespace ffmpeg
 		// But this is not treated as an error.
 		if(av_packet.pts < 0 || av_packet.dts < 0 || av_packet.size <= 0)
 		{
-			_logtw(this, "Dropping packet with invalid timestamp or size. track:%d, pts:%" PRId64 ", dts:%" PRId64 ", size:%d",
+			logaw("Dropping packet with invalid timestamp or size. track:%d, pts:%" PRId64 ", dts:%" PRId64 ", size:%d",
 				   media_track->GetId(), av_packet.pts, av_packet.dts, av_packet.size);
 			av_packet_unref(&av_packet);
 			return true;
@@ -490,7 +492,7 @@ namespace ffmpeg
 					new_data = NalStreamConverter::ConvertAnnexbToXvcc(packet->GetData(), packet->GetFragHeader());
 					if (new_data == nullptr)
 					{
-						_logte(this, "Failed to convert annexb to avcc. track:%d, format:%s, size:%zu",
+						logae(this, "Failed to convert annexb to avcc. track:%d, format:%s, size:%zu",
 							media_track->GetId(),
 							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
 							packet->GetData()->GetLength());
@@ -506,7 +508,7 @@ namespace ffmpeg
 					new_data = AacConverter::ConvertAdtsToRaw(packet->GetData(), nullptr);
 					if (new_data == nullptr)
 					{
-						_logte(this, "Failed to convert adts to raw. track:%d, format:%s, size:%zu",
+						logae(this, "Failed to convert adts to raw. track:%d, format:%s, size:%zu",
 							media_track->GetId(),
 							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
 							packet->GetData()->GetLength());
@@ -544,7 +546,7 @@ namespace ffmpeg
 					new_data = NalStreamConverter::ConvertAnnexbToXvcc(packet->GetData(), packet->GetFragHeader());
 					if (new_data == nullptr)
 					{
-						_logte(this, "Failed to convert annexb to hvcc. track:%d, format:%s, size:%zu",
+						logae(this, "Failed to convert annexb to hvcc. track:%d, format:%s, size:%zu",
 							media_track->GetId(),
 							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
 							packet->GetData()->GetLength());
@@ -560,7 +562,7 @@ namespace ffmpeg
 					new_data = NalStreamConverter::ConvertAnnexbToXvcc(packet->GetData(), packet->GetFragHeader());
 					if (new_data == nullptr)
 					{
-						_logte(this, "Failed to convert annexb to avcc. track:%d, format:%s, size:%zu",
+						logae(this, "Failed to convert annexb to avcc. track:%d, format:%s, size:%zu",
 							media_track->GetId(),
 							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
 							packet->GetData()->GetLength());
@@ -577,7 +579,7 @@ namespace ffmpeg
 					new_data = AacConverter::ConvertAdtsToRaw(packet->GetData(), nullptr);
 					if (new_data == nullptr)
 					{
-						_logte(this, "Failed to convert adts to raw. track:%d, format:%s, size:%zu",
+						logae(this, "Failed to convert adts to raw. track:%d, format:%s, size:%zu",
 							media_track->GetId(),
 							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
 							packet->GetData()->GetLength());
@@ -618,7 +620,7 @@ namespace ffmpeg
 		{
 			av_packet_unref(&av_packet);
 			SetState(WriterStateError);
-			_logte(this, "Context is not available");
+			logae(this, "Context is not available");
 
 			return false;
 		}
@@ -633,7 +635,7 @@ namespace ffmpeg
 		{
 			if (av_packet.dts < it->second)
 			{
-				_logtw(this, "To avoid non-monotonic DTS, the packet is dropped. track:%d, pts:%" PRId64 ", dts:%" PRId64 ", last_dts:%" PRId64 ", size:%d",
+				logaw("To avoid non-monotonic DTS, the packet is dropped. track:%d, pts:%" PRId64 ", dts:%" PRId64 ", last_dts:%" PRId64 ", size:%d",
 					   media_track->GetId(), av_packet.pts, av_packet.dts, it->second, av_packet.size);
 
 				av_packet_unref(&av_packet);
@@ -652,7 +654,7 @@ namespace ffmpeg
 			// (timeout / closed). Don't overwrite it.
 			if (error != AVERROR_EXIT)
 			{
-				_logte(this, "Failed to write frame. %s", ffmpeg::compat::AVErrorToString(error).CStr());
+				logae(this, "Failed to write frame. %s", ffmpeg::compat::AVErrorToString(error).CStr());
 			}
 
 			return false;

--- a/src/projects/modules/ffmpeg/writer.cpp
+++ b/src/projects/modules/ffmpeg/writer.cpp
@@ -483,7 +483,8 @@ namespace ffmpeg
 		// But this is not treated as an error.
 		if(av_packet.pts < 0 || av_packet.dts < 0 || av_packet.size <= 0)
 		{
-			logtw("Dropping packet with invalid timestamp or size. PTS: %" PRId64 ", DTS: %" PRId64 ", Size: %d", av_packet.pts, av_packet.dts, av_packet.size);
+			logtw("Dropping packet with invalid timestamp or size. track:%d, pts:%" PRId64 ", dts:%" PRId64 ", size:%d",
+				  media_track->GetId(), av_packet.pts, av_packet.dts, av_packet.size);
 			av_packet_unref(&av_packet);
 			return true;
 		}
@@ -564,7 +565,7 @@ namespace ffmpeg
 					if (new_data == nullptr)
 					{
 						auto err_msg = ov::String::FormatString(
-							"Failed to convert annexb to avcc. track:%d, format:%s, size:%zu",
+							"Failed to convert annexb to hvcc. track:%d, format:%s, size:%zu",
 							media_track->GetId(),
 							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
 							packet->GetData()->GetLength());

--- a/src/projects/modules/ffmpeg/writer.cpp
+++ b/src/projects/modules/ffmpeg/writer.cpp
@@ -42,11 +42,13 @@ namespace ffmpeg
 
 	void Writer::SetErrorMessage(const ov::String &message)
 	{
+		std::lock_guard<std::mutex> lock(_error_message_lock);
 		_error_message = message;
 	}
 
 	ov::String Writer::GetErrorMessage() const
 	{
+		std::lock_guard<std::mutex> lock(_error_message_lock);
 		return _error_message;
 	}
 
@@ -55,14 +57,16 @@ namespace ffmpeg
 		Writer *writer = (Writer *)opaque;
 		if(writer == nullptr)
 		{
-			logte("Writer is null. stop the writer.");
+			logte("Writer is null.");
 			return 1;
 		}
 
 		auto elapsed = std::chrono::steady_clock::now() - writer->GetLastPacketSentTime();
 		if(writer->GetState() == WriterStateClosed)
 		{
-			logte("Writer is closed. stop the writer.");
+			ov::String err_msg = "Writer was closed before I/O operation completed.";
+			logtw("%s", err_msg.CStr());
+			writer->SetErrorMessage(err_msg);
 			return 1;
 		}
 		else if(writer->GetState() == WriterStateConnecting)
@@ -70,7 +74,9 @@ namespace ffmpeg
 			int64_t elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
 			if(elapsed_ms > writer->GetConnectionTimeout())
 			{
-				logte("connection timeout occurred. stop the writer. %" PRId64 " milliseconds. ", elapsed_ms);
+				auto err_msg = ov::String::FormatString("Connection timeout occurred. %" PRId64 " milliseconds. ", elapsed_ms);
+				logtw("%s", err_msg.CStr());
+				writer->SetErrorMessage(err_msg);
 				return 1;
 			}
 		}
@@ -79,7 +85,9 @@ namespace ffmpeg
 			int64_t elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
 			if(elapsed_ms > writer->GetSendTimeout())
 			{
-				logte("Send timeout occurred. stop the writer. %" PRId64 " milliseconds. ", elapsed_ms);
+				auto err_msg = ov::String::FormatString("Send timeout occurred. %" PRId64 " milliseconds. ", elapsed_ms);
+				logtw("%s", err_msg.CStr());
+				writer->SetErrorMessage(err_msg);
 				return 1;
 			}
 		}
@@ -95,7 +103,9 @@ namespace ffmpeg
 	{
 		if (!url || url.IsEmpty() == true)
 		{
-			SetErrorMessage("Destination url is empty");
+			ov::String err_msg = "Destination url is empty";
+			logte("%s", err_msg.CStr());
+			SetErrorMessage(err_msg);
 			return false;
 		}
 
@@ -107,7 +117,9 @@ namespace ffmpeg
 		int error = avformat_alloc_output_context2(&av_format, nullptr, (_format != nullptr) ? _format.CStr() : nullptr, _url.CStr());
 		if (error < 0)
 		{
-			SetErrorMessage(ffmpeg::compat::AVErrorToString(error));
+			auto err_msg = ffmpeg::compat::AVErrorToString(error);
+			logte("Failed to allocate output context. %s", err_msg.CStr());
+			SetErrorMessage(err_msg);
 			return false;
 		}
 
@@ -136,28 +148,36 @@ namespace ffmpeg
 		auto av_format = GetAVFormatContext();
 		if (!av_format)
 		{
-			SetErrorMessage("Context is not available");
+			auto err_msg = ov::String("Context is not available");
+			logte("%s", err_msg.CStr());
+			SetErrorMessage(err_msg);
 			return nullptr;
 		}
 
 		AVStream *new_stream = avformat_new_stream(av_format.get(), nullptr);
 		if (!new_stream)
 		{
-			SetErrorMessage("Could not allocate stream");
+			auto err_msg = ov::String("Could not allocate stream");
+			logte("%s", err_msg.CStr());
+			SetErrorMessage(err_msg);
 			return nullptr;
 		}
 
 		std::shared_ptr<AVStream> av_stream(new_stream, [](AVStream *av_stream) {});
 		if (!av_stream)
 		{
-			SetErrorMessage("Could not create AVStream");
+			auto err_msg = ov::String("Could not create AVStream");
+			logte("%s", err_msg.CStr());
+			SetErrorMessage(err_msg);
 			return nullptr;
 		}
 
 		// Convert MediaTrack to AVStream
 		if (ffmpeg::compat::ToAVStream(media_track, av_stream.get()) == false)
 		{
-			SetErrorMessage("Could not convert track info to AVStream");
+			auto err_msg = ov::String("Could not convert track info to AVStream");
+			logte("%s", err_msg.CStr());
+			SetErrorMessage(err_msg);
 			return nullptr;
 		}
 
@@ -168,7 +188,9 @@ namespace ffmpeg
 	{
 		if (media_track == nullptr || av_stream == nullptr || av_stream->codecpar == nullptr)
 		{
-			SetErrorMessage("Could not add track. MediaTrack or AVStream is null");
+			auto err_msg = ov::String("Could not add track. MediaTrack or AVStream is null");
+			logte("%s", err_msg.CStr());
+			SetErrorMessage(err_msg);
 			return false;
 		}
 
@@ -188,7 +210,9 @@ namespace ffmpeg
 	{
 		if (media_track == nullptr || av_stream == nullptr || av_stream->codecpar == nullptr)
 		{
-			SetErrorMessage("Could not add event track. MediaTrack or AVStream is null");
+			auto err_msg = ov::String("Could not add event track. MediaTrack or AVStream is null");
+			logte("%s", err_msg.CStr());
+			SetErrorMessage(err_msg);
 			return false;
 		}
 
@@ -307,7 +331,9 @@ namespace ffmpeg
 		auto av_format = GetAVFormatContext();
 		if (av_format == nullptr)
 		{
-			SetErrorMessage("Context is not available");
+			auto err_msg = ov::String("Context is not available");
+			logte("%s", err_msg.CStr());
+			SetErrorMessage(err_msg);
 			return false;
 		}
 
@@ -338,7 +364,9 @@ namespace ffmpeg
 			{
 				SetState(WriterStateError);
 
-				SetErrorMessage(ffmpeg::compat::AVErrorToString(error));
+				auto err_msg = ffmpeg::compat::AVErrorToString(error);
+				logte("Failed to open output url. %s", err_msg.CStr());
+				SetErrorMessage(err_msg);
 
 				return false;
 			}
@@ -356,7 +384,9 @@ namespace ffmpeg
 		if (avformat_write_header(av_format.get(), &format_options) < 0)
 		{
 			SetState(WriterStateError);
-			SetErrorMessage("Could not create header");
+			auto err_msg = ov::String("Could not create header");
+			logte("%s", err_msg.CStr());
+			SetErrorMessage(err_msg);
 
 			return false;
 		}
@@ -405,14 +435,14 @@ namespace ffmpeg
 		// Writer is not connected, but it's not an error. Waiting for initialization.
 		if(GetState() != WriterStateConnected)
 		{
-			logtw("Writer is not initialized. state:%s", WriterStateToString(GetState()));
+			logtd("Writer is not initialized. state:%s", WriterStateToString(GetState()));
 			return true;
 		}
 
 		if (!packet)
 		{
-			SetErrorMessage("Packet is null");
-			return false;
+			logtw("Invalid packet. packet is null. Dropping.");
+			return true;
 		}
 
 		// Drop packets that do not need to be transmitted
@@ -442,7 +472,9 @@ namespace ffmpeg
 		AVPacket av_packet = {0};
 		if (ToAVPacket(av_packet, av_stream, packet, media_track, start_time) == false)
 		{
-			SetErrorMessage("Failed to convert MediaPacket to AVPacket");
+			auto err_msg = ov::String("Failed to convert MediaPacket to AVPacket");
+			logte("%s", err_msg.CStr());
+			SetErrorMessage(err_msg);
 			return false;
 		}
 
@@ -451,7 +483,7 @@ namespace ffmpeg
 		// But this is not treated as an error.
 		if(av_packet.pts < 0 || av_packet.dts < 0 || av_packet.size <= 0)
 		{
-			logtd("To avoid negative timestamps, the packet is dropped. track:%d, pts:%" PRId64 ", dts:%" PRId64 "", media_track->GetId(), av_packet.pts, av_packet.dts);
+			logtw("Dropping packet with invalid timestamp or size. PTS: %" PRId64 ", DTS: %" PRId64 ", Size: %d", av_packet.pts, av_packet.dts, av_packet.size);
 			av_packet_unref(&av_packet);
 			return true;
 		}
@@ -471,7 +503,13 @@ namespace ffmpeg
 					new_data = NalStreamConverter::ConvertAnnexbToXvcc(packet->GetData(), packet->GetFragHeader());
 					if (new_data == nullptr)
 					{
-						logtw("Failed to convert annexb to avcc");
+						auto err_msg = ov::String::FormatString(
+							"Failed to convert annexb to avcc. track:%d, format:%s, size:%zu",
+							media_track->GetId(),
+							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
+							packet->GetData()->GetLength());
+						logte("%s", err_msg.CStr());
+						SetErrorMessage(err_msg);
 						return false;
 					}
 					av_packet.size = new_data->GetLength();
@@ -484,7 +522,13 @@ namespace ffmpeg
 					new_data = AacConverter::ConvertAdtsToRaw(packet->GetData(), nullptr);
 					if (new_data == nullptr)
 					{
-						logtw("Failed to convert adts to raw");
+						auto err_msg = ov::String::FormatString(
+							"Failed to convert adts to raw. track:%d, format:%s, size:%zu",
+							media_track->GetId(),
+							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
+							packet->GetData()->GetLength());
+						logte("%s", err_msg.CStr());
+						SetErrorMessage(err_msg);
 						return false;
 					}
 					av_packet.size = new_data->GetLength();
@@ -497,7 +541,7 @@ namespace ffmpeg
 					AmfDocument document;
 					if (document.Decode(byte_stream) == false)
 					{
-						loge(OV_LOG_TAG".Events","Failed to decode AMF Event");
+						logw(OV_LOG_TAG".Events","Failed to decode AMF Event");
 						return true;
 					}
 
@@ -519,7 +563,13 @@ namespace ffmpeg
 					new_data = NalStreamConverter::ConvertAnnexbToXvcc(packet->GetData(), packet->GetFragHeader());
 					if (new_data == nullptr)
 					{
-						logtw("Failed to convert annexb to avcc");
+						auto err_msg = ov::String::FormatString(
+							"Failed to convert annexb to avcc. track:%d, format:%s, size:%zu",
+							media_track->GetId(),
+							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
+							packet->GetData()->GetLength());
+						logte("%s", err_msg.CStr());
+						SetErrorMessage(err_msg);
 						return false;
 					}
 					av_packet.size = new_data->GetLength();
@@ -532,7 +582,13 @@ namespace ffmpeg
 					new_data = NalStreamConverter::ConvertAnnexbToXvcc(packet->GetData(), packet->GetFragHeader());
 					if (new_data == nullptr)
 					{
-						logtw("Failed to convert annexb to avcc");
+						auto err_msg = ov::String::FormatString(
+							"Failed to convert annexb to avcc. track:%d, format:%s, size:%zu",
+							media_track->GetId(),
+							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
+							packet->GetData()->GetLength());
+						logte("%s", err_msg.CStr());
+						SetErrorMessage(err_msg);
 						return false;
 					}
 					av_packet.size = new_data->GetLength();
@@ -546,7 +602,13 @@ namespace ffmpeg
 					new_data = AacConverter::ConvertAdtsToRaw(packet->GetData(), nullptr);
 					if (new_data == nullptr)
 					{
-						logtw("Failed to convert adts to raw");
+						auto err_msg = ov::String::FormatString(
+							"Failed to convert adts to raw. track:%d, format:%s, size:%zu",
+							media_track->GetId(),
+							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
+							packet->GetData()->GetLength());
+						logte("%s", err_msg.CStr());
+						SetErrorMessage(err_msg);
 						return false;
 					}
 					av_packet.size = new_data->GetLength();
@@ -584,7 +646,9 @@ namespace ffmpeg
 		{
 			av_packet_unref(&av_packet);
 			SetState(WriterStateError);
-			SetErrorMessage("Context is not available");
+			auto err_msg = ov::String("Context is not available");
+			logte("%s", err_msg.CStr());
+			SetErrorMessage(err_msg);
 
 			return false;
 		}
@@ -599,11 +663,9 @@ namespace ffmpeg
 		{
 			if (av_packet.dts < it->second)
 			{
-				logtw("To avoid non-monotonic DTS, the packet is dropped. track:%d, pts:%" PRId64 ", dts:%" PRId64 ", last_dts:%" PRId64,
-					  media_track->GetId(),
-					  av_packet.pts,
-					  av_packet.dts,
-					  it->second);
+				logtw("To avoid non-monotonic DTS, the packet is dropped. track:%d, pts:%" PRId64 ", dts:%" PRId64 ", last_dts:%" PRId64 ", size:%d",
+					media_track->GetId(), av_packet.pts, av_packet.dts, it->second, av_packet.size);
+
 				av_packet_unref(&av_packet);
 				return true;
 			}
@@ -615,7 +677,15 @@ namespace ffmpeg
 		{
 			av_packet_unref(&av_packet);
 			SetState(WriterStateError);
-			SetErrorMessage(ffmpeg::compat::AVErrorToString(error));
+
+			// On AVERROR_EXIT, the interrupt callback has already set a more specific reason
+			// (timeout / closed). Don't overwrite it.
+			if (error != AVERROR_EXIT)
+			{
+				auto err_msg = ffmpeg::compat::AVErrorToString(error);
+				logte("Failed to write frame. %s", err_msg.CStr());
+				SetErrorMessage(err_msg);
+			}
 
 			return false;
 		}
@@ -635,7 +705,7 @@ namespace ffmpeg
 
 	std::chrono::steady_clock::time_point Writer::GetLastPacketSentTime()
 	{
-		return _last_packet_sent_time;
+		return _last_packet_sent_time.load();
 	}
 
 	std::shared_ptr<AVFormatContext> Writer::GetAVFormatContext() const

--- a/src/projects/modules/ffmpeg/writer.cpp
+++ b/src/projects/modules/ffmpeg/writer.cpp
@@ -11,17 +11,29 @@
 
 #define OV_LOG_TAG "FFmpegWriter"
 
+#define _logti(target, fmt, ...) logti("%s" fmt, (target)->_log_prefix.CStr(), ##__VA_ARGS__)
+#define _logtd(target, fmt, ...) logtd("%s" fmt, (target)->_log_prefix.CStr(), ##__VA_ARGS__)
+#define _logtw(target, fmt, ...) logtw("%s" fmt, (target)->_log_prefix.CStr(), ##__VA_ARGS__)
+#define _logtt(target, fmt, ...) logtt("%s" fmt, (target)->_log_prefix.CStr(), ##__VA_ARGS__)
+#define _logte(target, fmt, ...)                                               \
+	do                                                                         \
+	{                                                                          \
+		auto _err_msg = ov::String::FormatString(fmt, ##__VA_ARGS__);          \
+		logte("%s%s", (target)->_log_prefix.CStr(), _err_msg.CStr());          \
+		(target)->SetErrorMessage(_err_msg);                                   \
+	} while (0)
+
 namespace ffmpeg
 {
-	std::shared_ptr<Writer> Writer::Create()
+	std::shared_ptr<Writer> Writer::Create(const ov::String &log_prefix)
 	{
-		auto object = std::make_shared<Writer>();
+		auto object = std::make_shared<Writer>(log_prefix);
 
 		return object;
 	}
 
-	Writer::Writer()
-		: _state(WriterStateNone)
+	Writer::Writer(const ov::String &log_prefix)
+		: _state(WriterStateNone), _log_prefix(log_prefix)
 	{
 	}
 
@@ -64,9 +76,7 @@ namespace ffmpeg
 		auto elapsed = std::chrono::steady_clock::now() - writer->GetLastPacketSentTime();
 		if(writer->GetState() == WriterStateClosed)
 		{
-			ov::String err_msg = "Writer was closed before I/O operation completed.";
-			logtw("%s", err_msg.CStr());
-			writer->SetErrorMessage(err_msg);
+			_logte(writer, "Writer was closed before I/O operation completed.");
 			return 1;
 		}
 		else if(writer->GetState() == WriterStateConnecting)
@@ -74,9 +84,7 @@ namespace ffmpeg
 			int64_t elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
 			if(elapsed_ms > writer->GetConnectionTimeout())
 			{
-				auto err_msg = ov::String::FormatString("Connection timeout occurred. %" PRId64 " milliseconds. ", elapsed_ms);
-				logtw("%s", err_msg.CStr());
-				writer->SetErrorMessage(err_msg);
+				_logte(writer, "Connection timeout occurred. %" PRId64 " milliseconds. ", elapsed_ms);
 				return 1;
 			}
 		}
@@ -85,9 +93,7 @@ namespace ffmpeg
 			int64_t elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
 			if(elapsed_ms > writer->GetSendTimeout())
 			{
-				auto err_msg = ov::String::FormatString("Send timeout occurred. %" PRId64 " milliseconds. ", elapsed_ms);
-				logtw("%s", err_msg.CStr());
-				writer->SetErrorMessage(err_msg);
+				_logte(writer, "Send timeout occurred. %" PRId64 " milliseconds. ", elapsed_ms);
 				return 1;
 			}
 		}
@@ -103,9 +109,7 @@ namespace ffmpeg
 	{
 		if (!url || url.IsEmpty() == true)
 		{
-			ov::String err_msg = "Destination url is empty";
-			logte("%s", err_msg.CStr());
-			SetErrorMessage(err_msg);
+			_logte(this, "Destination url is empty");
 			return false;
 		}
 
@@ -117,9 +121,7 @@ namespace ffmpeg
 		int error = avformat_alloc_output_context2(&av_format, nullptr, (_format != nullptr) ? _format.CStr() : nullptr, _url.CStr());
 		if (error < 0)
 		{
-			auto err_msg = ffmpeg::compat::AVErrorToString(error);
-			logte("Failed to allocate output context. %s", err_msg.CStr());
-			SetErrorMessage(err_msg);
+			_logte(this, "Failed to allocate output context. %s", ffmpeg::compat::AVErrorToString(error).CStr());
 			return false;
 		}
 
@@ -148,36 +150,28 @@ namespace ffmpeg
 		auto av_format = GetAVFormatContext();
 		if (!av_format)
 		{
-			auto err_msg = ov::String("Context is not available");
-			logte("%s", err_msg.CStr());
-			SetErrorMessage(err_msg);
+			_logte(this, "Context is not available");
 			return nullptr;
 		}
 
 		AVStream *new_stream = avformat_new_stream(av_format.get(), nullptr);
 		if (!new_stream)
 		{
-			auto err_msg = ov::String("Could not allocate stream");
-			logte("%s", err_msg.CStr());
-			SetErrorMessage(err_msg);
+			_logte(this, "Could not allocate stream");
 			return nullptr;
 		}
 
 		std::shared_ptr<AVStream> av_stream(new_stream, [](AVStream *av_stream) {});
 		if (!av_stream)
 		{
-			auto err_msg = ov::String("Could not create AVStream");
-			logte("%s", err_msg.CStr());
-			SetErrorMessage(err_msg);
+			_logte(this, "Could not create AVStream");
 			return nullptr;
 		}
 
 		// Convert MediaTrack to AVStream
 		if (ffmpeg::compat::ToAVStream(media_track, av_stream.get()) == false)
 		{
-			auto err_msg = ov::String("Could not convert track info to AVStream");
-			logte("%s", err_msg.CStr());
-			SetErrorMessage(err_msg);
+			_logte(this, "Could not convert track info to AVStream");
 			return nullptr;
 		}
 
@@ -188,16 +182,14 @@ namespace ffmpeg
 	{
 		if (media_track == nullptr || av_stream == nullptr || av_stream->codecpar == nullptr)
 		{
-			auto err_msg = ov::String("Could not add track. MediaTrack or AVStream is null");
-			logte("%s", err_msg.CStr());
-			SetErrorMessage(err_msg);
+			_logte(this, "Could not add track. MediaTrack or AVStream is null");
 			return false;
 		}
 
 		std::lock_guard<std::shared_mutex> mlock(_track_map_lock);
 		_av_track_map[media_track->GetId()] = std::make_pair(av_stream, media_track);
 
-		logtt("Added %s track. id(%d), codec(%s), format(%s)",
+		_logtt(this, "Added %s track. id(%d), codec(%s), format(%s)",
 			  cmn::GetMediaTypeString(media_track->GetMediaType()),
 			  media_track->GetId(),
 			  ffmpeg::compat::GetCodecName(av_stream->codecpar->codec_id).CStr(),
@@ -210,16 +202,14 @@ namespace ffmpeg
 	{
 		if (media_track == nullptr || av_stream == nullptr || av_stream->codecpar == nullptr)
 		{
-			auto err_msg = ov::String("Could not add event track. MediaTrack or AVStream is null");
-			logte("%s", err_msg.CStr());
-			SetErrorMessage(err_msg);
+			_logte(this, "Could not add event track. MediaTrack or AVStream is null");
 			return false;
 		}
 
 		std::lock_guard<std::shared_mutex> mlock(_track_map_lock);
 		_event_track_map[std::make_pair(media_track->GetId(), format)] = std::make_pair(av_stream, media_track);
 
-		logtt("Added %s track. id(%d), codec(%s), format(%s)",
+		_logtt(this, "Added %s track. id(%d), codec(%s), format(%s)",
 			  cmn::GetMediaTypeString(media_track->GetMediaType()),
 			  media_track->GetId(),
 			  ffmpeg::compat::GetCodecName(av_stream->codecpar->codec_id).CStr(),
@@ -331,9 +321,7 @@ namespace ffmpeg
 		auto av_format = GetAVFormatContext();
 		if (av_format == nullptr)
 		{
-			auto err_msg = ov::String("Context is not available");
-			logte("%s", err_msg.CStr());
-			SetErrorMessage(err_msg);
+			_logte(this, "Context is not available");
 			return false;
 		}
 
@@ -364,9 +352,7 @@ namespace ffmpeg
 			{
 				SetState(WriterStateError);
 
-				auto err_msg = ffmpeg::compat::AVErrorToString(error);
-				logte("Failed to open output url. %s", err_msg.CStr());
-				SetErrorMessage(err_msg);
+				_logte(this, "Failed to open output url. %s", ffmpeg::compat::AVErrorToString(error).CStr());
 
 				return false;
 			}
@@ -384,9 +370,7 @@ namespace ffmpeg
 		if (avformat_write_header(av_format.get(), &format_options) < 0)
 		{
 			SetState(WriterStateError);
-			auto err_msg = ov::String("Could not create header");
-			logte("%s", err_msg.CStr());
-			SetErrorMessage(err_msg);
+			_logte(this, "Could not create header");
 
 			return false;
 		}
@@ -435,13 +419,17 @@ namespace ffmpeg
 		// Writer is not connected, but it's not an error. Waiting for initialization.
 		if(GetState() != WriterStateConnected)
 		{
-			logtd("Writer is not initialized. state:%s", WriterStateToString(GetState()));
+			_logtd(this, "Writer is not initialized. state:%s", WriterStateToString(GetState()));
 			return true;
 		}
 
+		// Although the caller should check for null before calling SendPacket,
+		// It will check for null again just in case. 
+		// Even if null is passed, only a warning is issued. 
+		// It is not considered a reason to stop the Writer.
 		if (!packet)
 		{
-			logtw("Invalid packet. packet is null. Dropping.");
+			_logtw(this, "Invalid packet. packet is null. Dropping.");
 			return true;
 		}
 
@@ -472,9 +460,7 @@ namespace ffmpeg
 		AVPacket av_packet = {0};
 		if (ToAVPacket(av_packet, av_stream, packet, media_track, start_time) == false)
 		{
-			auto err_msg = ov::String("Failed to convert MediaPacket to AVPacket");
-			logte("%s", err_msg.CStr());
-			SetErrorMessage(err_msg);
+			_logte(this, "Failed to convert MediaPacket to AVPacket");
 			return false;
 		}
 
@@ -483,8 +469,8 @@ namespace ffmpeg
 		// But this is not treated as an error.
 		if(av_packet.pts < 0 || av_packet.dts < 0 || av_packet.size <= 0)
 		{
-			logtw("Dropping packet with invalid timestamp or size. track:%d, pts:%" PRId64 ", dts:%" PRId64 ", size:%d",
-				  media_track->GetId(), av_packet.pts, av_packet.dts, av_packet.size);
+			_logtw(this, "Dropping packet with invalid timestamp or size. track:%d, pts:%" PRId64 ", dts:%" PRId64 ", size:%d",
+				   media_track->GetId(), av_packet.pts, av_packet.dts, av_packet.size);
 			av_packet_unref(&av_packet);
 			return true;
 		}
@@ -504,13 +490,10 @@ namespace ffmpeg
 					new_data = NalStreamConverter::ConvertAnnexbToXvcc(packet->GetData(), packet->GetFragHeader());
 					if (new_data == nullptr)
 					{
-						auto err_msg = ov::String::FormatString(
-							"Failed to convert annexb to avcc. track:%d, format:%s, size:%zu",
+						_logte(this, "Failed to convert annexb to avcc. track:%d, format:%s, size:%zu",
 							media_track->GetId(),
 							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
 							packet->GetData()->GetLength());
-						logte("%s", err_msg.CStr());
-						SetErrorMessage(err_msg);
 						return false;
 					}
 					av_packet.size = new_data->GetLength();
@@ -523,13 +506,10 @@ namespace ffmpeg
 					new_data = AacConverter::ConvertAdtsToRaw(packet->GetData(), nullptr);
 					if (new_data == nullptr)
 					{
-						auto err_msg = ov::String::FormatString(
-							"Failed to convert adts to raw. track:%d, format:%s, size:%zu",
+						_logte(this, "Failed to convert adts to raw. track:%d, format:%s, size:%zu",
 							media_track->GetId(),
 							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
 							packet->GetData()->GetLength());
-						logte("%s", err_msg.CStr());
-						SetErrorMessage(err_msg);
 						return false;
 					}
 					av_packet.size = new_data->GetLength();
@@ -542,11 +522,11 @@ namespace ffmpeg
 					AmfDocument document;
 					if (document.Decode(byte_stream) == false)
 					{
-						logw(OV_LOG_TAG".Events","Failed to decode AMF Event");
+						logw(OV_LOG_TAG".Events","%sFailed to decode AMF Event", _log_prefix.CStr());
 						return true;
 					}
 
-					logi(OV_LOG_TAG".Events","Inserted AMF Event. PTS: %" PRId64 ", %s", packet->GetPts(), document.ToString().Replace("\n", " ").CStr());
+					logi(OV_LOG_TAG".Events","%sInserted AMF Event. PTS: %" PRId64 ", %s", _log_prefix.CStr(), packet->GetPts(), document.ToString().Replace("\n", " ").CStr());
 				}
 				break;
 				default:
@@ -564,13 +544,10 @@ namespace ffmpeg
 					new_data = NalStreamConverter::ConvertAnnexbToXvcc(packet->GetData(), packet->GetFragHeader());
 					if (new_data == nullptr)
 					{
-						auto err_msg = ov::String::FormatString(
-							"Failed to convert annexb to hvcc. track:%d, format:%s, size:%zu",
+						_logte(this, "Failed to convert annexb to hvcc. track:%d, format:%s, size:%zu",
 							media_track->GetId(),
 							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
 							packet->GetData()->GetLength());
-						logte("%s", err_msg.CStr());
-						SetErrorMessage(err_msg);
 						return false;
 					}
 					av_packet.size = new_data->GetLength();
@@ -583,13 +560,10 @@ namespace ffmpeg
 					new_data = NalStreamConverter::ConvertAnnexbToXvcc(packet->GetData(), packet->GetFragHeader());
 					if (new_data == nullptr)
 					{
-						auto err_msg = ov::String::FormatString(
-							"Failed to convert annexb to avcc. track:%d, format:%s, size:%zu",
+						_logte(this, "Failed to convert annexb to avcc. track:%d, format:%s, size:%zu",
 							media_track->GetId(),
 							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
 							packet->GetData()->GetLength());
-						logte("%s", err_msg.CStr());
-						SetErrorMessage(err_msg);
 						return false;
 					}
 					av_packet.size = new_data->GetLength();
@@ -603,13 +577,10 @@ namespace ffmpeg
 					new_data = AacConverter::ConvertAdtsToRaw(packet->GetData(), nullptr);
 					if (new_data == nullptr)
 					{
-						auto err_msg = ov::String::FormatString(
-							"Failed to convert adts to raw. track:%d, format:%s, size:%zu",
+						_logte(this, "Failed to convert adts to raw. track:%d, format:%s, size:%zu",
 							media_track->GetId(),
 							cmn::GetBitstreamFormatString(packet->GetBitstreamFormat()),
 							packet->GetData()->GetLength());
-						logte("%s", err_msg.CStr());
-						SetErrorMessage(err_msg);
 						return false;
 					}
 					av_packet.size = new_data->GetLength();
@@ -647,9 +618,7 @@ namespace ffmpeg
 		{
 			av_packet_unref(&av_packet);
 			SetState(WriterStateError);
-			auto err_msg = ov::String("Context is not available");
-			logte("%s", err_msg.CStr());
-			SetErrorMessage(err_msg);
+			_logte(this, "Context is not available");
 
 			return false;
 		}
@@ -664,8 +633,8 @@ namespace ffmpeg
 		{
 			if (av_packet.dts < it->second)
 			{
-				logtw("To avoid non-monotonic DTS, the packet is dropped. track:%d, pts:%" PRId64 ", dts:%" PRId64 ", last_dts:%" PRId64 ", size:%d",
-					media_track->GetId(), av_packet.pts, av_packet.dts, it->second, av_packet.size);
+				_logtw(this, "To avoid non-monotonic DTS, the packet is dropped. track:%d, pts:%" PRId64 ", dts:%" PRId64 ", last_dts:%" PRId64 ", size:%d",
+					   media_track->GetId(), av_packet.pts, av_packet.dts, it->second, av_packet.size);
 
 				av_packet_unref(&av_packet);
 				return true;
@@ -683,9 +652,7 @@ namespace ffmpeg
 			// (timeout / closed). Don't overwrite it.
 			if (error != AVERROR_EXIT)
 			{
-				auto err_msg = ffmpeg::compat::AVErrorToString(error);
-				logte("Failed to write frame. %s", err_msg.CStr());
-				SetErrorMessage(err_msg);
+				_logte(this, "Failed to write frame. %s", ffmpeg::compat::AVErrorToString(error).CStr());
 			}
 
 			return false;
@@ -793,3 +760,4 @@ namespace ffmpeg
 		return true;
 	}
 }  // namespace ffmpeg
+

--- a/src/projects/modules/ffmpeg/writer.h
+++ b/src/projects/modules/ffmpeg/writer.h
@@ -116,7 +116,7 @@ namespace ffmpeg
 
 		ov::String _output_format_name;
 		AVIOInterruptCB _interrupt_cb;
-		std::chrono::steady_clock::time_point _last_packet_sent_time;
+		std::atomic<std::chrono::steady_clock::time_point> _last_packet_sent_time{std::chrono::steady_clock::time_point{}};
 		int32_t _connection_timeout = 5000;	// Default 5s
 		int32_t _send_timeout 		= 2000;	// Default 2s
 
@@ -124,5 +124,6 @@ namespace ffmpeg
 		std::map<int32_t, int64_t> _track_last_dts_map;
 
 		ov::String _error_message;
+		mutable std::mutex _error_message_lock;
 	};
 }  // namespace ffmpeg

--- a/src/projects/modules/ffmpeg/writer.h
+++ b/src/projects/modules/ffmpeg/writer.h
@@ -45,9 +45,9 @@ namespace ffmpeg
 		}
 		
 	public:
-		static std::shared_ptr<Writer> Create();
+		static std::shared_ptr<Writer> Create(const ov::String &log_prefix = "");
 
-		Writer();
+		Writer(const ov::String &log_prefix = "");
 		~Writer();
 
 		static int InterruptCallback(void *opaque);
@@ -125,5 +125,7 @@ namespace ffmpeg
 
 		ov::String _error_message;
 		mutable std::mutex _error_message_lock;
+
+		ov::String _log_prefix;
 	};
 }  // namespace ffmpeg

--- a/src/projects/publishers/file/file_session.cpp
+++ b/src/projects/publishers/file/file_session.cpp
@@ -16,14 +16,9 @@
 #include "file_private.h"
 #include "file_macro.h"
 
-#define LOG_PRFX "[%s](Id:%s) - "
-#define LOG_ARGS (GetStream() != nullptr ? GetStream()->GetUri().CStr() : "-"), \
-				 (GetRecord() != nullptr ? GetRecord()->GetId().CStr() : "-")
-#define _logti(fmt, ...) logti(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
-#define _logtd(fmt, ...) logtd(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
-#define _logtw(fmt, ...) logtw(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
-#define _logte(fmt, ...) logte(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
-#define _logtt(fmt, ...) logtt(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
+#define OV_LOG_PREFIX_FORMAT "[%s] (Id:%s) - "
+#define OV_LOG_PREFIX_VALUE (GetStream() != nullptr ? GetStream()->GetUri().CStr() : "-"), \
+							(GetRecord() != nullptr ? GetRecord()->GetId().CStr() : "-")
 
 namespace pub
 {
@@ -48,7 +43,7 @@ namespace pub
 
 	FileSession::~FileSession()
 	{
-		_logtt("FileSession(%d) has been terminated finally", GetId());
+		logat("FileSession(%d) has been terminated finally", GetId());
 		MonitorInstance->OnSessionDisconnected(*GetStream(), PublisherType::File);
 	}
 
@@ -58,7 +53,7 @@ namespace pub
 
 		if (StartRecord() == false)
 		{
-			_logte("Failed to start recording. id(%d)", GetId());
+			logae("Failed to start recording. id(%d)", GetId());
 			SetState(SessionState::Error);
 
 			auto record = GetRecord();
@@ -69,7 +64,7 @@ namespace pub
 			return false;
 		}
 
-		_logtt("FileSession(%d) has started.", GetId());
+		logat("FileSession(%d) has started.", GetId());
 
 		return Session::Start();
 	}
@@ -78,7 +73,7 @@ namespace pub
 	{
 		if (StopRecord() == false)
 		{
-			_logte("Failed to stop recording. id(%d)", GetId());
+			logae("Failed to stop recording. id(%d)", GetId());
 			SetState(SessionState::Error);
 			auto record = GetRecord();
 			if(record != nullptr)
@@ -88,7 +83,7 @@ namespace pub
 			return false;
 		}
 
-		_logtt("FileSession(%d) has stoped", GetId());
+		logat("FileSession(%d) has stopped", GetId());
 
 		return Session::Stop();
 	}
@@ -97,7 +92,7 @@ namespace pub
 	{
 		if (StopRecord() == false)
 		{
-			_logte("Failed to stop recording. id(%d)", GetId());
+			logae("Failed to stop recording. id(%d)", GetId());
 			SetState(SessionState::Error);
 			auto record = GetRecord();
 			if(record != nullptr)
@@ -109,7 +104,7 @@ namespace pub
 
 		if (StartRecord() == false)
 		{
-			_logte("Failed to start recording. id(%d)", GetId());
+			logae("Failed to start recording. id(%d)", GetId());
 			SetState(SessionState::Error);
 			auto record = GetRecord();
 			if(record != nullptr)
@@ -127,7 +122,7 @@ namespace pub
 		auto record = GetRecord();
 		if (record == nullptr)
 		{
-			_logte("Record information is not set. id(%d)", GetId());
+			logae("Record information is not set. id(%d)", GetId());
 			return false;
 		}
 
@@ -147,7 +142,7 @@ namespace pub
 
 		if (ov::PathManager::MakeDirectoryRecursive(tmp_real_directory.CStr()) == false)
 		{
-			_logte("Could not create directory. path(%s)", tmp_real_directory.CStr());
+			logae("Could not create directory. path(%s)", tmp_real_directory.CStr());
 
 			SetState(SessionState::Error);
 			record->SetState(info::Record::RecordState::Error);
@@ -155,18 +150,18 @@ namespace pub
 			return false;
 		}
 
-		_logtt("OutputFilePath : %s", record->GetOutputFilePath().CStr());
-		_logtt("OutputInfoPath : %s", record->GetOutputInfoPath().CStr());
-		_logtt("TmpPath        : %s", record->GetTmpPath().CStr());
-		_logtt("TmpDirectory   : %s", tmp_directory.CStr());
-		_logtt("TmpRealDirectory   : %s", tmp_real_directory.CStr());
+		logat("OutputFilePath : %s", record->GetOutputFilePath().CStr());
+		logat("OutputInfoPath : %s", record->GetOutputInfoPath().CStr());
+		logat("TmpPath        : %s", record->GetTmpPath().CStr());
+		logat("TmpDirectory   : %s", tmp_directory.CStr());
+		logat("TmpRealDirectory   : %s", tmp_real_directory.CStr());
 
 		auto writer = CreateWriter();
 		if (writer == nullptr)
 		{
 			SetState(SessionState::Error);
 			record->SetState(info::Record::RecordState::Error);
-			_logte("Failed to create writer. %s", record->GetInfoString().CStr());
+			logae("Failed to create writer. %s", record->GetInfoString().CStr());
 			return false;
 		}
 
@@ -174,7 +169,7 @@ namespace pub
 		{
 			SetState(SessionState::Error);
 			record->SetState(info::Record::RecordState::Error);
-			_logte("Failed to set URL. Reason(%s), %s", writer->GetErrorMessage().CStr(), record->GetInfoString().CStr());
+			logae("Failed to set URL. Reason(%s), %s", writer->GetErrorMessage().CStr(), record->GetInfoString().CStr());
 			return false;
 		}
 
@@ -215,7 +210,7 @@ namespace pub
 				auto media_track	  = GetStream()->GetTrackByVariant(variant, variant_index);
 				if (media_track == nullptr)
 				{
-					_logtw("Could not find track by VariantName: %s : %d", variant.CStr(), variant_index);
+					logaw("Could not find track by VariantName: %s : %d", variant.CStr(), variant_index);
 					continue;
 				}
 
@@ -231,7 +226,7 @@ namespace pub
 				auto media_track = GetStream()->GetTrack(track_id);
 				if (media_track == nullptr)
 				{
-					_logtw("Could not find track by TrackId: %d", track_id);
+					logaw("Could not find track by TrackId: %d", track_id);
 					continue;
 				}
 
@@ -242,17 +237,17 @@ namespace pub
 			}
 		}
 
-		_logtd("Create temporary file(%s) and default track id(%d)", writer->GetUrl().CStr(), _default_track);
+		logad("Create temporary file(%s) and default track id(%d)", writer->GetUrl().CStr(), _default_track);
 
 		if (writer->Start() == false)
 		{
 			SetState(SessionState::Error);
 			record->SetState(info::Record::RecordState::Error);
-			_logte("Failed to start writer. Reason(%s), %s", writer->GetErrorMessage().CStr(), record->GetInfoString().CStr());
+			logae("Failed to start writer. Reason(%s), %s", writer->GetErrorMessage().CStr(), record->GetInfoString().CStr());
 			return false;
 		}
 
-		_logtd("Recording Started. %s", record->GetInfoString().CStr());
+		logad("Recording Started. %s", record->GetInfoString().CStr());
 
 		return true;
 	}
@@ -303,7 +298,7 @@ namespace pub
 
 				if (ov::PathManager::MakeDirectoryRecursive(output_directory.CStr()) == false)
 				{
-					_logte("Could not create directory. path: %s", output_directory.CStr());
+					logae("Could not create directory. path: %s", output_directory.CStr());
 
 					SetState(SessionState::Error);
 					record->SetState(info::Record::RecordState::Error);
@@ -317,7 +312,7 @@ namespace pub
 
 				if (ov::PathManager::MakeDirectoryRecursive(info_directory.CStr()) == false)
 				{
-					_logte("Could not create directory. path: %s", info_directory.CStr());
+					logae("Could not create directory. path: %s", info_directory.CStr());
 
 					SetState(SessionState::Error);
 					record->SetState(info::Record::RecordState::Error);
@@ -330,7 +325,7 @@ namespace pub
 
 				if (rename(tmp_output_path.CStr(), output_path.CStr()) != 0)
 				{
-					_logte("Failed to move file. from: %s to: %s", tmp_output_path.CStr(), output_path.CStr());
+					logae("Failed to move file. from: %s to: %s", tmp_output_path.CStr(), output_path.CStr());
 
 					SetState(SessionState::Error);
 					record->SetState(info::Record::RecordState::Error);
@@ -338,19 +333,19 @@ namespace pub
 					return false;
 				}
 
-				_logtd("Replace the temporary file name with the target file name. from: %s, to: %s", tmp_output_path.CStr(), output_path.CStr());
+				logad("Replace the temporary file name with the target file name. from: %s, to: %s", tmp_output_path.CStr(), output_path.CStr());
 
 				// Append recorded information to the information file
 				if (FileExport::GetInstance()->ExportRecordToXml(info_path, record) == false)
 				{
-					_logte("Failed to export xml file. path: %s", info_path.CStr());
+					logae("Failed to export xml file. path: %s", info_path.CStr());
 				}
 
-				_logtd("Appends the recording result to the information file. path: %s", info_path.CStr());
+				logad("Appends the recording result to the information file. path: %s", info_path.CStr());
 
 				record->SetState(info::Record::RecordState::Stopped);
 
-				_logtd("Recording Completed. %s", record->GetInfoString().CStr());
+				logad("Recording Completed. %s", record->GetInfoString().CStr());
 								
 				record->IncreaseSequence();
 			}
@@ -380,7 +375,7 @@ namespace pub
 		}
 		catch (const std::bad_any_cast &e)
 		{
-			_logtw("An incorrect type of packet was input from the stream. (%s)", e.what());
+			logaw("An incorrect type of packet was input from the stream. (%s)", e.what());
 
 			return;
 		}
@@ -388,7 +383,7 @@ namespace pub
 		auto record = GetRecord();
 		if (!record)
 		{
-			_logte("Record information is not set. id(%d)", GetId());
+			logae("Record information is not set. id(%d)", GetId());
 			return;
 		}
 
@@ -427,7 +422,7 @@ namespace pub
 			{
 				if (record->UpdateNextScheduleTime() == false)
 				{
-					_logte("Failed to update next schedule time. request to stop recording.");
+					logae("Failed to update next schedule time. request to stop recording.");
 				}
 			}
 			else if (record->GetNextScheduleTime() <= std::chrono::system_clock::now())
@@ -436,7 +431,7 @@ namespace pub
 
 				if (record->UpdateNextScheduleTime() == false)
 				{
-					_logte("Failed to update next schedule time. request to stop recording.");
+					logae("Failed to update next schedule time. request to stop recording.");
 				}
 			}
 		}
@@ -456,7 +451,7 @@ namespace pub
 			{
 				SetState(SessionState::Error);
 				record->SetState(info::Record::RecordState::Error);
-				_logte("Failed to write packet. Reason(%s), %s", writer->GetErrorMessage().CStr(), record->GetInfoString().CStr());
+				logae("Failed to write packet. Reason(%s), %s", writer->GetErrorMessage().CStr(), record->GetInfoString().CStr());
 				DestroyWriter();
 
 				return;
@@ -512,7 +507,7 @@ namespace pub
 		auto record = GetRecord();
 		if(!record)
 		{
-			_logte("Record information is not set. id(%d)", GetId());
+			logae("Record information is not set. id(%d)", GetId());
 
 			return "";
 		}
@@ -545,7 +540,7 @@ namespace pub
 		auto record = GetRecord();
 		if(!record)
 		{
-			_logte("Record information is not set. id(%d)", GetId());
+			logae("Record information is not set. id(%d)", GetId());
 
 			return "";
 		}
@@ -581,7 +576,7 @@ namespace pub
 			_writer = nullptr;
 		}
 
-		_writer = ffmpeg::Writer::Create(ov::String::FormatString(LOG_PRFX, LOG_ARGS));
+		_writer = ffmpeg::Writer::Create(ov::String::FormatString(OV_LOG_PREFIX_FORMAT, OV_LOG_PREFIX_VALUE));
 		if (_writer == nullptr)
 		{
 			return nullptr;
@@ -653,25 +648,25 @@ namespace pub
 		auto writer = GetWriter();
 		if (writer == nullptr)
 		{
-			_logte("Writer is not created.");
+			logae("Writer is not created.");
 			return false;
 		}
 
 		// Check already added track
 		if (writer->GetTrackByTrackId(track->GetId()) != nullptr)
 		{
-			_logtw("Track already added. trackId: %d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
+			logaw("Track already added. trackId: %d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
 			return false;
 		}
 
 		if (IsSupportCodec(output_format, track->GetCodecId()) == false)
 		{
-			_logtw("Could not supported codec. trackId: %u, container: %s codec: %s, variantName: %s",
+			logaw("Could not supported codec. trackId: %u, container: %s codec: %s, variantName: %s",
 				   track->GetId(), output_format.CStr(), GetCodecIdString(track->GetCodecId()), track->GetVariantName().CStr());
 			return true;
 		}
 
-		_logtd("Adding track to writer. trackId: %d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
+		logad("Adding track to writer. trackId: %d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
 
 		SelectDefaultTrack(track);
 
@@ -679,6 +674,3 @@ namespace pub
 	}
 
 }  // namespace pub
-
-#undef LOG_PRFX
-#undef LOG_ARGS

--- a/src/projects/publishers/file/file_session.cpp
+++ b/src/projects/publishers/file/file_session.cpp
@@ -16,6 +16,15 @@
 #include "file_private.h"
 #include "file_macro.h"
 
+#define LOG_PRFX "[%s](Id:%s) - "
+#define LOG_ARGS (GetStream() != nullptr ? GetStream()->GetUri().CStr() : "-"), \
+				 (GetRecord() != nullptr ? GetRecord()->GetId().CStr() : "-")
+#define _logti(fmt, ...) logti(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
+#define _logtd(fmt, ...) logtd(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
+#define _logtw(fmt, ...) logtw(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
+#define _logte(fmt, ...) logte(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
+#define _logtt(fmt, ...) logtt(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
+
 namespace pub
 {
 	std::shared_ptr<FileSession> FileSession::Create(const std::shared_ptr<pub::Application> &application,
@@ -39,7 +48,7 @@ namespace pub
 
 	FileSession::~FileSession()
 	{
-		logtt("FileSession(%d) has been terminated finally", GetId());
+		_logtt("FileSession(%d) has been terminated finally", GetId());
 		MonitorInstance->OnSessionDisconnected(*GetStream(), PublisherType::File);
 	}
 
@@ -49,7 +58,7 @@ namespace pub
 
 		if (StartRecord() == false)
 		{
-			logte("Failed to start recording. id(%d)", GetId());
+			_logte("Failed to start recording. id(%d)", GetId());
 			SetState(SessionState::Error);
 
 			auto record = GetRecord();
@@ -60,7 +69,7 @@ namespace pub
 			return false;
 		}
 
-		logtt("FileSession(%d) has started.", GetId());
+		_logtt("FileSession(%d) has started.", GetId());
 
 		return Session::Start();
 	}
@@ -69,7 +78,7 @@ namespace pub
 	{
 		if (StopRecord() == false)
 		{
-			logte("Failed to stop recording. id(%d)", GetId());
+			_logte("Failed to stop recording. id(%d)", GetId());
 			SetState(SessionState::Error);
 			auto record = GetRecord();
 			if(record != nullptr)
@@ -79,7 +88,7 @@ namespace pub
 			return false;
 		}
 
-		logtt("FileSession(%d) has stoped", GetId());
+		_logtt("FileSession(%d) has stoped", GetId());
 
 		return Session::Stop();
 	}
@@ -88,7 +97,7 @@ namespace pub
 	{
 		if (StopRecord() == false)
 		{
-			logte("Failed to stop recording. id(%d)", GetId());
+			_logte("Failed to stop recording. id(%d)", GetId());
 			SetState(SessionState::Error);
 			auto record = GetRecord();
 			if(record != nullptr)
@@ -100,7 +109,7 @@ namespace pub
 
 		if (StartRecord() == false)
 		{
-			logte("Failed to start recording. id(%d)", GetId());
+			_logte("Failed to start recording. id(%d)", GetId());
 			SetState(SessionState::Error);
 			auto record = GetRecord();
 			if(record != nullptr)
@@ -118,7 +127,7 @@ namespace pub
 		auto record = GetRecord();
 		if (record == nullptr)
 		{
-			logte("Record information is not set. id(%d)", GetId());
+			_logte("Record information is not set. id(%d)", GetId());
 			return false;
 		}
 
@@ -138,7 +147,7 @@ namespace pub
 
 		if (ov::PathManager::MakeDirectoryRecursive(tmp_real_directory.CStr()) == false)
 		{
-			logte("Could not create directory. path(%s)", tmp_real_directory.CStr());
+			_logte("Could not create directory. path(%s)", tmp_real_directory.CStr());
 
 			SetState(SessionState::Error);
 			record->SetState(info::Record::RecordState::Error);
@@ -146,18 +155,18 @@ namespace pub
 			return false;
 		}
 
-		logtt("OutputFilePath : %s", record->GetOutputFilePath().CStr());
-		logtt("OutputInfoPath : %s", record->GetOutputInfoPath().CStr());
-		logtt("TmpPath        : %s", record->GetTmpPath().CStr());
-		logtt("TmpDirectory   : %s", tmp_directory.CStr());
-		logtt("TmpRealDirectory   : %s", tmp_real_directory.CStr());
+		_logtt("OutputFilePath : %s", record->GetOutputFilePath().CStr());
+		_logtt("OutputInfoPath : %s", record->GetOutputInfoPath().CStr());
+		_logtt("TmpPath        : %s", record->GetTmpPath().CStr());
+		_logtt("TmpDirectory   : %s", tmp_directory.CStr());
+		_logtt("TmpRealDirectory   : %s", tmp_real_directory.CStr());
 
 		auto writer = CreateWriter();
 		if (writer == nullptr)
 		{
 			SetState(SessionState::Error);
 			record->SetState(info::Record::RecordState::Error);
-			logte("Failed to create writer. %s", record->GetInfoString().CStr());
+			_logte("Failed to create writer. %s", record->GetInfoString().CStr());
 			return false;
 		}
 
@@ -165,7 +174,7 @@ namespace pub
 		{
 			SetState(SessionState::Error);
 			record->SetState(info::Record::RecordState::Error);
-			logte("Failed to set URL. Reason(%s), %s", writer->GetErrorMessage().CStr(), record->GetInfoString().CStr());
+			_logte("Failed to set URL. Reason(%s), %s", writer->GetErrorMessage().CStr(), record->GetInfoString().CStr());
 			return false;
 		}
 
@@ -206,7 +215,7 @@ namespace pub
 				auto media_track	  = GetStream()->GetTrackByVariant(variant, variant_index);
 				if (media_track == nullptr)
 				{
-					logtw("FileSession(%d) - Could not find track by VariantName: %s : %d", GetId(), variant.CStr(), variant_index);
+					_logtw("Could not find track by VariantName: %s : %d", variant.CStr(), variant_index);
 					continue;
 				}
 
@@ -222,7 +231,7 @@ namespace pub
 				auto media_track = GetStream()->GetTrack(track_id);
 				if (media_track == nullptr)
 				{
-					logtw("FileSession(%d) - Could not find track by TrackId: %d", GetId(), track_id);
+					_logtw("Could not find track by TrackId: %d", track_id);
 					continue;
 				}
 
@@ -233,17 +242,17 @@ namespace pub
 			}
 		}
 
-		logtd("Create temporary file(%s) and default track id(%d)", writer->GetUrl().CStr(), _default_track);
+		_logtd("Create temporary file(%s) and default track id(%d)", writer->GetUrl().CStr(), _default_track);
 
 		if (writer->Start() == false)
 		{
 			SetState(SessionState::Error);
 			record->SetState(info::Record::RecordState::Error);
-			logte("Failed to start writer. Reason(%s), %s", writer->GetErrorMessage().CStr(), record->GetInfoString().CStr());
+			_logte("Failed to start writer. Reason(%s), %s", writer->GetErrorMessage().CStr(), record->GetInfoString().CStr());
 			return false;
 		}
 
-		logtd("Recording Started. %s", record->GetInfoString().CStr());
+		_logtd("Recording Started. %s", record->GetInfoString().CStr());
 
 		return true;
 	}
@@ -294,7 +303,7 @@ namespace pub
 
 				if (ov::PathManager::MakeDirectoryRecursive(output_directory.CStr()) == false)
 				{
-					logte("Could not create directory. path: %s", output_directory.CStr());
+					_logte("Could not create directory. path: %s", output_directory.CStr());
 
 					SetState(SessionState::Error);
 					record->SetState(info::Record::RecordState::Error);
@@ -308,7 +317,7 @@ namespace pub
 
 				if (ov::PathManager::MakeDirectoryRecursive(info_directory.CStr()) == false)
 				{
-					logte("Could not create directory. path: %s", info_directory.CStr());
+					_logte("Could not create directory. path: %s", info_directory.CStr());
 
 					SetState(SessionState::Error);
 					record->SetState(info::Record::RecordState::Error);
@@ -321,7 +330,7 @@ namespace pub
 
 				if (rename(tmp_output_path.CStr(), output_path.CStr()) != 0)
 				{
-					logte("Failed to move file. from: %s to: %s", tmp_output_path.CStr(), output_path.CStr());
+					_logte("Failed to move file. from: %s to: %s", tmp_output_path.CStr(), output_path.CStr());
 
 					SetState(SessionState::Error);
 					record->SetState(info::Record::RecordState::Error);
@@ -329,19 +338,19 @@ namespace pub
 					return false;
 				}
 
-				logtd("Replace the temporary file name with the target file name. from: %s, to: %s", tmp_output_path.CStr(), output_path.CStr());
+				_logtd("Replace the temporary file name with the target file name. from: %s, to: %s", tmp_output_path.CStr(), output_path.CStr());
 
 				// Append recorded information to the information file
 				if (FileExport::GetInstance()->ExportRecordToXml(info_path, record) == false)
 				{
-					logte("Failed to export xml file. path: %s", info_path.CStr());
+					_logte("Failed to export xml file. path: %s", info_path.CStr());
 				}
 
-				logtd("Appends the recording result to the information file. path: %s", info_path.CStr());
+				_logtd("Appends the recording result to the information file. path: %s", info_path.CStr());
 
 				record->SetState(info::Record::RecordState::Stopped);
-				
-				logtd("Recording Completed. %s", record->GetInfoString().CStr());
+
+				_logtd("Recording Completed. %s", record->GetInfoString().CStr());
 								
 				record->IncreaseSequence();
 			}
@@ -371,7 +380,7 @@ namespace pub
 		}
 		catch (const std::bad_any_cast &e)
 		{
-			logtw("An incorrect type of packet was input from the stream. (%s)", e.what());
+			_logtw("An incorrect type of packet was input from the stream. (%s)", e.what());
 
 			return;
 		}
@@ -379,7 +388,7 @@ namespace pub
 		auto record = GetRecord();
 		if (!record)
 		{
-			logte("Record information is not set. id(%d)", GetId());
+			_logte("Record information is not set. id(%d)", GetId());
 			return;
 		}
 
@@ -418,7 +427,7 @@ namespace pub
 			{
 				if (record->UpdateNextScheduleTime() == false)
 				{
-					logte("Failed to update next schedule time. request to stop recording.");
+					_logte("Failed to update next schedule time. request to stop recording.");
 				}
 			}
 			else if (record->GetNextScheduleTime() <= std::chrono::system_clock::now())
@@ -427,7 +436,7 @@ namespace pub
 
 				if (record->UpdateNextScheduleTime() == false)
 				{
-					logte("Failed to update next schedule time. request to stop recording.");
+					_logte("Failed to update next schedule time. request to stop recording.");
 				}
 			}
 		}
@@ -447,7 +456,7 @@ namespace pub
 			{
 				SetState(SessionState::Error);
 				record->SetState(info::Record::RecordState::Error);
-				logte("Failed to write packet. Reason(%s), %s", writer->GetErrorMessage().CStr(), record->GetInfoString().CStr());
+				_logte("Failed to write packet. Reason(%s), %s", writer->GetErrorMessage().CStr(), record->GetInfoString().CStr());
 				DestroyWriter();
 
 				return;
@@ -503,7 +512,7 @@ namespace pub
 		auto record = GetRecord();
 		if(!record)
 		{
-			logte("Record information is not set. id(%d)", GetId());
+			_logte("Record information is not set. id(%d)", GetId());
 
 			return "";
 		}
@@ -536,8 +545,8 @@ namespace pub
 		auto record = GetRecord();
 		if(!record)
 		{
-			logte("Record information is not set. id(%d)", GetId());
-			
+			_logte("Record information is not set. id(%d)", GetId());
+
 			return "";
 		}
 
@@ -572,7 +581,7 @@ namespace pub
 			_writer = nullptr;
 		}
 
-		_writer = ffmpeg::Writer::Create();
+		_writer = ffmpeg::Writer::Create(ov::String::FormatString(LOG_PRFX, LOG_ARGS));
 		if (_writer == nullptr)
 		{
 			return nullptr;
@@ -644,25 +653,25 @@ namespace pub
 		auto writer = GetWriter();
 		if (writer == nullptr)
 		{
-			logte("Writer is not created.");
+			_logte("Writer is not created.");
 			return false;
 		}
 
 		// Check already added track
 		if (writer->GetTrackByTrackId(track->GetId()) != nullptr)
 		{
-			logtw("Track already added. trackId: %d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
+			_logtw("Track already added. trackId: %d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
 			return false;
 		}
 
 		if (IsSupportCodec(output_format, track->GetCodecId()) == false)
 		{
-			logtw("Could not supported codec. trackId: %u, container: %s codec: %s, variantName: %s",
-				  track->GetId(), output_format.CStr(), GetCodecIdString(track->GetCodecId()), track->GetVariantName().CStr());
+			_logtw("Could not supported codec. trackId: %u, container: %s codec: %s, variantName: %s",
+				   track->GetId(), output_format.CStr(), GetCodecIdString(track->GetCodecId()), track->GetVariantName().CStr());
 			return true;
 		}
 
-		logtd("Adding track to writer. trackId: %d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
+		_logtd("Adding track to writer. trackId: %d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
 
 		SelectDefaultTrack(track);
 
@@ -670,3 +679,6 @@ namespace pub
 	}
 
 }  // namespace pub
+
+#undef LOG_PRFX
+#undef LOG_ARGS

--- a/src/projects/publishers/push/push_session.cpp
+++ b/src/projects/publishers/push/push_session.cpp
@@ -14,14 +14,9 @@
 
 #include "push_private.h"
 
-#define LOG_PRFX "[%s](Id:%s) - "
-#define LOG_ARGS (GetStream() != nullptr ? GetStream()->GetUri().CStr() : "-"), \
-				 (_push != nullptr ? _push->GetId().CStr() : "-")
-#define _logti(fmt, ...) logti(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
-#define _logtd(fmt, ...) logtd(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
-#define _logtw(fmt, ...) logtw(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
-#define _logte(fmt, ...) logte(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
-#define _logtt(fmt, ...) logtt(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
+#define OV_LOG_PREFIX_FORMAT "[%s] (Id:%s) - "
+#define OV_LOG_PREFIX_VALUE (GetStream() != nullptr ? GetStream()->GetUri().CStr() : "-"), \
+							(_push != nullptr ? _push->GetId().CStr() : "-")
 
 namespace pub
 {
@@ -49,7 +44,7 @@ namespace pub
 	PushSession::~PushSession()
 	{
 		Stop();
-		_logtt("PushSession has been terminated finally");
+		logat("PushSession has been terminated finally");
 		MonitorInstance->OnSessionDisconnected(*GetStream(), PublisherType::Push);
 	}
 
@@ -58,7 +53,7 @@ namespace pub
 		auto push = GetPush();
 		if (push == nullptr)
 		{
-			_logte("Push object is null");
+			logae("Push object is null");
 			SetState(SessionState::Error);
 			return false;
 		}
@@ -80,14 +75,14 @@ namespace pub
 		if (writer == nullptr)
 		{
 			SetErrorState(push);
-			_logte("Failed to create session. %s", push->GetInfoString().CStr());
+			logae("Failed to create session. %s", push->GetInfoString().CStr());
 			return false;
 		}
 
 		if (writer->SetUrl(dest_url, ffmpeg::compat::GetFormatByProtocolType(push->GetProtocolType())) == false)
 		{
 			SetErrorState(push);
-			_logte("Failed to set URL. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
+			logae("Failed to set URL. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
 			return false;
 		}
 
@@ -132,7 +127,7 @@ namespace pub
 				auto media_track	  = GetStream()->GetTrackByVariant(variant, variant_index);
 				if (media_track == nullptr)
 				{
-					_logtw("Could not find track by VariantName: %s : %d", variant.CStr(), variant_index);
+					logaw("Could not find track by VariantName: %s : %d", variant.CStr(), variant_index);
 					continue;
 				}
 
@@ -148,7 +143,7 @@ namespace pub
 				auto media_track = GetStream()->GetTrack(track_id);
 				if (media_track == nullptr)
 				{
-					_logtw("Could not find track by TrackId: %d", track_id);
+					logaw("Could not find track by TrackId: %d", track_id);
 					continue;
 				}
 
@@ -163,7 +158,7 @@ namespace pub
 			{
 				if (AddTrack(data_track) == false)
 				{
-					_logtw("Could not add data track. trackId:%d, variantName: %s", data_track->GetId(), data_track->GetVariantName().CStr());
+					logaw("Could not add data track. trackId:%d, variantName: %s", data_track->GetId(), data_track->GetVariantName().CStr());
 				}
 			}
 		}
@@ -174,20 +169,20 @@ namespace pub
 		if (writer->Start() == false)
 		{
 			SetErrorState(push);
-			_logte("Failed to start session. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
+			logae("Failed to start session. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
 			return false;
 		}
 
 		if (StartSenderThread() == false)
 		{
 			SetErrorState(push, writer);
-			_logte("Failed to start sender thread. %s", push->GetInfoString().CStr());
+			logae("Failed to start sender thread. %s", push->GetInfoString().CStr());
 			return false;
 		}
 
 		push->SetState(info::Push::PushState::Pushing);
 
-		_logtd("PushSession(%d) has started.", GetId());
+		logad("PushSession(%d) has started.", GetId());
 
 		return Session::Start();
 	}
@@ -216,7 +211,7 @@ namespace pub
 
 			DestoryWriter();
 
-			_logtd("PushSession(%d) has stopped", GetId());
+			logad("PushSession(%d) has stopped", GetId());
 		}
 
 		return Session::Stop();
@@ -246,7 +241,7 @@ namespace pub
 		}
 		catch (const std::bad_any_cast &e)
 		{
-			_logtt("An incorrect type of packet was input from the stream. (%s)", e.what());
+			logat("An incorrect type of packet was input from the stream. (%s)", e.what());
 
 			return;
 		}
@@ -326,7 +321,7 @@ namespace pub
 
 			if (_sender_packet_queue.IsThresholdExceededFor(kThresholdGraceDuration))
 			{
-				_logte("Push session queue exceeded state persisted for more than %ld seconds. Terminating session. %s",
+				logae("Push session queue exceeded state persisted for more than %ld seconds. Terminating session. %s",
 					   std::chrono::duration_cast<std::chrono::seconds>(kThresholdGraceDuration).count(), push->GetInfoString().CStr());
 
 				SetErrorState(push, writer);
@@ -342,7 +337,7 @@ namespace pub
 			bool ret = writer->SendPacket(session_packet, &sent_bytes);
 			if (ret == false)
 			{
-				_logte("Failed to send packet. session will be terminated. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
+				logae("Failed to send packet. session will be terminated. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
 
 				SetErrorState(push, writer);
 				_sender_stop_flag = true;
@@ -379,7 +374,7 @@ namespace pub
 			_writer = nullptr;
 		}
 
-		_writer = ffmpeg::Writer::Create(ov::String::FormatString(LOG_PRFX, LOG_ARGS));
+		_writer = ffmpeg::Writer::Create(ov::String::FormatString(OV_LOG_PREFIX_FORMAT, OV_LOG_PREFIX_VALUE));
 		if (_writer == nullptr)
 		{
 			return nullptr;
@@ -481,19 +476,19 @@ namespace pub
 		// Check already added
 		if (writer->GetTrackByTrackId(track->GetId()) != nullptr)
 		{
-			_logtw("Track already added. trackId:%d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
+			logaw("Track already added. trackId:%d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
 			return false;
 		}
 
 		if (IsSupportTrack(push->GetProtocolType(), track) == false)
 		{
-			_logtw("Could not supported track. trackId:%u, codec: %s", track->GetId(), GetCodecIdString(track->GetCodecId()));
+			logaw("Could not supported track. trackId:%u, codec: %s", track->GetId(), GetCodecIdString(track->GetCodecId()));
 			return false;
 		}
 
 		if (IsSupportCodec(push->GetProtocolType(), track->GetCodecId()) == false)
 		{
-			_logtw("Could not supported codec. trackId:%u, codec: %s", track->GetId(), GetCodecIdString(track->GetCodecId()));
+			logaw("Could not supported codec. trackId:%u, codec: %s", track->GetId(), GetCodecIdString(track->GetCodecId()));
 			return false;
 		}
 
@@ -502,12 +497,12 @@ namespace pub
 		{
 			if (writer->GetTrackCountByType(track->GetMediaType()) >= 1)
 			{
-				_logtw("Could not add more than one video track for RTMP. trackId:%d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
+				logaw("Could not add more than one video track for RTMP. trackId:%d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
 				return false;
 			}
 		}
 
-		_logtd("Adding track. trackId:%d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
+		logad("Adding track. trackId:%d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
 
 		return writer->AddTrack(track);
 	}

--- a/src/projects/publishers/push/push_session.cpp
+++ b/src/projects/publishers/push/push_session.cpp
@@ -14,6 +14,15 @@
 
 #include "push_private.h"
 
+#define LOG_PRFX "[%s](Id:%s) - "
+#define LOG_ARGS (GetStream() != nullptr ? GetStream()->GetUri().CStr() : "-"), \
+				 (_push != nullptr ? _push->GetId().CStr() : "-")
+#define _logti(fmt, ...) logti(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
+#define _logtd(fmt, ...) logtd(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
+#define _logtw(fmt, ...) logtw(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
+#define _logte(fmt, ...) logte(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
+#define _logtt(fmt, ...) logtt(LOG_PRFX fmt, LOG_ARGS, ##__VA_ARGS__)
+
 namespace pub
 {
 	std::shared_ptr<PushSession> PushSession::Create(const std::shared_ptr<pub::Application> &application,
@@ -40,7 +49,7 @@ namespace pub
 	PushSession::~PushSession()
 	{
 		Stop();
-		logtt("PushSession(%d) has been terminated finally", GetId());
+		_logtt("PushSession has been terminated finally");
 		MonitorInstance->OnSessionDisconnected(*GetStream(), PublisherType::Push);
 	}
 
@@ -49,7 +58,7 @@ namespace pub
 		auto push = GetPush();
 		if (push == nullptr)
 		{
-			logte("Push object is null");
+			_logte("Push object is null");
 			SetState(SessionState::Error);
 			return false;
 		}
@@ -71,14 +80,14 @@ namespace pub
 		if (writer == nullptr)
 		{
 			SetErrorState(push);
-			logte("Failed to create session. %s", push->GetInfoString().CStr());
+			_logte("Failed to create session. %s", push->GetInfoString().CStr());
 			return false;
 		}
 
 		if (writer->SetUrl(dest_url, ffmpeg::compat::GetFormatByProtocolType(push->GetProtocolType())) == false)
 		{
 			SetErrorState(push);
-			logte("Failed to set URL. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
+			_logte("Failed to set URL. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
 			return false;
 		}
 
@@ -123,7 +132,7 @@ namespace pub
 				auto media_track	  = GetStream()->GetTrackByVariant(variant, variant_index);
 				if (media_track == nullptr)
 				{
-					logtw("PushSession(%d) - Could not find track by VariantName: %s : %d", GetId(), variant.CStr(), variant_index);
+					_logtw("Could not find track by VariantName: %s : %d", variant.CStr(), variant_index);
 					continue;
 				}
 
@@ -139,7 +148,7 @@ namespace pub
 				auto media_track = GetStream()->GetTrack(track_id);
 				if (media_track == nullptr)
 				{
-					logtw("PushSession(%d) - Could not find track by TrackId: %d", GetId(), track_id);
+					_logtw("Could not find track by TrackId: %d", track_id);
 					continue;
 				}
 
@@ -154,7 +163,7 @@ namespace pub
 			{
 				if (AddTrack(data_track) == false)
 				{
-					logtw("PushSession(%d) - Could not add data track. trackId:%d, variantName: %s", GetId(), data_track->GetId(), data_track->GetVariantName().CStr());
+					_logtw("Could not add data track. trackId:%d, variantName: %s", data_track->GetId(), data_track->GetVariantName().CStr());
 				}
 			}
 		}
@@ -165,20 +174,20 @@ namespace pub
 		if (writer->Start() == false)
 		{
 			SetErrorState(push);
-			logte("Failed to start session. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
+			_logte("Failed to start session. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
 			return false;
 		}
 
 		if (StartSenderThread() == false)
 		{
 			SetErrorState(push, writer);
-			logte("Failed to start sender thread. %s", push->GetInfoString().CStr());
+			_logte("Failed to start sender thread. %s", push->GetInfoString().CStr());
 			return false;
 		}
 
 		push->SetState(info::Push::PushState::Pushing);
 
-		logtd("PushSession(%d) has started.", GetId());
+		_logtd("PushSession(%d) has started.", GetId());
 
 		return Session::Start();
 	}
@@ -207,7 +216,7 @@ namespace pub
 
 			DestoryWriter();
 
-			logtd("PushSession(%d) has stopped", GetId());
+			_logtd("PushSession(%d) has stopped", GetId());
 		}
 
 		return Session::Stop();
@@ -237,7 +246,7 @@ namespace pub
 		}
 		catch (const std::bad_any_cast &e)
 		{
-			logtt("An incorrect type of packet was input from the stream. (%s)", e.what());
+			_logtt("An incorrect type of packet was input from the stream. (%s)", e.what());
 
 			return;
 		}
@@ -317,8 +326,8 @@ namespace pub
 
 			if (_sender_packet_queue.IsThresholdExceededFor(kThresholdGraceDuration))
 			{
-				logte("Push session queue exceeded state persisted for more than %ld seconds. Terminating session. %s",
-					  std::chrono::duration_cast<std::chrono::seconds>(kThresholdGraceDuration).count(), push->GetInfoString().CStr());
+				_logte("Push session queue exceeded state persisted for more than %ld seconds. Terminating session. %s",
+					   std::chrono::duration_cast<std::chrono::seconds>(kThresholdGraceDuration).count(), push->GetInfoString().CStr());
 
 				SetErrorState(push, writer);
 				_sender_stop_flag = true;
@@ -333,7 +342,7 @@ namespace pub
 			bool ret = writer->SendPacket(session_packet, &sent_bytes);
 			if (ret == false)
 			{
-				logte("Failed to send packet. session will be terminated. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
+				_logte("Failed to send packet. session will be terminated. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
 
 				SetErrorState(push, writer);
 				_sender_stop_flag = true;
@@ -370,7 +379,7 @@ namespace pub
 			_writer = nullptr;
 		}
 
-		_writer = ffmpeg::Writer::Create();
+		_writer = ffmpeg::Writer::Create(ov::String::FormatString(LOG_PRFX, LOG_ARGS));
 		if (_writer == nullptr)
 		{
 			return nullptr;
@@ -472,19 +481,19 @@ namespace pub
 		// Check already added
 		if (writer->GetTrackByTrackId(track->GetId()) != nullptr)
 		{
-			logtw("Track already added. trackId:%d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
+			_logtw("Track already added. trackId:%d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
 			return false;
 		}
 
 		if (IsSupportTrack(push->GetProtocolType(), track) == false)
 		{
-			logtw("Could not supported track. trackId:%u, codecId: %d", track->GetId(), ov::ToUnderlyingType(track->GetCodecId()));
+			_logtw("Could not supported track. trackId:%u, codec: %s", track->GetId(), GetCodecIdString(track->GetCodecId()));
 			return false;
 		}
 
 		if (IsSupportCodec(push->GetProtocolType(), track->GetCodecId()) == false)
 		{
-			logtw("Could not supported codec. trackId:%u, codecId: %d", track->GetId(), ov::ToUnderlyingType(track->GetCodecId()));
+			_logtw("Could not supported codec. trackId:%u, codec: %s", track->GetId(), GetCodecIdString(track->GetCodecId()));
 			return false;
 		}
 
@@ -493,12 +502,12 @@ namespace pub
 		{
 			if (writer->GetTrackCountByType(track->GetMediaType()) >= 1)
 			{
-				logtw("Could not add more than one video track for RTMP. trackId:%d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
+				_logtw("Could not add more than one video track for RTMP. trackId:%d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
 				return false;
 			}
 		}
 
-		logtd("PushSession(%d) Adding track. trackId:%d, variantName: %s", GetId(), track->GetId(), track->GetVariantName().CStr());
+		_logtd("Adding track. trackId:%d, variantName: %s", track->GetId(), track->GetVariantName().CStr());
 
 		return writer->AddTrack(track);
 	}


### PR DESCRIPTION
## Summary

Fixes #2079 — when a packet write failed (e.g. malformed AAC ADTS frame), the
log showed `Reason()` empty because `SetErrorMessage()` wasn't called in some
failure paths. This PR makes every failure populate the error message with
useful context (track id, format, payload size).

Also fixes two data races in the writer that were exposed once the error
message is touched from the FFmpeg interrupt callback.

## Changes

- Every error path now sets a clear error message and logs it at the call
  site, so the reason is visible in both `Reason(...)` and the FFmpegWriter
  log.
- `_error_message` is now mutex-protected (was a race between publisher
  thread and FFmpeg interrupt callback).
- `_last_packet_sent_time` is now `std::atomic` (same race).
- Log levels organized: setup errors → `logte`, runtime drops → `logtw`