### PR TITLE
docs: update quick-start README

### DIFF
--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -43,7 +43,7 @@ $ docker logs ome -f
 ## Run OvenPlayer Demo&#x20;
 
 ```bash
-$ docker run -d -p 8090:80 airensoft/ovenplayerdemo:latest
+$ docker run -d --name ovenplayerdemo -p 8090:80 ovenmedialabs/ovenplayerdemo:latest
 ```
 
 <details>

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -68,7 +68,7 @@ Publish your live stream to OvenMediaEngine using a live encoder like [OBS](http
 
 **RTMP** - rtmp://Your.Docker.Host.IP:1935/app/stream
 
-**SRT** - srt://Your.Docker.Host.IP:9999?streamid=srt%3A%2F%2FYour.Docker.Host.IP%3A9999%2Fapp%2Fstream
+**SRT** - srt://Your.Docker.Host.IP:9999?streamid=default/app/stream
 
 **WHIP** - http://Your.Docker.Host.IP:3333/app/stream?direction=whip
 


### PR DESCRIPTION
## Summary

- Update OvenPlayer demo Docker image from `airensoft/ovenplayerdemo:latest` to `ovenmedialabs/ovenplayerdemo:latest`, and add `--name` option
- Update SRT streamid format to the latest format (`default/app/stream`)