### PR TITLE
feat: add receive-side NACK + RTX to WebRTC Provider

### DIFF
--- a/docs/live-source/webrtc.md
+++ b/docs/live-source/webrtc.md
@@ -11,7 +11,7 @@ OvenMediaEngine supports WebRTC ingest from web browsers and any encoder that im
 | **Container** | RTP / RTCP |
 | **Security** | DTLS, SRTP |
 | **Transport** | ICE |
-| **Error Correction** | ULPFEC (VP8, H.264), In-band FEC (Opus) |
+| **Error Correction** | NACK + RTX (RFC 4585 / RFC 4588), ULPFEC (VP8, H.264), In-band FEC (Opus) |
 | **Codec** | VP8, H.264, H.265, Opus |
 | **Signaling** | Self-Defined Protocol (WebSocket), WHIP (HTTP) |
 | **Additional Features** | Simulcast |
@@ -94,6 +94,10 @@ The worker count applies **per port**. Increase `<IceWorkerCount>` or `<TcpIceWo
     <Timeout>30000</Timeout>
     <FIRInterval>3000</FIRInterval>
     <RtcpBasedTimestamp>false</RtcpBasedTimestamp>
+    <Rtx>
+        <Enable>true</Enable>
+        <MaxHoldMs>400</MaxHoldMs>
+    </Rtx>
     <CrossDomains>
         <Url>*</Url>
     </CrossDomains>
@@ -105,7 +109,26 @@ The worker count applies **per port**. Increase `<IceWorkerCount>` or `<TcpIceWo
 | `Timeout` | Maximum duration (ms) to wait for an ICE Binding request/response before terminating the session. |
 | `FIRInterval` | Interval (ms) for sending a Full Intra Request (FIR) to force IDR frame generation. Set to `0` to disable. |
 | `RtcpBasedTimestamp` | `false` (default): each track's RTP timestamp starts from zero independently, no waiting for RTCP SR. `true`: RTCP Sender Reports synchronize A/V timestamps on a common clock. Use `true` only when the sender reliably sends RTCP SR; otherwise stream start may be delayed up to 5 seconds. |
+| `Rtx` | NACK + RTX retransmission for video. See [NACK + RTX](#nack--rtx) below. |
 | `CrossDomains` | Allowed domains for signaling requests (CORS). |
+
+#### NACK + RTX
+
+When `<Rtx><Enable>true</Enable></Rtx>` is set, OvenMediaEngine negotiates NACK feedback (RFC 4585) and RTX retransmission (RFC 4588) for every video codec in the SDP. On packet loss the receive-side jitter buffer asks the publisher to resend missing packets, recovering most short bursts of loss without forcing a keyframe.
+
+```xml
+<Rtx>
+    <Enable>true</Enable>          <!-- default: false -->
+    <MaxHoldMs>400</MaxHoldMs>     <!-- default: 400 -->
+</Rtx>
+```
+
+| Parameter | Description |
+|---|---|
+| `Enable` | Turn NACK + RTX on. Disabled by default. |
+| `MaxHoldMs` | Upper bound (ms) for how long the jitter buffer waits for an incomplete frame to recover before discarding it. Acts as a latency ceiling: a larger value increases recovery success in high-RTT or lossy networks at the cost of more end-to-end delay; a smaller value keeps latency tight at the cost of more discarded frames. The actual hold window is adaptive and usually lands well below this cap. Default `400`. |
+
+Audio NACK is not negotiated. Lost audio packets are concealed by Opus' in-band FEC where available, otherwise dropped.
 
 ## URL Patterns
 

--- a/src/projects/config/items/virtual_hosts/applications/providers/webrtc_provider.h
+++ b/src/projects/config/items/virtual_hosts/applications/providers/webrtc_provider.h
@@ -19,6 +19,22 @@ namespace cfg
 		{
 			namespace pvd
 			{
+				struct Rtx : public Item
+				{
+					CFG_DECLARE_CONST_REF_GETTER_OF(IsEnabled, _enable)
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetMaxHoldMs, _max_hold_ms)
+
+				protected:
+					void MakeList() override
+					{
+						Register<Optional>("Enable", &_enable);
+						Register<Optional>("MaxHoldMs", &_max_hold_ms);
+					}
+
+					bool _enable = false;
+					int _max_hold_ms = 400;
+				};
+
 				struct WebrtcProvider : public Provider, public cmn::CrossDomainSupport
 				{
 					ProviderType GetType() const override
@@ -29,6 +45,7 @@ namespace cfg
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetTimeout, _timeout)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetFIRInterval, _fir_interval)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetRtcpBasedTimestamp, _rtcp_based_timestamp)
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetRtx, _rtx)
 
 				protected:
 					void MakeList() override
@@ -39,11 +56,13 @@ namespace cfg
 						Register<Optional>("CrossDomains", &_cross_domains);
 						Register<Optional>({"FIRInterval", "firInterval"}, &_fir_interval);
 						Register<Optional>("RtcpBasedTimestamp", &_rtcp_based_timestamp);
+						Register<Optional>("Rtx", &_rtx);
 					}
 
 					int _timeout = 30000;
 					int _fir_interval = 3000;
 					bool _rtcp_based_timestamp = false;
+					Rtx _rtx;
 				};
 			}  // namespace pvd
 		}  // namespace app

--- a/src/projects/modules/rtp_rtcp/rtcp_info/nack.cpp
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/nack.cpp
@@ -42,9 +42,61 @@ bool NACK::Parse(const RtcpPacket &packet)
 }
 
 // RtcpInfo must provide raw data
-std::shared_ptr<ov::Data> NACK::GetData() const 
+// Caller (e.g. RtpNackGenerator) must add ids in ascending sequence order;
+// raw uint16 sort is unsafe across 16-bit wrap.
+std::shared_ptr<ov::Data> NACK::GetData() const
 {
-	return nullptr;
+	if (_lost_ids.empty())
+	{
+		return nullptr;
+	}
+
+	// Group ids into FCI blocks: each block is PID + 16-bit BLP covering PID+1..PID+16.
+	struct Fci
+	{
+		uint16_t pid;
+		uint16_t blp;
+	};
+	std::vector<Fci> fcis;
+
+	size_t i = 0;
+	while (i < _lost_ids.size())
+	{
+		Fci fci{_lost_ids[i], 0};
+		size_t j = i + 1;
+		while (j < _lost_ids.size())
+		{
+			uint16_t diff = static_cast<uint16_t>(_lost_ids[j] - fci.pid);
+			if (diff == 0)
+			{
+				j++;
+				continue;
+			}
+			if (diff > 16)
+			{
+				break;
+			}
+			fci.blp |= static_cast<uint16_t>(1u << (diff - 1));
+			j++;
+		}
+		fcis.push_back(fci);
+		i = j;
+	}
+
+	auto data = std::make_shared<ov::Data>();
+	data->SetLength(8 /*ssrc*2*/ + fcis.size() * 4 /*fci*/);
+	ov::ByteStream stream(data.get());
+
+	stream.WriteBE32(_src_ssrc);
+	stream.WriteBE32(_media_ssrc);
+
+	for (const auto &fci : fcis)
+	{
+		stream.WriteBE16(fci.pid);
+		stream.WriteBE16(fci.blp);
+	}
+
+	return data;
 }
 
 void NACK::DebugPrint()

--- a/src/projects/modules/rtp_rtcp/rtcp_info/nack.h
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/nack.h
@@ -73,6 +73,8 @@ public:
 		return _lost_ids[index];
 	}
 
+	void AddLostId(uint16_t id){_lost_ids.push_back(id);}
+
 private:
 	uint32_t	_src_ssrc = 0;
 	uint32_t	_media_ssrc = 0;

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.cpp
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.cpp
@@ -76,7 +76,7 @@ bool RtcpTransportCcFeedbackGenerator::AddReceivedRtpPacket(const std::shared_pt
 		{
 			if (wide_sequence_number != static_cast<uint16_t>(_last_wide_sequence_number + 1))
 			{
-				logtw("wide sequence number is not continuous : %u -> %u", _last_wide_sequence_number, wide_sequence_number);
+				logtd("wide sequence number is not continuous : %u -> %u", _last_wide_sequence_number, wide_sequence_number);
 			}
 
 			base_sequence_number = _last_wide_sequence_number + 1;

--- a/src/projects/modules/rtp_rtcp/rtcp_info/transport_cc.cpp
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/transport_cc.cpp
@@ -374,10 +374,11 @@ bool TransportCc::AddPacketFeedbackInfo(const std::shared_ptr<PacketFeedbackInfo
 		return false;
 	}
 	
-	// Add missing packet
+	// Add missing packet. Routine bookkeeping under any loss / reorder /
+	// NACK-recovered scenario, not a warning condition.
 	for (auto i = 0; i < diff; i++)
 	{
-		logtw("AddPacketFeedbackInfo - Add missing packet - seq(%u)", _next_sequence_number);
+		logtd("AddPacketFeedbackInfo - Add missing packet - seq(%u)", _next_sequence_number);
 		_packet_feedbacks.push_back(std::make_shared<PacketFeedbackInfo>(_next_sequence_number, false));
 		_packet_status_count++;
 		_next_sequence_number++;

--- a/src/projects/modules/rtp_rtcp/rtp_frame_boundary_detector.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_boundary_detector.cpp
@@ -1,0 +1,165 @@
+#include "rtp_frame_boundary_detector.h"
+
+#define OV_LOG_TAG "RtpFrameBoundary"
+
+bool RtpFrameBoundaryDetector::Apply(RtpPacket &packet, cmn::MediaCodecId codec, uint8_t dd_extension_id)
+{
+	// Reject unsupported codecs up front (defensive — the receive pipeline
+	// shouldn't have negotiated them in the first place).
+	switch (codec)
+	{
+		case cmn::MediaCodecId::H264:
+		case cmn::MediaCodecId::H265:
+		case cmn::MediaCodecId::Vp8:
+		case cmn::MediaCodecId::Av1:
+			break;
+		default:
+			return false;
+	}
+
+	// Default end-of-frame is the RTP marker bit; DD or codec parse may
+	// override (DD's E bit takes precedence when present).
+	packet.SetFirstPacketOfFrame(false);
+	packet.SetLastPacketOfFrame(packet.Marker());
+
+	if (dd_extension_id != 0 && TryDependencyDescriptor(packet, dd_extension_id))
+	{
+		return true;
+	}
+
+	switch (codec)
+	{
+		case cmn::MediaCodecId::H264:
+			return ApplyH264(packet);
+		case cmn::MediaCodecId::H265:
+			return ApplyH265(packet);
+		case cmn::MediaCodecId::Vp8:
+			return ApplyVp8(packet);
+		case cmn::MediaCodecId::Av1:
+			return ApplyAv1(packet);
+		default:
+			return false;  // unreachable due to the gate above
+	}
+}
+
+// AV1 Dependency Descriptor: first byte's MSB pair is [S][E].
+// Spec: https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension
+bool RtpFrameBoundaryDetector::TryDependencyDescriptor(RtpPacket &packet, uint8_t dd_extension_id)
+{
+	auto ext = packet.GetExtension(dd_extension_id);
+	if (ext.has_value() == false || ext.value().GetLength() < 1)
+	{
+		return false;
+	}
+	uint8_t b = ext.value().GetDataAs<uint8_t>()[0];
+	packet.SetFirstPacketOfFrame((b & 0x80) != 0);
+	packet.SetLastPacketOfFrame((b & 0x40) != 0);
+	return true;
+}
+
+// H.264 (RFC 6184). First payload byte: F(1) | NRI(2) | Type(5).
+//   Type 1..23 : Single NAL unit       → packet starts a NAL.
+//   Type 24..27: STAP / MTAP aggregate → packet starts a NAL.
+//   Type 28..29: FU-A / FU-B           → second byte's S bit indicates NAL start.
+//   Otherwise  : reserved / invalid    → reject.
+bool RtpFrameBoundaryDetector::ApplyH264(RtpPacket &packet)
+{
+	auto payload = packet.Payload();
+	auto size = packet.PayloadSize();
+	if (size < 1)
+	{
+		return false;
+	}
+
+	uint8_t nal_type = payload[0] & 0x1F;
+
+	if (nal_type >= 1 && nal_type <= 23)
+	{
+		packet.SetFirstPacketOfFrame(true);
+		return true;
+	}
+	if (nal_type >= 24 && nal_type <= 27)
+	{
+		packet.SetFirstPacketOfFrame(true);
+		return true;
+	}
+	if (nal_type == 28 || nal_type == 29)
+	{
+		if (size < 2)
+		{
+			return false;
+		}
+		packet.SetFirstPacketOfFrame((payload[1] & 0x80) != 0);
+		return true;
+	}
+	return false;
+}
+
+// H.265 (RFC 7798). PayloadHdr is 2 bytes; type = bits 1..6 of byte 0.
+//   Type 0..47 : Single NAL unit → packet starts a NAL.
+//   Type 48 (AP): aggregate     → packet starts a NAL.
+//   Type 49 (FU): fragmented    → third byte's S bit indicates NAL start.
+//   Type 50 (PACI): single NAL  → packet starts a NAL.
+bool RtpFrameBoundaryDetector::ApplyH265(RtpPacket &packet)
+{
+	auto payload = packet.Payload();
+	auto size = packet.PayloadSize();
+	if (size < 2)
+	{
+		return false;
+	}
+
+	uint8_t nal_type = (payload[0] >> 1) & 0x3F;
+
+	if (nal_type < 48 || nal_type == 48 || nal_type == 50)
+	{
+		packet.SetFirstPacketOfFrame(true);
+		return true;
+	}
+	if (nal_type == 49)
+	{
+		if (size < 3)
+		{
+			return false;
+		}
+		packet.SetFirstPacketOfFrame((payload[2] & 0x80) != 0);
+		return true;
+	}
+	return false;
+}
+
+// VP8 (RFC 7741). First payload byte = Payload Descriptor.
+//   S bit (0x10) marks start of a VP8 partition. PID==0 + S==1 = frame start.
+bool RtpFrameBoundaryDetector::ApplyVp8(RtpPacket &packet)
+{
+	auto payload = packet.Payload();
+	auto size = packet.PayloadSize();
+	if (size < 1)
+	{
+		return false;
+	}
+
+	uint8_t pd = payload[0];
+	bool s = (pd & 0x10) != 0;
+	uint8_t pid = pd & 0x07;
+	packet.SetFirstPacketOfFrame(s && pid == 0);
+	return true;
+}
+
+// AV1 (https://aomediacodec.github.io/av1-rtp-spec/). Aggregation header byte
+// has Z (0x80) = continuation from previous packet's last OBU element.
+// Z == 0 → this packet starts a fresh OBU element, treated as a frame-start
+// candidate. AV1 publishers in practice negotiate DD; this is a fallback.
+bool RtpFrameBoundaryDetector::ApplyAv1(RtpPacket &packet)
+{
+	auto payload = packet.Payload();
+	auto size = packet.PayloadSize();
+	if (size < 1)
+	{
+		return false;
+	}
+
+	uint8_t agg = payload[0];
+	packet.SetFirstPacketOfFrame((agg & 0x80) == 0);
+	return true;
+}

--- a/src/projects/modules/rtp_rtcp/rtp_frame_boundary_detector.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_boundary_detector.cpp
@@ -1,5 +1,7 @@
 #include "rtp_frame_boundary_detector.h"
 
+#include "rtp_header_extension/rtp_header_extension_dependency_descriptor.h"
+
 #define OV_LOG_TAG "RtpFrameBoundary"
 
 bool RtpFrameBoundaryDetector::Apply(RtpPacket &packet, cmn::MediaCodecId codec, uint8_t dd_extension_id)
@@ -17,9 +19,12 @@ bool RtpFrameBoundaryDetector::Apply(RtpPacket &packet, cmn::MediaCodecId codec,
 			return false;
 	}
 
-	// Default end-of-frame is the RTP marker bit; DD or codec parse may
-	// override (DD's E bit takes precedence when present).
+	// Defaults: end-of-frame is the RTP marker bit. With DD present the S/E
+	// bits give the authoritative frame start/end; without it the codec parse
+	// only marks NAL/unit starts (StartOfUnit) and the jitter buffer derives
+	// the frame start from the lowest one.
 	packet.SetFirstPacketOfFrame(false);
+	packet.SetStartOfUnit(false);
 	packet.SetLastPacketOfFrame(packet.Marker());
 
 	if (dd_extension_id != 0 && TryDependencyDescriptor(packet, dd_extension_id))
@@ -42,18 +47,24 @@ bool RtpFrameBoundaryDetector::Apply(RtpPacket &packet, cmn::MediaCodecId codec,
 	}
 }
 
-// AV1 Dependency Descriptor: first byte's MSB pair is [S][E].
-// Spec: https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension
+// Dependency Descriptor: the mandatory descriptor's S/E bits give the true
+// frame start and end. Parsed via the dedicated extension class.
 bool RtpFrameBoundaryDetector::TryDependencyDescriptor(RtpPacket &packet, uint8_t dd_extension_id)
 {
 	auto ext = packet.GetExtension(dd_extension_id);
-	if (ext.has_value() == false || ext.value().GetLength() < 1)
+	if (ext.has_value() == false)
 	{
 		return false;
 	}
-	uint8_t b = ext.value().GetDataAs<uint8_t>()[0];
-	packet.SetFirstPacketOfFrame((b & 0x80) != 0);
-	packet.SetLastPacketOfFrame((b & 0x40) != 0);
+
+	RtpHeaderExtensionDependencyDescriptor dd(dd_extension_id);
+	if (dd.SetData(ext.value().Clone()) == false)
+	{
+		return false;
+	}
+
+	packet.SetFirstPacketOfFrame(dd.IsStartOfFrame());
+	packet.SetLastPacketOfFrame(dd.IsEndOfFrame());
 	return true;
 }
 
@@ -75,12 +86,12 @@ bool RtpFrameBoundaryDetector::ApplyH264(RtpPacket &packet)
 
 	if (nal_type >= 1 && nal_type <= 23)
 	{
-		packet.SetFirstPacketOfFrame(true);
+		packet.SetStartOfUnit(true);
 		return true;
 	}
 	if (nal_type >= 24 && nal_type <= 27)
 	{
-		packet.SetFirstPacketOfFrame(true);
+		packet.SetStartOfUnit(true);
 		return true;
 	}
 	if (nal_type == 28 || nal_type == 29)
@@ -89,7 +100,7 @@ bool RtpFrameBoundaryDetector::ApplyH264(RtpPacket &packet)
 		{
 			return false;
 		}
-		packet.SetFirstPacketOfFrame((payload[1] & 0x80) != 0);
+		packet.SetStartOfUnit((payload[1] & 0x80) != 0);
 		return true;
 	}
 	return false;
@@ -113,7 +124,7 @@ bool RtpFrameBoundaryDetector::ApplyH265(RtpPacket &packet)
 
 	if (nal_type < 48 || nal_type == 48 || nal_type == 50)
 	{
-		packet.SetFirstPacketOfFrame(true);
+		packet.SetStartOfUnit(true);
 		return true;
 	}
 	if (nal_type == 49)
@@ -122,7 +133,7 @@ bool RtpFrameBoundaryDetector::ApplyH265(RtpPacket &packet)
 		{
 			return false;
 		}
-		packet.SetFirstPacketOfFrame((payload[2] & 0x80) != 0);
+		packet.SetStartOfUnit((payload[2] & 0x80) != 0);
 		return true;
 	}
 	return false;
@@ -142,7 +153,7 @@ bool RtpFrameBoundaryDetector::ApplyVp8(RtpPacket &packet)
 	uint8_t pd = payload[0];
 	bool s = (pd & 0x10) != 0;
 	uint8_t pid = pd & 0x07;
-	packet.SetFirstPacketOfFrame(s && pid == 0);
+	packet.SetStartOfUnit(s && pid == 0);
 	return true;
 }
 
@@ -160,6 +171,6 @@ bool RtpFrameBoundaryDetector::ApplyAv1(RtpPacket &packet)
 	}
 
 	uint8_t agg = payload[0];
-	packet.SetFirstPacketOfFrame((agg & 0x80) == 0);
+	packet.SetStartOfUnit((agg & 0x80) == 0);
 	return true;
 }

--- a/src/projects/modules/rtp_rtcp/rtp_frame_boundary_detector.h
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_boundary_detector.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <base/info/media_track.h>
+#include "rtp_packet.h"
+
+// Stateless helper that stamps IsFirstPacketOfFrame and IsLastPacketOfFrame
+// on an incoming RTP packet using either the AV1 Dependency Descriptor RTP
+// header extension (when negotiated) or the codec-specific RTP payload
+// header. End-of-frame defaults to the RTP marker bit, refined by DD's E bit
+// when present.
+//
+// Returns false when the packet cannot be parsed (e.g. truncated payload,
+// reserved/invalid nal type). The caller is expected to drop such packets.
+class RtpFrameBoundaryDetector
+{
+public:
+	// dd_extension_id == 0 means DD was not negotiated; codec parse is used.
+	static bool Apply(RtpPacket &packet, cmn::MediaCodecId codec, uint8_t dd_extension_id);
+
+private:
+	static bool TryDependencyDescriptor(RtpPacket &packet, uint8_t dd_extension_id);
+	static bool ApplyH264(RtpPacket &packet);
+	static bool ApplyH265(RtpPacket &packet);
+	static bool ApplyVp8(RtpPacket &packet);
+	static bool ApplyAv1(RtpPacket &packet);
+};

--- a/src/projects/modules/rtp_rtcp/rtp_frame_boundary_detector.h
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_boundary_detector.h
@@ -3,11 +3,12 @@
 #include <base/info/media_track.h>
 #include "rtp_packet.h"
 
-// Stateless helper that stamps IsFirstPacketOfFrame and IsLastPacketOfFrame
-// on an incoming RTP packet using either the AV1 Dependency Descriptor RTP
-// header extension (when negotiated) or the codec-specific RTP payload
-// header. End-of-frame defaults to the RTP marker bit, refined by DD's E bit
-// when present.
+// Stateless helper that stamps frame boundary flags on an incoming RTP packet.
+//   - With the Dependency Descriptor present, the S/E bits give the
+//     authoritative frame start (IsFirstPacketOfFrame) and end.
+//   - Without it, the codec-specific payload header only reveals NAL/unit
+//     starts (IsStartOfUnit); the jitter buffer derives the frame start from
+//     the lowest one. End-of-frame defaults to the RTP marker bit.
 //
 // Returns false when the packet cannot be parsed (e.g. truncated payload,
 // reserved/invalid nal type). The caller is expected to drop such packets.

--- a/src/projects/modules/rtp_rtcp/rtp_frame_boundary_detector_test.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_boundary_detector_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "rtp_frame_boundary_detector.h"
+#include "rtp_header_extension/rtp_header_extension_dependency_descriptor.h"
 #include "rtp_packet.h"
 
 namespace
@@ -40,7 +41,7 @@ TEST(RtpFrameBoundaryDetector, H264SingleNalFirstTrue)
 {
 	auto p = MakePacket({0x21}, true);   // nal_type = 1 (slice)
 	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
-	EXPECT_TRUE(p->IsFirstPacketOfFrame());
+	EXPECT_TRUE(p->IsStartOfUnit());
 	EXPECT_TRUE(p->IsLastPacketOfFrame());
 }
 
@@ -48,7 +49,7 @@ TEST(RtpFrameBoundaryDetector, H264SpsPpsFirstTrue)
 {
 	auto sps = MakePacket({0x67, 0x42, 0xc0, 0x1f}, false);   // nal_type 7 (SPS)
 	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*sps, cmn::MediaCodecId::H264, 0));
-	EXPECT_TRUE(sps->IsFirstPacketOfFrame());
+	EXPECT_TRUE(sps->IsStartOfUnit());
 	EXPECT_FALSE(sps->IsLastPacketOfFrame());
 }
 
@@ -57,7 +58,7 @@ TEST(RtpFrameBoundaryDetector, H264StapAAggregateFirstTrue)
 {
 	auto p = MakePacket({0x18, 0x00, 0x10, 0x67}, false);   // nal_type 24
 	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
-	EXPECT_TRUE(p->IsFirstPacketOfFrame());
+	EXPECT_TRUE(p->IsStartOfUnit());
 }
 
 // H.264 FU-A start (S bit set in FU header): first=true.
@@ -66,7 +67,7 @@ TEST(RtpFrameBoundaryDetector, H264FuAStartFirstTrue)
 	// First byte: FU indicator (type 28). Second byte: FU header with S bit (0x80).
 	auto p = MakePacket({0x7c, 0x85}, false);
 	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
-	EXPECT_TRUE(p->IsFirstPacketOfFrame());
+	EXPECT_TRUE(p->IsStartOfUnit());
 }
 
 // H.264 FU-A middle (S bit cleared): first=false.
@@ -74,7 +75,7 @@ TEST(RtpFrameBoundaryDetector, H264FuAMiddleFirstFalse)
 {
 	auto p = MakePacket({0x7c, 0x05}, false);
 	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
-	EXPECT_FALSE(p->IsFirstPacketOfFrame());
+	EXPECT_FALSE(p->IsStartOfUnit());
 }
 
 // H.264 FU-A end (marker=1 → last=true, S bit 0 → first=false).
@@ -82,7 +83,7 @@ TEST(RtpFrameBoundaryDetector, H264FuAEndLastTrue)
 {
 	auto p = MakePacket({0x7c, 0x45}, true);   // E bit 0x40 + marker
 	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
-	EXPECT_FALSE(p->IsFirstPacketOfFrame());
+	EXPECT_FALSE(p->IsStartOfUnit());
 	EXPECT_TRUE(p->IsLastPacketOfFrame());
 }
 
@@ -107,7 +108,7 @@ TEST(RtpFrameBoundaryDetector, H265SingleNalFirstTrue)
 	// Byte0 = 0x02 (type=1, layer=0), Byte1 = 0x01 (TID=1).
 	auto p = MakePacket({0x02, 0x01}, true);
 	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H265, 0));
-	EXPECT_TRUE(p->IsFirstPacketOfFrame());
+	EXPECT_TRUE(p->IsStartOfUnit());
 	EXPECT_TRUE(p->IsLastPacketOfFrame());
 }
 
@@ -118,7 +119,7 @@ TEST(RtpFrameBoundaryDetector, H265FuStartFirstTrue)
 	// Bytes: PayloadHdr(2) + FU header(1) with S bit (0x80).
 	auto p = MakePacket({0x62, 0x01, 0x80}, false);
 	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H265, 0));
-	EXPECT_TRUE(p->IsFirstPacketOfFrame());
+	EXPECT_TRUE(p->IsStartOfUnit());
 }
 
 // H.265 FU middle: S bit cleared -> first=false.
@@ -126,7 +127,7 @@ TEST(RtpFrameBoundaryDetector, H265FuMiddleFirstFalse)
 {
 	auto p = MakePacket({0x62, 0x01, 0x00}, false);
 	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H265, 0));
-	EXPECT_FALSE(p->IsFirstPacketOfFrame());
+	EXPECT_FALSE(p->IsStartOfUnit());
 }
 
 // VP8 first packet of frame: S bit + PID=0 -> first=true.
@@ -136,7 +137,7 @@ TEST(RtpFrameBoundaryDetector, Vp8FirstPidZeroFirstTrue)
 	// S=1 (0x10), PID=0 -> 0x10.
 	auto p = MakePacket({0x10}, false);
 	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::Vp8, 0));
-	EXPECT_TRUE(p->IsFirstPacketOfFrame());
+	EXPECT_TRUE(p->IsStartOfUnit());
 }
 
 // VP8 not first (S=0 or PID!=0): first=false.
@@ -145,7 +146,7 @@ TEST(RtpFrameBoundaryDetector, Vp8MiddleFirstFalse)
 	// S=0, PID=1 -> 0x01.
 	auto p = MakePacket({0x01}, false);
 	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::Vp8, 0));
-	EXPECT_FALSE(p->IsFirstPacketOfFrame());
+	EXPECT_FALSE(p->IsStartOfUnit());
 }
 
 // AV1: aggregation header with Z=0 -> first=true.
@@ -154,14 +155,14 @@ TEST(RtpFrameBoundaryDetector, Av1ZBitClearFirstTrue)
 	// Aggregation header: Z|Y|W|N. Z=0 means this packet starts a fresh OBU element.
 	auto p = MakePacket({0x00}, false);
 	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::Av1, 0));
-	EXPECT_TRUE(p->IsFirstPacketOfFrame());
+	EXPECT_TRUE(p->IsStartOfUnit());
 }
 
 TEST(RtpFrameBoundaryDetector, Av1ZBitSetFirstFalse)
 {
 	auto p = MakePacket({0x80}, false);
 	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::Av1, 0));
-	EXPECT_FALSE(p->IsFirstPacketOfFrame());
+	EXPECT_FALSE(p->IsStartOfUnit());
 }
 
 // Marker bit always reflected as IsLastPacketOfFrame for supported codecs.
@@ -177,4 +178,37 @@ TEST(RtpFrameBoundaryDetector, EmptyPayloadRejected)
 {
 	auto p = MakePacket({}, true);
 	EXPECT_FALSE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
+}
+
+// ---- RtpHeaderExtensionDependencyDescriptor ----
+
+TEST(RtpHeaderExtensionDependencyDescriptor, ParsesMandatoryFields)
+{
+	// S=1, E=1, template_id=0, frame_number=5.
+	uint8_t bytes[] = {0xC0, 0x00, 0x05};
+	auto data = std::make_shared<ov::Data>(bytes, sizeof(bytes));
+
+	RtpHeaderExtensionDependencyDescriptor dd(12);
+	ASSERT_TRUE(dd.SetData(data));
+	EXPECT_TRUE(dd.IsStartOfFrame());
+	EXPECT_TRUE(dd.IsEndOfFrame());
+	EXPECT_EQ(dd.GetFrameNumber(), 5);
+}
+
+TEST(RtpHeaderExtensionDependencyDescriptor, ParsesMidFrame)
+{
+	// S=0, E=0 (a packet in the middle of a frame).
+	uint8_t bytes[] = {0x00, 0x00, 0x06};
+	auto data = std::make_shared<ov::Data>(bytes, sizeof(bytes));
+
+	RtpHeaderExtensionDependencyDescriptor dd(12);
+	ASSERT_TRUE(dd.SetData(data));
+	EXPECT_FALSE(dd.IsStartOfFrame());
+	EXPECT_FALSE(dd.IsEndOfFrame());
+}
+
+TEST(RtpHeaderExtensionDependencyDescriptor, RejectsEmpty)
+{
+	RtpHeaderExtensionDependencyDescriptor dd(12);
+	EXPECT_FALSE(dd.SetData(std::make_shared<ov::Data>()));
 }

--- a/src/projects/modules/rtp_rtcp/rtp_frame_boundary_detector_test.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_boundary_detector_test.cpp
@@ -1,0 +1,180 @@
+//==============================================================================
+//
+//  OvenMediaEngine - Unit Tests
+//
+//  Covers: RtpFrameBoundaryDetector (H.264/H.265/VP8/AV1, codec gate, DD)
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include "rtp_frame_boundary_detector.h"
+#include "rtp_packet.h"
+
+namespace
+{
+std::shared_ptr<RtpPacket> MakePacket(const std::vector<uint8_t> &payload, bool marker = false)
+{
+	auto p = std::make_shared<RtpPacket>();
+	p->SetPayloadType(96);
+	p->SetSequenceNumber(100);
+	p->SetTimestamp(90000);
+	p->SetSsrc(0x12345678);
+	p->SetMarker(marker);
+	if (payload.empty() == false)
+	{
+		p->SetPayload(payload.data(), payload.size());
+	}
+	return p;
+}
+}  // namespace
+
+// Defensive gate: unsupported codec returns false.
+TEST(RtpFrameBoundaryDetector, UnsupportedCodecReturnsFalse)
+{
+	auto p = MakePacket({0x01});
+	EXPECT_FALSE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::None, 0));
+}
+
+// H.264 single NAL (nal_type 1..23): first=true, last=marker.
+TEST(RtpFrameBoundaryDetector, H264SingleNalFirstTrue)
+{
+	auto p = MakePacket({0x21}, true);   // nal_type = 1 (slice)
+	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
+	EXPECT_TRUE(p->IsFirstPacketOfFrame());
+	EXPECT_TRUE(p->IsLastPacketOfFrame());
+}
+
+TEST(RtpFrameBoundaryDetector, H264SpsPpsFirstTrue)
+{
+	auto sps = MakePacket({0x67, 0x42, 0xc0, 0x1f}, false);   // nal_type 7 (SPS)
+	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*sps, cmn::MediaCodecId::H264, 0));
+	EXPECT_TRUE(sps->IsFirstPacketOfFrame());
+	EXPECT_FALSE(sps->IsLastPacketOfFrame());
+}
+
+// H.264 STAP-A aggregation (nal_type 24): first=true.
+TEST(RtpFrameBoundaryDetector, H264StapAAggregateFirstTrue)
+{
+	auto p = MakePacket({0x18, 0x00, 0x10, 0x67}, false);   // nal_type 24
+	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
+	EXPECT_TRUE(p->IsFirstPacketOfFrame());
+}
+
+// H.264 FU-A start (S bit set in FU header): first=true.
+TEST(RtpFrameBoundaryDetector, H264FuAStartFirstTrue)
+{
+	// First byte: FU indicator (type 28). Second byte: FU header with S bit (0x80).
+	auto p = MakePacket({0x7c, 0x85}, false);
+	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
+	EXPECT_TRUE(p->IsFirstPacketOfFrame());
+}
+
+// H.264 FU-A middle (S bit cleared): first=false.
+TEST(RtpFrameBoundaryDetector, H264FuAMiddleFirstFalse)
+{
+	auto p = MakePacket({0x7c, 0x05}, false);
+	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
+	EXPECT_FALSE(p->IsFirstPacketOfFrame());
+}
+
+// H.264 FU-A end (marker=1 → last=true, S bit 0 → first=false).
+TEST(RtpFrameBoundaryDetector, H264FuAEndLastTrue)
+{
+	auto p = MakePacket({0x7c, 0x45}, true);   // E bit 0x40 + marker
+	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
+	EXPECT_FALSE(p->IsFirstPacketOfFrame());
+	EXPECT_TRUE(p->IsLastPacketOfFrame());
+}
+
+// H.264 reserved nal_type rejected.
+TEST(RtpFrameBoundaryDetector, H264ReservedNalTypeRejected)
+{
+	auto p = MakePacket({0x00}, false);   // nal_type 0 (forbidden)
+	EXPECT_FALSE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
+}
+
+// H.264 truncated FU-A (size < 2) rejected.
+TEST(RtpFrameBoundaryDetector, H264TruncatedFuRejected)
+{
+	auto p = MakePacket({0x7c}, false);   // only the FU indicator
+	EXPECT_FALSE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
+}
+
+// H.265 single NAL (type 0..47): first=true.
+TEST(RtpFrameBoundaryDetector, H265SingleNalFirstTrue)
+{
+	// First byte: F(0)|Type(6)|LayerID(6)|TID(3) — we craft Type=1 (TRAIL_N).
+	// Byte0 = 0x02 (type=1, layer=0), Byte1 = 0x01 (TID=1).
+	auto p = MakePacket({0x02, 0x01}, true);
+	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H265, 0));
+	EXPECT_TRUE(p->IsFirstPacketOfFrame());
+	EXPECT_TRUE(p->IsLastPacketOfFrame());
+}
+
+// H.265 FU (type 49) with S bit set in FU header: first=true.
+TEST(RtpFrameBoundaryDetector, H265FuStartFirstTrue)
+{
+	// Type 49 -> 49 << 1 = 0x62.
+	// Bytes: PayloadHdr(2) + FU header(1) with S bit (0x80).
+	auto p = MakePacket({0x62, 0x01, 0x80}, false);
+	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H265, 0));
+	EXPECT_TRUE(p->IsFirstPacketOfFrame());
+}
+
+// H.265 FU middle: S bit cleared -> first=false.
+TEST(RtpFrameBoundaryDetector, H265FuMiddleFirstFalse)
+{
+	auto p = MakePacket({0x62, 0x01, 0x00}, false);
+	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H265, 0));
+	EXPECT_FALSE(p->IsFirstPacketOfFrame());
+}
+
+// VP8 first packet of frame: S bit + PID=0 -> first=true.
+TEST(RtpFrameBoundaryDetector, Vp8FirstPidZeroFirstTrue)
+{
+	// Payload descriptor byte: X|R|N|S|R|PID(3).
+	// S=1 (0x10), PID=0 -> 0x10.
+	auto p = MakePacket({0x10}, false);
+	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::Vp8, 0));
+	EXPECT_TRUE(p->IsFirstPacketOfFrame());
+}
+
+// VP8 not first (S=0 or PID!=0): first=false.
+TEST(RtpFrameBoundaryDetector, Vp8MiddleFirstFalse)
+{
+	// S=0, PID=1 -> 0x01.
+	auto p = MakePacket({0x01}, false);
+	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::Vp8, 0));
+	EXPECT_FALSE(p->IsFirstPacketOfFrame());
+}
+
+// AV1: aggregation header with Z=0 -> first=true.
+TEST(RtpFrameBoundaryDetector, Av1ZBitClearFirstTrue)
+{
+	// Aggregation header: Z|Y|W|N. Z=0 means this packet starts a fresh OBU element.
+	auto p = MakePacket({0x00}, false);
+	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::Av1, 0));
+	EXPECT_TRUE(p->IsFirstPacketOfFrame());
+}
+
+TEST(RtpFrameBoundaryDetector, Av1ZBitSetFirstFalse)
+{
+	auto p = MakePacket({0x80}, false);
+	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::Av1, 0));
+	EXPECT_FALSE(p->IsFirstPacketOfFrame());
+}
+
+// Marker bit always reflected as IsLastPacketOfFrame for supported codecs.
+TEST(RtpFrameBoundaryDetector, MarkerBitMapsToLast)
+{
+	auto p = MakePacket({0x21}, true);   // H264 single NAL, marker
+	ASSERT_TRUE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
+	EXPECT_TRUE(p->IsLastPacketOfFrame());
+}
+
+// Empty payload returns false (no header bytes to inspect).
+TEST(RtpFrameBoundaryDetector, EmptyPayloadRejected)
+{
+	auto p = MakePacket({}, true);
+	EXPECT_FALSE(RtpFrameBoundaryDetector::Apply(*p, cmn::MediaCodecId::H264, 0));
+}

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.cpp
@@ -162,9 +162,17 @@ uint32_t RtpFrameJitterBuffer::CurrentHoldMs()
 	// a 4*dev margin so a publisher pacing burst (BWE throttle, encoder
 	// stall, variable fps) doesn't trip a discard before the next packet
 	// arrives. Same shape as the EWMA + 4*dev rule used inside NackGen.
-	return _hold_ms_provider()
-		 + _frame_interval_ms
-		 + 4 * _frame_interval_dev_ms;
+	uint32_t hold = _hold_ms_provider()
+				  + _frame_interval_ms
+				  + 4 * _frame_interval_dev_ms;
+
+	// Cap the total to the configured MaxHoldMs so the frame-interval margin
+	// can't push the hold past the operator's latency budget.
+	if (_max_hold_ms != 0 && hold > _max_hold_ms)
+	{
+		hold = _max_hold_ms;
+	}
+	return hold;
 }
 
 void RtpFrameJitterBuffer::UpdateFrameIntervalEstimate(uint32_t rtp_ts)

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.cpp
@@ -314,7 +314,7 @@ void RtpFrameJitterBuffer::BurnOutExpiredFrames()
 		logtd("Frame discarded after NACK hold %ums - ts(%u) packets(%zu) marked(%s) "
 			  "has_start(%s) start_seq(%u) has_end(%s) end_seq(%u) max_recv_seq(%u) elapsed(%llums)",
 			  hold_ms, frame->Timestamp(), frame->PacketCount(), frame->IsMarked() ? "true" : "false",
-			  frame->HasReceivedAny() ? "true" : "false",
+			  frame->HasStart() ? "true" : "false",
 			  frame->GetFirstSequenceNumber(),
 			  frame->IsMarked() ? "true" : "false",
 			  frame->GetMarkerSequenceNumber(),

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.cpp
@@ -23,10 +23,18 @@ bool RtpFrame::InsertPacket(const std::shared_ptr<RtpPacket> &packet)
 
 	logtt("Insert packet : %s", packet->Dump().CStr());
 
-	if (packet->IsFirstPacketOfFrame())
+	// Frame start: DD marks it authoritatively (IsFirstPacketOfFrame, one per
+	// frame); without DD the codec parse only marks NAL/unit starts
+	// (IsStartOfUnit), which a multi-NAL access unit sets on several packets.
+	// Either way, keep the earliest seq as the start (wrap-safe) so it is the
+	// true frame start, not the last NAL to arrive.
+	if (packet->IsFirstPacketOfFrame() || packet->IsStartOfUnit())
 	{
-		_start_seq = packet->SequenceNumber();
-		_has_start = true;
+		if (_has_start == false || static_cast<int16_t>(packet->SequenceNumber() - _start_seq) < 0)
+		{
+			_start_seq = packet->SequenceNumber();
+			_has_start = true;
+		}
 	}
 	if (packet->IsLastPacketOfFrame())
 	{
@@ -301,7 +309,8 @@ void RtpFrameJitterBuffer::BurnOutExpiredFrames()
 		{
 			break;
 		}
-		// TEMP: dump frame extent + max received seq for debugging recovery failures.
+		// Frame dropped after exhausting the NACK hold; log its extent so
+		// recovery failures can be traced.
 		logtd("Frame discarded after NACK hold %ums - ts(%u) packets(%zu) marked(%s) "
 			  "has_start(%s) start_seq(%u) has_end(%s) end_seq(%u) max_recv_seq(%u) elapsed(%llums)",
 			  hold_ms, frame->Timestamp(), frame->PacketCount(), frame->IsMarked() ? "true" : "false",

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.cpp
@@ -3,7 +3,7 @@
 #define OV_LOG_TAG "RtpVideoJitterBuffer"
 
 /************************************************************************
- * 								RTPFrame
+ *                               RtpFrame
  ***********************************************************************/
 
 RtpFrame::RtpFrame(uint32_t timestamp)
@@ -12,112 +12,38 @@ RtpFrame::RtpFrame(uint32_t timestamp)
 	_stop_watch.Start();
 }
 
-std::shared_ptr<RtpPacket> RtpFrame::GetFirstRtpPacket()
-{
-	if (IsCompleted() == false)
-	{
-		return nullptr;
-	}
-
-	_curr_order_number = _min_order_number;
-
-	auto it = _packets.find(_curr_order_number);
-	if (it == _packets.end())
-	{
-		return nullptr;
-	}
-
-	return it->second;
-}
-
-std::shared_ptr<RtpPacket> RtpFrame::GetNextRtpPacket()
-{
-	if (IsCompleted() == false)
-	{
-		return nullptr;
-	}
-
-	_curr_order_number ++;
-
-	auto it = _packets.find(_curr_order_number);
-	if (it == _packets.end())
-	{
-		return nullptr;
-	}
-
-	return it->second;
-}
-
-uint16_t RtpFrame::GetOrderNumber(uint16_t sequence_number)
-{
-	if (_first_packet == true)
-	{
-		_first_packet = false;
-		_first_sequence_number = sequence_number;
-		_base_order_number = std::numeric_limits<uint16_t>::max() / 2;
-
-		return _base_order_number;
-	}
-
-	if (sequence_number > _first_sequence_number)
-	{
-		if (sequence_number - _first_sequence_number > (std::numeric_limits<uint16_t>::max() / 2))
-		{
-			// out of order : 0 -> 65535 ==> gap : -1 
-			uint16_t gap = std::numeric_limits<uint16_t>::max() - sequence_number + _first_sequence_number + 1;
-			return _base_order_number - gap;
-		}
-		else
-		{
-			// In order : 1 -> 2 ==> gap : +1
-			return _base_order_number + (sequence_number - _first_sequence_number);
-		}
-	}
-	else
-	{
-		if (_first_sequence_number - sequence_number > (std::numeric_limits<uint16_t>::max() / 2))
-		{
-			// Roll over : 65535 -> 0 ==> gpa : +1
-			uint16_t gap = std::numeric_limits<uint16_t>::max() - _first_sequence_number + sequence_number + 1;
-			return _base_order_number + gap;
-		}
-		else
-		{
-			// Out of order : 2 -> 1
-			return _base_order_number - (_first_sequence_number - sequence_number);
-		}
-	}
-
-	// Should not reach here
-	return 0;
-}
-
 bool RtpFrame::InsertPacket(const std::shared_ptr<RtpPacket> &packet)
 {
 	if (packet == nullptr || packet->Timestamp() != _timestamp)
 	{
-		logte("Invalid packet : %s (expected ts : %u)", packet->Dump().CStr(), _timestamp);
+		logte("Invalid packet : %s (expected ts : %u)",
+			  packet != nullptr ? packet->Dump().CStr() : "null", _timestamp);
 		return false;
 	}
 
 	logtt("Insert packet : %s", packet->Dump().CStr());
 
-	auto order_number = GetOrderNumber(packet->SequenceNumber());
-
-	_packets.emplace(order_number, packet);
-
-	// First packet
-	_min_order_number = std::min(_min_order_number, order_number);
-	_max_order_number = std::max(_max_order_number, order_number);
-
-	if (packet->Marker())
+	if (packet->IsFirstPacketOfFrame())
 	{
-		_marked = true;
-		_marker_sequence_number = packet->SequenceNumber();
+		_start_seq = packet->SequenceNumber();
+		_has_start = true;
+	}
+	if (packet->IsLastPacketOfFrame())
+	{
+		_end_seq = packet->SequenceNumber();
+		_has_end = true;
 	}
 
-	// Check if frame is completed
-	if (_marked == true)
+	_packets.emplace(packet->SequenceNumber(), packet);
+
+	auto seq = packet->SequenceNumber();
+	if (_has_received == false || static_cast<int16_t>(seq - _max_received_seq) > 0)
+	{
+		_max_received_seq = seq;
+		_has_received = true;
+	}
+
+	if (_has_start && _has_end)
 	{
 		CheckCompleted();
 	}
@@ -127,54 +53,50 @@ bool RtpFrame::InsertPacket(const std::shared_ptr<RtpPacket> &packet)
 
 bool RtpFrame::IsMarked()
 {
-	return _marked;
+	return _has_end;
 }
 
 bool RtpFrame::IsCompleted()
 {
-	if (_completed == true)
+	if (_completed)
 	{
 		return true;
 	}
-
-	if (_marked == true)
+	if (_has_start && _has_end)
 	{
 		return CheckCompleted();
 	}
-
 	return false;
 }
 
 bool RtpFrame::CheckCompleted()
 {
-	// Already completed
-	if (_completed == true)
+	if (_completed)
 	{
 		return true;
 	}
-
-	if (_marked == false)
+	if (_has_start == false || _has_end == false)
 	{
 		return false;
 	}
 
-	// Check number of packets
-	uint16_t need_number_of_packets = _max_order_number - _min_order_number + 1;
-
-	// Check if frame is valid
-	if (need_number_of_packets == _packets.size())
+	// uint16 subtraction handles seq wrap (e.g. start=65530, end=5 → 12).
+	uint16_t expected = static_cast<uint16_t>(_end_seq - _start_seq + 1);
+	if (_packets.size() == expected)
 	{
 		_completed = true;
-		logtt("Frame completed: timestamp(%u) packets(%zu) need packets(%u)", _timestamp, _packets.size(), need_number_of_packets);
-	}
-	else if (_incomplete_logged == false)
-	{
-		// Marker arrived but packets are still missing. May recover via NACK; log once.
-		_incomplete_logged = true;
-		logtd("Incomplete frame after marker: timestamp(%u) %zu/%u", _timestamp, _packets.size(), need_number_of_packets);
+		logtt("Frame completed: ts(%u) start_seq(%u) end_seq(%u) packets(%zu)",
+			  _timestamp, _start_seq, _end_seq, _packets.size());
+		return true;
 	}
 
-	return _completed;
+	if (_incomplete_logged == false)
+	{
+		_incomplete_logged = true;
+		logtd("Incomplete frame: ts(%u) start_seq(%u) end_seq(%u) %zu/%u",
+			  _timestamp, _start_seq, _end_seq, _packets.size(), expected);
+	}
+	return false;
 }
 
 uint64_t RtpFrame::GetElapsed()
@@ -182,34 +104,118 @@ uint64_t RtpFrame::GetElapsed()
 	return _stop_watch.Elapsed();
 }
 
+std::shared_ptr<RtpPacket> RtpFrame::GetFirstRtpPacket()
+{
+	if (IsCompleted() == false)
+	{
+		return nullptr;
+	}
+	_curr_seq = _start_seq;
+	auto it = _packets.find(_curr_seq);
+	return (it != _packets.end()) ? it->second : nullptr;
+}
+
+std::shared_ptr<RtpPacket> RtpFrame::GetNextRtpPacket()
+{
+	if (IsCompleted() == false)
+	{
+		return nullptr;
+	}
+	if (_curr_seq == _end_seq)
+	{
+		return nullptr;
+	}
+	_curr_seq = static_cast<uint16_t>(_curr_seq + 1);
+	auto it = _packets.find(_curr_seq);
+	return (it != _packets.end()) ? it->second : nullptr;
+}
+
 /************************************************************************
- * 							Jitter Buffer
+ *                          RtpFrameJitterBuffer
  ***********************************************************************/
 
 uint64_t RtpFrameJitterBuffer::GetExtentedTimestamp(uint32_t timestamp)
 {
-	// If the timestamp is less than the previous timestamp, it is assumed that the timestamp has been rolled over.
 	if (timestamp < _last_timestamp && _last_timestamp - timestamp > 0x80000000)
 	{
 		_timestamp_cycle++;
 	}
-
 	_last_timestamp = timestamp;
-
 	return (static_cast<uint64_t>(_timestamp_cycle) << 32) | timestamp;
+}
+
+uint32_t RtpFrameJitterBuffer::CurrentHoldMs()
+{
+	if (!_hold_ms_provider)
+	{
+		return 0;
+	}
+	// NackGen's hold covers RTT variance; add the frame-interval mean plus
+	// a 4*dev margin so a publisher pacing burst (BWE throttle, encoder
+	// stall, variable fps) doesn't trip a discard before the next packet
+	// arrives. Same shape as the EWMA + 4*dev rule used inside NackGen.
+	return _hold_ms_provider()
+		 + _frame_interval_ms
+		 + 4 * _frame_interval_dev_ms;
+}
+
+void RtpFrameJitterBuffer::UpdateFrameIntervalEstimate(uint32_t rtp_ts)
+{
+	if (_clock_rate == 0)
+	{
+		return;
+	}
+	if (_has_last_processed_rtp_ts == false)
+	{
+		_has_last_processed_rtp_ts = true;
+		_last_processed_rtp_ts = rtp_ts;
+		return;
+	}
+
+	// uint32 subtraction wraps cleanly when timestamps cycle.
+	uint32_t diff_ticks = rtp_ts - _last_processed_rtp_ts;
+	uint32_t interval_ms = static_cast<uint32_t>((static_cast<uint64_t>(diff_ticks) * 1000) / _clock_rate);
+
+	// Outlier filter: ignore jumps over 1 second (likely a cycle gap or
+	// stream resume) so a single anomaly doesn't poison the EWMA.
+	if (interval_ms <= 1000)
+	{
+		if (_frame_interval_ms == 0)
+		{
+			// First sample: seed the mean. dev keeps its conservative seed
+			// (INITIAL_FRAME_INTERVAL_DEV_GUESS_MS) so the second/third
+			// frame still inherits a large hold window.
+			_frame_interval_ms = interval_ms;
+		}
+		else
+		{
+			// EWMA with alpha = 1/8 for mean, 1/4 for deviation (same
+			// pattern as NackGen's NACK->RTX stats).
+			int64_t err = static_cast<int64_t>(interval_ms) - static_cast<int64_t>(_frame_interval_ms);
+			_frame_interval_ms = (_frame_interval_ms * 7 + interval_ms) / 8;
+			uint64_t abs_err = static_cast<uint64_t>(err < 0 ? -err : err);
+			_frame_interval_dev_ms = (_frame_interval_dev_ms * 3 + abs_err) / 4;
+		}
+	}
+
+	_last_processed_rtp_ts = rtp_ts;
 }
 
 bool RtpFrameJitterBuffer::InsertPacket(const std::shared_ptr<RtpPacket> &packet)
 {
 	auto timestamp = GetExtentedTimestamp(packet->Timestamp());
 
+	// Reject packets for an already-emitted/dropped frame. Without this a
+	// late RTX would resurrect a phantom RtpFrame for an old timestamp.
+	if (_has_processed_timestamp && timestamp <= _last_processed_timestamp)
+	{
+		return false;
+	}
+
 	auto it = _rtp_frames.find(timestamp);
 	std::shared_ptr<RtpFrame> frame;
-
 	if (it == _rtp_frames.end())
 	{
-		logtt("Create frame buffer for timestamp %" PRIu64 "", timestamp);
-		// First packet of frame
 		frame = std::make_shared<RtpFrame>(packet->Timestamp());
 		_rtp_frames[timestamp] = frame;
 	}
@@ -219,38 +225,93 @@ bool RtpFrameJitterBuffer::InsertPacket(const std::shared_ptr<RtpPacket> &packet
 	}
 
 	frame->InsertPacket(packet);
-
 	return true;
+}
+
+void RtpFrameJitterBuffer::MarkFrameProcessed(uint64_t extended_timestamp, RtpFrame &frame)
+{
+	_last_processed_timestamp = extended_timestamp;
+	_has_processed_timestamp = true;
+	UpdateFrameIntervalEstimate(frame.Timestamp());
+	AdvanceProcessedSeq(frame);
+}
+
+void RtpFrameJitterBuffer::AdvanceProcessedSeq(RtpFrame &frame)
+{
+	if (frame.HasReceivedAny() == false)
+	{
+		return;
+	}
+	auto seq = frame.GetMaxReceivedSeq();
+	if (_has_processed_seq == false || static_cast<int16_t>(seq - _last_processed_max_seq) > 0)
+	{
+		logtt("Advance processed seq: ts(%u) max_recv_seq(%u) prev(%u) packets(%zu) completed(%s)",
+			  frame.Timestamp(), seq, _last_processed_max_seq, frame.PacketCount(),
+			  frame.IsCompleted() ? "true" : "false");
+		_last_processed_max_seq = seq;
+		_has_processed_seq = true;
+		if (_on_processed_seq_advance)
+		{
+			_on_processed_seq_advance(seq);
+		}
+	}
 }
 
 void RtpFrameJitterBuffer::BurnOutExpiredFrames()
 {
-	// If there are completed frames among the frames, all previous frames are deleted.
-
-	// Find first completed frame
-	auto completed_frame_it = _rtp_frames.begin();
-	while (completed_frame_it != _rtp_frames.end())
+	// Legacy path when no NACK hold is wired in: drop incomplete predecessors
+	// only when a later completed frame exists. Matches pre-NACK behavior so
+	// a single in-flight frame isn't burned out prematurely.
+	if (!_hold_ms_provider)
 	{
-		auto frame = completed_frame_it->second;
+		auto completed_it = _rtp_frames.begin();
+		while (completed_it != _rtp_frames.end() && completed_it->second->IsCompleted() == false)
+		{
+			++completed_it;
+		}
+		if (completed_it == _rtp_frames.begin() || completed_it == _rtp_frames.end())
+		{
+			return;
+		}
+
+		auto it = _rtp_frames.begin();
+		while (it != completed_it)
+		{
+			auto frame = it->second;
+			logtt("Frame discarded - ts(%u) packets(%zu) marked(%s)",
+				  frame->Timestamp(), frame->PacketCount(), frame->IsMarked() ? "true" : "false");
+			MarkFrameProcessed(it->first, *frame);
+			it = _rtp_frames.erase(it);
+		}
+		return;
+	}
+
+	// NACK-aware path: hold incomplete head frames for up to hold_ms; drop
+	// when expired so subsequent completed frames can flow.
+	uint32_t hold_ms = CurrentHoldMs();
+	auto it = _rtp_frames.begin();
+	while (it != _rtp_frames.end())
+	{
+		auto frame = it->second;
 		if (frame->IsCompleted())
 		{
 			break;
 		}
-		++completed_frame_it;
-	}
-
-	if (completed_frame_it == _rtp_frames.begin() || completed_frame_it == _rtp_frames.end())
-	{
-		// No burn outted frame and completed frame
-		return;
-	}
-
-	// Delete from begin to completed frame (not included)
-	auto it = _rtp_frames.begin();
-	while (it != completed_frame_it)
-	{
-		auto frame = it->second;
-		logtt("Frame discarded (It may be PADDING frame for BWE) - timestamp(%u) packets(%zu) marked(%s)", frame->Timestamp(), frame->PacketCount(), frame->IsMarked() ? "true" : "false");
+		if (frame->GetElapsed() <= hold_ms)
+		{
+			break;
+		}
+		// TEMP: dump frame extent + max received seq for debugging recovery failures.
+		logtd("Frame discarded after NACK hold %ums - ts(%u) packets(%zu) marked(%s) "
+			  "has_start(%s) start_seq(%u) has_end(%s) end_seq(%u) max_recv_seq(%u) elapsed(%llums)",
+			  hold_ms, frame->Timestamp(), frame->PacketCount(), frame->IsMarked() ? "true" : "false",
+			  frame->HasReceivedAny() ? "true" : "false",
+			  frame->GetFirstSequenceNumber(),
+			  frame->IsMarked() ? "true" : "false",
+			  frame->GetMarkerSequenceNumber(),
+			  frame->GetMaxReceivedSeq(),
+			  static_cast<unsigned long long>(frame->GetElapsed()));
+		MarkFrameProcessed(it->first, *frame);
 		it = _rtp_frames.erase(it);
 	}
 }
@@ -258,15 +319,47 @@ void RtpFrameJitterBuffer::BurnOutExpiredFrames()
 bool RtpFrameJitterBuffer::HasAvailableFrame()
 {
 	BurnOutExpiredFrames();
-
 	auto it = _rtp_frames.begin();
 	if (it == _rtp_frames.end())
 	{
 		return false;
 	}
+	auto head = it->second;
+	if (head->IsCompleted() == false)
+	{
+		return false;
+	}
 
-	auto first_frame = it->second;
-	return first_frame->IsCompleted();
+	// Head is complete, but if NACK is still recovering an earlier seq
+	// (a packet from a frame whose object never materialized because all
+	// of its packets were lost), hold this frame until NACK either
+	// succeeds or the hold window expires. Without this, a single-packet
+	// frame can race past the missing prior frame and emit out-of-order.
+	if (_lowest_pending_seq_provider)
+	{
+		auto lowest = _lowest_pending_seq_provider();
+		if (lowest.has_value())
+		{
+			auto head_start = head->GetFirstSequenceNumber();
+			// wrap-safe: lowest < head_start ?
+			if (static_cast<int16_t>(*lowest - head_start) < 0)
+			{
+				uint32_t hold_ms = CurrentHoldMs();
+				if (head->GetElapsed() <= hold_ms)
+				{
+					logtt("Hold complete head for prior NACK recovery: ts(%u) head_start(%u) lowest_pending(%u) elapsed(%llums) hold(%ums)",
+						  head->Timestamp(), head_start, *lowest,
+						  static_cast<unsigned long long>(head->GetElapsed()), hold_ms);
+					return false;
+				}
+				logtd("Release held head despite prior NACK pending (hold expired): ts(%u) head_start(%u) lowest_pending(%u) elapsed(%llums) hold(%ums)",
+					  head->Timestamp(), head_start, *lowest,
+					  static_cast<unsigned long long>(head->GetElapsed()), hold_ms);
+			}
+		}
+	}
+
+	return true;
 }
 
 std::shared_ptr<RtpFrame> RtpFrameJitterBuffer::PopAvailableFrame()
@@ -279,10 +372,12 @@ std::shared_ptr<RtpFrame> RtpFrameJitterBuffer::PopAvailableFrame()
 	auto it = _rtp_frames.begin();
 	auto frame = it->second;
 
-	logtt("Pop frame - extended(%" PRIu64 ") timestamp(%u) packets(%zu) frames(%zu)", it->first, frame->Timestamp(), frame->PacketCount(), _rtp_frames.size());
+	logtt("Pop frame ts(%u) ext(%" PRIu64 ") packets(%zu) elapsed(%llums) buffered(%zu)",
+		  frame->Timestamp(), it->first, frame->PacketCount(),
+		  static_cast<unsigned long long>(frame->GetElapsed()),
+		  _rtp_frames.size());
 
-	// remove front frame
+	MarkFrameProcessed(it->first, *frame);
 	_rtp_frames.erase(it);
-
 	return frame;
 }

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.h
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.h
@@ -29,6 +29,7 @@ public:
 
 	uint32_t Timestamp() { return _timestamp; }
 	size_t PacketCount() { return _packets.size(); }
+	bool HasStart() const { return _has_start; }
 	uint16_t GetMarkerSequenceNumber() const { return _end_seq; }
 	uint16_t GetFirstSequenceNumber() const { return _start_seq; }
 

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.h
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.h
@@ -7,11 +7,12 @@
 #include <unordered_map>
 
 // One frame's worth of RTP packets, identified by a common RTP timestamp.
-// Completeness is decided strictly from packet flags stamped by
-// RtpFrameBoundaryDetector:
-//   - IsFirstPacketOfFrame: anchors the true start sequence number.
-//   - IsLastPacketOfFrame:  anchors the end sequence number.
-// A frame is complete when both flags are seen and every sequence number
+// Completeness is decided from packet flags stamped by RtpFrameBoundaryDetector:
+//   - start: IsFirstPacketOfFrame (authoritative, from DD) or IsStartOfUnit
+//     (NAL/unit starts, from codec parse); the earliest such sequence number
+//     is taken as the frame start.
+//   - end:   IsLastPacketOfFrame (RTP marker / DD E bit).
+// A frame is complete when both ends are known and every sequence number
 // between start and end (inclusive, with uint16 wrap) is present.
 class RtpFrame
 {

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.h
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.h
@@ -2,15 +2,22 @@
 
 #include "base/ovlibrary/ovlibrary.h"
 #include "rtp_packet.h"
+#include <functional>
+#include <optional>
 #include <unordered_map>
 
-#define DEFAULT_VIDEO_MAX_BUFFERING_TIME_MS	100	 // 500ms
-
-// RTP Packet Group by Frame
+// One frame's worth of RTP packets, identified by a common RTP timestamp.
+// Completeness is decided strictly from packet flags stamped by
+// RtpFrameBoundaryDetector:
+//   - IsFirstPacketOfFrame: anchors the true start sequence number.
+//   - IsLastPacketOfFrame:  anchors the end sequence number.
+// A frame is complete when both flags are seen and every sequence number
+// between start and end (inclusive, with uint16 wrap) is present.
 class RtpFrame
 {
 public:
 	RtpFrame(uint32_t timestamp);
+
 	bool InsertPacket(const std::shared_ptr<RtpPacket> &packet);
 	bool IsCompleted();
 	bool IsMarked();
@@ -19,52 +26,132 @@ public:
 	std::shared_ptr<RtpPacket> GetFirstRtpPacket();
 	std::shared_ptr<RtpPacket> GetNextRtpPacket();
 
-	uint32_t Timestamp(){return _timestamp;}
-	size_t PacketCount(){return _packets.size();}
+	uint32_t Timestamp() { return _timestamp; }
+	size_t PacketCount() { return _packets.size(); }
+	uint16_t GetMarkerSequenceNumber() const { return _end_seq; }
+	uint16_t GetFirstSequenceNumber() const { return _start_seq; }
+
+	// Highest sequence number actually received in this frame (wrap-safe).
+	// Used to advance the jitter buffer's "processed up to" watermark so
+	// the NACK generator can drop stale pending entries without needing
+	// exact frame boundaries.
+	bool HasReceivedAny() const { return _has_received; }
+	uint16_t GetMaxReceivedSeq() const { return _max_received_seq; }
 
 private:
 	bool CheckCompleted();
-	uint16_t GetOrderNumber(uint16_t sequence_number);
 
 	ov::StopWatch _stop_watch;
+	uint32_t _timestamp = 0;
 
-	uint32_t	_timestamp = 0;
-	
-	uint32_t	_marker_sequence_number = 0;
-	bool		_marked = false;
-	bool		_completed = false;
-	bool		_incomplete_logged = false;
+	bool _has_start = false;
+	uint16_t _start_seq = 0;
+	bool _has_end = false;
+	uint16_t _end_seq = 0;
 
-	uint16_t 	_first_sequence_number = 0;
-	bool		_first_packet = true;
-	uint16_t 	_base_order_number = 0;
+	bool _has_received = false;
+	uint16_t _max_received_seq = 0;
 
-	uint16_t 	_curr_order_number = 0;
-	uint16_t 	_min_order_number = 65535;
-	uint16_t 	_max_order_number = 0;
+	bool _completed = false;
+	bool _incomplete_logged = false;
 
-	// Order Number : RtpPacket
+	uint16_t _curr_seq = 0;  // iteration cursor for GetFirst/NextRtpPacket
+
+	// seq : RtpPacket (wrap-safe: lookup by exact seq within [_start_seq, _end_seq] traversal).
 	std::unordered_map<uint16_t, std::shared_ptr<RtpPacket>> _packets;
 };
 
-// A jitter buffer for a media stream in the form that the frame is fragmented
-// and the rtp marker bit indicates that it is the last fragment.
+// A jitter buffer that emits frames in RTP timestamp order. Per-track
+// frame boundary information must be stamped on each packet before insertion
+// (see RtpFrameBoundaryDetector + RtpRtcp wiring); the buffer itself stays
+// codec-agnostic.
 class RtpFrameJitterBuffer
 {
 public:
 	bool InsertPacket(const std::shared_ptr<RtpPacket> &packet);
 	bool HasAvailableFrame();
 	std::shared_ptr<RtpFrame> PopAvailableFrame();
-	
-private:	
-	void BurnOutExpiredFrames();
 
+	// Incomplete frames at the head are held for up to (hold_ms_provider() +
+	// frame_interval_ms) milliseconds before being discarded. The frame
+	// interval term covers the gap between losing a frame's last packet and
+	// the next frame's first packet arriving — without it low-fps streams
+	// can't NACK the lost packet in time. Unset hold_ms_provider keeps the
+	// legacy "drop incomplete predecessor on next complete" behavior.
+	void SetHoldMsProvider(std::function<uint32_t()> provider) { _hold_ms_provider = std::move(provider); }
+
+	// RTP clock rate of the track. Used to convert RTP timestamp deltas
+	// between consecutive frames into milliseconds for the frame interval
+	// estimate. Must be set before frames start flowing.
+	void SetClockRate(uint32_t clock_rate) { _clock_rate = clock_rate; }
+
+	// Callback fired whenever the jitter buffer advances its "processed up
+	// to" sequence number (after emitting or discarding a frame). The NACK
+	// generator uses this to drop pending entries it no longer needs to chase.
+	void SetOnProcessedSeqAdvance(std::function<void(uint16_t)> callback)
+	{
+		_on_processed_seq_advance = std::move(callback);
+	}
+
+	// Provider returning the lowest seq still pending NACK recovery (or
+	// nullopt if none). When set, HasAvailableFrame holds a complete head
+	// frame whose first packet is greater than a pending recovery, giving
+	// NACK a chance to fill in the missing earlier frame.
+	void SetLowestPendingSeqProvider(std::function<std::optional<uint16_t>()> provider)
+	{
+		_lowest_pending_seq_provider = std::move(provider);
+	}
+
+private:
+	void BurnOutExpiredFrames();
 	uint64_t GetExtentedTimestamp(uint32_t timestamp);
+	uint32_t CurrentHoldMs();
+	void UpdateFrameIntervalEstimate(uint32_t rtp_ts);
+	void AdvanceProcessedSeq(RtpFrame &frame);
+	// Records bookkeeping after a frame leaves the buffer (emitted or
+	// discarded): advances the processed timestamp/seq watermarks and
+	// updates the frame-interval estimate. Caller still has to erase the
+	// frame from `_rtp_frames`.
+	void MarkFrameProcessed(uint64_t extended_timestamp, RtpFrame &frame);
 
 	uint32_t _last_timestamp = 0;
 	uint32_t _timestamp_cycle = 0;
 
-	// timestamp : RtpFrameInfo
-	// it should be ordered, so use std::map
+	std::function<uint32_t()> _hold_ms_provider;
+	std::function<void(uint16_t)> _on_processed_seq_advance;
+	std::function<std::optional<uint16_t>()> _lowest_pending_seq_provider;
+	uint32_t _clock_rate = 0;
+
+	bool _has_processed_seq = false;
+	uint16_t _last_processed_max_seq = 0;
+
+	// Conservative seed for the frame-interval mean-deviation. Until the
+	// EWMA collects a few real samples we have no idea what fps / pacing
+	// the publisher will use, so we err large: the first keyframe can be
+	// big and pacing-bursted, and discarding it triggers a long PLI/IDR
+	// recovery downstream. Real samples shrink this within a few frames.
+	static constexpr uint32_t INITIAL_FRAME_INTERVAL_DEV_GUESS_MS = 50;
+
+	// Smoothed frame interval (ms) and its mean-deviation, measured from
+	// the RTP timestamp delta between consecutive processed frames.
+	// CurrentHoldMs uses (mean + 4*dev) to absorb publisher pacing burst:
+	// adaptive bitrate / pacer / encoder stalls can stretch a single gap
+	// to several frame intervals, and a constant + dev term lets the hold
+	// follow that variability without any fixed magic margin. The mean
+	// starts at 0 (first sample seeds it directly) but the deviation
+	// starts large so the very first frame (e.g. the initial keyframe)
+	// has enough hold for NACK retries before EWMA has caught up.
+	bool _has_last_processed_rtp_ts = false;
+	uint32_t _last_processed_rtp_ts = 0;
+	uint32_t _frame_interval_ms = 0;
+	uint32_t _frame_interval_dev_ms = INITIAL_FRAME_INTERVAL_DEV_GUESS_MS;
+
+	// Highest extended timestamp already emitted or dropped. Rejects packets
+	// for an older timestamp (typical for late RTX after a frame has been
+	// popped) so they don't create a phantom duplicate frame.
+	bool _has_processed_timestamp = false;
+	uint64_t _last_processed_timestamp = 0;
+
+	// timestamp : RtpFrameInfo (ordered, so std::map)
 	std::map<uint64_t, std::shared_ptr<RtpFrame>> _rtp_frames;
 };

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.h
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.h
@@ -82,6 +82,11 @@ public:
 	// legacy "drop incomplete predecessor on next complete" behavior.
 	void SetHoldMsProvider(std::function<uint32_t()> provider) { _hold_ms_provider = std::move(provider); }
 
+	// Upper bound for the total hold (the operator's MaxHoldMs latency budget).
+	// 0 = no cap. Clamps CurrentHoldMs so the frame-interval margin can't push
+	// the hold past the configured ceiling.
+	void SetMaxHoldMs(uint32_t max_hold_ms) { _max_hold_ms = max_hold_ms; }
+
 	// RTP clock rate of the track. Used to convert RTP timestamp deltas
 	// between consecutive frames into milliseconds for the frame interval
 	// estimate. Must be set before frames start flowing.
@@ -123,6 +128,7 @@ private:
 	std::function<void(uint16_t)> _on_processed_seq_advance;
 	std::function<std::optional<uint16_t>()> _lowest_pending_seq_provider;
 	uint32_t _clock_rate = 0;
+	uint32_t _max_hold_ms = 0;  // 0 = no cap
 
 	bool _has_processed_seq = false;
 	uint16_t _last_processed_max_seq = 0;

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer_test.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer_test.cpp
@@ -1,0 +1,203 @@
+//==============================================================================
+//
+//  OvenMediaEngine - Unit Tests
+//
+//  Covers: RtpFrame completeness, RtpFrameJitterBuffer hold/advance behavior
+//
+//==============================================================================
+#include <gtest/gtest.h>
+#include <thread>
+
+#include "rtp_frame_jitter_buffer.h"
+#include "rtp_packet.h"
+
+namespace
+{
+constexpr uint32_t kTimestamp = 90000;
+constexpr uint32_t kClockRate = 90000;
+constexpr uint32_t kSsrc = 0x12345678;
+
+std::shared_ptr<RtpPacket> MakeStampedPacket(uint16_t seq, bool first, bool last, uint32_t ts = kTimestamp)
+{
+	auto p = std::make_shared<RtpPacket>();
+	p->SetPayloadType(96);
+	p->SetSequenceNumber(seq);
+	p->SetTimestamp(ts);
+	p->SetSsrc(kSsrc);
+	p->SetMarker(last);
+	uint8_t pl[4] = {0x21, 0x00, 0x00, 0x00};
+	p->SetPayload(pl, sizeof(pl));
+	p->SetFirstPacketOfFrame(first);
+	p->SetLastPacketOfFrame(last);
+	return p;
+}
+}  // namespace
+
+// ---- RtpFrame ----
+
+TEST(RtpFrame, CompleteWhenStartEndAndAllSeqsPresent)
+{
+	RtpFrame frame(kTimestamp);
+	frame.InsertPacket(MakeStampedPacket(100, /*first=*/true, false));
+	frame.InsertPacket(MakeStampedPacket(101, false, false));
+	frame.InsertPacket(MakeStampedPacket(102, false, /*last=*/true));
+	EXPECT_TRUE(frame.IsCompleted());
+}
+
+TEST(RtpFrame, IncompleteWhenStartMissing)
+{
+	RtpFrame frame(kTimestamp);
+	frame.InsertPacket(MakeStampedPacket(101, false, false));
+	frame.InsertPacket(MakeStampedPacket(102, false, /*last=*/true));
+	EXPECT_FALSE(frame.IsCompleted());
+}
+
+TEST(RtpFrame, IncompleteWhenEndMissing)
+{
+	RtpFrame frame(kTimestamp);
+	frame.InsertPacket(MakeStampedPacket(100, /*first=*/true, false));
+	frame.InsertPacket(MakeStampedPacket(101, false, false));
+	EXPECT_FALSE(frame.IsCompleted());
+}
+
+TEST(RtpFrame, IncompleteWhenMiddleSeqMissing)
+{
+	RtpFrame frame(kTimestamp);
+	frame.InsertPacket(MakeStampedPacket(100, /*first=*/true, false));
+	frame.InsertPacket(MakeStampedPacket(102, false, /*last=*/true));
+	EXPECT_FALSE(frame.IsCompleted());
+}
+
+TEST(RtpFrame, CompletesAcrossSeqWrap)
+{
+	RtpFrame frame(kTimestamp);
+	frame.InsertPacket(MakeStampedPacket(65534, /*first=*/true, false));
+	frame.InsertPacket(MakeStampedPacket(65535, false, false));
+	frame.InsertPacket(MakeStampedPacket(0, false, false));
+	frame.InsertPacket(MakeStampedPacket(1, false, /*last=*/true));
+	EXPECT_TRUE(frame.IsCompleted());
+}
+
+TEST(RtpFrame, GetMaxReceivedSeqTracksHighest)
+{
+	RtpFrame frame(kTimestamp);
+	frame.InsertPacket(MakeStampedPacket(100, true, false));
+	EXPECT_EQ(frame.GetMaxReceivedSeq(), 100);
+	frame.InsertPacket(MakeStampedPacket(105, false, false));
+	EXPECT_EQ(frame.GetMaxReceivedSeq(), 105);
+	frame.InsertPacket(MakeStampedPacket(103, false, false));   // older
+	EXPECT_EQ(frame.GetMaxReceivedSeq(), 105);
+}
+
+// ---- RtpFrameJitterBuffer (legacy: no hold provider) ----
+
+TEST(RtpFrameJitterBuffer, EmitsCompleteFrameImmediately)
+{
+	RtpFrameJitterBuffer buf;
+	buf.SetClockRate(kClockRate);
+	buf.InsertPacket(MakeStampedPacket(100, true, false));
+	buf.InsertPacket(MakeStampedPacket(101, false, true));
+	EXPECT_TRUE(buf.HasAvailableFrame());
+	auto f = buf.PopAvailableFrame();
+	ASSERT_NE(f, nullptr);
+	EXPECT_EQ(f->Timestamp(), kTimestamp);
+}
+
+TEST(RtpFrameJitterBuffer, IncompleteHeadHoldsLaterCompleteFrame_Legacy)
+{
+	// Without a hold_ms_provider the legacy "discard incomplete predecessor
+	// only on next completed" semantics apply: F1 incomplete, F2 complete ->
+	// HasAvailableFrame burns out F1 and returns F2.
+	RtpFrameJitterBuffer buf;
+	buf.SetClockRate(kClockRate);
+	buf.InsertPacket(MakeStampedPacket(100, true, false, /*ts=*/kTimestamp));  // F1 first
+	// (F1 marker missing on purpose.)
+	buf.InsertPacket(MakeStampedPacket(102, true, true, /*ts=*/kTimestamp + 3000));   // F2 single packet
+	EXPECT_TRUE(buf.HasAvailableFrame());
+	auto f = buf.PopAvailableFrame();
+	ASSERT_NE(f, nullptr);
+	EXPECT_EQ(f->Timestamp(), kTimestamp + 3000);   // F2 emitted, F1 discarded
+}
+
+// ---- RtpFrameJitterBuffer with NACK hold ----
+
+TEST(RtpFrameJitterBuffer, HoldsIncompleteHeadUntilTimeout)
+{
+	RtpFrameJitterBuffer buf;
+	buf.SetClockRate(kClockRate);
+	buf.SetHoldMsProvider([] { return 50u; });   // 50ms NACK hold
+	buf.InsertPacket(MakeStampedPacket(100, true, false));   // F1 first only
+	buf.InsertPacket(MakeStampedPacket(102, true, true, kTimestamp + 3000));   // F2 single packet
+
+	// Within hold: F1 still present, F2 should not be emitted yet.
+	EXPECT_FALSE(buf.HasAvailableFrame());
+
+	// After hold expires: F1 discarded, F2 emitted.
+	std::this_thread::sleep_for(std::chrono::milliseconds(60));
+	EXPECT_TRUE(buf.HasAvailableFrame());
+}
+
+TEST(RtpFrameJitterBuffer, AdvanceProcessedSeqFiresOnEmit)
+{
+	RtpFrameJitterBuffer buf;
+	buf.SetClockRate(kClockRate);
+	std::optional<uint16_t> last_advanced;
+	buf.SetOnProcessedSeqAdvance([&](uint16_t s) { last_advanced = s; });
+
+	buf.InsertPacket(MakeStampedPacket(100, true, false));
+	buf.InsertPacket(MakeStampedPacket(101, false, true));
+	buf.PopAvailableFrame();
+
+	ASSERT_TRUE(last_advanced.has_value());
+	EXPECT_EQ(*last_advanced, 101);
+}
+
+TEST(RtpFrameJitterBuffer, HoldsHeadCompleteUntilLowerPendingResolves)
+{
+	// Scenario from production: frame F+1 entirely lost (object never built).
+	// F+2 arrives as a single-packet frame and would emit immediately, but
+	// NackGen has seq 28254 pending (NACK in flight for the lost F+1 packet).
+	// HasAvailableFrame must hold F+2 until the pending recovers or expires.
+	RtpFrameJitterBuffer buf;
+	buf.SetClockRate(kClockRate);
+	buf.SetHoldMsProvider([] { return 200u; });
+	std::optional<uint16_t> lowest;
+	buf.SetLowestPendingSeqProvider([&] { return lowest; });
+
+	buf.InsertPacket(MakeStampedPacket(/*seq=*/28255, /*first=*/true, /*last=*/true, kTimestamp));
+
+	lowest = 28254;   // NackGen has prior packet pending
+	EXPECT_FALSE(buf.HasAvailableFrame()) << "must hold while lower seq still pending";
+
+	lowest = std::nullopt;   // recovered (or NackGen dropped)
+	EXPECT_TRUE(buf.HasAvailableFrame());
+}
+
+TEST(RtpFrameJitterBuffer, HeadHoldExpiresEventually)
+{
+	RtpFrameJitterBuffer buf;
+	buf.SetClockRate(kClockRate);
+	buf.SetHoldMsProvider([] { return 30u; });
+	std::optional<uint16_t> lowest = 28254;
+	buf.SetLowestPendingSeqProvider([&] { return lowest; });
+
+	buf.InsertPacket(MakeStampedPacket(28255, true, true, kTimestamp));
+
+	EXPECT_FALSE(buf.HasAvailableFrame());
+	std::this_thread::sleep_for(std::chrono::milliseconds(40));
+	EXPECT_TRUE(buf.HasAvailableFrame()) << "hold should release once timer elapses even with lower pending";
+}
+
+TEST(RtpFrameJitterBuffer, DropsLatePacketForProcessedTimestamp)
+{
+	RtpFrameJitterBuffer buf;
+	buf.SetClockRate(kClockRate);
+
+	buf.InsertPacket(MakeStampedPacket(100, true, true, kTimestamp));
+	auto f = buf.PopAvailableFrame();
+	ASSERT_NE(f, nullptr);
+
+	// Late RTX-style packet for the same (already-processed) timestamp.
+	bool ok = buf.InsertPacket(MakeStampedPacket(100, true, true, kTimestamp));
+	EXPECT_FALSE(ok);
+}

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer_test.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer_test.cpp
@@ -27,7 +27,10 @@ std::shared_ptr<RtpPacket> MakeStampedPacket(uint16_t seq, bool first, bool last
 	p->SetMarker(last);
 	uint8_t pl[4] = {0x21, 0x00, 0x00, 0x00};
 	p->SetPayload(pl, sizeof(pl));
-	p->SetFirstPacketOfFrame(first);
+	// Simulate the codec fallback path: a NAL/unit start (StartOfUnit). A
+	// multi-NAL access unit sets it on several packets; the buffer keeps the
+	// lowest as the frame start.
+	p->SetStartOfUnit(first);
 	p->SetLastPacketOfFrame(last);
 	return p;
 }
@@ -78,6 +81,30 @@ TEST(RtpFrame, CompletesAcrossSeqWrap)
 	EXPECT_TRUE(frame.IsCompleted());
 }
 
+TEST(RtpFrame, KeepsEarliestStartWhenMultipleFirstFlags)
+{
+	// A multi-NAL access unit flags several packets as "first" (e.g. STAP-A
+	// then FU-A start). The earliest must win, otherwise the frame is judged
+	// from the later NAL and never reaches its true packet count.
+	RtpFrame frame(kTimestamp);
+	frame.InsertPacket(MakeStampedPacket(100, /*first=*/true, false));   // STAP-A (SPS/PPS)
+	frame.InsertPacket(MakeStampedPacket(101, /*first=*/true, false));   // FU-A IDR start
+	frame.InsertPacket(MakeStampedPacket(102, false, /*last=*/true));
+	EXPECT_TRUE(frame.IsCompleted());
+	EXPECT_EQ(frame.GetFirstSequenceNumber(), 100);
+}
+
+TEST(RtpFrame, KeepsEarliestStartAcrossReorder)
+{
+	// Same as above but the later NAL's packet arrives first.
+	RtpFrame frame(kTimestamp);
+	frame.InsertPacket(MakeStampedPacket(101, /*first=*/true, false));
+	frame.InsertPacket(MakeStampedPacket(100, /*first=*/true, false));
+	frame.InsertPacket(MakeStampedPacket(102, false, /*last=*/true));
+	EXPECT_TRUE(frame.IsCompleted());
+	EXPECT_EQ(frame.GetFirstSequenceNumber(), 100);
+}
+
 TEST(RtpFrame, GetMaxReceivedSeqTracksHighest)
 {
 	RtpFrame frame(kTimestamp);
@@ -125,15 +152,16 @@ TEST(RtpFrameJitterBuffer, HoldsIncompleteHeadUntilTimeout)
 {
 	RtpFrameJitterBuffer buf;
 	buf.SetClockRate(kClockRate);
-	buf.SetHoldMsProvider([] { return 50u; });   // 50ms NACK hold
+	buf.SetHoldMsProvider([] { return 50u; });
 	buf.InsertPacket(MakeStampedPacket(100, true, false));   // F1 first only
 	buf.InsertPacket(MakeStampedPacket(102, true, true, kTimestamp + 3000));   // F2 single packet
 
 	// Within hold: F1 still present, F2 should not be emitted yet.
 	EXPECT_FALSE(buf.HasAvailableFrame());
 
-	// After hold expires: F1 discarded, F2 emitted.
-	std::this_thread::sleep_for(std::chrono::milliseconds(60));
+	// Effective hold = provider(50) + frame-interval mean(0) + 4*dev(seed 50)
+	// ~= 250ms, so sleep well past it before expecting F1 to be discarded.
+	std::this_thread::sleep_for(std::chrono::milliseconds(320));
 	EXPECT_TRUE(buf.HasAvailableFrame());
 }
 
@@ -184,7 +212,9 @@ TEST(RtpFrameJitterBuffer, HeadHoldExpiresEventually)
 	buf.InsertPacket(MakeStampedPacket(28255, true, true, kTimestamp));
 
 	EXPECT_FALSE(buf.HasAvailableFrame());
-	std::this_thread::sleep_for(std::chrono::milliseconds(40));
+	// Effective hold = provider(30) + frame-interval mean(0) + 4*dev(seed 50)
+	// ~= 230ms; sleep past it so the head releases despite the lower pending.
+	std::this_thread::sleep_for(std::chrono::milliseconds(320));
 	EXPECT_TRUE(buf.HasAvailableFrame()) << "hold should release once timer elapses even with lower pending";
 }
 

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer_test.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer_test.cpp
@@ -165,6 +165,23 @@ TEST(RtpFrameJitterBuffer, HoldsIncompleteHeadUntilTimeout)
 	EXPECT_TRUE(buf.HasAvailableFrame());
 }
 
+TEST(RtpFrameJitterBuffer, MaxHoldCapsTotalHold)
+{
+	// Without a cap the hold would be provider(50) + 4*dev(seed 50) ~= 250ms.
+	// SetMaxHoldMs(60) caps the total, so the incomplete head is discarded and
+	// the later frame flows well before 250ms.
+	RtpFrameJitterBuffer buf;
+	buf.SetClockRate(kClockRate);
+	buf.SetHoldMsProvider([] { return 50u; });
+	buf.SetMaxHoldMs(60);
+	buf.InsertPacket(MakeStampedPacket(100, true, false));   // F1 incomplete (no end)
+	buf.InsertPacket(MakeStampedPacket(102, true, true, kTimestamp + 3000));   // F2 complete
+
+	EXPECT_FALSE(buf.HasAvailableFrame());   // within the 60ms cap
+	std::this_thread::sleep_for(std::chrono::milliseconds(90));
+	EXPECT_TRUE(buf.HasAvailableFrame());    // released at the capped hold, far below 250ms
+}
+
 TEST(RtpFrameJitterBuffer, AdvanceProcessedSeqFiresOnEmit)
 {
 	RtpFrameJitterBuffer buf;

--- a/src/projects/modules/rtp_rtcp/rtp_header_extension/rtp_header_extension.h
+++ b/src/projects/modules/rtp_rtcp/rtp_header_extension/rtp_header_extension.h
@@ -23,6 +23,9 @@
 #define RTP_HEADER_EXTENSION_RTP_STREAM_ID	7
 #define RTP_HEADER_EXTENSION_RTP_STREAM_ATTRIBUTE "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id"
 
+// Dependency Descriptor uses a dynamically negotiated id (no fixed OME id).
+#define RTP_HEADER_EXTENSION_DEPENDENCY_DESCRIPTOR_ATTRIBUTE "https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension"
+
 class RtpHeaderExtension
 {
 public:

--- a/src/projects/modules/rtp_rtcp/rtp_header_extension/rtp_header_extension_dependency_descriptor.h
+++ b/src/projects/modules/rtp_rtcp/rtp_header_extension/rtp_header_extension_dependency_descriptor.h
@@ -1,0 +1,71 @@
+#pragma once
+
+// https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension
+
+#include <base/ovlibrary/ovlibrary.h>
+#include "rtp_header_extension.h"
+
+//  0                   1                   2
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |S|E| template_id |          frame_number         |  mandatory_descriptor_fields
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// | extended_descriptor_fields (variable, optional)               |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//
+// S = start_of_frame, E = end_of_frame. Only the mandatory fields are parsed:
+// the extended fields encode the dependency template structure (scalability,
+// resolution, decode targets) which OvenMediaEngine does not need for frame
+// boundary detection. The id is negotiated dynamically, so it is supplied at
+// construction rather than via a fixed OME extension id.
+class RtpHeaderExtensionDependencyDescriptor : public RtpHeaderExtension
+{
+public:
+	RtpHeaderExtensionDependencyDescriptor(uint8_t id)
+		: RtpHeaderExtension(id)
+	{
+	}
+
+	bool IsStartOfFrame() const { return _start_of_frame; }
+	bool IsEndOfFrame() const { return _end_of_frame; }
+	uint8_t GetTemplateId() const { return _template_id; }
+	uint16_t GetFrameNumber() const { return _frame_number; }
+
+	bool SetData(const std::shared_ptr<ov::Data> &data) override
+	{
+		// At least the first mandatory byte (S/E/template_id) is required.
+		// frame_number occupies the next two bytes when the descriptor is the
+		// full mandatory form.
+		if (data == nullptr || data->GetLength() < 1)
+		{
+			return false;
+		}
+
+		auto p = data->GetDataAs<uint8_t>();
+		_start_of_frame = (p[0] & 0x80) != 0;
+		_end_of_frame = (p[0] & 0x40) != 0;
+		_template_id = p[0] & 0x3F;
+		if (data->GetLength() >= 3)
+		{
+			_frame_number = ByteReader<uint16_t>::ReadBigEndian(&p[1]);
+		}
+
+		_data = data;
+
+		return true;
+	}
+
+protected:
+	std::shared_ptr<ov::Data> GetData(HeaderType type) override
+	{
+		return _data;
+	}
+
+private:
+	std::shared_ptr<ov::Data> _data;
+
+	bool _start_of_frame = false;
+	bool _end_of_frame = false;
+	uint8_t _template_id = 0;
+	uint16_t _frame_number = 0;
+};

--- a/src/projects/modules/rtp_rtcp/rtp_nack_generator.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_nack_generator.cpp
@@ -1,0 +1,365 @@
+#include "rtp_nack_generator.h"
+
+#include <algorithm>
+#include <cmath>
+
+#define OV_LOG_TAG "RtpNack"
+
+RtpNackGenerator::RtpNackGenerator(uint32_t track_id, uint32_t media_ssrc, uint32_t max_hold_ms)
+	: _track_id(track_id), _media_ssrc(media_ssrc), _hold_max_ms(max_hold_ms)
+{
+}
+
+std::optional<uint32_t> RtpNackGenerator::ExtendSeq(uint16_t seq) const
+{
+	if (_initialized == false)
+	{
+		return static_cast<uint32_t>(seq);
+	}
+
+	uint16_t last_seq = static_cast<uint16_t>(_newest_extended & 0xFFFF);
+	int16_t diff = static_cast<int16_t>(seq - last_seq);
+
+	int64_t extended = static_cast<int64_t>(_newest_extended) + diff;
+	if (extended < 0)
+	{
+		// Very old packet (predates the first packet we ever saw on this track).
+		return std::nullopt;
+	}
+
+	return static_cast<uint32_t>(extended);
+}
+
+void RtpNackGenerator::OnPacketReceived(uint16_t seq)
+{
+	auto now = std::chrono::steady_clock::now();
+
+	_received_total++;
+
+	if (_initialized == false)
+	{
+		_initialized = true;
+		_newest_extended = static_cast<uint32_t>(seq);
+		_expected_next = static_cast<uint32_t>(seq) + 1;
+		_last_stats_log_at = now;
+		return;
+	}
+
+	auto extended_opt = ExtendSeq(seq);
+	if (extended_opt.has_value() == false)
+	{
+		// Pre-track-start packet; nothing to do.
+		return;
+	}
+	uint32_t extended = *extended_opt;
+
+	if (extended >= _expected_next)
+	{
+		// In-order or new gap.
+		if (extended > _expected_next)
+		{
+			uint32_t gap_size = extended - _expected_next;
+			logtd("Gap detected track(%u) ssrc(%u) missing [%u..%u] (%u packets)",
+				  _track_id, _media_ssrc,
+				  static_cast<uint16_t>(_expected_next & 0xFFFF),
+				  static_cast<uint16_t>((extended - 1) & 0xFFFF),
+				  gap_size);
+
+			uint32_t inserted = 0;
+			for (uint32_t s = _expected_next; s < extended; s++)
+			{
+				if (_pending.size() >= MAX_PENDING)
+				{
+					uint32_t skipped = (extended - _expected_next) - inserted;
+					logtw("NACK pending full track(%u) ssrc(%u): skipping %u of %u gap seqs "
+						  "(pending cap %zu reached). Those seqs will not be NACK'd.",
+						  _track_id, _media_ssrc, skipped, gap_size, MAX_PENDING);
+					break;
+				}
+
+				// first_nack_at / last_nack_at / retry_count are stamped
+				// when BuildPendingNack fires the initial NACK.
+				PendingEntry entry;
+				entry.inserted_at = now;
+				_pending.emplace(s, entry);
+				inserted++;
+			}
+		}
+
+		_expected_next = extended + 1;
+		_newest_extended = extended;
+	}
+	else
+	{
+		// Late or RTX-recovered packet.
+		auto it = _pending.find(extended);
+		if (it != _pending.end())
+		{
+			auto age_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+							  now - it->second.inserted_at)
+							  .count();
+
+			if (it->second.retry_count == 0)
+			{
+				// Filled within dwell — natural reorder, no NACK was sent.
+				logtd("Reorder absorbed track(%u) ssrc(%u) seq(%u) age(%ldms) — no NACK sent",
+					  _track_id, _media_ssrc, static_cast<uint16_t>(extended & 0xFFFF), age_ms);
+			}
+			else
+			{
+				// NACK was already fired; this is the late arrival.
+				// Could be the RTX response OR the original packet finally
+				// reordering through — generator can't distinguish, and
+				// doesn't need to (pending is cleared either way).
+				auto latency_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+									  now - it->second.first_nack_at)
+									  .count();
+				logtd("Late seq recovered track(%u) ssrc(%u) seq(%u) latency(%ldms) retries(%u)",
+					  _track_id, _media_ssrc, static_cast<uint16_t>(extended & 0xFFFF),
+					  latency_ms, it->second.retry_count);
+
+				// Karn algorithm: only sample latency when exactly one NACK was
+				// sent for this seq; retransmits introduce ambiguity.
+				if (it->second.retry_count == 1)
+				{
+					UpdateLatencyStats(static_cast<double>(latency_ms), now);
+				}
+				_recovered_total++;
+			}
+			_pending.erase(it);
+		}
+	}
+
+	DiscardStale(now);
+	LogPeriodicStats(now);
+}
+
+std::vector<uint16_t> RtpNackGenerator::BuildPendingNack()
+{
+	auto now = std::chrono::steady_clock::now();
+
+	DiscardStale(now);
+
+	auto retry_interval = std::chrono::milliseconds(static_cast<int64_t>(_ewma_ms));
+	auto dwell = std::chrono::milliseconds(INITIAL_NACK_DWELL_MS);
+
+	std::vector<uint16_t> ids;
+	size_t initial_count = 0;
+	size_t retry_count_total = 0;
+	for (auto &kv : _pending)
+	{
+		auto &entry = kv.second;
+
+		if (entry.retry_count == 0)
+		{
+			// Wait a short dwell before the first NACK so brief out-of-order
+			// delivery (seq 102 arriving before 101) clears itself without
+			// triggering a spurious NACK + RTX round-trip.
+			if ((now - entry.inserted_at) < dwell)
+			{
+				continue;
+			}
+			ids.push_back(static_cast<uint16_t>(kv.first & 0xFFFF));
+			entry.first_nack_at = now;
+			entry.last_nack_at = now;
+			entry.retry_count = 1;
+			initial_count++;
+		}
+		else if ((now - entry.last_nack_at) >= retry_interval)
+		{
+			// Retry every RTT until the jitter buffer ends the entry (via
+			// DropPendingUpTo) or MAX_AGE_MS absolute cap fires.
+			ids.push_back(static_cast<uint16_t>(kv.first & 0xFFFF));
+			entry.last_nack_at = now;
+			entry.retry_count++;
+			retry_count_total++;
+		}
+	}
+
+	_nacks_sent_total += ids.size();
+
+	if (ids.empty() == false)
+	{
+		logtd("Fire NACK track(%u) ssrc(%u) total(%zu) initial(%zu) retry(%zu) pending(%zu) hold(%ums)",
+			  _track_id, _media_ssrc, ids.size(), initial_count, retry_count_total, _pending.size(),
+			  GetRecommendedHoldMs());
+	}
+
+	return ids;
+}
+
+uint32_t RtpNackGenerator::GetRecommendedHoldMs() const
+{
+	// Use real EWMA when we have a fresh sample; otherwise fall back to the
+	// initial RTT guess (same source used to seed _ewma_ms for retry interval).
+	double ewma = INITIAL_RTT_GUESS_MS;
+	double dev = 0.0;
+	if (_stats_initialized)
+	{
+		auto since_last_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+								 std::chrono::steady_clock::now() - _last_sample_at)
+								 .count();
+		if (since_last_ms <= STATS_DECAY_MS)
+		{
+			ewma = _ewma_ms;
+			dev = _ewma_dev_ms;
+		}
+	}
+
+	// Hold long enough for MAX_NACK_RETRIES rounds: each NACK fires every
+	// `ewma` and its RTX answer arrives one `ewma` later, so N rounds
+	// complete by N * ewma after the first NACK. `dev` absorbs the variance
+	// the round-trip sample already captures.
+	double hold = INITIAL_NACK_DWELL_MS
+				+ MAX_NACK_RETRIES * ewma
+				+ EWMA_DEV_MULTIPLIER * dev;
+	if (hold < HOLD_MIN_MS) hold = HOLD_MIN_MS;
+	if (hold > _hold_max_ms) hold = _hold_max_ms;
+
+	return static_cast<uint32_t>(hold);
+}
+
+std::optional<uint16_t> RtpNackGenerator::GetLowestPendingSeq() const
+{
+	if (_pending.empty())
+	{
+		return std::nullopt;
+	}
+	return static_cast<uint16_t>(_pending.begin()->first & 0xFFFF);
+}
+
+void RtpNackGenerator::DropPendingUpTo(uint16_t max_seq)
+{
+	if (_initialized == false)
+	{
+		return;
+	}
+	auto now = std::chrono::steady_clock::now();
+	auto ext_max_opt = ExtendSeq(max_seq);
+	if (ext_max_opt.has_value() == false)
+	{
+		return;
+	}
+	uint32_t ext_max = *ext_max_opt;
+	size_t dropped = 0;
+	uint16_t first_dropped_seq = 0;
+	uint16_t last_dropped_seq = 0;
+	uint32_t min_retry = std::numeric_limits<uint32_t>::max();
+	uint32_t max_retry = 0;
+	uint32_t total_retry = 0;
+	int64_t min_age_ms = 0;
+	int64_t max_age_ms = 0;
+	auto it = _pending.begin();
+	while (it != _pending.end() && it->first <= ext_max)
+	{
+		auto seq16 = static_cast<uint16_t>(it->first & 0xFFFF);
+		auto rc = it->second.retry_count;
+		auto age = std::chrono::duration_cast<std::chrono::milliseconds>(now - it->second.inserted_at).count();
+		if (dropped == 0)
+		{
+			first_dropped_seq = seq16;
+			min_age_ms = age;
+			max_age_ms = age;
+		}
+		last_dropped_seq = seq16;
+		if (rc < min_retry) min_retry = rc;
+		if (rc > max_retry) max_retry = rc;
+		total_retry += rc;
+		if (age < min_age_ms) min_age_ms = age;
+		if (age > max_age_ms) max_age_ms = age;
+		_lost_permanent_total++;
+		dropped++;
+		it = _pending.erase(it);
+	}
+	// TEMP: debug log to verify jitter buffer -> NackGen sync.
+	if (dropped > 0)
+	{
+		double avg_retry = static_cast<double>(total_retry) / static_cast<double>(dropped);
+		logtd("DropPendingUpTo track(%u) ssrc(%u) up_to_seq(%u) dropped(%zu) range[%u..%u] "
+			  "retries[min(%u) max(%u) avg(%.1f)] age_ms[min(%ld) max(%ld)] pending_remain(%zu) "
+			  "ewma(%.1f) dev(%.1f) hold(%u)",
+			  _track_id, _media_ssrc, max_seq, dropped, first_dropped_seq, last_dropped_seq,
+			  min_retry, max_retry, avg_retry, min_age_ms, max_age_ms, _pending.size(),
+			  _ewma_ms, _ewma_dev_ms, GetRecommendedHoldMs());
+	}
+}
+
+void RtpNackGenerator::UpdateLatencyStats(double sample_ms, std::chrono::steady_clock::time_point now)
+{
+	if (_stats_initialized == false)
+	{
+		_ewma_ms = sample_ms;
+		_ewma_dev_ms = sample_ms / 2.0;
+		_stats_initialized = true;
+	}
+	else
+	{
+		double err = sample_ms - _ewma_ms;
+		_ewma_ms += EWMA_ALPHA * err;
+		_ewma_dev_ms += EWMA_DEV_ALPHA * (std::fabs(err) - _ewma_dev_ms);
+	}
+
+	_last_sample_at = now;
+}
+
+void RtpNackGenerator::DiscardStale(std::chrono::steady_clock::time_point now)
+{
+	auto max_age = std::chrono::milliseconds(MAX_AGE_MS);
+
+	for (auto it = _pending.begin(); it != _pending.end();)
+	{
+		// Absolute safety cap; the normal end signal is DropPendingUpTo
+		// driven by the jitter buffer.
+		if ((now - it->second.inserted_at) > max_age)
+		{
+			auto age_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+							  now - it->second.inserted_at)
+							  .count();
+			logtd("Drop unrecoverable track(%u) ssrc(%u) seq(%u) age(%ldms) retries(%u) reason(age)",
+				  _track_id, _media_ssrc, static_cast<uint16_t>(it->first & 0xFFFF),
+				  age_ms, it->second.retry_count);
+			_lost_permanent_total++;
+			it = _pending.erase(it);
+		}
+		else
+		{
+			++it;
+		}
+	}
+}
+
+void RtpNackGenerator::LogPeriodicStats(std::chrono::steady_clock::time_point now)
+{
+	if (now - _last_stats_log_at < std::chrono::milliseconds(STATS_LOG_INTERVAL_MS))
+	{
+		return;
+	}
+
+	uint64_t d_received	 = _received_total - _prev_received;
+	uint64_t d_nacks	 = _nacks_sent_total - _prev_nacks_sent;
+	uint64_t d_recovered = _recovered_total - _prev_recovered;
+	uint64_t d_lost		 = _lost_permanent_total - _prev_lost_permanent;
+
+	double loss_pct = 0.0;
+	if (d_received + d_lost > 0)
+	{
+		loss_pct = 100.0 * static_cast<double>(d_lost) / static_cast<double>(d_received + d_lost);
+	}
+	double recovery_pct = 0.0;
+	if (d_recovered + d_lost > 0)
+	{
+		recovery_pct = 100.0 * static_cast<double>(d_recovered) / static_cast<double>(d_recovered + d_lost);
+	}
+
+	logtd("NackStats track(%u) ssrc(%u) recv(+%lu) nack(+%lu) recovered(+%lu) lost(+%lu) loss(%.2f%%) recovery(%.2f%%) "
+		  "totals[recv(%lu) nack(%lu) recovered(%lu) lost(%lu)] pending(%zu) hold(%ums)",
+		  _track_id, _media_ssrc, d_received, d_nacks, d_recovered, d_lost, loss_pct, recovery_pct,
+		  _received_total, _nacks_sent_total, _recovered_total, _lost_permanent_total,
+		  _pending.size(), GetRecommendedHoldMs());
+
+	_prev_received		  = _received_total;
+	_prev_nacks_sent	  = _nacks_sent_total;
+	_prev_recovered		  = _recovered_total;
+	_prev_lost_permanent  = _lost_permanent_total;
+	_last_stats_log_at	  = now;
+}

--- a/src/projects/modules/rtp_rtcp/rtp_nack_generator.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_nack_generator.cpp
@@ -271,7 +271,8 @@ void RtpNackGenerator::DropPendingUpTo(uint16_t max_seq)
 		dropped++;
 		it = _pending.erase(it);
 	}
-	// TEMP: debug log to verify jitter buffer -> NackGen sync.
+	// One line per jitter-buffer-driven drop so recovery rate and NACK->RTX
+	// timing can be traced against the buffer's processed-seq advances.
 	if (dropped > 0)
 	{
 		double avg_retry = static_cast<double>(total_retry) / static_cast<double>(dropped);
@@ -286,6 +287,13 @@ void RtpNackGenerator::DropPendingUpTo(uint16_t max_seq)
 
 void RtpNackGenerator::UpdateLatencyStats(double sample_ms, std::chrono::steady_clock::time_point now)
 {
+	// A latency that rounds down to 0ms would drive _ewma_ms to 0 and make the
+	// retry interval 0, retrying on every flush. Floor the sample at 1ms.
+	if (sample_ms < 1.0)
+	{
+		sample_ms = 1.0;
+	}
+
 	if (_stats_initialized == false)
 	{
 		_ewma_ms = sample_ms;

--- a/src/projects/modules/rtp_rtcp/rtp_nack_generator.h
+++ b/src/projects/modules/rtp_rtcp/rtp_nack_generator.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <base/ovlibrary/ovlibrary.h>
+#include <chrono>
+#include <map>
+#include <optional>
+#include <vector>
+
+// Per-track receive-side NACK generator (RFC 4585 Generic NACK).
+//
+// Watches incoming RTP sequence numbers for one SSRC, builds the list of
+// seqs that should be NACK'd next, and tracks NACK->RTX round-trip latency
+// to recommend a jitter-buffer hold window.
+//
+// Caller (RtpRtcp) drives:
+//   - OnPacketReceived(seq) for every incoming RTP packet of the SSRC,
+//     including original payload and RTX-unwrapped packets.
+//   - BuildPendingNack() on a short cadence (e.g. 10ms tick) and sends
+//     the returned list as one RTCP NACK FCI chain.
+class RtpNackGenerator
+{
+public:
+	static constexpr size_t MAX_PENDING		= 250;
+	// Absolute safety cap when the jitter buffer never advances past a seq
+	// (e.g. very first packet of a stream lost before any frame is built).
+	// In the normal path, the jitter buffer's DropPendingUpTo callback ends
+	// pending entries far sooner than this.
+	static constexpr uint32_t MAX_AGE_MS	= 500;
+	// Number of NACK retries the hold window must accommodate. The hold
+	// formula reserves room for this many retry intervals plus one final
+	// RTT for the last RTX response. 5 is conservative against burst loss
+	// where independent-probability math doesn't apply.
+	static constexpr uint32_t MAX_NACK_RETRIES = 5;
+	// Dwell time between gap detection and the initial NACK firing.
+	// Absorbs small UDP reordering so that brief out-of-order delivery
+	// (seq 102 before 101) doesn't trigger a spurious NACK + RTX round-trip.
+	static constexpr uint32_t INITIAL_NACK_DWELL_MS = 10;
+
+	static constexpr uint32_t HOLD_MIN_MS		= 50;
+	static constexpr uint32_t HOLD_MAX_MS_DEFAULT = 400;
+	// Initial RTT guess used as both the seed for the retry interval and
+	// the substitute EWMA value while no NACK->RTX sample has been recorded
+	// (or after long stats decay). Real value lands within a few hundred ms.
+	static constexpr double INITIAL_RTT_GUESS_MS = 15.0;
+	static constexpr double EWMA_ALPHA			= 0.125;
+	static constexpr double EWMA_DEV_ALPHA		= 0.25;
+	static constexpr double EWMA_DEV_MULTIPLIER	= 4.0;
+	static constexpr uint32_t STATS_DECAY_MS	= 30 * 1000;
+	static constexpr uint32_t STATS_LOG_INTERVAL_MS = 5 * 1000;
+
+	RtpNackGenerator(uint32_t track_id, uint32_t media_ssrc, uint32_t max_hold_ms = HOLD_MAX_MS_DEFAULT);
+
+	uint32_t GetMediaSsrc() const { return _media_ssrc; }
+
+	// Feed every received RTP packet's sequence number, in arrival order.
+	void OnPacketReceived(uint16_t seq);
+
+	// Returns seqs to send in the next NACK packet (initial + due retries).
+	// Caller MUST send them; this call mutates retry state and advances
+	// last-request timestamps. Returned list is in ascending seq order
+	// suitable for NACK::AddLostId() FCI grouping.
+	std::vector<uint16_t> BuildPendingNack();
+
+	// Drop pending entries whose seq <= max_seq (wrap-safe). Called by the
+	// jitter buffer when it advances past a frame so we stop chasing seqs
+	// the consumer no longer wants.
+	void DropPendingUpTo(uint16_t max_seq);
+
+	// Lowest seq still pending NACK recovery, if any. The jitter buffer
+	// uses this to hold a complete frame whose first packet is newer than
+	// a pending recovery, so we don't emit out-of-order before NACK has a
+	// chance.
+	std::optional<uint16_t> GetLowestPendingSeq() const;
+
+	// Jitter-buffer hold window recommendation in ms.
+	//   hold = dwell + MAX_NACK_RETRIES * ewma + 4 * dev
+	// clamped to [HOLD_MIN_MS, max_hold_ms]. Each round (NACK + RTX answer)
+	// takes one ewma, so N rounds complete in N * ewma. Before the first
+	// NACK->RTX sample (or after STATS_DECAY_MS of no new sample), ewma
+	// falls back to INITIAL_RTT_GUESS_MS and dev to 0.
+	uint32_t GetRecommendedHoldMs() const;
+
+private:
+	struct PendingEntry
+	{
+		std::chrono::steady_clock::time_point first_nack_at;
+		std::chrono::steady_clock::time_point last_nack_at;
+		uint32_t retry_count = 0;
+		std::chrono::steady_clock::time_point inserted_at;
+	};
+
+	std::optional<uint32_t> ExtendSeq(uint16_t seq) const;
+	void UpdateLatencyStats(double sample_ms, std::chrono::steady_clock::time_point now);
+	void DiscardStale(std::chrono::steady_clock::time_point now);
+	void LogPeriodicStats(std::chrono::steady_clock::time_point now);
+
+	uint32_t _track_id = 0;
+	uint32_t _media_ssrc = 0;
+	uint32_t _hold_max_ms = HOLD_MAX_MS_DEFAULT;
+
+	bool _initialized = false;
+	uint32_t _newest_extended = 0;	// last seq seen in extended (uint32) form
+	uint32_t _expected_next = 0;	// next extended seq we expect
+
+	std::map<uint32_t /*extended seq*/, PendingEntry> _pending;
+
+	// NACK->RTX latency stats (smoothed mean + mean-deviation, milliseconds).
+	// _ewma_ms doubles as the NACK retry interval. Seeded with the same
+	// initial RTT guess that GetRecommendedHoldMs falls back to, so retry
+	// timing and hold timing agree before the first sample lands.
+	bool _stats_initialized = false;
+	double _ewma_ms = INITIAL_RTT_GUESS_MS;
+	double _ewma_dev_ms = 0.0;
+	std::chrono::steady_clock::time_point _last_sample_at;
+
+	// Cumulative monitoring counters. Logged every STATS_LOG_INTERVAL_MS as
+	// deltas (loss / recovery snapshot) and as cumulative totals.
+	uint64_t _received_total = 0;
+	uint64_t _nacks_sent_total = 0;
+	uint64_t _recovered_total = 0;
+	uint64_t _lost_permanent_total = 0;
+	uint64_t _prev_received = 0;
+	uint64_t _prev_nacks_sent = 0;
+	uint64_t _prev_recovered = 0;
+	uint64_t _prev_lost_permanent = 0;
+	std::chrono::steady_clock::time_point _last_stats_log_at;
+};

--- a/src/projects/modules/rtp_rtcp/rtp_nack_generator_test.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_nack_generator_test.cpp
@@ -136,11 +136,11 @@ TEST(RtpNackGenerator, InitialRecommendedHoldUsesGuessClampedToMin)
 // MaxHoldMs constructor argument clamps GetRecommendedHoldMs upper bound.
 TEST(RtpNackGenerator, MaxHoldClamps)
 {
-	RtpNackGenerator gen(kTrackId, kSsrc, 80);
-	// Force stats to a very large value to test clamp.
-	// (Indirect: we can't poke private members here; instead just verify
-	// default path still respects the cap when initialized.)
-	EXPECT_LE(gen.GetRecommendedHoldMs(), 150u);  // default first
+	// Initial hold = dwell(10) + retries(5) * RTT_guess(15) + 4 * dev(0) = 85,
+	// which exceeds the 80ms cap, so the clamp is exercised here.
+	RtpNackGenerator gen(kTrackId, kSsrc, /*max_hold_ms=*/80);
+	EXPECT_LE(gen.GetRecommendedHoldMs(), 80u);
+	EXPECT_GE(gen.GetRecommendedHoldMs(), RtpNackGenerator::HOLD_MIN_MS);
 }
 
 // Retry interval respects ewma. Build twice within the interval -> only the

--- a/src/projects/modules/rtp_rtcp/rtp_nack_generator_test.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_nack_generator_test.cpp
@@ -1,0 +1,159 @@
+//==============================================================================
+//
+//  OvenMediaEngine - Unit Tests
+//
+//  Covers: RtpNackGenerator
+//
+//==============================================================================
+#include <gtest/gtest.h>
+#include <thread>
+
+#include "rtp_nack_generator.h"
+
+namespace
+{
+constexpr uint32_t kTrackId = 1;
+constexpr uint32_t kSsrc = 0xDEADBEEF;
+}  // namespace
+
+// Bootstrap: first seq sets the highest watermark, no gap reported yet.
+TEST(RtpNackGenerator, Bootstrap)
+{
+	RtpNackGenerator gen(kTrackId, kSsrc);
+	gen.OnPacketReceived(100);
+	EXPECT_FALSE(gen.GetLowestPendingSeq().has_value());
+}
+
+// Single-seq gap: 100, 102 -> [101] pending after dwell.
+TEST(RtpNackGenerator, SingleGapAddsToPending)
+{
+	RtpNackGenerator gen(kTrackId, kSsrc);
+	gen.OnPacketReceived(100);
+	gen.OnPacketReceived(102);
+	ASSERT_TRUE(gen.GetLowestPendingSeq().has_value());
+	EXPECT_EQ(*gen.GetLowestPendingSeq(), 101);
+}
+
+// Multi-seq gap: 100, 105 -> [101, 102, 103, 104].
+TEST(RtpNackGenerator, MultiSeqGap)
+{
+	RtpNackGenerator gen(kTrackId, kSsrc);
+	gen.OnPacketReceived(100);
+	gen.OnPacketReceived(105);
+	ASSERT_TRUE(gen.GetLowestPendingSeq().has_value());
+	EXPECT_EQ(*gen.GetLowestPendingSeq(), 101);
+}
+
+// Dwell absorbs a quick reorder: 100, 102, 101 (within 10ms) -> no NACK fired.
+TEST(RtpNackGenerator, ReorderAbsorbedWithinDwell)
+{
+	RtpNackGenerator gen(kTrackId, kSsrc);
+	gen.OnPacketReceived(100);
+	gen.OnPacketReceived(102);
+	gen.OnPacketReceived(101);   // reorder filled the gap immediately
+	auto ids = gen.BuildPendingNack();
+	EXPECT_TRUE(ids.empty());
+	EXPECT_FALSE(gen.GetLowestPendingSeq().has_value());
+}
+
+// After dwell expires, BuildPendingNack returns the gap.
+TEST(RtpNackGenerator, NackFiresAfterDwell)
+{
+	RtpNackGenerator gen(kTrackId, kSsrc);
+	gen.OnPacketReceived(100);
+	gen.OnPacketReceived(102);
+	std::this_thread::sleep_for(std::chrono::milliseconds(RtpNackGenerator::INITIAL_NACK_DWELL_MS + 5));
+	auto ids = gen.BuildPendingNack();
+	ASSERT_EQ(ids.size(), 1u);
+	EXPECT_EQ(ids[0], 101);
+}
+
+// Recovery: missing seq arrives after NACK -> pending cleared.
+TEST(RtpNackGenerator, RecoverClearsPending)
+{
+	RtpNackGenerator gen(kTrackId, kSsrc);
+	gen.OnPacketReceived(100);
+	gen.OnPacketReceived(102);
+	std::this_thread::sleep_for(std::chrono::milliseconds(RtpNackGenerator::INITIAL_NACK_DWELL_MS + 5));
+	gen.BuildPendingNack();      // fires NACK for 101
+	gen.OnPacketReceived(101);   // recovered
+	EXPECT_FALSE(gen.GetLowestPendingSeq().has_value());
+}
+
+// DropPendingUpTo: explicit jitter-buffer-driven cleanup.
+TEST(RtpNackGenerator, DropPendingUpToRemovesAtAndBelow)
+{
+	RtpNackGenerator gen(kTrackId, kSsrc);
+	gen.OnPacketReceived(100);
+	gen.OnPacketReceived(105);   // adds 101, 102, 103, 104
+	gen.DropPendingUpTo(102);    // drops 101, 102
+	ASSERT_TRUE(gen.GetLowestPendingSeq().has_value());
+	EXPECT_EQ(*gen.GetLowestPendingSeq(), 103);
+}
+
+// Seq wrap: highest=65530, then 5 -> gap [65531..65535, 0..4].
+TEST(RtpNackGenerator, SeqWrapDetectsGap)
+{
+	RtpNackGenerator gen(kTrackId, kSsrc);
+	gen.OnPacketReceived(65530);
+	gen.OnPacketReceived(5);
+	ASSERT_TRUE(gen.GetLowestPendingSeq().has_value());
+	EXPECT_EQ(*gen.GetLowestPendingSeq(), 65531);
+}
+
+// Old packet beyond expected window is ignored, not added as gap.
+TEST(RtpNackGenerator, OldSeqDoesNotCreateGap)
+{
+	RtpNackGenerator gen(kTrackId, kSsrc);
+	gen.OnPacketReceived(100);
+	gen.OnPacketReceived(99);   // late / reorder; not in pending
+	EXPECT_FALSE(gen.GetLowestPendingSeq().has_value());
+}
+
+// GetLowestPendingSeq returns the smallest pending seq.
+TEST(RtpNackGenerator, LowestPendingTracksSmallest)
+{
+	RtpNackGenerator gen(kTrackId, kSsrc);
+	gen.OnPacketReceived(100);
+	gen.OnPacketReceived(110);   // adds 101..109
+	ASSERT_TRUE(gen.GetLowestPendingSeq().has_value());
+	EXPECT_EQ(*gen.GetLowestPendingSeq(), 101);
+
+	gen.OnPacketReceived(101);   // recovers 101
+	ASSERT_TRUE(gen.GetLowestPendingSeq().has_value());
+	EXPECT_EQ(*gen.GetLowestPendingSeq(), 102);
+}
+
+// Initial RTT seeding: GetRecommendedHoldMs uses INITIAL_RTT_GUESS_MS until
+// the first sample lands, then EWMA-derived value. Result is clamped to
+// at least HOLD_MIN_MS.
+TEST(RtpNackGenerator, InitialRecommendedHoldUsesGuessClampedToMin)
+{
+	RtpNackGenerator gen(kTrackId, kSsrc);
+	EXPECT_GE(gen.GetRecommendedHoldMs(), RtpNackGenerator::HOLD_MIN_MS);
+}
+
+// MaxHoldMs constructor argument clamps GetRecommendedHoldMs upper bound.
+TEST(RtpNackGenerator, MaxHoldClamps)
+{
+	RtpNackGenerator gen(kTrackId, kSsrc, 80);
+	// Force stats to a very large value to test clamp.
+	// (Indirect: we can't poke private members here; instead just verify
+	// default path still respects the cap when initialized.)
+	EXPECT_LE(gen.GetRecommendedHoldMs(), 150u);  // default first
+}
+
+// Retry interval respects ewma. Build twice within the interval -> only the
+// initial entry returns the seq once.
+TEST(RtpNackGenerator, RetryNotDoubleFiredWithinInterval)
+{
+	RtpNackGenerator gen(kTrackId, kSsrc);
+	gen.OnPacketReceived(100);
+	gen.OnPacketReceived(102);
+	std::this_thread::sleep_for(std::chrono::milliseconds(RtpNackGenerator::INITIAL_NACK_DWELL_MS + 5));
+	auto first_round = gen.BuildPendingNack();
+	ASSERT_EQ(first_round.size(), 1u);
+
+	auto immediate_again = gen.BuildPendingNack();
+	EXPECT_TRUE(immediate_again.empty()) << "should not retry before retry_interval (ewma) elapses";
+}

--- a/src/projects/modules/rtp_rtcp/rtp_packet.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packet.cpp
@@ -60,6 +60,7 @@ RtpPacket::RtpPacket(const RtpPacket &src)
 	_is_keyframe = src._is_keyframe;
 	_is_first_packet_of_frame = src._is_first_packet_of_frame;
 	_is_last_packet_of_frame = src._is_last_packet_of_frame;
+	_is_start_of_unit = src._is_start_of_unit;
 	_is_video_packet = src._is_video_packet;
 	_rtsp_channel = src._rtsp_channel;
 	_created_time = std::chrono::system_clock::now();

--- a/src/projects/modules/rtp_rtcp/rtp_packet.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packet.cpp
@@ -34,8 +34,12 @@ RtpPacket::RtpPacket(const std::shared_ptr<const ov::Data> &data)
 
 RtpPacket::RtpPacket(const RtpPacket &src)
 {
+	_has_padding = src._has_padding;
+	_has_extension = src._has_extension;
+	_cc = src._cc;
 	_marker = src._marker;
 	_payload_type = src._payload_type;
+	_is_fec = src._is_fec;
 	_origin_payload_type = src._origin_payload_type;
 	_ssrc = src._ssrc;
 	_payload_offset = src._payload_offset;
@@ -44,7 +48,6 @@ RtpPacket::RtpPacket(const RtpPacket &src)
 	_extension_size = src._extension_size;
 	_sequence_number = src._sequence_number;
 	_timestamp = src._timestamp;
-	_extension_size = src._extension_size;
 	_extensions = src._extensions;
 	_extension_buffer_offset = src._extension_buffer_offset;
 	_extension_type = src._extension_type;
@@ -56,6 +59,7 @@ RtpPacket::RtpPacket(const RtpPacket &src)
 	_ntp_timestamp = src._ntp_timestamp;
 	_is_keyframe = src._is_keyframe;
 	_is_first_packet_of_frame = src._is_first_packet_of_frame;
+	_is_last_packet_of_frame = src._is_last_packet_of_frame;
 	_is_video_packet = src._is_video_packet;
 	_rtsp_channel = src._rtsp_channel;
 	_created_time = std::chrono::system_clock::now();

--- a/src/projects/modules/rtp_rtcp/rtp_packet.h
+++ b/src/projects/modules/rtp_rtcp/rtp_packet.h
@@ -134,6 +134,9 @@ public:
 	void		SetFirstPacketOfFrame(bool flag) {_is_first_packet_of_frame = flag;}
 	bool		IsFirstPacketOfFrame() const {return _is_first_packet_of_frame;}
 
+	void		SetLastPacketOfFrame(bool flag) {_is_last_packet_of_frame = flag;}
+	bool		IsLastPacketOfFrame() const {return _is_last_packet_of_frame;}
+
 	void		SetRtspChannel(uint32_t rtsp_channel) {_rtsp_channel = rtsp_channel;}
 	uint32_t	GetRtspChannel() const {return _rtsp_channel;}
 
@@ -176,6 +179,7 @@ protected:
 	bool		_is_video_packet = false;
 	bool		_is_keyframe = false;
 	bool		_is_first_packet_of_frame = false;
+	bool		_is_last_packet_of_frame = false;
 
 	uint32_t	_rtsp_channel = 0; // If it is from RTSP, _rtsp_channel is valid
 };

--- a/src/projects/modules/rtp_rtcp/rtp_packet.h
+++ b/src/projects/modules/rtp_rtcp/rtp_packet.h
@@ -131,11 +131,21 @@ public:
 	void		SetKeyframe(bool flag) {_is_keyframe = flag;}
 	bool		IsKeyframe() const {return _is_keyframe;}
 
+	// The genuine first packet of the frame. Set by the send packetizer, and
+	// on receive by the Dependency Descriptor (S bit), which marks it
+	// authoritatively. Without DD the receive path can't know it per-packet
+	// and uses StartOfUnit instead.
 	void		SetFirstPacketOfFrame(bool flag) {_is_first_packet_of_frame = flag;}
 	bool		IsFirstPacketOfFrame() const {return _is_first_packet_of_frame;}
 
 	void		SetLastPacketOfFrame(bool flag) {_is_last_packet_of_frame = flag;}
 	bool		IsLastPacketOfFrame() const {return _is_last_packet_of_frame;}
+
+	// Receive-side fallback when DD is absent: the boundary detector stamps
+	// every packet that begins a NAL/OBU/VP8 partition. The jitter buffer
+	// takes the lowest such sequence number as the frame's first packet.
+	void		SetStartOfUnit(bool flag) {_is_start_of_unit = flag;}
+	bool		IsStartOfUnit() const {return _is_start_of_unit;}
 
 	void		SetRtspChannel(uint32_t rtsp_channel) {_rtsp_channel = rtsp_channel;}
 	uint32_t	GetRtspChannel() const {return _rtsp_channel;}
@@ -180,6 +190,7 @@ protected:
 	bool		_is_keyframe = false;
 	bool		_is_first_packet_of_frame = false;
 	bool		_is_last_packet_of_frame = false;
+	bool		_is_start_of_unit = false;
 
 	uint32_t	_rtsp_channel = 0; // If it is from RTSP, _rtsp_channel is valid
 };

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
@@ -233,19 +233,25 @@ RtpRtcp::RtxResult RtpRtcp::TryUnwrapRtx(std::shared_ptr<RtpPacket> &packet)
 	uint8_t original_pt = 0;
 	uint32_t media_ssrc = 0;
 	bool learned = false;
+	bool known = false;
 
-	auto rtx_it = _rtx_streams.find(rtx_ssrc);
-	if (rtx_it != _rtx_streams.end())
 	{
-		if (packet->PayloadType() != rtx_it->second.rtx_payload_type)
+		std::lock_guard<std::mutex> lock(_rtx_streams_lock);
+		auto rtx_it = _rtx_streams.find(rtx_ssrc);
+		if (rtx_it != _rtx_streams.end())
 		{
-			logtt("Drop packet on RTX SSRC %u with non-RTX PT %u", rtx_ssrc, packet->PayloadType());
-			return RtxResult::Drop;
+			if (packet->PayloadType() != rtx_it->second.rtx_payload_type)
+			{
+				logtt("Drop packet on RTX SSRC %u with non-RTX PT %u", rtx_ssrc, packet->PayloadType());
+				return RtxResult::Drop;
+			}
+			original_pt = rtx_it->second.original_payload_type;
+			media_ssrc = rtx_it->second.media_ssrc;
+			known = true;
 		}
-		original_pt = rtx_it->second.original_payload_type;
-		media_ssrc = rtx_it->second.media_ssrc;
 	}
-	else
+
+	if (known == false)
 	{
 		auto pt_it = _rtx_pt_to_original.find(packet->PayloadType());
 		if (pt_it == _rtx_pt_to_original.end())
@@ -285,7 +291,10 @@ RtpRtcp::RtxResult RtpRtcp::TryUnwrapRtx(std::shared_ptr<RtpPacket> &packet)
 
 	if (learned)
 	{
-		_rtx_streams[rtx_ssrc] = RtxStreamInfo{media_ssrc, packet->PayloadType(), original_pt};
+		{
+			std::lock_guard<std::mutex> lock(_rtx_streams_lock);
+			_rtx_streams[rtx_ssrc] = RtxStreamInfo{media_ssrc, packet->PayloadType(), original_pt};
+		}
 		logti("Learned RTX stream rtx_ssrc(%u) -> media_ssrc(%u) pt(%u->%u)",
 			  rtx_ssrc, media_ssrc, packet->PayloadType(), original_pt);
 	}
@@ -381,7 +390,9 @@ bool RtpRtcp::EnableNack(uint32_t track_id, uint32_t media_ssrc, uint32_t max_ho
 bool RtpRtcp::RegisterRtxStream(uint32_t rtx_ssrc, uint32_t media_ssrc,
 								 uint8_t rtx_payload_type, uint8_t original_payload_type)
 {
-	std::lock_guard<std::shared_mutex> lock(_state_lock);
+	// Guarded by its own lock (not _state_lock) so it stays consistent with
+	// the receive-path learned write in TryUnwrapRtx.
+	std::lock_guard<std::mutex> lock(_rtx_streams_lock);
 	_rtx_streams[rtx_ssrc] = RtxStreamInfo{media_ssrc, rtx_payload_type, original_payload_type};
 	logti("RegisterRtxStream rtx_ssrc(%u) media_ssrc(%u) rtx_pt(%u) orig_pt(%u)",
 		  rtx_ssrc, media_ssrc, rtx_payload_type, original_payload_type);

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
@@ -339,17 +339,25 @@ bool RtpRtcp::SendNACK(uint32_t track_id, const std::vector<uint16_t> &lost_ids)
 void RtpRtcp::FlushNackIfDue(uint32_t track_id, const std::shared_ptr<RtpNackGenerator> &generator)
 {
 	auto now = std::chrono::steady_clock::now();
-	auto last_flush = _last_nack_flush_at[track_id];
-	if (now - last_flush < std::chrono::milliseconds(NACK_COALESCE_MS))
+
+	// Coalescing-window check + watermark update under a dedicated lock, since
+	// the receive path only holds a shared_lock on _state_lock. Stamp the
+	// watermark before sending so concurrent receives don't double-flush.
 	{
-		return;
+		std::lock_guard<std::mutex> lock(_last_nack_flush_at_lock);
+		auto it = _last_nack_flush_at.find(track_id);
+		if (it != _last_nack_flush_at.end() && (now - it->second) < std::chrono::milliseconds(NACK_COALESCE_MS))
+		{
+			return;
+		}
+		_last_nack_flush_at[track_id] = now;
 	}
+
 	auto lost_ids = generator->BuildPendingNack();
 	if (lost_ids.empty() == false)
 	{
 		SendNACK(track_id, lost_ids);
 	}
-	_last_nack_flush_at[track_id] = now;
 }
 
 bool RtpRtcp::EnableNack(uint32_t track_id, uint32_t media_ssrc, uint32_t max_hold_ms)
@@ -357,7 +365,10 @@ bool RtpRtcp::EnableNack(uint32_t track_id, uint32_t media_ssrc, uint32_t max_ho
 	std::lock_guard<std::shared_mutex> lock(_state_lock);
 	auto generator = std::make_shared<RtpNackGenerator>(track_id, media_ssrc, max_hold_ms);
 	_nack_generators[track_id] = generator;
-	_last_nack_flush_at[track_id] = std::chrono::steady_clock::now();
+	{
+		std::lock_guard<std::mutex> flush_lock(_last_nack_flush_at_lock);
+		_last_nack_flush_at[track_id] = std::chrono::steady_clock::now();
+	}
 
 	// Wire dynamic hold window into the matching frame jitter buffer. The
 	// jitter buffer uses NACK-driven RTX latency stats to decide how long
@@ -372,6 +383,9 @@ bool RtpRtcp::EnableNack(uint32_t track_id, uint32_t media_ssrc, uint32_t max_ho
 			auto gen = weak_gen.lock();
 			return gen ? gen->GetRecommendedHoldMs() : 0;
 		});
+		// MaxHoldMs is the operator's latency ceiling for the whole hold,
+		// not just the NACK/RTX RTT component.
+		buf_it->second->SetMaxHoldMs(max_hold_ms);
 		buf_it->second->SetOnProcessedSeqAdvance([weak_gen](uint16_t max_seq) {
 			auto gen = weak_gen.lock();
 			if (gen) gen->DropPendingUpTo(max_seq);

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
@@ -6,6 +6,8 @@
 #include "rtcp_receiver.h"
 #include "rtcp_info/fir.h"
 #include "rtcp_info/pli.h"
+#include "rtcp_info/nack.h"
+#include "rtx_rtp_packet.h"
 
 #include "modules/rtsp/rtsp_data.h"
 
@@ -62,10 +64,17 @@ bool RtpRtcp::AddRtpReceiver(const std::shared_ptr<MediaTrack> &track, const Rtp
 		case cmn::BitstreamFormat::H264_RTP_RFC_6184:
 		case cmn::BitstreamFormat::H265_RTP_RFC_7798:
 		case cmn::BitstreamFormat::VP8_RTP_RFC_7741:
-		case cmn::BitstreamFormat::AAC_MPEG4_GENERIC:
-			_rtp_frame_jitter_buffers[track_id] = std::make_shared<RtpFrameJitterBuffer>();
+		{
+			auto buf = std::make_shared<RtpFrameJitterBuffer>();
+			buf->SetClockRate(track->GetTimeBase().GetDen());
+			_rtp_frame_jitter_buffers[track_id] = buf;
 			break;
+		}
+		// 1 RTP packet = 1 frame. AAC fragmentation unsupported.
+		// Not needed on WebRTC path; on RTSP path only stereo 500 kbps+ or
+		// multichannel hits it, so uncommon in practice. TODO if a real case shows up.
 		case cmn::BitstreamFormat::OPUS_RTP_RFC_7587:
+		case cmn::BitstreamFormat::AAC_MPEG4_GENERIC:
 			_rtp_minimal_jitter_buffers[track_id] = std::make_shared<RtpMinimalJitterBuffer>();
 			break;
 		default:
@@ -145,7 +154,7 @@ bool RtpRtcp::SendRtpPacket(const std::shared_ptr<RtpPacket> &rtp_packet)
 		}
 
 		compound_rtcp_data->Append(_rtcp_sdes->GetData());
-		
+
 		if(SendDataToNextNode(NodeType::Rtcp, compound_rtcp_data) == false)
 		{
 			logt("RTCP","Send RTCP failed : pt(%d) ssrc(%u)", rtp_packet->PayloadType(), rtp_packet->Ssrc());
@@ -211,6 +220,190 @@ bool RtpRtcp::SendFIR(uint32_t track_id)
 	return SendDataToNextNode(NodeType::Rtcp, rtcp_packet->GetData());
 }
 
+// RTX (RFC 4588) detection + unwrap. Two paths share the same body:
+//  (a) SSRC pre-registered via RegisterRtxStream (offer SDP declared
+//      a=ssrc-group:FID): direct lookup.
+//  (b) PT is in the negotiated RTX PT map: resolve the track via mid/rid
+//      extension, learn the media SSRC from RtpReceiveStatistics, and
+//      cache the RTX SSRC for subsequent packets. Required for simulcast
+//      WHIP where browsers omit ssrc-group:FID.
+RtpRtcp::RtxResult RtpRtcp::TryUnwrapRtx(std::shared_ptr<RtpPacket> &packet)
+{
+	uint32_t rtx_ssrc = packet->Ssrc();
+	uint8_t original_pt = 0;
+	uint32_t media_ssrc = 0;
+	bool learned = false;
+
+	auto rtx_it = _rtx_streams.find(rtx_ssrc);
+	if (rtx_it != _rtx_streams.end())
+	{
+		if (packet->PayloadType() != rtx_it->second.rtx_payload_type)
+		{
+			logtt("Drop packet on RTX SSRC %u with non-RTX PT %u", rtx_ssrc, packet->PayloadType());
+			return RtxResult::Drop;
+		}
+		original_pt = rtx_it->second.original_payload_type;
+		media_ssrc = rtx_it->second.media_ssrc;
+	}
+	else
+	{
+		auto pt_it = _rtx_pt_to_original.find(packet->PayloadType());
+		if (pt_it == _rtx_pt_to_original.end())
+		{
+			return RtxResult::NotRtx;
+		}
+
+		auto track_id_opt = FindTrackId(packet);
+		if (track_id_opt.has_value() == false)
+		{
+			logtt("RTX packet PT %u on unknown track, dropping", packet->PayloadType());
+			return RtxResult::Drop;
+		}
+		auto stat_it = _receive_statistics.find(track_id_opt.value());
+		if (stat_it == _receive_statistics.end())
+		{
+			logtt("RTX packet PT %u before primary media seen, dropping", packet->PayloadType());
+			return RtxResult::Drop;
+		}
+		original_pt = pt_it->second;
+		media_ssrc = stat_it->second->GetMediaSSRC();
+		learned = true;
+	}
+
+	auto unpacked = RtxRtpPacket::Unpack(*packet, original_pt, media_ssrc);
+	if (unpacked == nullptr)
+	{
+		// Padding-only RTX probe; still report to transport-cc so the
+		// sender sees an ack for the wire sequence number.
+		logtt("Drop padding-only RTX ssrc(%u) pt(%u)", rtx_ssrc, packet->PayloadType());
+		if (_transport_cc_feedback_enabled && _transport_cc_generator != nullptr)
+		{
+			_transport_cc_generator->AddReceivedRtpPacket(packet);
+		}
+		return RtxResult::Drop;
+	}
+
+	if (learned)
+	{
+		_rtx_streams[rtx_ssrc] = RtxStreamInfo{media_ssrc, packet->PayloadType(), original_pt};
+		logti("Learned RTX stream rtx_ssrc(%u) -> media_ssrc(%u) pt(%u->%u)",
+			  rtx_ssrc, media_ssrc, packet->PayloadType(), original_pt);
+	}
+
+	packet = unpacked;
+	return RtxResult::Unwrapped;
+}
+
+bool RtpRtcp::SendNACK(uint32_t track_id, const std::vector<uint16_t> &lost_ids)
+{
+	if (lost_ids.empty())
+	{
+		return false;
+	}
+
+	auto stat_it = _receive_statistics.find(track_id);
+	if (stat_it == _receive_statistics.end())
+	{
+		return false;
+	}
+	auto stat = stat_it->second;
+
+	auto nack = std::make_shared<NACK>();
+	nack->SetSrcSsrc(stat->GetReceiverSSRC());
+	nack->SetMediaSsrc(stat->GetMediaSSRC());
+	for (auto id : lost_ids)
+	{
+		nack->AddLostId(id);
+	}
+
+	auto rtcp_packet = std::make_shared<RtcpPacket>();
+	if (rtcp_packet->Build(nack) == false)
+	{
+		return false;
+	}
+
+	_last_sent_rtcp_packet = rtcp_packet;
+	logtd("SendNACK track(%u) media_ssrc(%u) count(%zu)", track_id, stat->GetMediaSSRC(), lost_ids.size());
+	return SendDataToNextNode(NodeType::Rtcp, rtcp_packet->GetData());
+}
+
+void RtpRtcp::FlushNackIfDue(uint32_t track_id, const std::shared_ptr<RtpNackGenerator> &generator)
+{
+	auto now = std::chrono::steady_clock::now();
+	auto last_flush = _last_nack_flush_at[track_id];
+	if (now - last_flush < std::chrono::milliseconds(NACK_COALESCE_MS))
+	{
+		return;
+	}
+	auto lost_ids = generator->BuildPendingNack();
+	if (lost_ids.empty() == false)
+	{
+		SendNACK(track_id, lost_ids);
+	}
+	_last_nack_flush_at[track_id] = now;
+}
+
+bool RtpRtcp::EnableNack(uint32_t track_id, uint32_t media_ssrc, uint32_t max_hold_ms)
+{
+	std::lock_guard<std::shared_mutex> lock(_state_lock);
+	auto generator = std::make_shared<RtpNackGenerator>(track_id, media_ssrc, max_hold_ms);
+	_nack_generators[track_id] = generator;
+	_last_nack_flush_at[track_id] = std::chrono::steady_clock::now();
+
+	// Wire dynamic hold window into the matching frame jitter buffer. The
+	// jitter buffer uses NACK-driven RTX latency stats to decide how long
+	// to hold an incomplete frame before discarding it. We also wire the
+	// reverse direction so the jitter buffer can end NACK pending entries
+	// as soon as it advances past their seq.
+	auto buf_it = _rtp_frame_jitter_buffers.find(track_id);
+	if (buf_it != _rtp_frame_jitter_buffers.end())
+	{
+		std::weak_ptr<RtpNackGenerator> weak_gen = generator;
+		buf_it->second->SetHoldMsProvider([weak_gen]() -> uint32_t {
+			auto gen = weak_gen.lock();
+			return gen ? gen->GetRecommendedHoldMs() : 0;
+		});
+		buf_it->second->SetOnProcessedSeqAdvance([weak_gen](uint16_t max_seq) {
+			auto gen = weak_gen.lock();
+			if (gen) gen->DropPendingUpTo(max_seq);
+		});
+		buf_it->second->SetLowestPendingSeqProvider([weak_gen]() -> std::optional<uint16_t> {
+			auto gen = weak_gen.lock();
+			if (!gen) return std::nullopt;
+			return gen->GetLowestPendingSeq();
+		});
+	}
+
+	logti("EnableNack track(%u) ssrc(%u)", track_id, media_ssrc);
+	return true;
+}
+
+bool RtpRtcp::RegisterRtxStream(uint32_t rtx_ssrc, uint32_t media_ssrc,
+								 uint8_t rtx_payload_type, uint8_t original_payload_type)
+{
+	std::lock_guard<std::shared_mutex> lock(_state_lock);
+	_rtx_streams[rtx_ssrc] = RtxStreamInfo{media_ssrc, rtx_payload_type, original_payload_type};
+	logti("RegisterRtxStream rtx_ssrc(%u) media_ssrc(%u) rtx_pt(%u) orig_pt(%u)",
+		  rtx_ssrc, media_ssrc, rtx_payload_type, original_payload_type);
+	return true;
+}
+
+bool RtpRtcp::RegisterRtxPayloadType(uint8_t rtx_payload_type, uint8_t original_payload_type)
+{
+	std::lock_guard<std::shared_mutex> lock(_state_lock);
+	_rtx_pt_to_original[rtx_payload_type] = original_payload_type;
+	logti("RegisterRtxPayloadType rtx_pt(%u) orig_pt(%u)", rtx_payload_type, original_payload_type);
+	return true;
+}
+
+bool RtpRtcp::SetDependencyDescriptorExtId(uint8_t dd_extension_id)
+{
+	std::lock_guard<std::shared_mutex> lock(_state_lock);
+	_dd_extension_id = dd_extension_id;
+	logti("SetDependencyDescriptorExtId dd_ext(%u)", dd_extension_id);
+	return true;
+}
+
 bool RtpRtcp::IsTransportCcFeedbackEnabled() const
 {
 	return _transport_cc_feedback_enabled;
@@ -260,14 +453,24 @@ std::optional<uint32_t> RtpRtcp::FindTrackId(const std::shared_ptr<const RtpPack
 		// Get mid from rtp header extension
 		auto mid = rtp_packet->GetExtension(rtp_track_id.mid_extension_id);
 		auto rid = rtp_packet->GetExtension(rtp_track_id.rid_extension_id);
+		auto rrid = rtp_track_id.rrid_extension_id != 0
+						? rtp_packet->GetExtension(rtp_track_id.rrid_extension_id)
+						: std::nullopt;
 
 		// with mid or mid + rid
 		if (rtp_track_id.mid.has_value() && mid.has_value() &&
 			mid.value().ToString() == rtp_track_id.mid.value())
 		{
-			// mid + rid
+			// mid + rid (primary packets)
 			if (rtp_track_id.rid.has_value() && rid.has_value() &&
 				rid.value().ToString() == rtp_track_id.rid.value())
+			{
+				return rtp_track_id.GetTrackId();
+			}
+			// mid + rrid (RTX packets in libwebrtc simulcast; rrid carries
+			// the same string the primary stream's rid did).
+			if (rtp_track_id.rid.has_value() && rrid.has_value() &&
+				rrid.value().ToString() == rtp_track_id.rid.value())
 			{
 				return rtp_track_id.GetTrackId();
 			}
@@ -441,6 +644,11 @@ bool RtpRtcp::OnRtpReceived(NodeType from_node, const std::shared_ptr<const ov::
 {
 	auto packet = std::make_shared<RtpPacket>(data);
 
+	if (TryUnwrapRtx(packet) == RtxResult::Drop)
+	{
+		return false;
+	}
+
 	std::optional<uint32_t> track_id_opt = GetTrackId(packet->Ssrc());
 	if (track_id_opt.has_value() == false)
 	{
@@ -508,6 +716,19 @@ bool RtpRtcp::OnRtpReceived(NodeType from_node, const std::shared_ptr<const ov::
 
 	stat->AddReceivedRtpPacket(packet);
 
+	// Receive-side NACK: feed seq to per-track generator, then flush pending
+	// NACKs on a short coalescing window (every NACK_COALESCE_MS). Send is
+	// done on the socket thread so it shares a single writer with the
+	// other RTCP outputs (RR, transport-cc) on the Node chain.
+	{
+		auto nack_it = _nack_generators.find(track_id);
+		if (nack_it != _nack_generators.end())
+		{
+			nack_it->second->OnPacketReceived(packet->SequenceNumber());
+			FlushNackIfDue(track_id, nack_it->second);
+		}
+	}
+
 	// Send ReceiverReport
 	if (stat->HasElapsedSinceLastReportBlock(RECEIVER_REPORT_CYCLE_MS) && stat->IsSenderReportReceived() == true)
 	{
@@ -558,10 +779,10 @@ bool RtpRtcp::OnRtpReceived(NodeType from_node, const std::shared_ptr<const ov::
 		case cmn::BitstreamFormat::H264_RTP_RFC_6184:
 		case cmn::BitstreamFormat::H265_RTP_RFC_7798:
 		case cmn::BitstreamFormat::VP8_RTP_RFC_7741:
-		case cmn::BitstreamFormat::AAC_MPEG4_GENERIC:
 			jitter_buffer_type = 1;
 			break;
 		case cmn::BitstreamFormat::OPUS_RTP_RFC_7587:
+		case cmn::BitstreamFormat::AAC_MPEG4_GENERIC:
 			jitter_buffer_type = 2;
 			break;
 		default:
@@ -596,6 +817,29 @@ bool RtpRtcp::OnRtpReceived(NodeType from_node, const std::shared_ptr<const ov::
 		}
 
 		auto jitter_buffer = buffer_it->second;
+
+		// Padding-only RTP (BWE probing / keepalive) carries no codec data;
+		// receive-stats / NACK gen / transport-cc above already accounted for
+		// it. Skip frame boundary stamping + jitter buffer.
+		if (packet->PayloadSize() == 0)
+		{
+			return true;
+		}
+
+		// Frame boundary flags must be stamped before jitter buffer insertion.
+		// Unparseable payloads (bad nal_type, truncated) are dropped here so
+		// downstream never sees a broken frame.
+		if (RtpFrameBoundaryDetector::Apply(*packet, track->GetCodecId(), _dd_extension_id) == false)
+		{
+			auto pl = packet->Payload();
+			auto sz = packet->PayloadSize();
+			logtw("Drop unparseable packet track(%u) ssrc(%u) seq(%u) pt(%u) codec(%d) size(%zu) head[%02x %02x %02x %02x]",
+				  track_id, packet->Ssrc(), packet->SequenceNumber(), packet->PayloadType(),
+				  static_cast<int>(track->GetCodecId()), sz,
+				  sz > 0 ? pl[0] : 0, sz > 1 ? pl[1] : 0,
+				  sz > 2 ? pl[2] : 0, sz > 3 ? pl[3] : 0);
+			return false;
+		}
 
 		jitter_buffer->InsertPacket(packet);
 

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.h
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.h
@@ -14,6 +14,8 @@
 #include "rtp_nack_generator.h"
 #include "rtp_frame_boundary_detector.h"
 
+#include <mutex>
+
 
 
 #define RECEIVER_REPORT_CYCLE_MS	500
@@ -180,6 +182,11 @@ private:
 		uint8_t original_payload_type;
 	};
 	std::unordered_map<uint32_t /*rtx_ssrc*/, RtxStreamInfo> _rtx_streams;
+
+	// _rtx_streams is learned on the receive path (TryUnwrapRtx) while only a
+	// shared_lock on _state_lock is held, so it needs its own mutex: a shared
+	// lock allows concurrent readers, and a map write racing a reader is UB.
+	std::mutex _rtx_streams_lock;
 
 	// rtx_pt -> original_pt, set up from negotiated SDP to detect RTX packets
 	// dynamically when the RTX SSRC isn't pre-declared (simulcast WHIP).

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.h
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.h
@@ -170,6 +170,11 @@ private:
 	std::unordered_map<uint32_t, std::shared_ptr<RtpNackGenerator>> _nack_generators;
 	std::unordered_map<uint32_t, std::chrono::steady_clock::time_point> _last_nack_flush_at;
 
+	// _last_nack_flush_at is updated on the receive path (FlushNackIfDue) under
+	// only a shared_lock on _state_lock, so it needs its own mutex to serialize
+	// concurrent receives (operator[] can insert/rehash).
+	std::mutex _last_nack_flush_at_lock;
+
 	// Negotiated DD extension id (0 = not negotiated). The detector falls
 	// back to codec payload parse when 0.
 	uint8_t _dd_extension_id = 0;

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.h
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.h
@@ -11,12 +11,15 @@
 #include "rtp_frame_jitter_buffer.h"
 #include "rtp_minimal_jitter_buffer.h"
 #include "rtp_receive_statistics.h"
+#include "rtp_nack_generator.h"
+#include "rtp_frame_boundary_detector.h"
 
 
 
 #define RECEIVER_REPORT_CYCLE_MS	500
 #define TRANSPORT_CC_CYCLE_MS		50
 #define SDES_CYCLE_MS 500
+#define NACK_COALESCE_MS			10
 
 class RtpRtcpInterface : public ov::EnableSharedFromThis<RtpRtcpInterface>
 {
@@ -48,6 +51,10 @@ public:
 		uint32_t mid_extension_id = 0;
 		std::optional<ov::String> rid;
 		uint32_t rid_extension_id = 0;
+		// Extension id for `repaired-rtp-stream-id` carried on RTX packets
+		// (libwebrtc simulcast). When set, FindTrackId(packet) also matches
+		// mid + rrid where rrid equals this track's `rid`.
+		uint32_t rrid_extension_id = 0;
 
 	private:
 		uint32_t track_id = 0;
@@ -64,6 +71,30 @@ public:
 	bool SendRtpPacket(const std::shared_ptr<RtpPacket> &packet);
 	bool SendPLI(uint32_t track_id);
 	bool SendFIR(uint32_t track_id);
+
+	// Enable receive-side NACK for the given track. Creates a per-track
+	// RtpNackGenerator that observes incoming sequence numbers and drives
+	// outbound NACK feedback. max_hold_ms is the upper bound for the
+	// jitter buffer hold time recommendation (operator-tunable latency budget).
+	bool EnableNack(uint32_t track_id, uint32_t media_ssrc, uint32_t max_hold_ms);
+
+	// Register an RTX stream so that RTP packets arriving on rtx_ssrc with
+	// rtx_payload_type are unwrapped (RFC 4588) and re-injected as original
+	// (media_ssrc, original_payload_type) before depacketization.
+	bool RegisterRtxStream(uint32_t rtx_ssrc, uint32_t media_ssrc,
+						   uint8_t rtx_payload_type, uint8_t original_payload_type);
+
+	// Register an RTX payload type pairing. When an RTP packet arrives with
+	// this payload type on an unknown SSRC (typical for simulcast WHIP where
+	// browsers don't declare ssrc-group:FID in SDP), it is detected as RTX,
+	// the original track is resolved via mid/rid extension, and the RTX SSRC
+	// is cached for subsequent packets.
+	bool RegisterRtxPayloadType(uint8_t rtx_payload_type, uint8_t original_payload_type);
+
+	// Register negotiated Dependency Descriptor extension id (video m-line scope).
+	// Call only when DD was negotiated; otherwise the detector falls back to
+	// the codec's RTP payload header parse.
+	bool SetDependencyDescriptorExtId(uint8_t dd_extension_id);
 
 	bool IsTransportCcFeedbackEnabled() const;
 	bool EnableTransportCcFeedback(uint8_t extension_id);
@@ -83,6 +114,20 @@ public:
 private:
 	bool OnRtpReceived(NodeType from_node, const std::shared_ptr<const ov::Data> &data);
 	bool OnRtcpReceived(NodeType from_node, const std::shared_ptr<const ov::Data> &data);
+
+	bool SendNACK(uint32_t track_id, const std::vector<uint16_t> &lost_ids);
+
+	// Coalesced NACK flush for a single track. Sends if the coalescing
+	// window has elapsed; otherwise no-op.
+	void FlushNackIfDue(uint32_t track_id, const std::shared_ptr<RtpNackGenerator> &generator);
+
+	// RTX (RFC 4588) detection + unwrap. On entry, packet is the raw RTP
+	// packet from the wire. On Unwrapped return, packet has been replaced
+	// with the original media packet (PT/SSRC/seq restored). Drop indicates
+	// the input was RTX but should not be processed further (padding-only
+	// probe, PT mismatch, unresolved track).
+	enum class RtxResult { NotRtx, Unwrapped, Drop };
+	RtxResult TryUnwrapRtx(std::shared_ptr<RtpPacket> &packet);
 
 	std::shared_ptr<RtpFrameJitterBuffer> GetJitterBuffer(uint8_t payload_type);
 
@@ -118,6 +163,27 @@ private:
 	// Receiver SSRC (For RTCP RR, FIR... etc)
 	// track_id : Receiver Statistics
 	std::unordered_map<uint32_t, std::shared_ptr<RtpReceiveStatistics>> _receive_statistics;
+
+	// Per-track receive-side NACK generator.
+	std::unordered_map<uint32_t, std::shared_ptr<RtpNackGenerator>> _nack_generators;
+	std::unordered_map<uint32_t, std::chrono::steady_clock::time_point> _last_nack_flush_at;
+
+	// Negotiated DD extension id (0 = not negotiated). The detector falls
+	// back to codec payload parse when 0.
+	uint8_t _dd_extension_id = 0;
+
+	// RTX SSRC -> {media_ssrc, rtx_pt, original_pt}
+	struct RtxStreamInfo
+	{
+		uint32_t media_ssrc;
+		uint8_t rtx_payload_type;
+		uint8_t original_payload_type;
+	};
+	std::unordered_map<uint32_t /*rtx_ssrc*/, RtxStreamInfo> _rtx_streams;
+
+	// rtx_pt -> original_pt, set up from negotiated SDP to detect RTX packets
+	// dynamically when the RTX SSRC isn't pre-declared (simulcast WHIP).
+	std::unordered_map<uint8_t /*rtx_pt*/, uint8_t /*original_pt*/> _rtx_pt_to_original;
 
 	// Transport-cc feedback
 	std::shared_ptr<RtcpTransportCcFeedbackGenerator> _transport_cc_generator = nullptr;

--- a/src/projects/modules/rtp_rtcp/rtx_rtp_packet.cpp
+++ b/src/projects/modules/rtp_rtcp/rtx_rtp_packet.cpp
@@ -45,3 +45,26 @@ void RtxRtpPacket::SetOriginalSequenceNumber(uint16_t seq_no)
 {
 	ByteWriter<uint16_t>::WriteBigEndian(&_buffer[_payload_offset - RTX_HEADER_SIZE], seq_no);
 }
+
+std::shared_ptr<RtpPacket> RtxRtpPacket::Unpack(const RtpPacket &rtx_packet, uint8_t original_payload_type, uint32_t original_ssrc)
+{
+	if (rtx_packet.PayloadSize() < RTX_HEADER_SIZE)
+	{
+		return nullptr;
+	}
+
+	uint16_t osn = ByteReader<uint16_t>::ReadBigEndian(rtx_packet.Payload());
+
+	// Copy original payload to a temp buffer first since SetPayload memcpys
+	// into the same buffer region (source/dest would overlap otherwise).
+	std::vector<uint8_t> original_payload(rtx_packet.Payload() + RTX_HEADER_SIZE,
+										   rtx_packet.Payload() + rtx_packet.PayloadSize());
+
+	auto packet = std::make_shared<RtpPacket>(rtx_packet);
+	packet->SetPayloadType(original_payload_type);
+	packet->SetSsrc(original_ssrc);
+	packet->SetSequenceNumber(osn);
+	packet->SetPayload(original_payload.data(), original_payload.size());
+
+	return packet;
+}

--- a/src/projects/modules/rtp_rtcp/rtx_rtp_packet.h
+++ b/src/projects/modules/rtp_rtcp/rtx_rtp_packet.h
@@ -35,6 +35,11 @@ public:
 
 	void SetOriginalSequenceNumber(uint16_t seq_no);
 
+	// Receiver-side helper. Unwraps an incoming RTX-formatted RtpPacket (RFC 4588)
+	// into the original RtpPacket using the negotiated original PT/SSRC.
+	// Returns nullptr if the packet is too small to contain the OSN header.
+	static std::shared_ptr<RtpPacket> Unpack(const RtpPacket &rtx_packet, uint8_t original_payload_type, uint32_t original_ssrc);
+
 private:
 	bool PackageAsRtx(uint32_t rtx_ssrc, uint8_t rtx_payload_type, const RtpPacket &src);
 

--- a/src/projects/providers/webrtc/webrtc_application.cpp
+++ b/src/projects/providers/webrtc/webrtc_application.cpp
@@ -10,7 +10,9 @@
 #include "webrtc_private.h"
 #include "webrtc_application.h"
 
+#include <base/ovlibrary/converter.h>
 #include <modules/rtp_rtcp/rtp_header_extension/rtp_header_extension.h>
+#include <set>
 
 namespace pvd
 {
@@ -64,6 +66,7 @@ namespace pvd
 
 		bool transport_cc_enabled = true;
 		bool composition_time_enabled = true;
+		bool rtx_enabled = GetConfig().GetProviders().GetWebrtcProvider().GetRtx().IsEnabled();
 
 		auto offer_sdp = std::make_shared<SessionDescription>(SessionDescription::SdpType::Offer);
 		offer_sdp->SetOrigin("OvenMediaEngine", ov::Random::GenerateUInt32(), 2, "IN", 4, "127.0.0.1");
@@ -107,25 +110,53 @@ namespace pvd
 		std::shared_ptr<PayloadAttr> payload;
 		// H264
 		payload = std::make_shared<PayloadAttr>();
-		payload->SetRtpmap(payload_type_num++, "H264", 90000);
+		uint8_t h264_pt = payload_type_num++;
+		payload->SetRtpmap(h264_pt, "H264", 90000);
 		payload->SetFmtp(ov::String::FormatString("packetization-mode=1;profile-level-id=%x;level-asymmetry-allowed=1",	0x42e01f));
 		payload->EnableRtcpFb(PayloadAttr::RtcpFbType::CcmFir, true);
+		if (rtx_enabled)
+		{
+			payload->EnableRtcpFb(PayloadAttr::RtcpFbType::Nack, true);
+		}
 		payload->EnableRtcpFb(PayloadAttr::RtcpFbType::NackPli, true);
 		payload->EnableRtcpFb(PayloadAttr::RtcpFbType::TransportCc, true);
 		video_media_desc->AddPayload(payload);
 
+		// H264 RTX
+		if (rtx_enabled)
+		{
+			payload = std::make_shared<PayloadAttr>();
+			payload->SetRtpmap(payload_type_num++, "rtx", 90000);
+			payload->SetFmtp(ov::String::FormatString("apt=%u", h264_pt));
+			video_media_desc->AddPayload(payload);
+		}
+
 		// VP8
 		payload = std::make_shared<PayloadAttr>();
-		payload->SetRtpmap(payload_type_num++, "VP8", 90000);
+		uint8_t vp8_pt = payload_type_num++;
+		payload->SetRtpmap(vp8_pt, "VP8", 90000);
 		payload->EnableRtcpFb(PayloadAttr::RtcpFbType::CcmFir, true);
+		if (rtx_enabled)
+		{
+			payload->EnableRtcpFb(PayloadAttr::RtcpFbType::Nack, true);
+		}
 		payload->EnableRtcpFb(PayloadAttr::RtcpFbType::NackPli, true);
-		
+
 		if (transport_cc_enabled)
 		{
 			payload->EnableRtcpFb(PayloadAttr::RtcpFbType::TransportCc, true);
 		}
 
 		video_media_desc->AddPayload(payload);
+
+		// VP8 RTX
+		if (rtx_enabled)
+		{
+			payload = std::make_shared<PayloadAttr>();
+			payload->SetRtpmap(payload_type_num++, "rtx", 90000);
+			payload->SetFmtp(ov::String::FormatString("apt=%u", vp8_pt));
+			video_media_desc->AddPayload(payload);
+		}
 
 		video_media_desc->Update();
 		offer_sdp->AddMedia(video_media_desc);
@@ -174,6 +205,8 @@ namespace pvd
 		{
 			return nullptr;
 		}
+
+		bool rtx_enabled = GetConfig().GetProviders().GetWebrtcProvider().GetRtx().IsEnabled();
 
 		auto answer_sdp = std::make_shared<SessionDescription>(SessionDescription::SdpType::Answer);
 		answer_sdp->SetOrigin("OvenMediaEngine", ov::Random::GenerateUInt32(), 2, "IN", 4, "127.0.0.1");
@@ -273,10 +306,46 @@ namespace pvd
 				answer_media_desc->AddExtmap(extmap_id, extmap_attribute);
 			}
 
+			// Repaired RTP-STREAM-ID (rrid). libwebrtc stamps this on RTX
+			// packets in simulcast in place of rid; without it the receive
+			// side can't resolve which simulcast layer an RTX packet belongs to.
+			if (rtx_enabled &&
+				offer_media_desc->FindExtmapItem("urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id", extmap_id, extmap_attribute))
+			{
+				answer_media_desc->AddExtmap(extmap_id, extmap_attribute);
+			}
+
+			// AV1 Dependency Descriptor (used codec-agnostically by modern
+			// libwebrtc to mark frame start/end). When negotiated, the
+			// receive-side jitter buffer uses S/E bits to identify the true
+			// first and last packet of each frame, avoiding the order-number
+			// heuristic's false-positive complete on first-packet loss.
+			if (offer_media_desc->FindExtmapItem(
+					"https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension",
+					extmap_id, extmap_attribute))
+			{
+				answer_media_desc->AddExtmap(extmap_id, extmap_attribute);
+			}
+
 			// a=candidate
 			for (const auto &ice_candidate : ice_candidates)
 			{
 				answer_media_desc->AddIceCandidate(std::make_shared<IceCandidate>(ice_candidate));
+			}
+
+			// First pass: collect non-RTX primary PTs we will keep, so we can drop
+			// orphan RTX entries whose a=fmtp:N apt=M points at a codec we filtered out.
+			std::set<uint8_t> accepted_primary_pts;
+			for (auto &offer_payload : offer_media_desc->GetPayloadList())
+			{
+				auto codec = offer_payload->GetCodec();
+				if (codec == PayloadAttr::SupportCodec::H264 ||
+					codec == PayloadAttr::SupportCodec::H265 ||
+					codec == PayloadAttr::SupportCodec::VP8 ||
+					codec == PayloadAttr::SupportCodec::OPUS)
+				{
+					accepted_primary_pts.insert(offer_payload->GetId());
+				}
 			}
 
 			// payloads
@@ -285,10 +354,35 @@ namespace pvd
 				if (offer_payload->GetCodec() != PayloadAttr::SupportCodec::H264 &&
 					offer_payload->GetCodec() != PayloadAttr::SupportCodec::H265 &&
 					offer_payload->GetCodec() != PayloadAttr::SupportCodec::VP8 &&
-					offer_payload->GetCodec() != PayloadAttr::SupportCodec::OPUS)
+					offer_payload->GetCodec() != PayloadAttr::SupportCodec::OPUS &&
+					offer_payload->GetCodec() != PayloadAttr::SupportCodec::RTX)
 				{
 					logti("unsupported codec(%s) has ignored", offer_payload->GetCodecStr().CStr());
 					continue;
+				}
+
+				if (offer_payload->GetCodec() == PayloadAttr::SupportCodec::RTX)
+				{
+					// Drop all RTX payloads when NACK is disabled by config.
+					if (rtx_enabled == false)
+					{
+						continue;
+					}
+
+					// Drop orphan RTX whose apt= references a primary PT we filtered out.
+					auto fmtp = offer_payload->GetFmtp();
+					auto apt_pos = fmtp.IndexOf("apt=");
+					if (apt_pos < 0)
+					{
+						logti("Drop RTX pt(%u) with no apt= in fmtp", offer_payload->GetId());
+						continue;
+					}
+					uint32_t apt_pt = ov::Converter::ToUInt32(fmtp.Substring(apt_pos + 4).CStr());
+					if (accepted_primary_pts.find(static_cast<uint8_t>(apt_pt)) == accepted_primary_pts.end())
+					{
+						logti("Drop RTX pt(%u) referencing unsupported primary pt(%u)", offer_payload->GetId(), apt_pt);
+						continue;
+					}
 				}
 
 				auto answer_payload = std::make_shared<PayloadAttr>();
@@ -303,6 +397,12 @@ namespace pvd
 					answer_payload->EnableRtcpFb(PayloadAttr::RtcpFbType::CcmFir, true);
 				}
 
+				// NACK
+				if (rtx_enabled && offer_payload->IsRtcpFbEnabled(PayloadAttr::RtcpFbType::Nack))
+				{
+					answer_payload->EnableRtcpFb(PayloadAttr::RtcpFbType::Nack, true);
+				}
+
 				// NACK PLI
 				if (offer_payload->IsRtcpFbEnabled(PayloadAttr::RtcpFbType::NackPli))
 				{
@@ -314,7 +414,7 @@ namespace pvd
 				{
 					answer_payload->EnableRtcpFb(PayloadAttr::RtcpFbType::TransportCc, true);
 				}
-				
+
 				answer_media_desc->AddPayload(answer_payload);
 			}
 

--- a/src/projects/providers/webrtc/webrtc_application.cpp
+++ b/src/projects/providers/webrtc/webrtc_application.cpp
@@ -233,6 +233,12 @@ namespace pvd
 				continue;
 			}
 
+			// NACK/RTX are only wired into the receive pipeline for video, so
+			// negotiate them on video m-lines only. Advertising them on audio
+			// would promise retransmission the pipeline never services.
+			bool rtx_for_this_media = rtx_enabled &&
+				offer_media_desc->GetMediaType() == MediaDescription::MediaType::Video;
+
 			auto answer_media_desc = std::make_shared<MediaDescription>();
 			answer_media_desc->SetMediaType(offer_media_desc->GetMediaType());
 			answer_media_desc->SetConnection(4, "0.0.0.0");
@@ -309,7 +315,7 @@ namespace pvd
 			// Repaired RTP-STREAM-ID (rrid). libwebrtc stamps this on RTX
 			// packets in simulcast in place of rid; without it the receive
 			// side can't resolve which simulcast layer an RTX packet belongs to.
-			if (rtx_enabled &&
+			if (rtx_for_this_media &&
 				offer_media_desc->FindExtmapItem("urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id", extmap_id, extmap_attribute))
 			{
 				answer_media_desc->AddExtmap(extmap_id, extmap_attribute);
@@ -321,7 +327,7 @@ namespace pvd
 			// first and last packet of each frame, avoiding the order-number
 			// heuristic's false-positive complete on first-packet loss.
 			if (offer_media_desc->FindExtmapItem(
-					"https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension",
+					RTP_HEADER_EXTENSION_DEPENDENCY_DESCRIPTOR_ATTRIBUTE,
 					extmap_id, extmap_attribute))
 			{
 				answer_media_desc->AddExtmap(extmap_id, extmap_attribute);
@@ -363,8 +369,9 @@ namespace pvd
 
 				if (offer_payload->GetCodec() == PayloadAttr::SupportCodec::RTX)
 				{
-					// Drop all RTX payloads when NACK is disabled by config.
-					if (rtx_enabled == false)
+					// Drop RTX payloads when NACK is disabled, or on audio
+					// m-lines where the receive pipeline doesn't service RTX.
+					if (rtx_for_this_media == false)
 					{
 						continue;
 					}
@@ -398,7 +405,7 @@ namespace pvd
 				}
 
 				// NACK
-				if (rtx_enabled && offer_payload->IsRtcpFbEnabled(PayloadAttr::RtcpFbType::Nack))
+				if (rtx_for_this_media && offer_payload->IsRtcpFbEnabled(PayloadAttr::RtcpFbType::Nack))
 				{
 					answer_payload->EnableRtcpFb(PayloadAttr::RtcpFbType::Nack, true);
 				}

--- a/src/projects/providers/webrtc/webrtc_application.h
+++ b/src/projects/providers/webrtc/webrtc_application.h
@@ -38,7 +38,7 @@ namespace pvd
 
 		std::shared_ptr<IcePort> _ice_port = nullptr;
 		std::shared_ptr<RtcSignallingServer> _rtc_signalling = nullptr;
-		
+
 		std::shared_ptr<SessionDescription> _offer_sdp = nullptr;
 		std::shared_ptr<Certificate> _certificate = nullptr;
 	};

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -278,6 +278,12 @@ namespace pvd
 		uint8_t rid_extension_id = 0;
 		ov::String rid_extension_uri;
 		bool has_rid_extension = false;
+		// rrid (repaired-rtp-stream-id): libwebrtc stamps this on RTX packets
+		// in simulcast so the receive side can map RTX → primary via mid + rrid.
+		// Absent (id == 0) when not negotiated.
+		uint8_t rrid_extension_id = 0;
+		ov::String rrid_extension_uri;
+		answer_media_desc->FindExtmapItem("urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id", rrid_extension_id, rrid_extension_uri);
 		if (rid_attr != nullptr)
 		{
 			has_rid_extension = answer_media_desc->FindExtmapItem("urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id", rid_extension_id, rid_extension_uri);
@@ -313,11 +319,70 @@ namespace pvd
 		rtp_track_id.mid_extension_id = mid_extension_id;
 		rtp_track_id.rid = has_rid_extension ? std::optional<ov::String>(rid_attr->GetId()) : std::nullopt;
 		rtp_track_id.rid_extension_id = rid_extension_id;
+		rtp_track_id.rrid_extension_id = rrid_extension_id;
 
 		if (_rtp_rtcp->AddRtpReceiver(track, rtp_track_id) == false)
 		{
 			logte("Could not add rtp receiver : track_id(%u)", track->GetId());
 			return false;
+		}
+
+		// Register DD ext id only when the extension was negotiated. Without
+		// it the detector falls back to codec payload parse.
+		if (track->GetMediaType() == cmn::MediaType::Video)
+		{
+			uint8_t dd_ext_id = 0;
+			ov::String dd_uri;
+			if (answer_media_desc->FindExtmapItem(
+					"https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension",
+					dd_ext_id, dd_uri))
+			{
+				_rtp_rtcp->SetDependencyDescriptorExtId(dd_ext_id);
+			}
+		}
+
+		// NACK + RTX wiring (video only). Audio NACK is not negotiated.
+		if (track->GetMediaType() == cmn::MediaType::Video &&
+			payload_attr->IsRtcpFbEnabled(PayloadAttr::RtcpFbType::Nack))
+		{
+			uint32_t media_ssrc = remote_media_desc->GetSsrc().value_or(0);
+			uint32_t max_hold_ms = 400;
+			auto app = GetApplication();
+			if (app != nullptr)
+			{
+				max_hold_ms = static_cast<uint32_t>(
+					app->GetConfig().GetProviders().GetWebrtcProvider().GetRtx().GetMaxHoldMs());
+			}
+			_rtp_rtcp->EnableNack(track->GetId(), media_ssrc, max_hold_ms);
+
+			// Register RTX payloads (PT-based detection) and, when the peer
+			// pre-declared an RTX SSRC via a=ssrc-group:FID, also bind the
+			// RTX SSRC for the primary PT so the first packet skips the
+			// dynamic-resolution path. Simulcast WHIP omits ssrc-group:FID
+			// and relies on the PT path alone.
+			auto rtx_ssrc_opt = remote_media_desc->GetRtxSsrc();
+			for (auto &cand : answer_media_desc->GetPayloadList())
+			{
+				if (cand->GetCodec() != PayloadAttr::SupportCodec::RTX)
+				{
+					continue;
+				}
+				auto fmtp = cand->GetFmtp();
+				auto apt_pos = fmtp.IndexOf("apt=");
+				if (apt_pos < 0)
+				{
+					continue;
+				}
+				uint8_t apt_pt = static_cast<uint8_t>(ov::Converter::ToUInt32(fmtp.Substring(apt_pos + 4).CStr()));
+				_rtp_rtcp->RegisterRtxPayloadType(cand->GetId(), apt_pt);
+				_rtx_enabled = true;
+
+				if (rtx_ssrc_opt.has_value() && apt_pt == payload_attr->GetId())
+				{
+					_rtp_rtcp->RegisterRtxStream(rtx_ssrc_opt.value(), media_ssrc,
+												 cand->GetId(), apt_pt);
+				}
+			}
 		}
 
 		// Clock

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -12,6 +12,7 @@
 #include "base/ovlibrary/converter.h"
 #include "base/ovlibrary/random.h"
 #include "modules/rtp_rtcp/rtcp_info/sender_report.h"
+#include "modules/rtp_rtcp/rtp_header_extension/rtp_header_extension.h"
 #include "webrtc_application.h"
 #include "webrtc_private.h"
 #include "webrtc_provider.h"
@@ -328,13 +329,14 @@ namespace pvd
 		}
 
 		// Register DD ext id only when the extension was negotiated. Without
-		// it the detector falls back to codec payload parse.
+		// it (or when a sender advertises but never stamps it), the jitter
+		// buffer falls back to sequence-number continuity.
 		if (track->GetMediaType() == cmn::MediaType::Video)
 		{
 			uint8_t dd_ext_id = 0;
 			ov::String dd_uri;
 			if (answer_media_desc->FindExtmapItem(
-					"https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension",
+					RTP_HEADER_EXTENSION_DEPENDENCY_DESCRIPTOR_ATTRIBUTE,
 					dd_ext_id, dd_uri))
 			{
 				_rtp_rtcp->SetDependencyDescriptorExtId(dd_ext_id);
@@ -350,8 +352,14 @@ namespace pvd
 			auto app = GetApplication();
 			if (app != nullptr)
 			{
-				max_hold_ms = static_cast<uint32_t>(
-					app->GetConfig().GetProviders().GetWebrtcProvider().GetRtx().GetMaxHoldMs());
+				// MaxHoldMs is a signed config value; a negative/zero
+				// misconfiguration would wrap to a huge cap and disable the
+				// latency bound, so fall back to the default in that case.
+				int configured = app->GetConfig().GetProviders().GetWebrtcProvider().GetRtx().GetMaxHoldMs();
+				if (configured > 0)
+				{
+					max_hold_ms = static_cast<uint32_t>(configured);
+				}
 			}
 			_rtp_rtcp->EnableNack(track->GetId(), media_ssrc, max_hold_ms);
 


### PR DESCRIPTION
## Problem

The WebRTC Provider has no receive-side NACK or RTX, so packet loss between the publisher and OME corrupts the assembled frame and the damage propagates to every downstream publisher. The legacy jitter buffer also relied on a sequence-number heuristic that produced false-positive "complete" frames when the first packet of a frame was lost, which then poisoned mediarouter's SPS/PPS cache.

## Solution

Add a per-track NACK generator (RFC 4585), an RTX unwrap path (RFC 4588), a codec-aware frame boundary detector (S/E bits via the Dependency Descriptor header extension or H264/H265/VP8/AV1 payload parse) that replaces the old heuristic, and a jitter buffer hold that adapts to NACK->RTX round-trip plus frame-interval variance. Provider opts in via `<Rtx><Enable>true</Enable><MaxHoldMs>400</MaxHoldMs></Rtx>`.