### PR TITLE
refactor(mq): refactoring and stabilization

### DIFF
--- a/src/projects/base/info/managed_queue.h
+++ b/src/projects/base/info/managed_queue.h
@@ -154,7 +154,7 @@ namespace info
 			  _threshold(threshold),
 			  _threshold_mode(ThresholdMode::CountBased),
 			  _threshold_value(threshold),
-			  _threshold_exceeded_time_in_us(0),
+			  _threshold_exceeded_time_ms(0),
 			  _buffering_delay(0),
 			  _input_message_count(0),
 			  _output_message_count(0),
@@ -249,9 +249,9 @@ namespace info
 			return _waiting_time_in_us;
 		}
 
-		int64_t GetThresholdExceededTimeInUs() const
+		int64_t GetThresholdExceededTimeMs() const
 		{
-			return _threshold_exceeded_time_in_us;
+			return _threshold_exceeded_time_ms;
 		}
 
 		void SetUrn(std::shared_ptr<URN> urn, const char* type_name)
@@ -312,7 +312,7 @@ namespace info
 		size_t _threshold_value = 0;
 
 		// threshold_exceeded_time increases from the point the queue is exceeded
-		int64_t _threshold_exceeded_time_in_us = 0;
+		int64_t _threshold_exceeded_time_ms = 0;
 
 		// Buffering delay (milliseconds).
 		int _buffering_delay = 0;

--- a/src/projects/base/info/managed_queue.h
+++ b/src/projects/base/info/managed_queue.h
@@ -251,7 +251,7 @@ namespace info
 
 		int64_t GetThresholdExceededTimeMs() const
 		{
-			return _threshold_exceeded_time_ms;
+			return _threshold_exceeded_time_ms.load();
 		}
 
 		void SetUrn(std::shared_ptr<URN> urn, const char* type_name)

--- a/src/projects/base/info/managed_queue.h
+++ b/src/projects/base/info/managed_queue.h
@@ -312,7 +312,7 @@ namespace info
 		size_t _threshold_value = 0;
 
 		// threshold_exceeded_time increases from the point the queue is exceeded
-		int64_t _threshold_exceeded_time_ms = 0;
+		std::atomic<int64_t> _threshold_exceeded_time_ms{0};
 
 		// Buffering delay (milliseconds).
 		int _buffering_delay = 0;

--- a/src/projects/mediarouter/mediarouter_stream.cpp
+++ b/src/projects/mediarouter/mediarouter_stream.cpp
@@ -48,6 +48,7 @@ MediaRouteStream::MediaRouteStream(const std::shared_ptr<info::Stream> &stream, 
 MediaRouteStream::~MediaRouteStream()
 {
 	_media_packet_stash.clear();
+	_packets_queue.Stop();
 	_packets_queue.Clear();
 }
 

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -25,6 +25,8 @@
 
 namespace ov
 {
+	// Shutdown order: Stop() -> join threads -> delete queue.
+	// Deleting the queue while a thread waits in Dequeue/Front/Back is UB.  The destructor calls Stop() just in case.
 	template <typename T>
 	class ManagedQueue : public info::ManagedQueue
 	{
@@ -68,6 +70,9 @@ namespace ov
 
 		~ManagedQueue()
 		{
+			// Defensive: wake any remaining waiters so they can exit
+			Stop();
+
 			Clear();
 
 			// Unregister to the server metrics

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -40,11 +40,8 @@ namespace ov
 			std::chrono::steady_clock::time_point _start;
 			bool _urgent = false;
 
-			ManagedQueueNode(const T& value, bool urgent, ManagedQueueNode* next_node = nullptr)
-				: data(value), next(next_node), _start(std::chrono::steady_clock::time_point::min()), _urgent(urgent)
-			{
-				_start = std::chrono::steady_clock::now();
-			}
+			ManagedQueueNode(T value, bool urgent, ManagedQueueNode *next_node = nullptr)
+				: data(std::move(value)), next(next_node), _start(std::chrono::steady_clock::now()), _urgent(urgent) {}
 		};
 
 	public:
@@ -61,16 +58,11 @@ namespace ov
 		{
 			info::ManagedQueue::SetUrn(urn, Demangle(typeid(T).name()).CStr());
 
-			// Register to the server metrics
-			// If the Unique id is duplicated or memory allocation failed, retry
-			while (true)
-			{
-				SetId(IssueUniqueQueueId());
+			SetId(IssueUniqueQueueId());
 
-				if (MonitorInstance->OnQueueCreated(*this) == true)
-				{
-					break;
-				}
+			if (MonitorInstance->OnQueueCreated(*this) == false)
+			{
+				logw(LOG_TAG, "Failed to register queue to monitor. id:%u", GetId());
 			}
 		}
 
@@ -104,21 +96,17 @@ namespace ov
 			info::ManagedQueue::SetThresholdByTime(validated_time_ms);
 
 			MonitorInstance->OnQueueUpdated(*this);
-		}				
-
-		// Urgent item will be inserted at the front of the queue
-		void Enqueue(const T& item, bool urgent = false, int timeout = Infinite)
-		{
-			auto node = new ManagedQueueNode(item, urgent);
-			EnqeuePos pos = urgent ? EnqeuePos::EnqueuFrontPos : EnqeuePos::EnqueuBackPos;
-
-			EnqueueInternal(node, timeout, pos);
 		}
 
 		// Urgent item will be inserted at the front of the queue
-		void Enqueue(T&& item, bool urgent = false, int timeout = Infinite)
+		void Enqueue(T item, bool urgent = false, int timeout = Infinite)
 		{
-			auto node = new ManagedQueueNode(item, urgent);
+			auto node = new ManagedQueueNode(std::move(item), urgent);
+			if(node == nullptr)
+			{
+				loge(LOG_TAG, "Failed to allocate memory for queue node.");
+				return;
+			}
 			EnqeuePos pos = urgent ? EnqeuePos::EnqueuFrontPos : EnqeuePos::EnqueuBackPos;
 
 			EnqueueInternal(node, timeout, pos);
@@ -280,11 +268,7 @@ namespace ov
 			_output_message_count++;
 
 			// Update statistics of waiting time (microseconds)
-			if (node->_start != std::chrono::steady_clock::time_point::max())
-			{
-				auto current = std::chrono::steady_clock::now();
-				_waiting_time_in_us = _waiting_time_in_us * 0.9 + std::chrono::duration_cast<std::chrono::microseconds>(current - node->_start).count() * 0.1;
-			}
+			_waiting_time_in_us = _waiting_time_in_us * 0.9 + std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - node->_start).count() * 0.1;
 
 			delete node;
 

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -440,9 +440,15 @@ namespace ov
 			{
 				std::chrono::steady_clock::time_point expire = (timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 				auto result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
-					return (!IsThresholdExceeded());
+					return (!IsThresholdExceeded() || _stop);
 				});
-				if (!result || _stop)
+				if (_stop)
+				{
+					logw(LOG_TAG, "[%s] Stop is requested. Failed to enqueue item.", GetInfoString().CStr());
+					delete node;
+					return;
+				}
+				else if (!result)
 				{
 					loge(LOG_TAG, "[%s] queue is full. q.size(%zu), q.threshold(%zu)", _urn->ToString().CStr(), _size, _threshold);
 					delete node;

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -92,8 +92,7 @@ namespace ov
 		// The effective item count is estimated as: input_message_per_second * time_ms / 1000.
 		void SetThresholdByTime(size_t time_ms)
 		{
-			const size_t validated_time_ms = (time_ms < 0) ? 0U : time_ms;
-			info::ManagedQueue::SetThresholdByTime(validated_time_ms);
+			info::ManagedQueue::SetThresholdByTime(time_ms);
 
 			MonitorInstance->OnQueueUpdated(*this);
 		}
@@ -290,7 +289,7 @@ namespace ov
 		}
 
 		// Returns true if the queue has been over its threshold for at least `duration`.
-		// Notes: exceeded time is updated only on each stats tick (MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC 100ms)
+		// Notes: exceeded time is updated only on each stats tick (MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC)
 		bool IsThresholdExceededFor(std::chrono::milliseconds duration) const
 		{
 			return _threshold_exceeded_time_ms >= static_cast<int64_t>(duration.count());

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -101,8 +101,8 @@ namespace ov
 		// Urgent item will be inserted at the front of the queue
 		void Enqueue(T item, bool urgent = false, int timeout = Infinite)
 		{
-			auto node = new ManagedQueueNode(std::move(item), urgent);
-			if(node == nullptr)
+			auto node = new(std::nothrow) ManagedQueueNode(std::move(item), urgent);
+			if (node == nullptr)
 			{
 				loge(LOG_TAG, "Failed to allocate memory for queue node.");
 				return;
@@ -421,16 +421,9 @@ namespace ov
 			EnqueuFrontPos = 0,
 			EnqueuBackPos
 		};
-
 		void EnqueueInternal(ManagedQueueNode* node, int timeout, EnqeuePos push_method)
 		{
-			auto unique_lock = std::unique_lock(_mutex);			
-
-			if (!node)
-			{
-				logc(LOG_TAG, "Failed to allocate memory. id:%u", GetId());
-				return;
-			}
+			auto unique_lock = std::unique_lock(_mutex);
 
 			// Update statistics of input message count
 			_input_message_count++;

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -297,7 +297,7 @@ namespace ov
 		// Notes: exceeded time is updated only on each stats tick (MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC)
 		bool IsThresholdExceededFor(std::chrono::milliseconds duration) const
 		{
-			return _threshold_exceeded_time_ms >= static_cast<int64_t>(duration.count());
+			return _threshold_exceeded_time_ms.load() >= static_cast<int64_t>(duration.count());
 		}
 
 		// Cleared all items in the queue
@@ -540,7 +540,7 @@ namespace ov
 
 				if (IsThresholdExceeded())
 				{
-					_threshold_exceeded_time_ms += elapsed_time;
+					_threshold_exceeded_time_ms.fetch_add(elapsed_time);
 
 					// Logging
 					_last_logging_time += elapsed_time;
@@ -556,7 +556,7 @@ namespace ov
 				}
 				else
 				{
-					_threshold_exceeded_time_ms = 0;
+					_threshold_exceeded_time_ms.store(0);
 #if DEBUG
 					logt(LOG_TAG, "Stable. %s", GetInfoString().CStr());
 #endif					
@@ -576,7 +576,7 @@ namespace ov
 
 			_last_input_message_count = 0;
 			_last_output_message_count = 0;
-			_threshold_exceeded_time_ms = 0;
+			_threshold_exceeded_time_ms.store(0);
 
 			_last_logging_time = 0;
 			_last_logged_peak = 0;

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -106,7 +106,7 @@ namespace ov
 				loge(LOG_TAG, "Failed to allocate memory for queue node.");
 				return;
 			}
-			EnqeuePos pos = urgent ? EnqeuePos::EnqueuFrontPos : EnqeuePos::EnqueuBackPos;
+			EnqueuePos pos = urgent ? EnqueuePos::EnqueueFrontPos : EnqueuePos::EnqueueBackPos;
 
 			EnqueueInternal(node, timeout, pos);
 		}
@@ -415,12 +415,13 @@ namespace ov
 		// If the queue is full, it waits until the queue is less than the threshold or the timeout expires.
 		// If the timeout expires, the message is dropped.
 		// This is to avoid dropping items when the queue size exceeds the threshold, if it exceeds it momentarily due to jitter.
-		enum EnqeuePos : int8_t
+		enum EnqueuePos : int8_t
 		{
-			EnqueuFrontPos = 0,
-			EnqueuBackPos
+			EnqueueFrontPos = 0,
+			EnqueueBackPos
 		};
-		void EnqueueInternal(ManagedQueueNode* node, int timeout, EnqeuePos push_method)
+
+		void EnqueueInternal(ManagedQueueNode* node, int timeout, EnqueuePos push_method)
 		{
 			auto unique_lock = std::unique_lock(_mutex);
 
@@ -448,7 +449,7 @@ namespace ov
 				}
 			}
 
-			if (push_method == EnqeuePos::EnqueuBackPos)
+			if (push_method == EnqueuePos::EnqueueBackPos)
 			{
 				PushBack(node);
 			}

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -293,7 +293,7 @@ namespace ov
 		// Notes: exceeded time is updated only on each stats tick (MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC 100ms)
 		bool IsThresholdExceededFor(std::chrono::milliseconds duration) const
 		{
-			return _threshold_exceeded_time_in_us >= static_cast<int64_t>(duration.count());
+			return _threshold_exceeded_time_ms >= static_cast<int64_t>(duration.count());
 		}
 
 		// Cleared all items in the queue
@@ -535,7 +535,7 @@ namespace ov
 
 				if (IsThresholdExceeded())
 				{
-					_threshold_exceeded_time_in_us += elapsed_time;
+					_threshold_exceeded_time_ms += elapsed_time;
 
 					// Logging
 					_last_logging_time += elapsed_time;
@@ -551,7 +551,7 @@ namespace ov
 				}
 				else
 				{
-					_threshold_exceeded_time_in_us = 0;
+					_threshold_exceeded_time_ms = 0;
 #if DEBUG
 					logt(LOG_TAG, "Stable. %s", GetInfoString().CStr());
 #endif					
@@ -571,7 +571,7 @@ namespace ov
 
 			_last_input_message_count = 0;
 			_last_output_message_count = 0;
-			_threshold_exceeded_time_in_us = 0;
+			_threshold_exceeded_time_ms = 0;
 
 			_last_logging_time = 0;
 			_last_logged_peak = 0;

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -643,7 +643,7 @@ namespace ov
 		std::condition_variable _condition;
 
 		// Stop flag
-		bool _stop;
+		std::atomic<bool> _stop;
 
 		// Set by InjectWakeup(), consumed by Dequeue(). A pending one-shot
 		// wakeup. Unlike _stop, the queue stays usable.
@@ -654,7 +654,7 @@ namespace ov
 
 		// Prevent exceed threshold. If true, the queue will not exceed the threshold
 		// Wait until the queue falls below the threshold
-		bool _exceed_threshold_and_wait_enabled = false;
+		std::atomic<bool> _exceed_threshold_and_wait_enabled{false};
 	};
 
 }  // namespace ov

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -370,6 +370,13 @@ namespace ov
 		// Buffer keeps items for a certain amount of time
 		void SetBufferingDelay(int delay_ms)
 		{
+			auto unique_lock = std::unique_lock(_mutex);
+			if(delay_ms < 0)
+			{
+				logw(LOG_TAG, "[%s] Invalid buffering delay value: %d. Setting to 0.", GetInfoString().CStr(), delay_ms);
+				delay_ms = 0;
+			}
+
 			_buffering_delay = delay_ms;
 		}
 

--- a/src/projects/monitoring/server_metrics.cpp
+++ b/src/projects/monitoring/server_metrics.cpp
@@ -174,13 +174,13 @@ namespace mon
 		auto delete_lazy_stream_timeout_conf = _server_config->GetModules().GetRecovery().GetDeleteLazyStreamTimeout();
 		if (delete_lazy_stream_timeout_conf > 0)
 		{
-			if ((queue_info.GetThresholdExceededTimeInUs() > delete_lazy_stream_timeout_conf) && (!queue_info.GetUrn()->GetStreamName().IsEmpty()))
+			if ((queue_info.GetThresholdExceededTimeMs() > delete_lazy_stream_timeout_conf) && (!queue_info.GetUrn()->GetStreamName().IsEmpty()))
 			{
 				auto vhost_app	 = queue_info.GetUrn()->GetVHostAppName();
 				auto stream_name = queue_info.GetUrn()->GetStreamName();
 
 				logtc("The %s queue has been exceeded for %" PRId64 " ms. stream will be forcibly deleted. VhostApp(%s), Stream(%s)",
-					  queue_info.GetUrn()->ToString().CStr(), queue_info.GetThresholdExceededTimeInUs(), vhost_app.CStr(), stream_name.CStr());
+					  queue_info.GetUrn()->ToString().CStr(), queue_info.GetThresholdExceededTimeMs(), vhost_app.CStr(), stream_name.CStr());
 
 				if (vhost_app.IsValid())
 				{

--- a/src/projects/publishers/push/push_session.cpp
+++ b/src/projects/publishers/push/push_session.cpp
@@ -273,6 +273,8 @@ namespace pub
 	void PushSession::StopSenderThread()
 	{
 		_sender_stop_flag = true;
+		
+		_sender_packet_queue.InjectWakeup();
 
 		if (_sender_thread.joinable())
 		{


### PR DESCRIPTION
### Summary
A collection of bug fixes that improve ManagedQueue's thread safety, shutdown stability, and code consistency. It safely wakes up waiting threads on shutdown so they can exit, converts shared flags to atomic types, and cleans up inconsistent units (us→ms) and typos.

### Changes
- **Thread safety:** Changed _stop, _exceed_threshold_and_wait_enabled, and _threshold_exceeded_time_ms to std::atomic
- **Safe shutdown**: wait_until in EnqueueInternal now exits immediately on _stop; the destructor defensively calls Stop(); added Stop()/InjectWakeup() in the MediaRouteStream/PushSession shutdown paths to wake waiting threads
- **Unit cleanup:** _threshold_exceeded_time_in_us → _threshold_exceeded_time_ms (including getter and usages)
- **Typo fixes:** EnqeuePos/EnqueuFrontPos/EnqueuBackPos → EnqueuePos/EnqueueFrontPos/EnqueueBackPos
- **Cleanup/optimization:** Consolidated duplicate Enqueue overloads into pass-by-value + std::move, handled allocation failure with new(std::nothrow), added negative-value validation in SetBufferingDelay, and removed dead code such as unnecessary nullptr/range checks