### PR TITLE
fix: distribute WebRTC UDP ICE across multiple ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,7 +128,7 @@ ENV     DEBIAN_FRONTEND=noninteractive
 RUN     apt-get update && apt-get install -y tzdata sudo libgomp1
 
 WORKDIR         /opt/ovenmediaengine/bin
-EXPOSE          80/tcp 8080/tcp 8090/tcp 1935/tcp 3333/tcp 3334/tcp 4000-4005/udp 10000/udp 10000/tcp 9000/tcp
+EXPOSE          80/tcp 8080/tcp 8090/tcp 1935/tcp 3333/tcp 3334/tcp 4000-4005/udp 10000-10003/udp 10000/tcp 9000/tcp
 COPY            --from=build /opt/ovenmediaengine /opt/ovenmediaengine
 
 ENV     NVIDIA_VISIBLE_DEVICES=all

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Although we have tested OvenMediaEngine on the platforms listed below, it may wo
 ### Docker
 ```bash
 docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
--p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000:10000/udp -p 10000:10000/tcp \
+-p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10003:10000-10003/udp -p 10000:10000/tcp \
 ovenmedialabs/ovenmediaengine:latest
 ```
 
@@ -83,7 +83,7 @@ You can also store the configuration files on your host:
 
 ```bash
 docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
--p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000:10000/udp -p 10000:10000/tcp \
+-p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10003:10000-10003/udp -p 10000:10000/tcp \
 -v ome-origin-conf:/opt/ovenmediaengine/bin/origin_conf \
 -v ome-edge-conf:/opt/ovenmediaengine/bin/edge_conf \
 ovenmedialabs/ovenmediaengine:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     - "3333:3333/tcp" # WebRTC Signaling / LLHLS
     - "3334:3334/tcp" # TLS WebRTC Signaling / LLHLS - Optional unless TLS is enabled
     - "3478:3478/tcp" # WebRTC TURN
-    - "10000:10000/udp" # WebRTC Candidate
-    - "10000:10000/tcp" # WebRTC Candidate
+    - "10000-10003:10000-10003/udp" # WebRTC Candidate (UDP, 4 ports for thread distribution)
+    - "10000:10000/tcp" # WebRTC Candidate (Direct TCP ICE)
     environment:
     - OME_HOST_IP=192.168.0.160
     - OME_ORIGIN_PORT=9000
@@ -23,7 +23,7 @@ services:
     - OME_WEBRTC_SIGNALLING_PORT=3333 #LLHLS or WebRTC should be different if both are enabled.
     - OME_WEBRTC_SIGNALLING_TLS_PORT=3334 # Optional, unless using TLS
     - OME_WEBRTC_TCP_RELAY_PORT=3478
-    - OME_WEBRTC_CANDIDATE_PORT=10000/udp
+    - OME_WEBRTC_CANDIDATE_PORT=10000-10003/udp
     - OME_WEBRTC_TCP_ICE_PORT=10000/tcp
     restart: always
     # Uncomment the following line to use your own configuration file (./origin_conf/Server.xml)
@@ -40,8 +40,8 @@ services:
     ports:
     - "4333:3333/tcp" # WebRTC Signaling / LLHLS
     - "3479:3479/tcp" # WebRTC TURN
-    - "10001:10001/udp" # WebRTC Candidate
-    - "10001:10001/tcp" # WebRTC Candidate
+    - "10004-10007:10004-10007/udp" # WebRTC Candidate (UDP, 4 ports for thread distribution)
+    - "10004:10004/tcp" # WebRTC Candidate (Direct TCP ICE)
     environment:
     - OME_HOST_IP=192.168.0.160
     - DEFAULT_ORIGIN_SERVER=192.168.0.160
@@ -50,8 +50,8 @@ services:
     - OME_WEBRTC_SIGNALLING_PORT=3333 #LLHLS or WebRTC should be different if both are enabled.
     - OME_WEBRTC_SIGNALLING_TLS_PORT=3334 # Optional, unless using TLS
     - OME_WEBRTC_TCP_RELAY_PORT=3479
-    - OME_WEBRTC_CANDIDATE_PORT=10001/udp
-    - OME_WEBRTC_TCP_ICE_PORT=10001/tcp
+    - OME_WEBRTC_CANDIDATE_PORT=10004-10007/udp
+    - OME_WEBRTC_TCP_ICE_PORT=10004/tcp
     restart: always
     # Uncomment the following line to use your own configuration file (./edge_conf/Server.xml)
     #volumes:

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -121,13 +121,12 @@ The `<Bind>` is the configuration for the server port that will be used. Bind co
 
                 <IceCandidates>
                     <!-- ${PublicIP} is resolved via <StunServer>. Falls back to all local IPs if STUN fails. -->
-                    <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+                    <IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate>
                     <!-- Direct TCP ICE (RFC 6544) -->
                     <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
                     <!-- TURN relay for clients that do not support Direct TCP ICE -->
                     <TcpRelay>${PublicIP}:3478</TcpRelay>
                     <TcpRelayForce>false</TcpRelayForce>
-                    <IceWorkerCount>1</IceWorkerCount>
                     <TcpIceWorkerCount>1</TcpIceWorkerCount>
                     <TcpRelayWorkerCount>1</TcpRelayWorkerCount>
                 </IceCandidates>
@@ -158,13 +157,12 @@ The `<Bind>` is the configuration for the server port that will be used. Bind co
                 </Signalling>
                 <IceCandidates>
                     <!-- ${PublicIP} is resolved via <StunServer>. Falls back to all local IPs if STUN fails. -->
-                    <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+                    <IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate>
                     <!-- Direct TCP ICE (RFC 6544) -->
                     <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
                     <!-- TURN relay for clients that do not support Direct TCP ICE -->
                     <TcpRelay>${PublicIP}:3478</TcpRelay>
                     <TcpRelayForce>false</TcpRelayForce>
-                    <IceWorkerCount>1</IceWorkerCount>
                     <TcpIceWorkerCount>1</TcpIceWorkerCount>
                     <TcpRelayWorkerCount>1</TcpRelayWorkerCount>
                 </IceCandidates>
@@ -508,13 +506,12 @@ Finally, `Server.xml` is configured as follows:
 
                 <IceCandidates>
                     <!-- ${PublicIP} is resolved via <StunServer>. Falls back to all local IPs if STUN fails. -->
-                    <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+                    <IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate>
                     <!-- Direct TCP ICE (RFC 6544) -->
                     <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
                     <!-- TURN relay for clients that do not support Direct TCP ICE -->
                     <TcpRelay>${PublicIP}:3478</TcpRelay>
                     <TcpRelayForce>false</TcpRelayForce>
-                    <IceWorkerCount>1</IceWorkerCount>
                     <TcpIceWorkerCount>1</TcpIceWorkerCount>
                     <TcpRelayWorkerCount>1</TcpRelayWorkerCount>
                 </IceCandidates>
@@ -545,13 +542,12 @@ Finally, `Server.xml` is configured as follows:
                 </Signalling>
                 <IceCandidates>
                     <!-- ${PublicIP} is resolved via <StunServer>. Falls back to all local IPs if STUN fails. -->
-                    <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+                    <IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate>
                     <!-- Direct TCP ICE (RFC 6544) -->
                     <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
                     <!-- TURN relay for clients that do not support Direct TCP ICE -->
                     <TcpRelay>${PublicIP}:3478</TcpRelay>
                     <TcpRelayForce>false</TcpRelayForce>
-                    <IceWorkerCount>1</IceWorkerCount>
                     <TcpIceWorkerCount>1</TcpIceWorkerCount>
                     <TcpRelayWorkerCount>1</TcpRelayWorkerCount>
                 </IceCandidates>

--- a/docs/configuration/ipv6.md
+++ b/docs/configuration/ipv6.md
@@ -129,8 +129,8 @@ To use IPv6 ICE Candidate, you need to add an IPv6 `<IceCandidate>` to `/<Server
             <WebRTC>
                 ...
                 <IceCandidates>
-                    <IceCandidate>*:10000/udp</IceCandidate>
-                    <IceCandidate>[::]:10000/udp</IceCandidate>
+                    <IceCandidate>*:10000-10003/udp</IceCandidate>
+                    <IceCandidate>[::]:10000-10003/udp</IceCandidate>
                 </IceCandidates>
                 ...
             </WebRTC>

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -173,6 +173,6 @@ $ sudo firewall-cmd --add-port=9999/udp
 $ sudo firewall-cmd --add-port=4000/udp
 $ sudo firewall-cmd --add-port=3478/tcp
 $ sudo firewall-cmd --add-port=9000/tcp
-$ sudo firewall-cmd --add-port=10000/udp
+$ sudo firewall-cmd --add-port=10000-10003/udp
 $ sudo firewall-cmd --add-port=10000/tcp
 ```

--- a/docs/getting-started/getting-started-with-docker.md
+++ b/docs/getting-started/getting-started-with-docker.md
@@ -10,7 +10,7 @@ OvenMediaEngine provides the Docker image from [OvenMedia Labs Docker Hub](https
 
 ```sh
 docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
--p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000:10000/udp -p 10000:10000/tcp \
+-p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10003:10000-10003/udp -p 10000:10000/tcp \
 ovenmedialabs/ovenmediaengine:latest
 ```
 
@@ -29,7 +29,7 @@ For example, to run a specific release:
 
 ```sh
 docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
--p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000:10000/udp -p 10000:10000/tcp \
+-p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10003:10000-10003/udp -p 10000:10000/tcp \
 ovenmedialabs/ovenmediaengine:v0.20.5
 ```
 
@@ -59,7 +59,7 @@ You can set the following environment variables.
 | `OME_WEBRTC_SIGNALLING_PORT`     | `3333`            |
 | `OME_WEBRTC_SIGNALLING_TLS_PORT` | `3334`            |
 | `OME_WEBRTC_TCP_RELAY_PORT`      | `3478`            |
-| `OME_WEBRTC_CANDIDATE_PORT`      | `10000/udp`       |
+| `OME_WEBRTC_CANDIDATE_PORT`      | `10000-10003/udp` |
 | `OME_WEBRTC_TCP_ICE_PORT`        | `10000/tcp`       |
 
 ## Getting Started with Complex Configuration
@@ -134,7 +134,7 @@ docker run -d -it --name ome -e OME_HOST_IP=Your.HOST.IP.Address \
 -v $OME_DOCKER_HOME/conf:/opt/ovenmediaengine/bin/origin_conf \
 -v $OME_DOCKER_HOME/logs:/var/log/ovenmediaengine \
 -p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 \
--p 10000:10000/udp -p 10000:10000/tcp \
+-p 10000-10003:10000-10003/udp -p 10000:10000/tcp \
 ovenmedialabs/ovenmediaengine:latest
 ```
 

--- a/docs/live-source/webrtc.md
+++ b/docs/live-source/webrtc.md
@@ -28,11 +28,11 @@ OvenMediaEngine supports WebRTC ingest from web browsers and any encoder that im
         <TLSPort>3334</TLSPort>
     </Signalling>
     <IceCandidates>
-        <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+        <!-- UDP ICE scales by port count: each port is handled by one thread. Use a range (~4) to spread across cores. -->
+        <IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate> <!-- 4 ports = 4 UDP ICE threads -->
         <IceCandidate>${PublicIP}:3479/tcp</IceCandidate>  <!-- Direct TCP ICE (RFC 6544) -->
         <TcpRelay>${PublicIP}:3478</TcpRelay>              <!-- TURN relay -->
         <TcpRelayForce>false</TcpRelayForce>
-        <IceWorkerCount>4</IceWorkerCount>
         <TcpIceWorkerCount>1</TcpIceWorkerCount>
         <TcpRelayWorkerCount>1</TcpRelayWorkerCount>
         <DefaultTransport>udptcp</DefaultTransport>
@@ -62,25 +62,28 @@ Use `${PublicIP}` to have OME auto-resolve the public IP via `<StunServer>` at s
 `*` causes OME to advertise every network interface (including Docker bridge interfaces `172.17.x.x`, VPN adapters, and internal NICs) as ICE candidates. Encoders will attempt connectivity checks against all of them, which significantly increases ICE negotiation time and can cause connection delays or failures.
 
 Always specify the exact IP the encoder can reach:
-- Specific IP: `<IceCandidate>203.0.113.1:10000/udp</IceCandidate>`
-- Auto-detected via STUN: `<IceCandidate>${PublicIP}:10000/udp</IceCandidate>` (requires `<StunServer>` in `Server.xml`)
+- Specific IP: `<IceCandidate>203.0.113.1:10000-10003/udp</IceCandidate>`
+- Auto-detected via STUN: `<IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate>` (requires `<StunServer>` in `Server.xml`)
 
 :::
 
 
 #### Worker Threads
 
-Each transport type has an independent worker-thread pool:
+OvenMediaEngine handles each transport type independently, but they scale across CPU cores differently:
 
-| Configuration | Default | Applies to |
+| Configuration | Default | Scaling |
 |---|---|---|
-| `<IceWorkerCount>` | 1 | UDP ICE candidate sockets |
-| `<TcpIceWorkerCount>` | 1 | Direct TCP ICE candidate sockets (RFC 6544) |
-| `<TcpRelayWorkerCount>` | 1 | TURN relay sockets |
+| `<TcpIceWorkerCount>` | 1 | Direct TCP ICE (RFC 6544). Connections on one port are distributed across this many threads. |
+| `<TcpRelayWorkerCount>` | 1 | TURN relay. Connections on one port are distributed across this many threads. |
 
-The worker count applies **per port**. Increase `<IceWorkerCount>` or `<TcpIceWorkerCount>` when handling a large number of simultaneous publishers on a multi-core server.
+**UDP ICE scales by the number of ports.** Each UDP port is bound to a single socket and serviced by a single thread, so one UDP port uses a single CPU core. To spread UDP ICE across CPU cores, advertise a range of UDP ports. Around 4 is a good starting point on a multi-core server:
 
-> **Prefer a single port with a higher worker count over multiple ports.** Adding ports multiplies both the thread count and the number of ICE candidates advertised to clients, and more candidates mean slower ICE negotiation. For throughput scaling, raise the worker count on a single port instead.
+```xml
+<IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate> <!-- 4 ports = 4 UDP ICE threads -->
+```
+
+Direct TCP ICE and TURN relay are connection-oriented. A single port accepts many connections that are distributed across `<TcpIceWorkerCount>` / `<TcpRelayWorkerCount>` threads, so those scale on one port without adding ports.
 
 #### Default Transport
 

--- a/docs/live-source/webrtc.md
+++ b/docs/live-source/webrtc.md
@@ -29,7 +29,7 @@ OvenMediaEngine supports WebRTC ingest from web browsers and any encoder that im
     </Signalling>
     <IceCandidates>
         <!-- UDP ICE scales by port count: each port is handled by one thread. Use a range (~4) to spread across cores. -->
-        <IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate> <!-- 4 ports = 4 UDP ICE threads -->
+        <IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate> <!-- 4 UDP ports = 4 receive threads per advertised IP -->
         <IceCandidate>${PublicIP}:3479/tcp</IceCandidate>  <!-- Direct TCP ICE (RFC 6544) -->
         <TcpRelay>${PublicIP}:3478</TcpRelay>              <!-- TURN relay -->
         <TcpRelayForce>false</TcpRelayForce>
@@ -77,10 +77,10 @@ OvenMediaEngine handles each transport type independently, but they scale across
 | `<TcpIceWorkerCount>` | 1 | Direct TCP ICE (RFC 6544). Connections on one port are distributed across this many threads. |
 | `<TcpRelayWorkerCount>` | 1 | TURN relay. Connections on one port are distributed across this many threads. |
 
-**UDP ICE scales by the number of ports.** Each UDP port is bound to a single socket and serviced by a single thread, so one UDP port uses a single CPU core. To spread UDP ICE across CPU cores, advertise a range of UDP ports. Around 4 is a good starting point on a multi-core server:
+**UDP ICE scales by the number of ports.** Each UDP port binds one socket per advertised IP, each serviced by a single thread, so a single UDP port is handled by one thread. To spread UDP ICE across CPU cores, advertise a range of UDP ports. Around 4 is a good starting point on a multi-core server:
 
 ```xml
-<IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate> <!-- 4 ports = 4 UDP ICE threads -->
+<IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate> <!-- 4 UDP ports = 4 receive threads per advertised IP -->
 ```
 
 Direct TCP ICE and TURN relay are connection-oriented. A single port accepts many connections that are distributed across `<TcpIceWorkerCount>` / `<TcpRelayWorkerCount>` threads, so those scale on one port without adding ports.

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -264,13 +264,12 @@ The `WorkerCount` in `<Bind>` can set the thread responsible for sending and rec
             </Signalling>
             <IceCandidates>
                 <!-- ${PublicIP} is resolved via <StunServer>. Falls back to all local IPs if STUN fails. -->
-                <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+                <IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate>
                 <!-- Direct TCP ICE (RFC 6544) -->
                 <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
                 <!-- TURN relay for clients that do not support Direct TCP ICE -->
                 <TcpRelay>${PublicIP}:3478</TcpRelay>
                 <TcpRelayForce>false</TcpRelayForce>
-                <IceWorkerCount>1</IceWorkerCount>
                 <TcpIceWorkerCount>1</TcpIceWorkerCount>
                 <TcpRelayWorkerCount>1</TcpRelayWorkerCount>
             </IceCandidates>

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -12,7 +12,7 @@ Run docker with the command below. `OME_HOST_IP` must be an IP address accessibl
 
 ```sh
 $ docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
--p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000:10000/udp -p 10000:10000/tcp \
+-p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10003:10000-10003/udp -p 10000:10000/tcp \
 ovenmedialabs/ovenmediaengine:latest
 ```
 

--- a/docs/streaming/webrtc-publishing.md
+++ b/docs/streaming/webrtc-publishing.md
@@ -37,7 +37,7 @@ Add `<WebRTC>` under `<Bind><Publishers>` in `Server.xml`:
             <!-- ${PublicIP} is auto-resolved via <StunServer> at startup.             -->
             <!-- UDP ICE scales by PORT count: each UDP port is serviced by one thread.  -->
             <!-- Use a port range (~4) to spread UDP ICE across cores.                   -->
-            <IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate> <!-- 4 ports = 4 UDP ICE threads -->
+            <IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate> <!-- 4 UDP ports = 4 receive threads per advertised IP -->
             <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>   <!-- Direct TCP ICE (RFC 6544) -->
             <TcpRelay>${PublicIP}:3478</TcpRelay>               <!-- TURN relay (WebRTC/TCP via TURN) -->
             <TcpRelayForce>false</TcpRelayForce>
@@ -86,10 +86,10 @@ OvenMediaEngine handles each transport type independently, but they scale across
 | `<TcpIceWorkerCount>` | 1 | Direct TCP ICE (RFC 6544). Connections on one port are distributed across this many threads. |
 | `<TcpRelayWorkerCount>` | 1 | TURN relay. Connections on one port are distributed across this many threads. |
 
-**UDP ICE scales by the number of ports.** Each UDP port is bound to a single socket and serviced by a single thread, so one UDP port uses a single CPU core. To spread UDP ICE across CPU cores, advertise a range of UDP ports:
+**UDP ICE scales by the number of ports.** Each UDP port binds one socket per advertised IP, each serviced by a single thread, so a single UDP port is handled by one thread. To spread UDP ICE across CPU cores, advertise a range of UDP ports:
 
 ```xml
-<IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate> <!-- 4 ports = 4 UDP ICE threads -->
+<IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate> <!-- 4 UDP ports = 4 receive threads per advertised IP -->
 ```
 
 Each port in the range is bound separately and assigned to its own thread. Around 4 ports is a good starting point on a multi-core server.

--- a/docs/streaming/webrtc-publishing.md
+++ b/docs/streaming/webrtc-publishing.md
@@ -35,15 +35,14 @@ Add `<WebRTC>` under `<Bind><Publishers>` in `Server.xml`:
             <!-- * advertises every network interface (docker, VPN, etc.) as a         -->
             <!-- candidate, which slows down ICE negotiation on the browser side.      -->
             <!-- ${PublicIP} is auto-resolved via <StunServer> at startup.             -->
-            <!-- Use a single port and raise IceWorkerCount for throughput scaling     -->
-            <!-- instead of adding more ports.                                         -->
-            <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+            <!-- UDP ICE scales by PORT count: each UDP port is serviced by one thread.  -->
+            <!-- Use a port range (~4) to spread UDP ICE across cores.                   -->
+            <IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate> <!-- 4 ports = 4 UDP ICE threads -->
             <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>   <!-- Direct TCP ICE (RFC 6544) -->
             <TcpRelay>${PublicIP}:3478</TcpRelay>               <!-- TURN relay (WebRTC/TCP via TURN) -->
             <TcpRelayForce>false</TcpRelayForce>
-            <IceWorkerCount>4</IceWorkerCount>           <!-- Increase for high viewer count -->
-            <TcpIceWorkerCount>1</TcpIceWorkerCount>     <!-- Worker threads for Direct TCP ICE -->
-            <TcpRelayWorkerCount>1</TcpRelayWorkerCount> <!-- Worker threads for TURN relay -->
+            <TcpIceWorkerCount>1</TcpIceWorkerCount>     <!-- Direct TCP ICE scales with this value -->
+            <TcpRelayWorkerCount>1</TcpRelayWorkerCount> <!-- TURN relay scales with this value -->
             <DefaultTransport>udptcp</DefaultTransport>  <!-- udptcp (default) | udp | tcp | relay | all -->
         </IceCandidates>
     </WebRTC>
@@ -65,8 +64,8 @@ OvenMediaEngine supports three transport types for ICE candidates:
 
 The IP address in `<IceCandidate>` determines which addresses are advertised to browsers as ICE candidates. You can use:
 
-- A specific IP: `<IceCandidate>203.0.113.1:10000/udp</IceCandidate>`
-- `${PublicIP}` to auto-detect the public IP via the configured `<StunServer>`: `<IceCandidate>${PublicIP}:10000/udp</IceCandidate>`
+- A specific IP: `<IceCandidate>203.0.113.1:10000-10003/udp</IceCandidate>`
+- `${PublicIP}` to auto-detect the public IP via the configured `<StunServer>`: `<IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate>`
 
 
 :::danger
@@ -80,21 +79,22 @@ When `*` is specified, OvenMediaEngine collects the IP address of every network 
 
 When no `?transport` query parameter is specified, the behavior follows `<DefaultTransport>` (default: `udptcp`). By default, OME sends UDP and Direct TCP candidates. TURN relay info (`iceServers`) is only included when `?transport=relay` or `?transport=all` is used, or when `<TcpRelayForce>` is `true`.
 
-Each transport type has a dedicated worker-thread pool. You can tune the thread count independently:
+OvenMediaEngine handles each transport type independently, but they scale across CPU cores differently:
 
-| Configuration | Default | Applies to |
+| Configuration | Default | Scaling |
 |---|---|---|
-| `<IceWorkerCount>` | 1 | UDP ICE socket threads |
-| `<TcpIceWorkerCount>` | 1 | Direct TCP ICE socket threads (RFC 6544) |
-| `<TcpRelayWorkerCount>` | 1 | TURN relay socket threads |
+| `<TcpIceWorkerCount>` | 1 | Direct TCP ICE (RFC 6544). Connections on one port are distributed across this many threads. |
+| `<TcpRelayWorkerCount>` | 1 | TURN relay. Connections on one port are distributed across this many threads. |
 
-For most deployments the default of `1` is fine. Increase `<IceWorkerCount>` / `<TcpIceWorkerCount>` when serving many simultaneous viewers on a multi-core server.
+**UDP ICE scales by the number of ports.** Each UDP port is bound to a single socket and serviced by a single thread, so one UDP port uses a single CPU core. To spread UDP ICE across CPU cores, advertise a range of UDP ports:
 
-> **Note:** `<IceWorkerCount>` and `<TcpIceWorkerCount>` are independent. Each defaults to `1` when not set. Setting `<IceWorkerCount>` does **not** affect Direct TCP ICE sockets; set `<TcpIceWorkerCount>` separately to tune the Direct TCP ICE thread count.
->
-> The worker count applies **per port**. For example, `IceWorkerCount=4` with a single UDP port creates **4** UDP ICE threads.
->
-> **Prefer a single port with a higher `<IceWorkerCount>` over multiple ports.** Adding more ports multiplies the thread count (`N ports x IceWorkerCount`) and, more importantly, multiplies the number of ICE candidates advertised to clients, which slows down ICE negotiation. For throughput scaling, increase `<IceWorkerCount>` on a single port instead.
+```xml
+<IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate> <!-- 4 ports = 4 UDP ICE threads -->
+```
+
+Each port in the range is bound separately and assigned to its own thread. Around 4 ports is a good starting point on a multi-core server.
+
+Direct TCP ICE and TURN relay are connection-oriented. A single port accepts many connections that are distributed across `<TcpIceWorkerCount>` / `<TcpRelayWorkerCount>` threads, so those scale on one port without adding ports.
 
 #### Default Transport
 
@@ -403,13 +403,13 @@ OME may sometimes not be able to get the server's public IP on its local interfa
                 ...
             <IceCandidates>
                 <!-- ${PublicIP} is resolved via <StunServer>. Falls back to all local IPs if STUN fails. -->
-                <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+                <!-- UDP ICE scales by port count: each port is handled by one thread. -->
+                <IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate>
                 <!-- Direct TCP ICE (RFC 6544) -->
                 <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
                 <!-- TURN relay for clients that do not support Direct TCP ICE -->
                 <TcpRelay>${PublicIP}:3478</TcpRelay>
                 <TcpRelayForce>false</TcpRelayForce>
-                <IceWorkerCount>1</IceWorkerCount>
                 <TcpIceWorkerCount>1</TcpIceWorkerCount>
                 <TcpRelayWorkerCount>1</TcpRelayWorkerCount>
             </IceCandidates>
@@ -489,7 +489,7 @@ The `<DefaultTransport>` element sets the transport policy applied when no `?tra
 
 ```xml
 <IceCandidates>
-    <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+    <IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate>
     <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
     <TcpRelay>${PublicIP}:3478</TcpRelay>
     <DefaultTransport>udptcp</DefaultTransport>  <!-- udptcp (default) | udp | tcp | relay | all -->

--- a/misc/conf_examples/Edge.xml
+++ b/misc/conf_examples/Edge.xml
@@ -73,13 +73,13 @@
 				</Signalling>
 				<IceCandidates>
 					<!-- Set OME_HOST_IP to your public IP (default: * = all local IPs) -->
-					<IceCandidate>${env:OME_HOST_IP:*}:${env:OME_WEBRTC_CANDIDATE_PORT:10000/udp}</IceCandidate>
+					<!-- UDP ICE scales by port count: each port is handled by one thread. The default range spreads load across cores. -->
+					<IceCandidate>${env:OME_HOST_IP:*}:${env:OME_WEBRTC_CANDIDATE_PORT:10000-10003/udp}</IceCandidate>
 					<!-- Direct TCP ICE (RFC 6544) -->
 					<IceCandidate>${env:OME_HOST_IP:*}:${env:OME_WEBRTC_TCP_ICE_PORT:10000/tcp}</IceCandidate>
 					<!-- TURN relay for clients that do not support Direct TCP ICE -->
 					<TcpRelay>${env:OME_HOST_IP:*}:${env:OME_WEBRTC_TCP_RELAY_PORT:3478}</TcpRelay>
 					<TcpRelayForce>false</TcpRelayForce>
-					<IceWorkerCount>1</IceWorkerCount>
 					<TcpIceWorkerCount>1</TcpIceWorkerCount>
 					<TcpRelayWorkerCount>1</TcpRelayWorkerCount>
 				</IceCandidates>

--- a/misc/conf_examples/Origin.xml
+++ b/misc/conf_examples/Origin.xml
@@ -78,13 +78,13 @@
 				</Signalling>
 				<IceCandidates>
 					<!-- Set OME_HOST_IP to your public IP (default: * = all local IPs) -->
-					<IceCandidate>${env:OME_HOST_IP:*}:${env:OME_WEBRTC_CANDIDATE_PORT:10000/udp}</IceCandidate>
+					<!-- UDP ICE scales by port count: each port is handled by one thread. The default range spreads load across cores. -->
+					<IceCandidate>${env:OME_HOST_IP:*}:${env:OME_WEBRTC_CANDIDATE_PORT:10000-10003/udp}</IceCandidate>
 					<!-- Direct TCP ICE (RFC 6544) -->
 					<IceCandidate>${env:OME_HOST_IP:*}:${env:OME_WEBRTC_TCP_ICE_PORT:10000/tcp}</IceCandidate>
 					<!-- TURN relay for clients that do not support Direct TCP ICE -->
 					<TcpRelay>${env:OME_HOST_IP:*}:${env:OME_WEBRTC_TCP_RELAY_PORT:3478}</TcpRelay>
 					<TcpRelayForce>false</TcpRelayForce>
-					<IceWorkerCount>1</IceWorkerCount>
 					<TcpIceWorkerCount>1</TcpIceWorkerCount>
 					<TcpRelayWorkerCount>1</TcpRelayWorkerCount>
 				</IceCandidates>
@@ -115,13 +115,13 @@
 				</Signalling>
 				<IceCandidates>
 					<!-- Set OME_HOST_IP to your public IP (default: * = all local IPs) -->
-					<IceCandidate>${env:OME_HOST_IP:*}:${env:OME_WEBRTC_CANDIDATE_PORT:10000/udp}</IceCandidate>
+					<!-- UDP ICE scales by port count: each port is handled by one thread. The default range spreads load across cores. -->
+					<IceCandidate>${env:OME_HOST_IP:*}:${env:OME_WEBRTC_CANDIDATE_PORT:10000-10003/udp}</IceCandidate>
 					<!-- Direct TCP ICE (RFC 6544) -->
 					<IceCandidate>${env:OME_HOST_IP:*}:${env:OME_WEBRTC_TCP_ICE_PORT:10000/tcp}</IceCandidate>
 					<!-- TURN relay for clients that do not support Direct TCP ICE -->
 					<TcpRelay>${env:OME_HOST_IP:*}:${env:OME_WEBRTC_TCP_RELAY_PORT:3478}</TcpRelay>
 					<TcpRelayForce>false</TcpRelayForce>
-					<IceWorkerCount>1</IceWorkerCount>
 					<TcpIceWorkerCount>1</TcpIceWorkerCount>
 					<TcpRelayWorkerCount>1</TcpRelayWorkerCount>
 				</IceCandidates>

--- a/misc/conf_examples/Server.xml
+++ b/misc/conf_examples/Server.xml
@@ -85,15 +85,15 @@
 
 				<IceCandidates>
 					<!-- ${PublicIP} is resolved via <StunServer>. Falls back to all local IPs if STUN fails. -->
-					<!-- <IceCandidate>[::]:10000/udp</IceCandidate> -->
-					<IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+					<!-- UDP ICE scales by port count: each port is handled by one thread. Use a range to spread load across cores. -->
+					<!-- <IceCandidate>[::]:10000-10003/udp</IceCandidate> -->
+					<IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate>
 					<!-- Direct TCP ICE (RFC 6544) -->
 					<IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
 					<!-- <EnableLinkLocalAddress>true</EnableLinkLocalAddress> --> <!-- Include IPv6 link-local (fe80::) addresses when using [::] wildcard -->
 					<!-- TURN relay for clients that do not support Direct TCP ICE -->
 					<TcpRelay>${PublicIP}:3478</TcpRelay>
 					<TcpRelayForce>false</TcpRelayForce>
-					<IceWorkerCount>1</IceWorkerCount>
 					<TcpIceWorkerCount>1</TcpIceWorkerCount>
 					<TcpRelayWorkerCount>1</TcpRelayWorkerCount>
 				</IceCandidates>
@@ -124,15 +124,15 @@
 				</Signalling>
 				<IceCandidates>
 					<!-- ${PublicIP} is resolved via <StunServer>. Falls back to all local IPs if STUN fails. -->
-					<!-- <IceCandidate>[::]:10000/udp</IceCandidate> -->
-					<IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+					<!-- UDP ICE scales by port count: each port is handled by one thread. Use a range to spread load across cores. -->
+					<!-- <IceCandidate>[::]:10000-10003/udp</IceCandidate> -->
+					<IceCandidate>${PublicIP}:10000-10003/udp</IceCandidate>
 					<!-- Direct TCP ICE (RFC 6544) -->
 					<IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
 					<!-- <EnableLinkLocalAddress>true</EnableLinkLocalAddress> --> <!-- Include IPv6 link-local (fe80::) addresses when using [::] wildcard -->
 					<!-- TURN relay for clients that do not support Direct TCP ICE -->
 					<TcpRelay>${PublicIP}:3478</TcpRelay>
 					<TcpRelayForce>false</TcpRelayForce>
-					<IceWorkerCount>1</IceWorkerCount>
 					<TcpIceWorkerCount>1</TcpIceWorkerCount>
 					<TcpRelayWorkerCount>1</TcpRelayWorkerCount>
 				</IceCandidates>


### PR DESCRIPTION
## Problem
The documentation said a single UDP ICE port with a higher IceWorkerCount scales across threads. In reality a UDP port is bound to one socket and serviced by a single thread, so that setup never used more than one CPU core.

## Solution
Document and default to a UDP port range (4 ports) for thread distribution, and update the Docker port mappings, EXPOSE, compose, and config examples to match. Remove the IceWorkerCount knob from examples since it has no effect for UDP today.