### PR TITLE
feat: handle concurrent RTP/RTCP receive on ICE candidate switch

### DIFF
--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.cpp
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.cpp
@@ -24,6 +24,7 @@ RtcpTransportCcFeedbackGenerator::RtcpTransportCcFeedbackGenerator(uint8_t exten
 
 bool RtcpTransportCcFeedbackGenerator::AddReceivedRtpPacket(const std::shared_ptr<RtpPacket> &packet)
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	auto wide_sequence_number_opt = packet->GetExtension<uint16_t>(_extension_id);
 	if (wide_sequence_number_opt.has_value() == false)
 	{
@@ -156,6 +157,7 @@ bool RtcpTransportCcFeedbackGenerator::AddReceivedRtpPacket(const std::shared_pt
 
 bool RtcpTransportCcFeedbackGenerator::HasElapsedSinceLastTransportCc(uint32_t milliseconds)
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	auto now = std::chrono::steady_clock::now();
 	auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - _last_report_time).count();
 
@@ -169,6 +171,7 @@ bool RtcpTransportCcFeedbackGenerator::HasElapsedSinceLastTransportCc(uint32_t m
 
 std::shared_ptr<RtcpPacket> RtcpTransportCcFeedbackGenerator::GenerateTransportCcMessage()
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	if (_transport_cc == nullptr)
 	{
 		return nullptr;

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.cpp
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.cpp
@@ -32,11 +32,14 @@ bool RtcpTransportCcFeedbackGenerator::AddReceivedRtpPacket(const std::shared_pt
 	if (wide_sequence_number_opt.has_value() == false)
 	{
 		// There is no transport-wide sequence number in the RTP header extension.
-		// The limiter is a function-local static shared across instances/threads,
-		// so keep it atomic and stop decrementing once exhausted.
+		// The limiter is a function-local static shared across instances/threads;
+		// CAS-decrement only while positive so it never drops below zero.
 		static std::atomic<int> log_remaining{10};
-		if (log_remaining.load(std::memory_order_relaxed) > 0 &&
-			log_remaining.fetch_sub(1, std::memory_order_relaxed) > 0)
+		int cur = log_remaining.load(std::memory_order_relaxed);
+		while (cur > 0 && log_remaining.compare_exchange_weak(cur, cur - 1, std::memory_order_relaxed) == false)
+		{
+		}
+		if (cur > 0)
 		{
 			logtw("AddReceivedRtpPacket: There is no transport-wide sequence number in the RTP header extension : %s", packet->Dump().CStr());
 		}

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.cpp
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.cpp
@@ -155,29 +155,24 @@ bool RtcpTransportCcFeedbackGenerator::AddReceivedRtpPacket(const std::shared_pt
 	return true;
 }
 
-bool RtcpTransportCcFeedbackGenerator::HasElapsedSinceLastTransportCc(uint32_t milliseconds)
+std::shared_ptr<RtcpPacket> RtcpTransportCcFeedbackGenerator::GenerateTransportCcMessageIfElapsed(uint32_t milliseconds)
 {
 	std::lock_guard<std::mutex> lock(_lock);
+
+	// Check elapsed and build under one lock so concurrent receives can't both
+	// pass the interval check and emit feedback for the same window.
 	auto now = std::chrono::steady_clock::now();
 	auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - _last_report_time).count();
-
-	if (elapsed >= milliseconds)
-	{
-		return true;
-	}
-
-	return false;
-}
-
-std::shared_ptr<RtcpPacket> RtcpTransportCcFeedbackGenerator::GenerateTransportCcMessage()
-{
-	std::lock_guard<std::mutex> lock(_lock);
-	if (_transport_cc == nullptr)
+	if (elapsed < milliseconds || _transport_cc == nullptr)
 	{
 		return nullptr;
 	}
 
 	_transport_cc->SetMediaSsrc(_last_media_ssrc);
+
+	// TEMP(verify): remove after confirming transport-cc cadence in a live run
+	logti("transport-cc feedback generated: elapsed(%lldms) packets(%u)",
+		  static_cast<long long>(elapsed), _transport_cc->GetPacketStatusCount());
 
 	logtt("Generate Transport CC message : Sender SSRC(%u), Media SSRC(%u), Base Sequence Number(%u), Reference Time(%u), Packet Feedback Count(%u)",
 		  _transport_cc->GetSenderSsrc(), _transport_cc->GetMediaSsrc(), _transport_cc->GetBaseSequenceNumber(), _transport_cc->GetReferenceTime(), _transport_cc->GetPacketStatusCount());
@@ -185,7 +180,7 @@ std::shared_ptr<RtcpPacket> RtcpTransportCcFeedbackGenerator::GenerateTransportC
 	auto rtcp_packet = std::make_shared<RtcpPacket>();
 	rtcp_packet->Build(_transport_cc);
 
-	_last_report_time = std::chrono::steady_clock::now();
+	_last_report_time = now;
 
 	_transport_cc.reset();
 

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.cpp
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.cpp
@@ -9,6 +9,8 @@
 
 #include "rtcp_transport_cc_feedback_generator.h"
 
+#include <atomic>
+
 #include "../rtp_header_extension/rtp_header_extension_transport_cc.h"
 
 #define OV_LOG_TAG "transport-cc"
@@ -24,16 +26,19 @@ RtcpTransportCcFeedbackGenerator::RtcpTransportCcFeedbackGenerator(uint8_t exten
 
 bool RtcpTransportCcFeedbackGenerator::AddReceivedRtpPacket(const std::shared_ptr<RtpPacket> &packet)
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	// Extension read uses only the packet (local) and _extension_id (set once in
+	// ctor), so it stays outside the lock; a packet without it never contends.
 	auto wide_sequence_number_opt = packet->GetExtension<uint16_t>(_extension_id);
 	if (wide_sequence_number_opt.has_value() == false)
 	{
-		// There is no transport-wide sequence number in the RTP header extension
-		static int log_times = 10;
-		if (log_times > 0)
+		// There is no transport-wide sequence number in the RTP header extension.
+		// The limiter is a function-local static shared across instances/threads,
+		// so keep it atomic and stop decrementing once exhausted.
+		static std::atomic<int> log_remaining{10};
+		if (log_remaining.load(std::memory_order_relaxed) > 0 &&
+			log_remaining.fetch_sub(1, std::memory_order_relaxed) > 0)
 		{
 			logtw("AddReceivedRtpPacket: There is no transport-wide sequence number in the RTP header extension : %s", packet->Dump().CStr());
-			log_times--;
 		}
 		return false;
 	}
@@ -46,6 +51,9 @@ bool RtcpTransportCcFeedbackGenerator::AddReceivedRtpPacket(const std::shared_pt
 	// Add feedback info
 	int64_t delta = 0;
 	uint8_t delta_size = 0;
+
+	// _transport_cc and the running counters below are shared; lock from here.
+	std::lock_guard<std::mutex> lock(_lock);
 
 	// first packet of feedback message
 	if (_transport_cc == nullptr)
@@ -169,10 +177,6 @@ std::shared_ptr<RtcpPacket> RtcpTransportCcFeedbackGenerator::GenerateTransportC
 	}
 
 	_transport_cc->SetMediaSsrc(_last_media_ssrc);
-
-	// TEMP(verify): remove after confirming transport-cc cadence in a live run
-	logti("transport-cc feedback generated: elapsed(%lldms) packets(%u)",
-		  static_cast<long long>(elapsed), _transport_cc->GetPacketStatusCount());
 
 	logtt("Generate Transport CC message : Sender SSRC(%u), Media SSRC(%u), Base Sequence Number(%u), Reference Time(%u), Packet Feedback Count(%u)",
 		  _transport_cc->GetSenderSsrc(), _transport_cc->GetMediaSsrc(), _transport_cc->GetBaseSequenceNumber(), _transport_cc->GetReferenceTime(), _transport_cc->GetPacketStatusCount());

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.h
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.h
@@ -12,6 +12,8 @@
 #include "../rtp_packet.h"
 #include "transport_cc.h"
 
+#include <mutex>
+
 // https://datatracker.ietf.org/doc/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
 
 // RTP header extension format
@@ -61,6 +63,7 @@ public:
 	std::shared_ptr<RtcpPacket> GenerateTransportCcMessage();
 	uint32_t GetPacketStatusCount() const
 	{
+		std::lock_guard<std::mutex> lock(_lock);
 		if (_transport_cc == nullptr)
 		{
 			return 0;
@@ -85,4 +88,6 @@ private:
 	std::shared_ptr<TransportCc> _transport_cc = nullptr;
 
 	std::chrono::steady_clock::time_point _last_report_time;
+
+	mutable std::mutex _lock;
 };

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.h
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.h
@@ -59,8 +59,10 @@ public:
 	RtcpTransportCcFeedbackGenerator(uint8_t extension_id, uint32_t sender_ssrc);
 
 	bool AddReceivedRtpPacket(const std::shared_ptr<RtpPacket> &packet);
-	bool HasElapsedSinceLastTransportCc(uint32_t milliseconds);
-	std::shared_ptr<RtcpPacket> GenerateTransportCcMessage();
+
+	// Atomically: if at least `milliseconds` elapsed since the last report,
+	// build and return the feedback packet (resetting the interval); else nullptr.
+	std::shared_ptr<RtcpPacket> GenerateTransportCcMessageIfElapsed(uint32_t milliseconds);
 	uint32_t GetPacketStatusCount() const
 	{
 		std::lock_guard<std::mutex> lock(_lock);

--- a/src/projects/modules/rtp_rtcp/rtcp_transport_cc_feedback_generator_test.cpp
+++ b/src/projects/modules/rtp_rtcp/rtcp_transport_cc_feedback_generator_test.cpp
@@ -1,0 +1,127 @@
+//==============================================================================
+//
+//  OvenMediaEngine - Unit Tests
+//
+//  Covers: RtcpTransportCcFeedbackGenerator (atomic check-and-generate)
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "rtcp_info/rtcp_transport_cc_feedback_generator.h"
+#include "rtp_header_extension/rtp_header_extension_transport_cc.h"
+#include "rtp_header_extension/rtp_header_extensions.h"
+#include "rtp_packet.h"
+
+namespace
+{
+constexpr uint8_t kExtId = 5;
+constexpr uint32_t kSenderSsrc = 0x11111111;
+constexpr uint32_t kMediaSsrc = 0xDEADBEEF;
+
+// Build a received RTP packet carrying a transport-wide sequence number.
+// SetExtensions writes only the wire buffer (GetExtension reads the parsed
+// map), so serialize and re-parse to populate it the way the receive path does.
+std::shared_ptr<RtpPacket> MakeTwccPacket(uint16_t tw_seq, uint16_t rtp_seq)
+{
+	auto src = std::make_shared<RtpPacket>();
+	src->SetPayloadType(96);
+	src->SetSequenceNumber(rtp_seq);
+	src->SetSsrc(kMediaSsrc);
+	src->SetTimestamp(static_cast<uint32_t>(rtp_seq) * 90);
+
+	auto ext = std::make_shared<RtpHeaderExtensionTransportCc>(kExtId);
+	ext->SetSequenceNumber(tw_seq);
+
+	RtpHeaderExtensions extensions;
+	extensions.AddExtention(ext);
+	src->SetExtensions(extensions);
+
+	uint8_t payload[16] = {0};
+	src->SetPayload(payload, sizeof(payload));
+
+	return std::make_shared<RtpPacket>(src->GetData());
+}
+}  // namespace
+
+// Sanity: the helper produces a packet whose transport-wide seq round-trips.
+// If this fails, the generator tests below are testing the wrong thing.
+TEST(RtcpTransportCcFeedbackGenerator, HelperRoundTripsExtension)
+{
+	auto packet = MakeTwccPacket(1234, 1000);
+	auto value = packet->GetExtension<uint16_t>(kExtId);
+	ASSERT_TRUE(value.has_value());
+	EXPECT_EQ(*value, 1234);
+}
+
+// No packets accumulated -> nothing to send regardless of elapsed time.
+TEST(RtcpTransportCcFeedbackGenerator, EmptyReturnsNull)
+{
+	RtcpTransportCcFeedbackGenerator gen(kExtId, kSenderSsrc);
+	EXPECT_EQ(gen.GenerateTransportCcMessageIfElapsed(0), nullptr);
+}
+
+// The fix: check-and-consume happen under one lock. After a message is
+// generated the batch is consumed, so an immediate second call returns null
+// even though the 0ms interval check would otherwise pass again.
+TEST(RtcpTransportCcFeedbackGenerator, GeneratesThenResets)
+{
+	RtcpTransportCcFeedbackGenerator gen(kExtId, kSenderSsrc);
+	ASSERT_TRUE(gen.AddReceivedRtpPacket(MakeTwccPacket(1, 1000)));
+	ASSERT_TRUE(gen.AddReceivedRtpPacket(MakeTwccPacket(2, 1001)));
+
+	ASSERT_NE(gen.GenerateTransportCcMessageIfElapsed(0), nullptr);
+	EXPECT_EQ(gen.GenerateTransportCcMessageIfElapsed(0), nullptr);
+}
+
+// When the interval has not elapsed the batch must be kept, not consumed.
+TEST(RtcpTransportCcFeedbackGenerator, NotElapsedKeepsBatch)
+{
+	RtcpTransportCcFeedbackGenerator gen(kExtId, kSenderSsrc);
+	ASSERT_TRUE(gen.AddReceivedRtpPacket(MakeTwccPacket(1, 1000)));
+
+	EXPECT_EQ(gen.GenerateTransportCcMessageIfElapsed(100000), nullptr);
+	EXPECT_NE(gen.GenerateTransportCcMessageIfElapsed(0), nullptr);
+}
+
+// Many threads add and generate against one generator: must not crash or
+// deadlock, and must still produce feedback. Run under ThreadSanitizer to
+// catch data races on the generator's internal state.
+TEST(RtcpTransportCcFeedbackGenerator, ConcurrentAddAndGenerate)
+{
+	RtcpTransportCcFeedbackGenerator gen(kExtId, kSenderSsrc);
+
+	std::vector<std::shared_ptr<RtpPacket>> pool;
+	for (int i = 0; i < 256; i++)
+	{
+		pool.push_back(MakeTwccPacket(static_cast<uint16_t>(i), static_cast<uint16_t>(1000 + i)));
+	}
+
+	constexpr int kThreads = 8;
+	constexpr int kIters = 500;
+	std::atomic<int> generated{0};
+
+	std::vector<std::thread> threads;
+	for (int t = 0; t < kThreads; t++)
+	{
+		threads.emplace_back([&, t]() {
+			for (int i = 0; i < kIters; i++)
+			{
+				gen.AddReceivedRtpPacket(pool[(t * kIters + i) % pool.size()]);
+				if (gen.GenerateTransportCcMessageIfElapsed(0) != nullptr)
+				{
+					generated.fetch_add(1);
+				}
+			}
+		});
+	}
+	for (auto &thread : threads)
+	{
+		thread.join();
+	}
+
+	EXPECT_GT(generated.load(), 0);
+}

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizer_h264.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizer_h264.cpp
@@ -15,8 +15,9 @@ std::shared_ptr<ov::Data> RtpDepacketizerH264::ParseAndAssembleFrame(std::vector
 		reserve_size += 16; // spare
 	}
 
-	// Reset FU-A DPS reassembly buffer at frame boundary
-	_fua_dps_buffer = nullptr;
+	// FU-A SPS/PPS reassembly scratch, local to this frame
+	std::shared_ptr<ov::Data> fua_dps_buffer = nullptr;
+	uint8_t fua_dps_nal_type = 0;
 
 	auto bitstream = std::make_shared<ov::Data>(reserve_size);
 	for(const auto &payload : payload_list)
@@ -32,7 +33,7 @@ std::shared_ptr<ov::Data> RtpDepacketizerH264::ParseAndAssembleFrame(std::vector
 		// Fragmented NAL units
 		if(nal_type == NaluType::kFuA)
 		{
-			result = ParseFuaAndConvertAnnexB(payload);
+			result = ParseFuaAndConvertAnnexB(payload, fua_dps_buffer, fua_dps_nal_type);
 			if(result == nullptr)
 			{
 				return nullptr;
@@ -65,7 +66,7 @@ std::shared_ptr<ov::Data> RtpDepacketizerH264::ParseAndAssembleFrame(std::vector
 	return bitstream;
 }
 
-std::shared_ptr<ov::Data> RtpDepacketizerH264::ParseFuaAndConvertAnnexB(const std::shared_ptr<ov::Data> &payload)
+std::shared_ptr<ov::Data> RtpDepacketizerH264::ParseFuaAndConvertAnnexB(const std::shared_ptr<ov::Data> &payload, std::shared_ptr<ov::Data> &fua_dps_buffer, uint8_t &fua_dps_nal_type)
 {
 	auto bitstream = std::make_shared<ov::Data>(payload->GetLength() + 16);
 
@@ -85,30 +86,30 @@ std::shared_ptr<ov::Data> RtpDepacketizerH264::ParseFuaAndConvertAnnexB(const st
 	// Cache SPS/PPS carried over FU-A (non-standard but possible encoders)
 	if(first_fragment)
 	{
-		_fua_dps_buffer = nullptr;
+		fua_dps_buffer = nullptr;
 
 		if (IsDecodingParmeterSets(original_nal_type))
 		{
-			_fua_dps_nal_type = original_nal_type;
-			_fua_dps_buffer = std::make_shared<ov::Data>();
-			_fua_dps_buffer->Append(&original_nal_header, NAL_HEADER_SIZE);
-			_fua_dps_buffer->Append(payload->Subdata(FUA_HEADER_SIZE));
+			fua_dps_nal_type = original_nal_type;
+			fua_dps_buffer = std::make_shared<ov::Data>();
+			fua_dps_buffer->Append(&original_nal_header, NAL_HEADER_SIZE);
+			fua_dps_buffer->Append(payload->Subdata(FUA_HEADER_SIZE));
 
 			// Single-fragment FU-A (S+E both set): flush immediately
 			if(last_fragment)
 			{
-				AddDecodingParameterSet(_fua_dps_nal_type, _fua_dps_buffer);
-				_fua_dps_buffer = nullptr;
+				AddDecodingParameterSet(fua_dps_nal_type, fua_dps_buffer);
+				fua_dps_buffer = nullptr;
 			}
 		}
 	}
-	else if (_fua_dps_buffer != nullptr)
+	else if (fua_dps_buffer != nullptr)
 	{
-		_fua_dps_buffer->Append(payload->Subdata(FUA_HEADER_SIZE));
+		fua_dps_buffer->Append(payload->Subdata(FUA_HEADER_SIZE));
 		if (last_fragment)
 		{
-			AddDecodingParameterSet(_fua_dps_nal_type, _fua_dps_buffer);
-			_fua_dps_buffer = nullptr;
+			AddDecodingParameterSet(fua_dps_nal_type, fua_dps_buffer);
+			fua_dps_buffer = nullptr;
 		}
 	}
 
@@ -235,8 +236,9 @@ bool RtpDepacketizerH264::IsDecodingParmeterSets(uint8_t nal_unit_type)
 			nal_unit_type == NaluType::kPps);
 }
 
-std::shared_ptr<ov::Data> RtpDepacketizerH264::GetDecodingParameterSetsToAnnexB() 
+std::shared_ptr<ov::Data> RtpDepacketizerH264::GetDecodingParameterSetsToAnnexB()
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	uint8_t start_prefix[ANNEXB_START_PREFIX_LENGTH] = {0, 0, 0, 1};
 
 	if(GetDecodingParameterSets().size() < 2) // It must contatin SPS, PPS

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizer_h264.h
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizer_h264.h
@@ -24,14 +24,10 @@ public:
 	std::shared_ptr<ov::Data> GetDecodingParameterSetsToAnnexB() override;
 
 private:
-	std::shared_ptr<ov::Data> ParseFuaAndConvertAnnexB(const std::shared_ptr<ov::Data> &payload);
+	std::shared_ptr<ov::Data> ParseFuaAndConvertAnnexB(const std::shared_ptr<ov::Data> &payload, std::shared_ptr<ov::Data> &fua_dps_buffer, uint8_t &fua_dps_nal_type);
 	std::shared_ptr<ov::Data> ParseStapAAndConvertToAnnexB(const std::shared_ptr<ov::Data> &payload);
 	std::shared_ptr<ov::Data> ConvertSingleNaluToAnnexB(const std::shared_ptr<ov::Data> &payload);
 
 	bool IsDecodingParmeterSets(uint8_t nal_unit_type);
-
-	// For FU-A SPS/PPS reassembly
-	std::shared_ptr<ov::Data> _fua_dps_buffer;
-	uint8_t _fua_dps_nal_type = 0;
 
 };

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizer_h265.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizer_h265.cpp
@@ -25,8 +25,9 @@ std::shared_ptr<ov::Data> RtpDepacketizerH265::ParseAndAssembleFrame(std::vector
 		reserve_size += 16;	 // spare
 	}
 
-	// Reset FU DPS reassembly buffer at frame boundary
-	_fu_dps_buffer = nullptr;
+	// FU VPS/SPS/PPS reassembly scratch, local to this frame
+	std::shared_ptr<ov::Data> fu_dps_buffer = nullptr;
+	uint8_t fu_dps_nal_type = 0;
 
 	auto bitstream = std::make_shared<ov::Data>(reserve_size);
 	for (const auto &payload : payload_list)
@@ -60,7 +61,7 @@ std::shared_ptr<ov::Data> RtpDepacketizerH265::ParseAndAssembleFrame(std::vector
 		// Fragmentation Units (FUs)
 		if (nuh_type == H265NaluType::kFUs)
 		{
-			result = ParseFUsAndConvertAnnexB(payload);
+			result = ParseFUsAndConvertAnnexB(payload, fu_dps_buffer, fu_dps_nal_type);
 			if (result == nullptr)
 			{
 				loge("RtpDepacketizerH265", "Failed to parse FU");
@@ -103,7 +104,7 @@ std::shared_ptr<ov::Data> RtpDepacketizerH265::ParseAndAssembleFrame(std::vector
 	return bitstream;
 }
 
-std::shared_ptr<ov::Data> RtpDepacketizerH265::ParseFUsAndConvertAnnexB(const std::shared_ptr<ov::Data> &payload)
+std::shared_ptr<ov::Data> RtpDepacketizerH265::ParseFUsAndConvertAnnexB(const std::shared_ptr<ov::Data> &payload, std::shared_ptr<ov::Data> &fu_dps_buffer, uint8_t &fu_dps_nal_type)
 {
 	/*
 	The structure of an FU
@@ -184,26 +185,26 @@ std::shared_ptr<ov::Data> RtpDepacketizerH265::ParseFUsAndConvertAnnexB(const st
 	const size_t fu_payload_length = payload->GetLength() - PAYLOAD_HEADER_SIZE - FU_HEADER_SIZE;
 	if (fu_s == 1)
 	{
-		_fu_dps_buffer = nullptr;
+		fu_dps_buffer = nullptr;
 
 		if (IsDecodingParmeterSets(fu_type))
 		{
-			_fu_dps_nal_type = fu_type;
-			_fu_dps_buffer = std::make_shared<ov::Data>();
+			fu_dps_nal_type = fu_type;
+			fu_dps_buffer = std::make_shared<ov::Data>();
 
 			uint8_t nal_header[2];
 			ByteWriter<uint16_t>::WriteBigEndian((uint8_t *)&nal_header[0], NUH_HEADER(fu_type, nuh_layer_id, nuh_temporal_id));
-			_fu_dps_buffer->Append(nal_header, PAYLOAD_HEADER_SIZE);
-			_fu_dps_buffer->Append(&buffer[offset], fu_payload_length);
+			fu_dps_buffer->Append(nal_header, PAYLOAD_HEADER_SIZE);
+			fu_dps_buffer->Append(&buffer[offset], fu_payload_length);
 		}
 	}
-	else if (_fu_dps_buffer != nullptr)
+	else if (fu_dps_buffer != nullptr)
 	{
-		_fu_dps_buffer->Append(&buffer[offset], fu_payload_length);
+		fu_dps_buffer->Append(&buffer[offset], fu_payload_length);
 		if (fu_e == 1)
 		{
-			AddDecodingParameterSet(_fu_dps_nal_type, _fu_dps_buffer);
-			_fu_dps_buffer = nullptr;
+			AddDecodingParameterSet(fu_dps_nal_type, fu_dps_buffer);
+			fu_dps_buffer = nullptr;
 		}
 	}
 
@@ -394,6 +395,7 @@ bool RtpDepacketizerH265::IsDecodingParmeterSets(uint8_t nal_unit_type)
 
 std::shared_ptr<ov::Data> RtpDepacketizerH265::GetDecodingParameterSetsToAnnexB()
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	uint8_t start_prefix[ANNEXB_START_PREFIX_LENGTH] = {0, 0, 0, 1};
 
 	if(GetDecodingParameterSets().size() < 3) // It must contatin VPS, SPS, PPS

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizer_h265.h
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizer_h265.h
@@ -37,15 +37,11 @@ public:
 	std::shared_ptr<ov::Data> ParseAndAssembleFrame(std::vector<std::shared_ptr<ov::Data>> payload_list) override;
 	std::shared_ptr<ov::Data> GetDecodingParameterSetsToAnnexB() override;
 private:
-	std::shared_ptr<ov::Data> ParseFUsAndConvertAnnexB(const std::shared_ptr<ov::Data> &payload);
+	std::shared_ptr<ov::Data> ParseFUsAndConvertAnnexB(const std::shared_ptr<ov::Data> &payload, std::shared_ptr<ov::Data> &fu_dps_buffer, uint8_t &fu_dps_nal_type);
 	std::shared_ptr<ov::Data> ParseAPsAndConvertAnnexB(const std::shared_ptr<ov::Data> &payload);
 	std::shared_ptr<ov::Data> ConvertSingleNaluToAnnexB(const std::shared_ptr<ov::Data> &payload);
 
 	void AppendBitstream(std::shared_ptr<ov::Data>&bitstream, uint8_t nal_type, uint8_t nal_header[2], const void *payload, size_t payload_length);
 	bool IsDecodingParmeterSets(uint8_t nal_unit_type);
-
-	// For FU DPS reassembly (VPS/SPS/PPS carried over FU units)
-	std::shared_ptr<ov::Data> _fu_dps_buffer;
-	uint8_t _fu_dps_nal_type = 0;
 
 };

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizing_manager.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizing_manager.cpp
@@ -35,6 +35,7 @@ std::map<uint8_t, std::shared_ptr<ov::Data>>& RtpDepacketizingManager::GetDecodi
 
 void RtpDepacketizingManager::AddDecodingParameterSet(uint8_t type, const std::shared_ptr<ov::Data> &value)
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	_parameter_sets[type] = value;
 }
 

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizing_manager.h
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizing_manager.h
@@ -3,6 +3,8 @@
 #include "rtp_rtcp_defines.h"
 #include "rtp_packet.h"
 
+#include <mutex>
+
 class RtpDepacketizingManager
 {
 public:
@@ -19,10 +21,17 @@ public:
 	static std::shared_ptr<RtpDepacketizingManager> Create(SupportedDepacketizerType type);
 	virtual std::shared_ptr<ov::Data> ParseAndAssembleFrame(std::vector<std::shared_ptr<ov::Data>> payload_list) = 0;
 	virtual std::shared_ptr<ov::Data> GetDecodingParameterSetsToAnnexB() { return nullptr; };
-public:	
-	std::map<uint8_t, std::shared_ptr<ov::Data>>& GetDecodingParameterSets();
+public:
 	void AddDecodingParameterSet(uint8_t type, const std::shared_ptr<ov::Data> &value);
 
+protected:
+	// Internal accessor; returns the raw map, so call only while holding _lock
+	std::map<uint8_t, std::shared_ptr<ov::Data>>& GetDecodingParameterSets();
+
+	// Guards _parameter_sets (the only cross-call shared state). Locked in
+	// AddDecodingParameterSet (write) and GetDecodingParameterSetsToAnnexB (read);
+	// GetDecodingParameterSets runs under the latter's lock
+	mutable std::mutex _lock;
 
 private:
 	std::map<uint8_t, std::shared_ptr<ov::Data>> _parameter_sets;

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.cpp
@@ -201,6 +201,7 @@ uint64_t RtpFrameJitterBuffer::GetExtentedTimestamp(uint32_t timestamp)
 
 bool RtpFrameJitterBuffer::InsertPacket(const std::shared_ptr<RtpPacket> &packet)
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	auto timestamp = GetExtentedTimestamp(packet->Timestamp());
 
 	auto it = _rtp_frames.find(timestamp);
@@ -257,6 +258,12 @@ void RtpFrameJitterBuffer::BurnOutExpiredFrames()
 
 bool RtpFrameJitterBuffer::HasAvailableFrame()
 {
+	std::lock_guard<std::mutex> lock(_lock);
+	return HasAvailableFrameInternal();
+}
+
+bool RtpFrameJitterBuffer::HasAvailableFrameInternal()
+{
 	BurnOutExpiredFrames();
 
 	auto it = _rtp_frames.begin();
@@ -271,7 +278,8 @@ bool RtpFrameJitterBuffer::HasAvailableFrame()
 
 std::shared_ptr<RtpFrame> RtpFrameJitterBuffer::PopAvailableFrame()
 {
-	if (HasAvailableFrame() == false)
+	std::lock_guard<std::mutex> lock(_lock);
+	if (HasAvailableFrameInternal() == false)
 	{
 		return nullptr;
 	}

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.h
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.h
@@ -3,6 +3,7 @@
 #include "base/ovlibrary/ovlibrary.h"
 #include "rtp_packet.h"
 #include <unordered_map>
+#include <mutex>
 
 #define DEFAULT_VIDEO_MAX_BUFFERING_TIME_MS	100	 // 500ms
 
@@ -56,7 +57,9 @@ public:
 	bool HasAvailableFrame();
 	std::shared_ptr<RtpFrame> PopAvailableFrame();
 	
-private:	
+private:
+	// Non-locking core shared by HasAvailableFrame() and PopAvailableFrame()
+	bool HasAvailableFrameInternal();
 	void BurnOutExpiredFrames();
 
 	uint64_t GetExtentedTimestamp(uint32_t timestamp);
@@ -67,4 +70,6 @@ private:
 	// timestamp : RtpFrameInfo
 	// it should be ordered, so use std::map
 	std::map<uint64_t, std::shared_ptr<RtpFrame>> _rtp_frames;
+
+	mutable std::mutex _lock;
 };

--- a/src/projects/modules/rtp_rtcp/rtp_minimal_jitter_buffer.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_minimal_jitter_buffer.cpp
@@ -4,6 +4,7 @@
 
 bool RtpMinimalJitterBuffer::InsertPacket(const std::shared_ptr<RtpPacket> &packet)
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	// Already it determined this packet was lost
 	if(packet->SequenceNumber() < _next_sequence_number)
 	{
@@ -16,6 +17,7 @@ bool RtpMinimalJitterBuffer::InsertPacket(const std::shared_ptr<RtpPacket> &pack
 
 bool RtpMinimalJitterBuffer::HasAvailablePacket()
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	if(_rtp_packets.size() <= 0)
 	{
 		return false;
@@ -26,6 +28,7 @@ bool RtpMinimalJitterBuffer::HasAvailablePacket()
 
 std::shared_ptr<RtpPacket> RtpMinimalJitterBuffer::PopAvailablePacket()
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	std::shared_ptr<RtpPacketBox> packet_box = nullptr;
 
 	// First packet

--- a/src/projects/modules/rtp_rtcp/rtp_minimal_jitter_buffer.h
+++ b/src/projects/modules/rtp_rtcp/rtp_minimal_jitter_buffer.h
@@ -3,6 +3,7 @@
 #include "base/ovlibrary/ovlibrary.h"
 #include "rtp_packet.h"
 #include <unordered_map>
+#include <mutex>
 
 #define DEFAULT_AUDIO_MAX_BUFFERING_TIME_MS	200
 
@@ -33,4 +34,6 @@ private:
 	// sequence number : RtpFrameInfo
 	// it should be ordered, so use std::map
 	std::map<uint16_t, std::shared_ptr<RtpPacketBox>> _rtp_packets;
+
+	mutable std::mutex _lock;
 };

--- a/src/projects/modules/rtp_rtcp/rtp_nack_generator.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_nack_generator.cpp
@@ -32,6 +32,7 @@ std::optional<uint32_t> RtpNackGenerator::ExtendSeq(uint16_t seq) const
 
 void RtpNackGenerator::OnPacketReceived(uint16_t seq)
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	auto now = std::chrono::steady_clock::now();
 
 	_received_total++;
@@ -136,6 +137,7 @@ void RtpNackGenerator::OnPacketReceived(uint16_t seq)
 
 std::vector<uint16_t> RtpNackGenerator::BuildPendingNack()
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	auto now = std::chrono::steady_clock::now();
 
 	DiscardStale(now);
@@ -182,13 +184,19 @@ std::vector<uint16_t> RtpNackGenerator::BuildPendingNack()
 	{
 		logtd("Fire NACK track(%u) ssrc(%u) total(%zu) initial(%zu) retry(%zu) pending(%zu) hold(%ums)",
 			  _track_id, _media_ssrc, ids.size(), initial_count, retry_count_total, _pending.size(),
-			  GetRecommendedHoldMs());
+			  GetRecommendedHoldMsInternal());
 	}
 
 	return ids;
 }
 
 uint32_t RtpNackGenerator::GetRecommendedHoldMs() const
+{
+	std::lock_guard<std::mutex> lock(_lock);
+	return GetRecommendedHoldMsInternal();
+}
+
+uint32_t RtpNackGenerator::GetRecommendedHoldMsInternal() const
 {
 	// Use real EWMA when we have a fresh sample; otherwise fall back to the
 	// initial RTT guess (same source used to seed _ewma_ms for retry interval).
@@ -221,6 +229,7 @@ uint32_t RtpNackGenerator::GetRecommendedHoldMs() const
 
 std::optional<uint16_t> RtpNackGenerator::GetLowestPendingSeq() const
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	if (_pending.empty())
 	{
 		return std::nullopt;
@@ -230,6 +239,7 @@ std::optional<uint16_t> RtpNackGenerator::GetLowestPendingSeq() const
 
 void RtpNackGenerator::DropPendingUpTo(uint16_t max_seq)
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	if (_initialized == false)
 	{
 		return;
@@ -281,7 +291,7 @@ void RtpNackGenerator::DropPendingUpTo(uint16_t max_seq)
 			  "ewma(%.1f) dev(%.1f) hold(%u)",
 			  _track_id, _media_ssrc, max_seq, dropped, first_dropped_seq, last_dropped_seq,
 			  min_retry, max_retry, avg_retry, min_age_ms, max_age_ms, _pending.size(),
-			  _ewma_ms, _ewma_dev_ms, GetRecommendedHoldMs());
+			  _ewma_ms, _ewma_dev_ms, GetRecommendedHoldMsInternal());
 	}
 }
 
@@ -363,7 +373,7 @@ void RtpNackGenerator::LogPeriodicStats(std::chrono::steady_clock::time_point no
 		  "totals[recv(%lu) nack(%lu) recovered(%lu) lost(%lu)] pending(%zu) hold(%ums)",
 		  _track_id, _media_ssrc, d_received, d_nacks, d_recovered, d_lost, loss_pct, recovery_pct,
 		  _received_total, _nacks_sent_total, _recovered_total, _lost_permanent_total,
-		  _pending.size(), GetRecommendedHoldMs());
+		  _pending.size(), GetRecommendedHoldMsInternal());
 
 	_prev_received		  = _received_total;
 	_prev_nacks_sent	  = _nacks_sent_total;

--- a/src/projects/modules/rtp_rtcp/rtp_nack_generator.h
+++ b/src/projects/modules/rtp_rtcp/rtp_nack_generator.h
@@ -3,6 +3,7 @@
 #include <base/ovlibrary/ovlibrary.h>
 #include <chrono>
 #include <map>
+#include <mutex>
 #include <optional>
 #include <vector>
 
@@ -93,6 +94,8 @@ private:
 	void UpdateLatencyStats(double sample_ms, std::chrono::steady_clock::time_point now);
 	void DiscardStale(std::chrono::steady_clock::time_point now);
 	void LogPeriodicStats(std::chrono::steady_clock::time_point now);
+	// Hold recommendation core; assumes _lock is already held.
+	uint32_t GetRecommendedHoldMsInternal() const;
 
 	uint32_t _track_id = 0;
 	uint32_t _media_ssrc = 0;
@@ -124,4 +127,6 @@ private:
 	uint64_t _prev_recovered = 0;
 	uint64_t _prev_lost_permanent = 0;
 	std::chrono::steady_clock::time_point _last_stats_log_at;
+
+	mutable std::mutex _lock;
 };

--- a/src/projects/modules/rtp_rtcp/rtp_receive_statistics.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_receive_statistics.cpp
@@ -15,6 +15,7 @@ RtpReceiveStatistics::RtpReceiveStatistics(uint32_t media_ssrc, uint32_t clock_r
 
 bool RtpReceiveStatistics::AddReceivedRtpPacket(const std::shared_ptr<RtpPacket> &packet)
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	if(_first == true)
 	{
 		_first = false;
@@ -33,6 +34,7 @@ bool RtpReceiveStatistics::AddReceivedRtpPacket(const std::shared_ptr<RtpPacket>
 
 bool RtpReceiveStatistics::AddReceivedRtcpSenderReport(const std::shared_ptr<SenderReport> &report)
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	_last_sr_received_time = std::chrono::steady_clock::now();
 
 	// the middle 32 bits out of 64 in the NTP timestamp
@@ -44,21 +46,25 @@ bool RtpReceiveStatistics::AddReceivedRtcpSenderReport(const std::shared_ptr<Sen
 
 uint32_t RtpReceiveStatistics::GetMediaSSRC()
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	return _media_ssrc;
 }
 
 uint32_t RtpReceiveStatistics::GetReceiverSSRC()
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	return _receiver_ssrc;
 }
 
 uint64_t RtpReceiveStatistics::GetNumberOfFirRequests()
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	return _fir_request_count;
 }
 
 void RtpReceiveStatistics::OnFirRequested()
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	_fir_request_count ++;
 }
 
@@ -126,16 +132,19 @@ bool RtpReceiveStatistics::UpdateStat(const std::shared_ptr<RtpPacket> &packet)
 
 bool RtpReceiveStatistics::HasElapsedSinceLastReportBlock(uint32_t milliseconds)
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	return _report_block_timer.IsElapsed(milliseconds);
 }
 
 bool RtpReceiveStatistics::IsSenderReportReceived()
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	return _last_sr_timestamp != 0;
 }
 
 std::shared_ptr<ReportBlock> RtpReceiveStatistics::GenerateReportBlock()
 {
+	std::lock_guard<std::mutex> lock(_lock);
 	int32_t extented_highest_seq = _cycles + _highest_seq;
 	int32_t expected_packet_count = extented_highest_seq - _init_seq + 1;
 

--- a/src/projects/modules/rtp_rtcp/rtp_receive_statistics.h
+++ b/src/projects/modules/rtp_rtcp/rtp_receive_statistics.h
@@ -4,6 +4,8 @@
 #include "rtp_packet.h"
 #include "rtcp_info/sender_report.h"
 
+#include <mutex>
+
 #define RTP_SEQ_MOD	(1<<16)
 #define MAX_DROPOUT	3000
 #define	MAX_MISORDER 100
@@ -62,4 +64,7 @@ private:
 	uint64_t	_fir_request_count = 0;
 
 	ov::StopWatch	_report_block_timer;
+
+	// Locked at the public methods; InitSeq/UpdateSeq/UpdateStat run under it
+	mutable std::mutex _lock;
 };

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
@@ -669,11 +669,18 @@ std::shared_ptr<RtcpPacket> RtpRtcp::GenerateTransportCcFeedbackIfNeeded(const s
 {
 	std::shared_ptr<RtcpTransportCcFeedbackGenerator> generator;
 	{
+		// Common path after init: shared lock for a concurrent read.
+		std::shared_lock<std::shared_mutex> lock(_transport_cc_generator_lock);
+		generator = _transport_cc_generator;
+	}
+	if (generator == nullptr)
+	{
+		// First packet: take the exclusive lock and create, re-checking in case
+		// another thread won the race. Receiver SSRC is unknown, so reuse the
+		// first track's RR ssrc (wide sequence means media ssrc may not be unique).
 		std::lock_guard<std::shared_mutex> lock(_transport_cc_generator_lock);
 		if (_transport_cc_generator == nullptr)
 		{
-			// Receiver SSRC is unknown, so reuse the first track's RR ssrc. Wide
-			// sequence means media ssrc may not be unique, so the first one is used.
 			_transport_cc_generator = std::make_shared<RtcpTransportCcFeedbackGenerator>(_transport_cc_feedback_extension_id.load(), receiver_ssrc);
 		}
 		generator = _transport_cc_generator;

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
@@ -382,10 +382,10 @@ std::shared_ptr<MediaTrack> RtpRtcp::GetTrack(uint32_t track_id) const
 	return it->second;
 }
 
-std::shared_ptr<RtpFrameJitterBuffer> RtpRtcp::GetJitterBuffer(uint8_t payload_type)
+std::shared_ptr<RtpFrameJitterBuffer> RtpRtcp::GetJitterBuffer(uint32_t track_id)
 {
 	std::shared_lock<std::shared_mutex> lock(_track_info_lock);
-	auto it = _rtp_frame_jitter_buffers.find(payload_type);
+	auto it = _rtp_frame_jitter_buffers.find(track_id);
 	if (it == _rtp_frame_jitter_buffers.end())
 	{
 		return nullptr;
@@ -393,10 +393,10 @@ std::shared_ptr<RtpFrameJitterBuffer> RtpRtcp::GetJitterBuffer(uint8_t payload_t
 	return it->second;
 }
 
-std::shared_ptr<RtpMinimalJitterBuffer> RtpRtcp::GetMinimalJitterBuffer(uint8_t payload_type)
+std::shared_ptr<RtpMinimalJitterBuffer> RtpRtcp::GetMinimalJitterBuffer(uint32_t track_id)
 {
 	std::shared_lock<std::shared_mutex> lock(_track_info_lock);
-	auto it = _rtp_minimal_jitter_buffers.find(payload_type);
+	auto it = _rtp_minimal_jitter_buffers.find(track_id);
 	if (it == _rtp_minimal_jitter_buffers.end())
 	{
 		return nullptr;

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
@@ -439,7 +439,7 @@ std::shared_ptr<RtcpPacket> RtpRtcp::GenerateTransportCcFeedbackIfNeeded(const s
 		{
 			// Receiver SSRC is unknown, so reuse the first track's RR ssrc. Wide
 			// sequence means media ssrc may not be unique, so the first one is used.
-			_transport_cc_generator = std::make_shared<RtcpTransportCcFeedbackGenerator>(_transport_cc_feedback_extension_id, receiver_ssrc);
+			_transport_cc_generator = std::make_shared<RtcpTransportCcFeedbackGenerator>(_transport_cc_feedback_extension_id.load(), receiver_ssrc);
 		}
 		generator = _transport_cc_generator;
 	}

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
@@ -674,10 +674,9 @@ std::shared_ptr<RtcpPacket> RtpRtcp::GenerateTransportCcFeedbackIfNeeded(const s
 
 	generator->AddReceivedRtpPacket(packet);
 
-	if (generator->HasElapsedSinceLastTransportCc(TRANSPORT_CC_CYCLE_MS) &&
-		(_video_receiver_enabled ? (is_video && marker) : true))
+	if (_video_receiver_enabled ? (is_video && marker) : true)
 	{
-		return generator->GenerateTransportCcMessage();
+		return generator->GenerateTransportCcMessageIfElapsed(TRANSPORT_CC_CYCLE_MS);
 	}
 	return nullptr;
 }

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
@@ -278,14 +278,14 @@ RtpRtcp::RtxResult RtpRtcp::TryUnwrapRtx(std::shared_ptr<RtpPacket> &packet)
 			logtt("RTX packet PT %u on unknown track, dropping", packet->PayloadType());
 			return RtxResult::Drop;
 		}
-		auto stat_it = _receive_statistics.find(track_id_opt.value());
-		if (stat_it == _receive_statistics.end())
+		auto stat = FindReceiveStatistics(track_id_opt.value());
+		if (stat == nullptr)
 		{
 			logtt("RTX packet PT %u before primary media seen, dropping", packet->PayloadType());
 			return RtxResult::Drop;
 		}
 		original_pt = pt_it->second;
-		media_ssrc = stat_it->second->GetMediaSSRC();
+		media_ssrc = stat->GetMediaSSRC();
 		learned = true;
 	}
 
@@ -295,9 +295,17 @@ RtpRtcp::RtxResult RtpRtcp::TryUnwrapRtx(std::shared_ptr<RtpPacket> &packet)
 		// Padding-only RTX probe; still report to transport-cc so the
 		// sender sees an ack for the wire sequence number.
 		logtt("Drop padding-only RTX ssrc(%u) pt(%u)", rtx_ssrc, packet->PayloadType());
-		if (_transport_cc_feedback_enabled && _transport_cc_generator != nullptr)
+		if (_transport_cc_feedback_enabled)
 		{
-			_transport_cc_generator->AddReceivedRtpPacket(packet);
+			std::shared_ptr<RtcpTransportCcFeedbackGenerator> generator;
+			{
+				std::shared_lock<std::shared_mutex> lock(_transport_cc_generator_lock);
+				generator = _transport_cc_generator;
+			}
+			if (generator != nullptr)
+			{
+				generator->AddReceivedRtpPacket(packet);
+			}
 		}
 		return RtxResult::Drop;
 	}
@@ -323,12 +331,11 @@ bool RtpRtcp::SendNACK(uint32_t track_id, const std::vector<uint16_t> &lost_ids)
 		return false;
 	}
 
-	auto stat_it = _receive_statistics.find(track_id);
-	if (stat_it == _receive_statistics.end())
+	auto stat = FindReceiveStatistics(track_id);
+	if (stat == nullptr)
 	{
 		return false;
 	}
-	auto stat = stat_it->second;
 
 	auto nack = std::make_shared<NACK>();
 	nack->SetSrcSsrc(stat->GetReceiverSSRC());
@@ -344,7 +351,7 @@ bool RtpRtcp::SendNACK(uint32_t track_id, const std::vector<uint16_t> &lost_ids)
 		return false;
 	}
 
-	_last_sent_rtcp_packet = rtcp_packet;
+	SetLastSentRtcpPacket(rtcp_packet);
 	logtd("SendNACK track(%u) media_ssrc(%u) count(%zu)", track_id, stat->GetMediaSSRC(), lost_ids.size());
 	return SendDataToNextNode(NodeType::Rtcp, rtcp_packet->GetData());
 }

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
@@ -25,21 +25,26 @@ RtpRtcp::~RtpRtcp()
 
 bool RtpRtcp::AddRtpSender(uint8_t payload_type, uint32_t ssrc, uint32_t codec_rate, ov::String cname)
 {
-	std::shared_lock<std::shared_mutex> lock(_state_lock);
+	std::shared_lock<std::shared_mutex> state_lock(_state_lock);
 	if(GetNodeState() != ov::Node::NodeState::Ready)
 	{
 		logtt("It can only be called in the ready state.");
 		return false;
 	}
 
-	_rtcp_sr_generators[ssrc] = std::make_shared<RtcpSRGenerator>(ssrc, codec_rate);
+	auto sr_generator = std::make_shared<RtcpSRGenerator>(ssrc, codec_rate);
+	auto sdes_chunk = std::make_shared<SdesChunk>(ssrc, SdesChunk::Type::CNAME, cname);
 
-	if(_sdes == nullptr)
 	{
-		_sdes = std::make_shared<Sdes>();
-	}
+		std::lock_guard<std::shared_mutex> lock(_rtcp_send_state_lock);
+		_rtcp_sr_generators[ssrc] = sr_generator;
 
-	_sdes->AddChunk(std::make_shared<SdesChunk>(ssrc, SdesChunk::Type::CNAME, cname));
+		if(_sdes == nullptr)
+		{
+			_sdes = std::make_shared<Sdes>();
+		}
+		_sdes->AddChunk(sdes_chunk);
+	}
 
 	logtt("AddRtpSender : %d / %u / %u / %s", payload_type, ssrc, codec_rate, cname.CStr());
 
@@ -48,7 +53,7 @@ bool RtpRtcp::AddRtpSender(uint8_t payload_type, uint32_t ssrc, uint32_t codec_r
 
 bool RtpRtcp::AddRtpReceiver(const std::shared_ptr<MediaTrack> &track, const RtpTrackIdentifier &rtp_track_id)
 {
-	std::shared_lock<std::shared_mutex> lock(_state_lock);
+	std::shared_lock<std::shared_mutex> state_lock(_state_lock);
 	if(GetNodeState() != ov::Node::NodeState::Ready)
 	{
 		logtt("It can only be called in the ready state.");
@@ -57,20 +62,26 @@ bool RtpRtcp::AddRtpReceiver(const std::shared_ptr<MediaTrack> &track, const Rtp
 
 	auto track_id = track->GetId();
 
-	switch(track->GetOriginBitstream())
 	{
-		case cmn::BitstreamFormat::H264_RTP_RFC_6184:
-		case cmn::BitstreamFormat::H265_RTP_RFC_7798:
-		case cmn::BitstreamFormat::VP8_RTP_RFC_7741:
-		case cmn::BitstreamFormat::AAC_MPEG4_GENERIC:
-			_rtp_frame_jitter_buffers[track_id] = std::make_shared<RtpFrameJitterBuffer>();
-			break;
-		case cmn::BitstreamFormat::OPUS_RTP_RFC_7587:
-			_rtp_minimal_jitter_buffers[track_id] = std::make_shared<RtpMinimalJitterBuffer>();
-			break;
-		default:
-			logte("RTP Receiver cannot support %d input stream format", static_cast<int8_t>(track->GetOriginBitstream()));
-			return false;
+		std::lock_guard<std::shared_mutex> lock(_track_info_lock);
+		switch(track->GetOriginBitstream())
+		{
+			case cmn::BitstreamFormat::H264_RTP_RFC_6184:
+			case cmn::BitstreamFormat::H265_RTP_RFC_7798:
+			case cmn::BitstreamFormat::VP8_RTP_RFC_7741:
+			case cmn::BitstreamFormat::AAC_MPEG4_GENERIC:
+				_rtp_frame_jitter_buffers[track_id] = std::make_shared<RtpFrameJitterBuffer>();
+				break;
+			case cmn::BitstreamFormat::OPUS_RTP_RFC_7587:
+				_rtp_minimal_jitter_buffers[track_id] = std::make_shared<RtpMinimalJitterBuffer>();
+				break;
+			default:
+				logte("RTP Receiver cannot support %d input stream format", static_cast<int8_t>(track->GetOriginBitstream()));
+				return false;
+		}
+
+		_tracks[track_id] = track;
+		_rtp_track_identifiers.push_back(rtp_track_id);
 	}
 
 	if (track->GetMediaType() == cmn::MediaType::Video)
@@ -82,8 +93,6 @@ bool RtpRtcp::AddRtpReceiver(const std::shared_ptr<MediaTrack> &track, const Rtp
 		_audio_receiver_enabled = true;
 	}
 
-	_tracks[track_id] = track;
-	_rtp_track_identifiers.push_back(rtp_track_id);
 	if (rtp_track_id.ssrc.has_value())
 	{
 		logti("AddRtpReceiver : %d / %u / %s / %s", track_id, rtp_track_id.ssrc.value(), rtp_track_id.mid.value_or(ov::String("")).CStr(), rtp_track_id.rid.value_or(ov::String("")).CStr());
@@ -104,7 +113,7 @@ bool RtpRtcp::Stop()
 
 bool RtpRtcp::SendRtpPacket(const std::shared_ptr<RtpPacket> &rtp_packet)
 {
-	std::shared_lock<std::shared_mutex> lock(_state_lock);
+	std::shared_lock<std::shared_mutex> state_lock(_state_lock);
 	// nothing to do before node start
 	if(GetNodeState() != ov::Node::NodeState::Started)
 	{
@@ -112,40 +121,48 @@ bool RtpRtcp::SendRtpPacket(const std::shared_ptr<RtpPacket> &rtp_packet)
 		return false;
 	}
 
-	// RTCP(SR + SR + SDES + SDES)
-	auto it = _rtcp_sr_generators.find(rtp_packet->Ssrc());
-    if(it != _rtcp_sr_generators.end())
-    {
-		auto rtcp_sr_generator = it->second;
-		rtcp_sr_generator->AddRTPPacketInfo(rtp_packet);
-	}
+	// Build the compound RTCP under the send lock, then send outside the lock
+	std::shared_ptr<ov::Data> compound_rtcp_data = nullptr;
+	{
+		std::lock_guard<std::shared_mutex> lock(_rtcp_send_state_lock);
 
-	if(_rtcp_sent_count == 0 || _rtcp_send_stop_watch.Elapsed() > SDES_CYCLE_MS)
-	{		
-		_rtcp_send_stop_watch.Update();
-		_rtcp_sent_count ++;
-
-		auto compound_rtcp_data = std::make_shared<ov::Data>(1024);
-		for(const auto &item : _rtcp_sr_generators)
+		// RTCP(SR + SR + SDES + SDES)
+		auto it = _rtcp_sr_generators.find(rtp_packet->Ssrc());
+		if(it != _rtcp_sr_generators.end())
 		{
-			auto rtcp_sr_generator = item.second;
-			auto rtcp_sr_packet = rtcp_sr_generator->PopRtcpSRPacket();
-			if(rtcp_sr_packet == nullptr)
-			{
-				continue;
-			}
-			compound_rtcp_data->Append(rtcp_sr_packet->GetData());
+			auto rtcp_sr_generator = it->second;
+			rtcp_sr_generator->AddRTPPacketInfo(rtp_packet);
 		}
 
-		if(_rtcp_sdes == nullptr)
+		if(_rtcp_sent_count == 0 || _rtcp_send_stop_watch.Elapsed() > SDES_CYCLE_MS)
 		{
 			_rtcp_send_stop_watch.Update();
-			_rtcp_sdes = std::make_shared<RtcpPacket>();
-			_rtcp_sdes->Build(_sdes);
-		}
+			_rtcp_sent_count ++;
 
-		compound_rtcp_data->Append(_rtcp_sdes->GetData());
-		
+			compound_rtcp_data = std::make_shared<ov::Data>(1024);
+			for(const auto &item : _rtcp_sr_generators)
+			{
+				auto rtcp_sr_generator = item.second;
+				auto rtcp_sr_packet = rtcp_sr_generator->PopRtcpSRPacket();
+				if(rtcp_sr_packet == nullptr)
+				{
+					continue;
+				}
+				compound_rtcp_data->Append(rtcp_sr_packet->GetData());
+			}
+
+			if(_rtcp_sdes == nullptr)
+			{
+				_rtcp_sdes = std::make_shared<RtcpPacket>();
+				_rtcp_sdes->Build(_sdes);
+			}
+
+			compound_rtcp_data->Append(_rtcp_sdes->GetData());
+		}
+	}
+
+	if(compound_rtcp_data != nullptr)
+	{
 		if(SendDataToNextNode(NodeType::Rtcp, compound_rtcp_data) == false)
 		{
 			logt("RTCP","Send RTCP failed : pt(%d) ssrc(%u)", rtp_packet->PayloadType(), rtp_packet->Ssrc());
@@ -157,21 +174,19 @@ bool RtpRtcp::SendRtpPacket(const std::shared_ptr<RtpPacket> &rtp_packet)
 	}
 
 	// Send RTP
-	_last_sent_rtp_packet = rtp_packet;
+	SetLastSentRtpPacket(rtp_packet);
 	return SendDataToNextNode(NodeType::Rtp, rtp_packet->GetData());
 }
 
 bool RtpRtcp::SendPLI(uint32_t track_id)
 {
-	auto stat_it = _receive_statistics.find(track_id);
-	if(stat_it == _receive_statistics.end())
+	auto stat = FindReceiveStatistics(track_id);
+	if(stat == nullptr)
 	{
 		// Never received such SSRC packet
 		return false;
 	}
 
-	auto stat = stat_it->second;
-	
 	auto pli = std::make_shared<PLI>();
 
 	pli->SetSrcSsrc(stat->GetReceiverSSRC());
@@ -180,22 +195,20 @@ bool RtpRtcp::SendPLI(uint32_t track_id)
 	auto rtcp_packet = std::make_shared<RtcpPacket>();
 	rtcp_packet->Build(pli);
 
-	_last_sent_rtcp_packet = rtcp_packet;
+	SetLastSentRtcpPacket(rtcp_packet);
 
 	return SendDataToNextNode(NodeType::Rtcp, rtcp_packet->GetData());
 }
 
 bool RtpRtcp::SendFIR(uint32_t track_id)
 {
-	auto stat_it = _receive_statistics.find(track_id);
-	if(stat_it == _receive_statistics.end())
+	auto stat = FindReceiveStatistics(track_id);
+	if(stat == nullptr)
 	{
 		// Never received such SSRC packet
 		return false;
 	}
 
-	auto stat = stat_it->second;
-	
 	auto fir = std::make_shared<FIR>();
 
 	fir->SetSrcSsrc(stat->GetReceiverSSRC());
@@ -206,7 +219,7 @@ bool RtpRtcp::SendFIR(uint32_t track_id)
 
 	stat->OnFirRequested();
 
-	_last_sent_rtcp_packet = rtcp_packet;
+	SetLastSentRtcpPacket(rtcp_packet);
 
 	return SendDataToNextNode(NodeType::Rtcp, rtcp_packet->GetData());
 }
@@ -231,6 +244,7 @@ void RtpRtcp::DisableTransportCcFeedback()
 
 std::optional<uint32_t> RtpRtcp::GetTrackId(uint32_t ssrc) const
 {
+	std::shared_lock<std::shared_mutex> lock(_ssrc_to_track_id_lock);
 	auto it = _ssrc_to_track_id.find(ssrc);
 	if(it == _ssrc_to_track_id.end())
 	{
@@ -249,6 +263,7 @@ std::optional<uint32_t> RtpRtcp::FindTrackId(const std::shared_ptr<const RtpPack
 		return track_id;
 	}
 
+	std::shared_lock<std::shared_mutex> lock(_track_info_lock);
 	for (const auto &rtp_track_id : _rtp_track_identifiers)
 	{
 		// with ssrc
@@ -291,6 +306,7 @@ std::optional<uint32_t> RtpRtcp::FindTrackId(const std::shared_ptr<const Sdes> &
 		return track_id;
 	}
 
+	std::shared_lock<std::shared_mutex> lock(_track_info_lock);
 	for (const auto &rtp_track_id : _rtp_track_identifiers)
 	{
 		// with ssrc
@@ -328,6 +344,7 @@ std::optional<uint32_t> RtpRtcp::FindTrackId(const std::shared_ptr<const Sdes> &
 
 std::optional<uint32_t> RtpRtcp::FindTrackId(uint8_t rtsp_inter_channel) const
 {
+	std::shared_lock<std::shared_mutex> lock(_track_info_lock);
 	for (const auto &rtp_track_id : _rtp_track_identifiers)
 	{
 		// with interleaved channel
@@ -342,14 +359,111 @@ std::optional<uint32_t> RtpRtcp::FindTrackId(uint8_t rtsp_inter_channel) const
 
 void RtpRtcp::ConnectSsrcToTrack(uint32_t ssrc, uint32_t track_id)
 {
-	if (_ssrc_to_track_id.find(ssrc) != _ssrc_to_track_id.end())
-	{	
-		logtw("SSRC(%u) is already connected to track ID(%u), it will be replaced.", ssrc, _ssrc_to_track_id[ssrc]);
+	{
+		std::lock_guard<std::shared_mutex> lock(_ssrc_to_track_id_lock);
+		if (_ssrc_to_track_id.find(ssrc) != _ssrc_to_track_id.end())
+		{
+			logtw("SSRC(%u) is already connected to track ID(%u), it will be replaced.", ssrc, _ssrc_to_track_id[ssrc]);
+		}
+		_ssrc_to_track_id[ssrc] = track_id;
 	}
 
 	logti("Connect SSRC(%u) to track ID(%u)", ssrc, track_id);
+}
 
-	_ssrc_to_track_id[ssrc] = track_id;
+std::shared_ptr<MediaTrack> RtpRtcp::GetTrack(uint32_t track_id) const
+{
+	std::shared_lock<std::shared_mutex> lock(_track_info_lock);
+	auto it = _tracks.find(track_id);
+	if (it == _tracks.end())
+	{
+		return nullptr;
+	}
+	return it->second;
+}
+
+std::shared_ptr<RtpFrameJitterBuffer> RtpRtcp::GetJitterBuffer(uint8_t payload_type)
+{
+	std::shared_lock<std::shared_mutex> lock(_track_info_lock);
+	auto it = _rtp_frame_jitter_buffers.find(payload_type);
+	if (it == _rtp_frame_jitter_buffers.end())
+	{
+		return nullptr;
+	}
+	return it->second;
+}
+
+std::shared_ptr<RtpMinimalJitterBuffer> RtpRtcp::GetMinimalJitterBuffer(uint8_t payload_type)
+{
+	std::shared_lock<std::shared_mutex> lock(_track_info_lock);
+	auto it = _rtp_minimal_jitter_buffers.find(payload_type);
+	if (it == _rtp_minimal_jitter_buffers.end())
+	{
+		return nullptr;
+	}
+	return it->second;
+}
+
+std::shared_ptr<RtpReceiveStatistics> RtpRtcp::GetOrCreateReceiveStatistics(uint32_t track_id, uint32_t ssrc, uint32_t clock_rate)
+{
+	std::lock_guard<std::shared_mutex> lock(_receive_statistics_lock);
+	auto it = _receive_statistics.find(track_id);
+	// Some encoders or servers do not provide SSRC in SDP, so it is extracted from
+	// the received packet. If the ssrc changes, the previous statistics are replaced.
+	if (it == _receive_statistics.end() || it->second->GetMediaSSRC() != ssrc)
+	{
+		auto stat = std::make_shared<RtpReceiveStatistics>(ssrc, clock_rate);
+		_receive_statistics[track_id] = stat;
+		return stat;
+	}
+	return it->second;
+}
+
+std::shared_ptr<RtpReceiveStatistics> RtpRtcp::FindReceiveStatistics(uint32_t track_id) const
+{
+	std::shared_lock<std::shared_mutex> lock(_receive_statistics_lock);
+	auto it = _receive_statistics.find(track_id);
+	if (it == _receive_statistics.end())
+	{
+		return nullptr;
+	}
+	return it->second;
+}
+
+std::shared_ptr<RtcpPacket> RtpRtcp::GenerateTransportCcFeedbackIfNeeded(const std::shared_ptr<RtpPacket> &packet, uint32_t receiver_ssrc, bool is_video, bool marker)
+{
+	std::shared_ptr<RtcpTransportCcFeedbackGenerator> generator;
+	{
+		std::lock_guard<std::shared_mutex> lock(_transport_cc_generator_lock);
+		if (_transport_cc_generator == nullptr)
+		{
+			// Receiver SSRC is unknown, so reuse the first track's RR ssrc. Wide
+			// sequence means media ssrc may not be unique, so the first one is used.
+			_transport_cc_generator = std::make_shared<RtcpTransportCcFeedbackGenerator>(_transport_cc_feedback_extension_id, receiver_ssrc);
+		}
+		generator = _transport_cc_generator;
+	}
+
+	generator->AddReceivedRtpPacket(packet);
+
+	if (generator->HasElapsedSinceLastTransportCc(TRANSPORT_CC_CYCLE_MS) &&
+		(_video_receiver_enabled ? (is_video && marker) : true))
+	{
+		return generator->GenerateTransportCcMessage();
+	}
+	return nullptr;
+}
+
+void RtpRtcp::SetLastSentRtpPacket(const std::shared_ptr<RtpPacket> &packet)
+{
+	std::lock_guard<std::shared_mutex> lock(_last_sent_packet_lock);
+	_last_sent_rtp_packet = packet;
+}
+
+void RtpRtcp::SetLastSentRtcpPacket(const std::shared_ptr<RtcpPacket> &packet)
+{
+	std::lock_guard<std::shared_mutex> lock(_last_sent_packet_lock);
+	_last_sent_rtcp_packet = packet;
 }
 
 // In general, since RTP_RTCP is the first node, there is no previous node. So it will not be called
@@ -481,30 +595,15 @@ bool RtpRtcp::OnRtpReceived(NodeType from_node, const std::shared_ptr<const ov::
 	}
 
 	auto track_id = track_id_opt.value();
-	auto track_it = _tracks.find(track_id);
-	if(track_it == _tracks.end())
+	auto track = GetTrack(track_id);
+	if(track == nullptr)
 	{
 		logte("Could not find track info for track ID %u", track_id);
 		return false;
 	}
-	auto track = track_it->second;
 
 	// For RTCP Receiver Report
-	std::shared_ptr<RtpReceiveStatistics> stat;
-	auto stat_it = _receive_statistics.find(track_id);
-	if(stat_it == _receive_statistics.end() || stat_it->second->GetMediaSSRC() != packet->Ssrc())
-	{
-		// First receive
-		// Some encoders or servers do not provide SSRC in SDP. Therefore, after receiving the packet, the ssrc can be extracted and used.
-		stat = std::make_shared<RtpReceiveStatistics>(packet->Ssrc(), track->GetTimeBase().GetDen());
-
-		// If ssrc is changed, the previous statistics should be deleted.
-		_receive_statistics[track_id] = stat;
-	}
-	else
-	{
-		stat = stat_it->second;
-	}
+	auto stat = GetOrCreateReceiveStatistics(track_id, packet->Ssrc(), track->GetTimeBase().GetDen());
 
 	stat->AddReceivedRtpPacket(packet);
 
@@ -519,7 +618,7 @@ bool RtpRtcp::OnRtpReceived(NodeType from_node, const std::shared_ptr<const ov::
 		auto rtcp_packet = std::make_shared<RtcpPacket>();
 		if(rtcp_packet->Build(report) == true)
 		{
-			_last_sent_rtcp_packet = rtcp_packet;
+			SetLastSentRtcpPacket(rtcp_packet);
 			SendDataToNextNode(NodeType::Rtcp, rtcp_packet->GetData());
 		}
 	}
@@ -527,42 +626,28 @@ bool RtpRtcp::OnRtpReceived(NodeType from_node, const std::shared_ptr<const ov::
 	// For Transport-wide CC feedback
 	if (_transport_cc_feedback_enabled == true)
 	{
-		if (_transport_cc_generator == nullptr)
+		auto feedback = GenerateTransportCcFeedbackIfNeeded(packet, stat->GetReceiverSSRC(),
+														   track->GetMediaType() == cmn::MediaType::Video, packet->Marker() == true);
+		if (feedback != nullptr)
 		{
-			// Since the Receiver SSRC is unknown, the same as the RR of the first track is used. Since it is a wide sequence, media ssrc may not be one. So this also just uses the first media ssrc.
-			_transport_cc_generator = std::make_shared<RtcpTransportCcFeedbackGenerator>(
-										_transport_cc_feedback_extension_id, 
-										stat->GetReceiverSSRC());
-		}
-
-		_transport_cc_generator->AddReceivedRtpPacket(packet);
-
-		// Send Transport-wide CC feedback
-		if ((_transport_cc_generator->HasElapsedSinceLastTransportCc(TRANSPORT_CC_CYCLE_MS)) && 
-			(_video_receiver_enabled ? (track->GetMediaType() == cmn::MediaType::Video && packet->Marker() == true) : true))
-		{
-			auto feedback = _transport_cc_generator->GenerateTransportCcMessage();
-			if (feedback != nullptr)
-			{
-				_last_sent_rtcp_packet = feedback;
-
-				auto feedback_data = feedback->GetData();
-				SendDataToNextNode(NodeType::Rtcp, feedback_data);
-			}
+			SetLastSentRtcpPacket(feedback);
+			SendDataToNextNode(NodeType::Rtcp, feedback->GetData());
 		}
 	}
 
-	int jitter_buffer_type = 0;
+	// Frame: H264/H265/VP8/AAC reassemble into a frame. Minimal: Opus passes per-packet.
+	enum class JitterBufferKind { None, Frame, Minimal };
+	JitterBufferKind jitter_buffer_kind = JitterBufferKind::None;
 	switch(track->GetOriginBitstream())
 	{
 		case cmn::BitstreamFormat::H264_RTP_RFC_6184:
 		case cmn::BitstreamFormat::H265_RTP_RFC_7798:
 		case cmn::BitstreamFormat::VP8_RTP_RFC_7741:
 		case cmn::BitstreamFormat::AAC_MPEG4_GENERIC:
-			jitter_buffer_type = 1;
+			jitter_buffer_kind = JitterBufferKind::Frame;
 			break;
 		case cmn::BitstreamFormat::OPUS_RTP_RFC_7587:
-			jitter_buffer_type = 2;
+			jitter_buffer_kind = JitterBufferKind::Minimal;
 			break;
 		default:
 			break;
@@ -585,17 +670,15 @@ bool RtpRtcp::OnRtpReceived(NodeType from_node, const std::shared_ptr<const ov::
 		rtp_packets.push_back(rtp_packet);
 	};
 
-	if(jitter_buffer_type == 1)
+	if(jitter_buffer_kind == JitterBufferKind::Frame)
 	{
-		auto buffer_it = _rtp_frame_jitter_buffers.find(track_id);
-		if(buffer_it == _rtp_frame_jitter_buffers.end())
+		auto jitter_buffer = GetJitterBuffer(track_id);
+		if(jitter_buffer == nullptr)
 		{
 			// can not happen
 			logte("Could not find jitter buffer for payload type %d", packet->PayloadType());
 			return false;
 		}
-
-		auto jitter_buffer = buffer_it->second;
 
 		jitter_buffer->InsertPacket(packet);
 
@@ -633,17 +716,15 @@ bool RtpRtcp::OnRtpReceived(NodeType from_node, const std::shared_ptr<const ov::
 			_observer->OnRtpFrameReceived(rtp_packets);
 		}
 	}
-	else if (jitter_buffer_type == 2)
+	else if (jitter_buffer_kind == JitterBufferKind::Minimal)
 	{
-		auto buffer_it = _rtp_minimal_jitter_buffers.find(track_id);
-		if (buffer_it == _rtp_minimal_jitter_buffers.end())
+		auto jitter_buffer = GetMinimalJitterBuffer(track_id);
+		if (jitter_buffer == nullptr)
 		{
 			// can not happen
 			logte("Could not find jitter buffer for ssrc %u", packet->Ssrc());
 			return false;
 		}
-
-		auto jitter_buffer = buffer_it->second;
 
 		jitter_buffer->InsertPacket(packet);
 
@@ -704,10 +785,9 @@ bool RtpRtcp::OnRtcpReceived(NodeType from_node, const std::shared_ptr<const ov:
 			auto track_id = GetTrackId(sr->GetSenderSsrc());
 			if (track_id.has_value())
 			{
-				auto stat_it = _receive_statistics.find(track_id.value());
-				if(stat_it != _receive_statistics.end())
+				auto stat = FindReceiveStatistics(track_id.value());
+				if(stat != nullptr)
 				{
-					auto stat = stat_it->second;
 					stat->AddReceivedRtcpSenderReport(sr);
 				}
 			}
@@ -724,10 +804,12 @@ bool RtpRtcp::OnRtcpReceived(NodeType from_node, const std::shared_ptr<const ov:
 
 std::shared_ptr<RtpPacket> RtpRtcp::GetLastSentRtpPacket()
 {
+	std::shared_lock<std::shared_mutex> lock(_last_sent_packet_lock);
 	return _last_sent_rtp_packet;
 }
 
 std::shared_ptr<RtcpPacket> RtpRtcp::GetLastSentRtcpPacket()
 {
+	std::shared_lock<std::shared_mutex> lock(_last_sent_packet_lock);
 	return _last_sent_rtcp_packet;
 }

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.h
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.h
@@ -87,8 +87,8 @@ private:
 	bool OnRtpReceived(NodeType from_node, const std::shared_ptr<const ov::Data> &data);
 	bool OnRtcpReceived(NodeType from_node, const std::shared_ptr<const ov::Data> &data);
 
-	std::shared_ptr<RtpFrameJitterBuffer> GetJitterBuffer(uint8_t payload_type);
-	std::shared_ptr<RtpMinimalJitterBuffer> GetMinimalJitterBuffer(uint8_t payload_type);
+	std::shared_ptr<RtpFrameJitterBuffer> GetJitterBuffer(uint32_t track_id);
+	std::shared_ptr<RtpMinimalJitterBuffer> GetMinimalJitterBuffer(uint32_t track_id);
 	std::shared_ptr<MediaTrack> GetTrack(uint32_t track_id) const;
 
 	std::shared_ptr<RtpReceiveStatistics> GetOrCreateReceiveStatistics(uint32_t track_id, uint32_t ssrc, uint32_t clock_rate);
@@ -142,9 +142,9 @@ private:
 
 	// _track_info_lock guards the receive-setup containers below
 	std::vector<RtpTrackIdentifier> _rtp_track_identifiers;
-	std::unordered_map<uint8_t, std::shared_ptr<RtpFrameJitterBuffer>> _rtp_frame_jitter_buffers;
-	std::unordered_map<uint8_t, std::shared_ptr<RtpMinimalJitterBuffer>> _rtp_minimal_jitter_buffers;
-	std::unordered_map<uint8_t, std::shared_ptr<MediaTrack>> _tracks;
+	std::unordered_map<uint32_t, std::shared_ptr<RtpFrameJitterBuffer>> _rtp_frame_jitter_buffers;
+	std::unordered_map<uint32_t, std::shared_ptr<RtpMinimalJitterBuffer>> _rtp_minimal_jitter_buffers;
+	std::unordered_map<uint32_t, std::shared_ptr<MediaTrack>> _tracks;
 	mutable std::shared_mutex _track_info_lock;
 
 	std::atomic<bool> _video_receiver_enabled = false;

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.h
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.h
@@ -12,6 +12,9 @@
 #include "rtp_minimal_jitter_buffer.h"
 #include "rtp_receive_statistics.h"
 
+#include <atomic>
+#include <mutex>
+#include <shared_mutex>
 
 
 #define RECEIVER_REPORT_CYCLE_MS	500
@@ -85,11 +88,21 @@ private:
 	bool OnRtcpReceived(NodeType from_node, const std::shared_ptr<const ov::Data> &data);
 
 	std::shared_ptr<RtpFrameJitterBuffer> GetJitterBuffer(uint8_t payload_type);
+	std::shared_ptr<RtpMinimalJitterBuffer> GetMinimalJitterBuffer(uint8_t payload_type);
+	std::shared_ptr<MediaTrack> GetTrack(uint32_t track_id) const;
 
-	std::shared_ptr<RtcpPacket> GenerateTransportCcFeedbackIfNeeded();
+	std::shared_ptr<RtpReceiveStatistics> GetOrCreateReceiveStatistics(uint32_t track_id, uint32_t ssrc, uint32_t clock_rate);
+	std::shared_ptr<RtpReceiveStatistics> FindReceiveStatistics(uint32_t track_id) const;
 
-	std::vector<RtpTrackIdentifier> _rtp_track_identifiers;
+	// Returns the transport-cc feedback packet to send (nullptr if not due yet)
+	std::shared_ptr<RtcpPacket> GenerateTransportCcFeedbackIfNeeded(const std::shared_ptr<RtpPacket> &packet, uint32_t receiver_ssrc, bool is_video, bool marker);
+
+	void SetLastSentRtpPacket(const std::shared_ptr<RtpPacket> &packet);
+	void SetLastSentRtcpPacket(const std::shared_ptr<RtcpPacket> &packet);
+
+	// _ssrc_to_track_id_lock guards _ssrc_to_track_id
 	std::map<uint32_t /*ssrc*/, uint32_t /*track_id*/> _ssrc_to_track_id;
+	mutable std::shared_mutex _ssrc_to_track_id_lock;
 
 	// Find track id by mid or rid
 	std::optional<uint32_t> FindTrackId(const std::shared_ptr<const RtpPacket> &rtp_packet) const;
@@ -104,35 +117,41 @@ private:
     time_t _last_sender_report_time = 0;
     uint64_t _send_packet_sequence_number = 0;
 
+	// Lifecycle gate: data path (send/receive) takes it shared, Stop/setup exclusive
 	std::shared_mutex _state_lock;
 	std::shared_ptr<RtpRtcpInterface> _observer;
-    std::map<uint32_t, std::shared_ptr<RtcpSRGenerator>> _rtcp_sr_generators;
+
+	// _rtcp_send_state_lock guards the send-side RTCP state below
+	std::map<uint32_t, std::shared_ptr<RtcpSRGenerator>> _rtcp_sr_generators;
 	std::shared_ptr<Sdes> _sdes = nullptr;
 	std::shared_ptr<RtcpPacket> _rtcp_sdes = nullptr;
 	ov::StopWatch _rtcp_send_stop_watch;
 	uint64_t _rtcp_sent_count = 0;
+	mutable std::shared_mutex _rtcp_send_state_lock;
 
-	bool _transport_cc_feedback_enabled = false;
-	uint8_t _transport_cc_feedback_extension_id = 0;
-	
-	// Receiver SSRC (For RTCP RR, FIR... etc)
-	// track_id : Receiver Statistics
+	std::atomic<bool> _transport_cc_feedback_enabled = false;
+	std::atomic<uint8_t> _transport_cc_feedback_extension_id = 0;
+
+	// _receive_statistics_lock guards _receive_statistics (track_id : receiver statistics)
 	std::unordered_map<uint32_t, std::shared_ptr<RtpReceiveStatistics>> _receive_statistics;
+	mutable std::shared_mutex _receive_statistics_lock;
 
-	// Transport-cc feedback
+	// _transport_cc_generator_lock guards _transport_cc_generator
 	std::shared_ptr<RtcpTransportCcFeedbackGenerator> _transport_cc_generator = nullptr;
+	mutable std::shared_mutex _transport_cc_generator_lock;
 
-	// Jitter buffer
-	// payload type : Jitter buffer
+	// _track_info_lock guards the receive-setup containers below
+	std::vector<RtpTrackIdentifier> _rtp_track_identifiers;
 	std::unordered_map<uint8_t, std::shared_ptr<RtpFrameJitterBuffer>> _rtp_frame_jitter_buffers;
 	std::unordered_map<uint8_t, std::shared_ptr<RtpMinimalJitterBuffer>> _rtp_minimal_jitter_buffers;
-
-	// payload type : MediaTrack Info
 	std::unordered_map<uint8_t, std::shared_ptr<MediaTrack>> _tracks;
-	bool _video_receiver_enabled = false;
-	bool _audio_receiver_enabled = false;
+	mutable std::shared_mutex _track_info_lock;
 
-	// Latest packet
+	std::atomic<bool> _video_receiver_enabled = false;
+	std::atomic<bool> _audio_receiver_enabled = false;
+
+	// _last_sent_packet_lock guards both last-sent packet pointers below
 	std::shared_ptr<RtpPacket>		_last_sent_rtp_packet = nullptr;
 	std::shared_ptr<RtcpPacket>		_last_sent_rtcp_packet = nullptr;
+	mutable std::shared_mutex _last_sent_packet_lock;
 };

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp_test.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp_test.cpp
@@ -283,12 +283,13 @@ TEST_F(RtpRtcpConcurrentReceive, MixedTrafficFromManyThreads)
 
 	rtp_rtcp->Stop();
 
+	// peak_in_flight is printed (not asserted): observed thread overlap depends
+	// on the scheduler, so on a low-core / loaded host it can read 1 even when
+	// the code is correct. The race verdict comes from TSan; the only hard
+	// check is that the path actually ran end to end (no total packet drop).
 	std::cout << "[ INFO     ] " << op.load() << " ops / " << kThreads
 			  << " threads, peak " << peak_in_flight.load() << " concurrent in receive, "
 			  << observer->_frames.load() << " frames delivered\n";
 
-	// Real overlap happened and the path ran end to end. The race verdict comes
-	// from TSan; this guards against silent serialization / total packet drop.
-	EXPECT_GE(peak_in_flight.load(), 2);
 	EXPECT_GT(observer->_frames.load(), 0);
 }

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp_test.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp_test.cpp
@@ -18,11 +18,18 @@
 #include "rtp_header_extension/rtp_header_extensions.h"
 #include "rtp_packet.h"
 #include "rtp_rtcp.h"
+#include "rtx_rtp_packet.h"
 
 namespace
 {
-constexpr uint32_t kTrackId = 1;
-constexpr uint32_t kSsrc = 0x12345678;
+constexpr uint32_t kVideoTrack = 1;
+constexpr uint32_t kAudioTrack = 2;
+constexpr uint32_t kMediaSsrc = 0x11111111;
+constexpr uint32_t kRtxSsrc = 0x22222222;
+constexpr uint32_t kAudioSsrc = 0x33333333;
+constexpr uint8_t kMediaPt = 96;
+constexpr uint8_t kRtxPt = 97;
+constexpr uint8_t kAudioPt = 111;
 constexpr uint8_t kTwccExtId = 5;
 
 class CountingObserver : public RtpRtcpInterface
@@ -41,39 +48,91 @@ public:
 	std::atomic<int> _rtcp{0};
 };
 
-std::shared_ptr<MediaTrack> MakeH264Track()
+std::shared_ptr<MediaTrack> MakeTrack(uint32_t id, cmn::MediaType type, cmn::MediaCodecId codec,
+									  int32_t clock_rate, cmn::BitstreamFormat bitstream)
 {
 	auto track = std::make_shared<MediaTrack>();
-	track->SetId(kTrackId);
-	track->SetMediaType(cmn::MediaType::Video);
-	track->SetCodecId(cmn::MediaCodecId::H264);
-	track->SetTimeBase(1, 90000);
-	track->SetOriginBitstream(cmn::BitstreamFormat::H264_RTP_RFC_6184);
+	track->SetId(id);
+	track->SetMediaType(type);
+	track->SetCodecId(codec);
+	track->SetTimeBase(1, clock_rate);
+	track->SetOriginBitstream(bitstream);
 	return track;
 }
 
-// Single-NAL H264 packet (first byte type 5 = IDR) carrying a transport-wide
-// sequence number, marker set so the boundary detector treats it as a complete
-// one-packet frame. Serialized to wire form the receive path re-parses.
-std::shared_ptr<ov::Data> MakeH264RtpData(uint16_t seq, uint32_t timestamp, uint16_t tw_seq)
+void AddTwcc(RtpPacket &packet, uint16_t tw_seq)
 {
-	auto packet = std::make_shared<RtpPacket>();
-	packet->SetPayloadType(96);
-	packet->SetMarker(true);
-	packet->SetSequenceNumber(seq);
-	packet->SetSsrc(kSsrc);
-	packet->SetTimestamp(timestamp);
-
 	auto ext = std::make_shared<RtpHeaderExtensionTransportCc>(kTwccExtId);
 	ext->SetSequenceNumber(tw_seq);
 	RtpHeaderExtensions extensions;
 	extensions.AddExtention(ext);
-	packet->SetExtensions(extensions);
+	packet.SetExtensions(extensions);
+}
 
-	const uint8_t payload[] = {0x65, 0x88, 0x84, 0x21, 0x00, 0x10, 0x20, 0x30};
-	packet->SetPayload(payload, sizeof(payload));
+// H264 single-NAL (IDR) media packet. with_twcc adds the transport-wide seq
+// extension; empty_payload yields a padding-only (0-length payload) packet.
+std::shared_ptr<ov::Data> MakeMediaData(uint16_t seq, uint32_t ts, bool with_twcc, bool empty_payload)
+{
+	RtpPacket packet;
+	packet.SetPayloadType(kMediaPt);
+	packet.SetMarker(true);
+	packet.SetSequenceNumber(seq);
+	packet.SetSsrc(kMediaSsrc);
+	packet.SetTimestamp(ts);
+	if (with_twcc)
+	{
+		AddTwcc(packet, seq);
+	}
+	if (empty_payload == false)
+	{
+		const uint8_t nal[] = {0x65, 0x88, 0x84, 0x21, 0x00, 0x10, 0x20, 0x30};
+		packet.SetPayload(nal, sizeof(nal));
+	}
+	return packet.GetData();
+}
 
-	return packet->GetData();
+// RTX-wrapped (RFC 4588) retransmission of an original media packet.
+std::shared_ptr<ov::Data> MakeRtxData(uint16_t rtx_seq, uint16_t original_seq, uint32_t ts)
+{
+	RtpPacket original;
+	original.SetPayloadType(kMediaPt);
+	original.SetMarker(true);
+	original.SetSequenceNumber(original_seq);
+	original.SetSsrc(kMediaSsrc);
+	original.SetTimestamp(ts);
+	AddTwcc(original, original_seq);
+	const uint8_t nal[] = {0x65, 0x88, 0x84, 0x21, 0x00, 0x10};
+	original.SetPayload(nal, sizeof(nal));
+
+	RtxRtpPacket rtx(kRtxSsrc, kRtxPt, original);
+	rtx.SetSequenceNumber(rtx_seq);
+	return rtx.GetData();
+}
+
+// RTX padding-only probe: payload smaller than the OSN header, so Unpack
+// returns nullptr (the path that reports the wire seq to transport-cc).
+std::shared_ptr<ov::Data> MakeRtxProbeData(uint16_t rtx_seq, uint16_t tw_seq)
+{
+	RtpPacket packet;
+	packet.SetPayloadType(kRtxPt);
+	packet.SetSequenceNumber(rtx_seq);
+	packet.SetSsrc(kRtxSsrc);
+	packet.SetTimestamp(static_cast<uint32_t>(rtx_seq) * 3000);
+	AddTwcc(packet, tw_seq);
+	return packet.GetData();
+}
+
+std::shared_ptr<ov::Data> MakeOpusData(uint16_t seq, uint32_t ts)
+{
+	RtpPacket packet;
+	packet.SetPayloadType(kAudioPt);
+	packet.SetMarker(true);
+	packet.SetSequenceNumber(seq);
+	packet.SetSsrc(kAudioSsrc);
+	packet.SetTimestamp(ts);
+	const uint8_t opus[] = {0xfc, 0xff, 0xfe, 0x01, 0x02};
+	packet.SetPayload(opus, sizeof(opus));
+	return packet.GetData();
 }
 }  // namespace
 
@@ -101,53 +160,119 @@ protected:
 
 // Simulates the ICE candidate-pair switch this PR guards against: the same
 // session's media briefly arrives on two socket-pool worker threads at once.
-// Many threads push the SAME track's RTP packets through the full receive path
-// (track lookup, receive stats, NACK, transport-cc, jitter buffer) concurrently.
+// Many threads push a MIX of packet types through the full receive path
+// concurrently so every guarded path runs contended:
+//   - H264 media with / without the transport-cc extension
+//   - RTX retransmissions (unwrap) and RTX padding-only probes
+//   - padding-only packets and deliberate seq gaps (NACK firing/retry)
+//   - Opus media (minimal jitter buffer)
 //
 // Build with -DOME_SANITIZE_THREAD=ON and run with --gtest_repeat=1000
 // --gtest_shuffle to surface data races on the shared receive state; without
 // TSan this still catches crashes / deadlocks.
-TEST_F(RtpRtcpConcurrentReceive, SameTrackFromManyThreads)
+TEST_F(RtpRtcpConcurrentReceive, MixedTrafficFromManyThreads)
 {
 	auto observer = std::make_shared<CountingObserver>();
 	auto rtp_rtcp = std::make_shared<RtpRtcp>(observer);
 
-	RtpRtcp::RtpTrackIdentifier rtp_track_id(kTrackId);
-	rtp_track_id.ssrc = kSsrc;
+	RtpRtcp::RtpTrackIdentifier video_id(kVideoTrack);
+	video_id.ssrc = kMediaSsrc;
+	RtpRtcp::RtpTrackIdentifier audio_id(kAudioTrack);
+	audio_id.ssrc = kAudioSsrc;
 
-	ASSERT_TRUE(rtp_rtcp->AddRtpReceiver(MakeH264Track(), rtp_track_id));
-	rtp_rtcp->EnableNack(kTrackId, kSsrc, 400);
+	ASSERT_TRUE(rtp_rtcp->AddRtpReceiver(
+		MakeTrack(kVideoTrack, cmn::MediaType::Video, cmn::MediaCodecId::H264, 90000,
+				  cmn::BitstreamFormat::H264_RTP_RFC_6184),
+		video_id));
+	ASSERT_TRUE(rtp_rtcp->AddRtpReceiver(
+		MakeTrack(kAudioTrack, cmn::MediaType::Audio, cmn::MediaCodecId::Opus, 48000,
+				  cmn::BitstreamFormat::OPUS_RTP_RFC_7587),
+		audio_id));
+
+	rtp_rtcp->EnableNack(kVideoTrack, kMediaSsrc, 400);
+	rtp_rtcp->RegisterRtxStream(kRtxSsrc, kMediaSsrc, kRtxPt, kMediaPt);
 	rtp_rtcp->EnableTransportCcFeedback(kTwccExtId);
 	ASSERT_TRUE(rtp_rtcp->Start());
 
 	constexpr int kThreads = 8;
-	constexpr int kIters = 500;
+	constexpr int kIters = 600;
 
-	// One near-sequential stream split across threads via a shared counter,
-	// like the same RTP flow being briefly drained by two socket workers at
-	// once. Thread scheduling still reorders arrivals, contending every lock.
-	std::atomic<uint32_t> next_seq{0};
-	std::atomic<int> in_flight{0};    // threads currently inside the receive path
+	std::atomic<uint32_t> op{0};          // global op counter -> scenario select
+	std::atomic<uint32_t> media_seq{0};   // video stream sequence
+	std::atomic<uint32_t> rtx_seq{0};     // rtx stream sequence
+	std::atomic<uint32_t> audio_seq{0};   // opus stream sequence
+	std::atomic<int> in_flight{0};
 	std::atomic<int> peak_in_flight{0};
+
+	auto feed = [&](const std::shared_ptr<ov::Data> &data) {
+		int cur = in_flight.fetch_add(1, std::memory_order_relaxed) + 1;
+		for (int prev = peak_in_flight.load(std::memory_order_relaxed);
+			 cur > prev && !peak_in_flight.compare_exchange_weak(prev, cur);)
+		{
+		}
+		rtp_rtcp->OnDataReceivedFromNextNode(NodeType::Srtp, data);
+		in_flight.fetch_sub(1, std::memory_order_relaxed);
+	};
+
 	std::vector<std::thread> threads;
 	for (int t = 0; t < kThreads; t++)
 	{
 		threads.emplace_back([&]() {
 			for (int i = 0; i < kIters; i++)
 			{
-				auto n = next_seq.fetch_add(1, std::memory_order_relaxed);
-				auto seq = static_cast<uint16_t>(n);
-				auto data = MakeH264RtpData(seq, n * 3000, seq);
-
-				int cur = in_flight.fetch_add(1, std::memory_order_relaxed) + 1;
-				for (int prev = peak_in_flight.load(std::memory_order_relaxed);
-					 cur > prev && !peak_in_flight.compare_exchange_weak(prev, cur);)
+				auto n = op.fetch_add(1, std::memory_order_relaxed);
+				switch (n % 8)
 				{
+					case 0:
+					case 1:
+					case 2:
+					{
+						// Normal media; every 11th seq is consumed but not sent
+						// to leave a gap the NACK generator must chase.
+						auto s = media_seq.fetch_add(1, std::memory_order_relaxed);
+						if (n % 11 != 0)
+						{
+							feed(MakeMediaData(static_cast<uint16_t>(s), s * 3000, true, false));
+						}
+						break;
+					}
+					case 3:
+					{
+						// Media without the transport-cc extension.
+						auto s = media_seq.fetch_add(1, std::memory_order_relaxed);
+						feed(MakeMediaData(static_cast<uint16_t>(s), s * 3000, false, false));
+						break;
+					}
+					case 4:
+					{
+						// RTX retransmission of a recent media seq.
+						auto r = rtx_seq.fetch_add(1, std::memory_order_relaxed);
+						auto osn = static_cast<uint16_t>(media_seq.load(std::memory_order_relaxed));
+						feed(MakeRtxData(static_cast<uint16_t>(r), osn, osn * 3000));
+						break;
+					}
+					case 5:
+					{
+						// RTX padding-only probe.
+						auto r = rtx_seq.fetch_add(1, std::memory_order_relaxed);
+						feed(MakeRtxProbeData(static_cast<uint16_t>(r), static_cast<uint16_t>(r)));
+						break;
+					}
+					case 6:
+					{
+						// Padding-only media (0-length payload).
+						auto s = media_seq.fetch_add(1, std::memory_order_relaxed);
+						feed(MakeMediaData(static_cast<uint16_t>(s), s * 3000, true, true));
+						break;
+					}
+					default:
+					{
+						// Opus -> minimal jitter buffer.
+						auto s = audio_seq.fetch_add(1, std::memory_order_relaxed);
+						feed(MakeOpusData(static_cast<uint16_t>(s), s * 960));
+						break;
+					}
 				}
-
-				rtp_rtcp->OnDataReceivedFromNextNode(NodeType::Srtp, data);
-
-				in_flight.fetch_sub(1, std::memory_order_relaxed);
 			}
 		});
 	}
@@ -158,13 +283,12 @@ TEST_F(RtpRtcpConcurrentReceive, SameTrackFromManyThreads)
 
 	rtp_rtcp->Stop();
 
-	// Visible evidence the run actually overlapped threads in the receive path
-	// (peak > 1) and ran the path end to end (frames reached the observer, so
-	// packets weren't dropped early). The real race verdict comes from TSan.
-	std::cout << "[ INFO     ] fed " << (kThreads * kIters) << " packets / " << kThreads
+	std::cout << "[ INFO     ] " << op.load() << " ops / " << kThreads
 			  << " threads, peak " << peak_in_flight.load() << " concurrent in receive, "
 			  << observer->_frames.load() << " frames delivered\n";
 
+	// Real overlap happened and the path ran end to end. The race verdict comes
+	// from TSan; this guards against silent serialization / total packet drop.
 	EXPECT_GE(peak_in_flight.load(), 2);
 	EXPECT_GT(observer->_frames.load(), 0);
 }

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp_test.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp_test.cpp
@@ -2,15 +2,169 @@
 //
 //  OvenMediaEngine - Unit Tests
 //
-//  tests/modules/rtp_rtcp/test_rtp_rtcp_placeholder.cpp
-//  Covers: RTP/RTCP packet construction & parsing
-//
-//  NOTE: Skeleton - expand with actual binary fixtures and state-machine tests.
+//  Covers: RtpRtcp receive path under concurrent same-track delivery
 //
 //==============================================================================
 #include <gtest/gtest.h>
 
-TEST(RtpRtcpPlaceholder, TodoImplementTests)
+#include <atomic>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#include "base/info/media_track.h"
+#include "base/ovlibrary/log.h"
+#include "rtp_header_extension/rtp_header_extension_transport_cc.h"
+#include "rtp_header_extension/rtp_header_extensions.h"
+#include "rtp_packet.h"
+#include "rtp_rtcp.h"
+
+namespace
 {
-	GTEST_SKIP() << "RTP/RTCP tests not yet implemented - see tests/modules/rtp_rtcp/";
+constexpr uint32_t kTrackId = 1;
+constexpr uint32_t kSsrc = 0x12345678;
+constexpr uint8_t kTwccExtId = 5;
+
+class CountingObserver : public RtpRtcpInterface
+{
+public:
+	void OnRtpFrameReceived(const std::vector<std::shared_ptr<RtpPacket>> &) override
+	{
+		_frames.fetch_add(1, std::memory_order_relaxed);
+	}
+	void OnRtcpReceived(const std::shared_ptr<RtcpInfo> &) override
+	{
+		_rtcp.fetch_add(1, std::memory_order_relaxed);
+	}
+
+	std::atomic<int> _frames{0};
+	std::atomic<int> _rtcp{0};
+};
+
+std::shared_ptr<MediaTrack> MakeH264Track()
+{
+	auto track = std::make_shared<MediaTrack>();
+	track->SetId(kTrackId);
+	track->SetMediaType(cmn::MediaType::Video);
+	track->SetCodecId(cmn::MediaCodecId::H264);
+	track->SetTimeBase(1, 90000);
+	track->SetOriginBitstream(cmn::BitstreamFormat::H264_RTP_RFC_6184);
+	return track;
+}
+
+// Single-NAL H264 packet (first byte type 5 = IDR) carrying a transport-wide
+// sequence number, marker set so the boundary detector treats it as a complete
+// one-packet frame. Serialized to wire form the receive path re-parses.
+std::shared_ptr<ov::Data> MakeH264RtpData(uint16_t seq, uint32_t timestamp, uint16_t tw_seq)
+{
+	auto packet = std::make_shared<RtpPacket>();
+	packet->SetPayloadType(96);
+	packet->SetMarker(true);
+	packet->SetSequenceNumber(seq);
+	packet->SetSsrc(kSsrc);
+	packet->SetTimestamp(timestamp);
+
+	auto ext = std::make_shared<RtpHeaderExtensionTransportCc>(kTwccExtId);
+	ext->SetSequenceNumber(tw_seq);
+	RtpHeaderExtensions extensions;
+	extensions.AddExtention(ext);
+	packet->SetExtensions(extensions);
+
+	const uint8_t payload[] = {0x65, 0x88, 0x84, 0x21, 0x00, 0x10, 0x20, 0x30};
+	packet->SetPayload(payload, sizeof(payload));
+
+	return packet->GetData();
+}
+}  // namespace
+
+// The per-packet info/warning logs (NACK / transport-cc reacting to the
+// concurrent, out-of-order synthetic load) are expected noise here, not bugs.
+// Silence info/warning for these tags so a --gtest_repeat=1000 run stays
+// readable, but keep error/critical visible: a real failure (e.g. a corrupted
+// map surfacing as a logte) must still print. Crashes, hangs, gtest asserts,
+// and TSan race reports are independent of OME logging and unaffected.
+class RtpRtcpConcurrentReceive : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+		for (const char *tag : {"RtpRtcp", "RtpNack", "RTCP", "transport-cc"})
+		{
+			::ov_log_set_enable(tag, OVLogLevelError, true);
+		}
+	}
+	void TearDown() override
+	{
+		::ov_log_reset_enable();
+	}
+};
+
+// Simulates the ICE candidate-pair switch this PR guards against: the same
+// session's media briefly arrives on two socket-pool worker threads at once.
+// Many threads push the SAME track's RTP packets through the full receive path
+// (track lookup, receive stats, NACK, transport-cc, jitter buffer) concurrently.
+//
+// Build with -DOME_SANITIZE_THREAD=ON and run with --gtest_repeat=1000
+// --gtest_shuffle to surface data races on the shared receive state; without
+// TSan this still catches crashes / deadlocks.
+TEST_F(RtpRtcpConcurrentReceive, SameTrackFromManyThreads)
+{
+	auto observer = std::make_shared<CountingObserver>();
+	auto rtp_rtcp = std::make_shared<RtpRtcp>(observer);
+
+	RtpRtcp::RtpTrackIdentifier rtp_track_id(kTrackId);
+	rtp_track_id.ssrc = kSsrc;
+
+	ASSERT_TRUE(rtp_rtcp->AddRtpReceiver(MakeH264Track(), rtp_track_id));
+	rtp_rtcp->EnableNack(kTrackId, kSsrc, 400);
+	rtp_rtcp->EnableTransportCcFeedback(kTwccExtId);
+	ASSERT_TRUE(rtp_rtcp->Start());
+
+	constexpr int kThreads = 8;
+	constexpr int kIters = 500;
+
+	// One near-sequential stream split across threads via a shared counter,
+	// like the same RTP flow being briefly drained by two socket workers at
+	// once. Thread scheduling still reorders arrivals, contending every lock.
+	std::atomic<uint32_t> next_seq{0};
+	std::atomic<int> in_flight{0};    // threads currently inside the receive path
+	std::atomic<int> peak_in_flight{0};
+	std::vector<std::thread> threads;
+	for (int t = 0; t < kThreads; t++)
+	{
+		threads.emplace_back([&]() {
+			for (int i = 0; i < kIters; i++)
+			{
+				auto n = next_seq.fetch_add(1, std::memory_order_relaxed);
+				auto seq = static_cast<uint16_t>(n);
+				auto data = MakeH264RtpData(seq, n * 3000, seq);
+
+				int cur = in_flight.fetch_add(1, std::memory_order_relaxed) + 1;
+				for (int prev = peak_in_flight.load(std::memory_order_relaxed);
+					 cur > prev && !peak_in_flight.compare_exchange_weak(prev, cur);)
+				{
+				}
+
+				rtp_rtcp->OnDataReceivedFromNextNode(NodeType::Srtp, data);
+
+				in_flight.fetch_sub(1, std::memory_order_relaxed);
+			}
+		});
+	}
+	for (auto &thread : threads)
+	{
+		thread.join();
+	}
+
+	rtp_rtcp->Stop();
+
+	// Visible evidence the run actually overlapped threads in the receive path
+	// (peak > 1) and ran the path end to end (frames reached the observer, so
+	// packets weren't dropped early). The real race verdict comes from TSan.
+	std::cout << "[ INFO     ] fed " << (kThreads * kIters) << " packets / " << kThreads
+			  << " threads, peak " << peak_in_flight.load() << " concurrent in receive, "
+			  << observer->_frames.load() << " frames delivered\n";
+
+	EXPECT_GE(peak_in_flight.load(), 2);
+	EXPECT_GT(observer->_frames.load(), 0);
 }

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -752,6 +752,7 @@ namespace pvd
 			payload_list.push_back(payload);
 		}
 
+		// Depacketizer is internally thread-safe.
 		auto bitstream = depacketizer->ParseAndAssembleFrame(payload_list);
 		if (bitstream == nullptr)
 		{
@@ -770,9 +771,12 @@ namespace pvd
 				bitstream_format = cmn::BitstreamFormat::H265_ANNEXB;
 				packet_type = cmn::PacketType::NALU;
 				cts_enabled = _cts_extmap_enabled == true;
-				if( _h26x_extradata_nalu.find(track->GetId()) == _h26x_extradata_nalu.end())
 				{
-					_h26x_extradata_nalu[track->GetId()] = depacketizer->GetDecodingParameterSetsToAnnexB();
+					std::lock_guard<std::mutex> lock(_sequence_header_lock);
+					if( _h26x_extradata_nalu.find(track->GetId()) == _h26x_extradata_nalu.end())
+					{
+						_h26x_extradata_nalu[track->GetId()] = depacketizer->GetDecodingParameterSetsToAnnexB();
+					}
 				}
 				break;
 
@@ -781,9 +785,12 @@ namespace pvd
 				bitstream_format = cmn::BitstreamFormat::H264_ANNEXB;
 				packet_type = cmn::PacketType::NALU;
 				cts_enabled = _cts_extmap_enabled == true;
-				if (_h26x_extradata_nalu.find(track->GetId()) == _h26x_extradata_nalu.end())
 				{
-					_h26x_extradata_nalu[track->GetId()] = depacketizer->GetDecodingParameterSetsToAnnexB();
+					std::lock_guard<std::mutex> lock(_sequence_header_lock);
+					if (_h26x_extradata_nalu.find(track->GetId()) == _h26x_extradata_nalu.end())
+					{
+						_h26x_extradata_nalu[track->GetId()] = depacketizer->GetDecodingParameterSetsToAnnexB();
+					}
 				}
 				break;
 
@@ -843,6 +850,9 @@ namespace pvd
 		// Reorder frames in DTS order
 		if (cts_enabled == true)
 		{
+			// Guards the DTS reorder buffer and the H264 parser below.
+			std::lock_guard<std::mutex> lock(_cts_reorder_lock);
+
 			// PTS order to DTS order
 			// Q and Flush (if slice type is I or P)
 			_dts_ordered_frame_buffer.emplace(dts, frame);
@@ -890,32 +900,36 @@ namespace pvd
 		auto track_id = track->GetId();
 		auto codec_id = track->GetCodecId();
 		bool is_h26x = (codec_id == cmn::MediaCodecId::H264 || codec_id == cmn::MediaCodecId::H265);
-		bool is_sent_sequence_header = _sent_sequence_header.find(track_id) != _sent_sequence_header.end();
-
 		auto packet_to_send = media_packet;
 
-		// If SPS/PPS/VPS are received out-of-band, replace them with the in-band format
-		// If the codec is H264 or H265 and the sequence header (SPS/PPS/VPS) has not been sent yet, prepend the sequence header to the current packet.
-		// TODO: If the current packet contains SPS/PPS/VPS, there is no need to prepend.
-		if (is_h26x && !is_sent_sequence_header)
+		// Guard the sequence-header check-and-set. SendFrame stays outside the lock.
 		{
-			auto new_packet = media_packet->ClonePacket();
+			std::lock_guard<std::mutex> lock(_sequence_header_lock);
 
-			auto it = _h26x_extradata_nalu.find(track_id);
-			if (it != _h26x_extradata_nalu.end() && it->second != nullptr)
+			bool is_sent_sequence_header = _sent_sequence_header.find(track_id) != _sent_sequence_header.end();
+
+			// If SPS/PPS/VPS are received out-of-band, replace them with the in-band format.
+			// If the codec is H264/H265 and the sequence header has not been sent yet, prepend it.
+			if (is_h26x && !is_sent_sequence_header)
 			{
-				// Since it is a NALU type, the data can simply be concatenated
-				auto prepend = std::make_shared<ov::Data>();
-				prepend->Append(it->second);			   // Decoding Parameter Sets (SPS/PPS/VPS)
-				prepend->Append(media_packet->GetData());  // Current frame data
+				auto new_packet = media_packet->ClonePacket();
 
-				new_packet->SetData(prepend);
+				auto it = _h26x_extradata_nalu.find(track_id);
+				if (it != _h26x_extradata_nalu.end() && it->second != nullptr)
+				{
+					// Since it is a NALU type, the data can simply be concatenated
+					auto prepend = std::make_shared<ov::Data>();
+					prepend->Append(it->second);			   // Decoding Parameter Sets (SPS/PPS/VPS)
+					prepend->Append(media_packet->GetData());  // Current frame data
 
-				logtp("Prepend Decoding Parameter Sets. track_id(%d) codec_id(%d) original_data_length(%d) new_data_length(%d)", track_id, codec_id, media_packet->GetDataLength(), new_packet->GetDataLength());
+					new_packet->SetData(prepend);
+
+					logtp("Prepend Decoding Parameter Sets. track_id(%d) codec_id(%d) original_data_length(%d) new_data_length(%d)", track_id, codec_id, media_packet->GetDataLength(), new_packet->GetDataLength());
+				}
+
+				packet_to_send = new_packet;
+				_sent_sequence_header[track_id] = true;
 			}
-
-			packet_to_send = new_packet;
-			_sent_sequence_header[track_id] = true;
 		}
 
 		SendFrame(packet_to_send);

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -770,7 +770,7 @@ namespace pvd
 				// Our H265 depacketizer always converts packet to Annex B
 				bitstream_format = cmn::BitstreamFormat::H265_ANNEXB;
 				packet_type = cmn::PacketType::NALU;
-				cts_enabled = _cts_extmap_enabled == true;
+				// CTS/DTS reorder is implemented for H264 only; H265 is sent without reordering
 				{
 					std::lock_guard<std::mutex> lock(_sequence_header_lock);
 					// Keep refreshing until the parameter sets are actually collected
@@ -883,11 +883,6 @@ namespace pvd
 								_dts_ordered_frame_buffer.clear();
 							}
 						}
-						break;
-					}
-					case cmn::BitstreamFormat::H265_ANNEXB:
-					{
-						// logtw("H265 is not supported yet");
 						break;
 					}
 					default:

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -854,44 +854,54 @@ namespace pvd
 		// Reorder frames in DTS order
 		if (cts_enabled == true)
 		{
-			// Guards the DTS reorder buffer and the H264 parser below.
-			std::lock_guard<std::mutex> lock(_cts_reorder_lock);
-
-			// PTS order to DTS order
-			// Q and Flush (if slice type is I or P)
-			_dts_ordered_frame_buffer.emplace(dts, frame);
-
-			switch (bitstream_format)
+			std::vector<std::shared_ptr<MediaPacket>> frames_to_send;
 			{
-				case cmn::BitstreamFormat::H264_ANNEXB:
+				// Guards the DTS reorder buffer and the H264 parser only.
+				std::lock_guard<std::mutex> lock(_cts_reorder_lock);
+
+				// PTS order to DTS order
+				// Q and Flush (if slice type is I or P)
+				_dts_ordered_frame_buffer.emplace(dts, frame);
+
+				switch (bitstream_format)
 				{
-					if (_h264_bitstream_parser.Parse(bitstream) == true)
+					case cmn::BitstreamFormat::H264_ANNEXB:
 					{
-						auto last_slice_type = _h264_bitstream_parser.GetLastSliceType();
-
-						logtt("PTS(%" PRId64 ") DTS(%" PRId64 ") Slice Type(%d)", adjusted_timestamp, dts, last_slice_type.has_value()?static_cast<int>(last_slice_type.value()):-1);
-
-						if (last_slice_type.has_value() == true && last_slice_type.value() != H264SliceType::B)
+						if (_h264_bitstream_parser.Parse(bitstream) == true)
 						{
-							// Flush All
-							for (auto &frame : _dts_ordered_frame_buffer)
-							{
-								OnFrame(track, frame.second);
-							}
-							_dts_ordered_frame_buffer.clear();
-						}
-					}
+							auto last_slice_type = _h264_bitstream_parser.GetLastSliceType();
 
-					return;
+							logtt("PTS(%" PRId64 ") DTS(%" PRId64 ") Slice Type(%d)", adjusted_timestamp, dts, last_slice_type.has_value()?static_cast<int>(last_slice_type.value()):-1);
+
+							if (last_slice_type.has_value() == true && last_slice_type.value() != H264SliceType::B)
+							{
+								// Flush All
+								for (auto &buffered : _dts_ordered_frame_buffer)
+								{
+									frames_to_send.push_back(buffered.second);
+								}
+								_dts_ordered_frame_buffer.clear();
+							}
+						}
+						break;
+					}
+					case cmn::BitstreamFormat::H265_ANNEXB:
+					{
+						// logtw("H265 is not supported yet");
+						break;
+					}
+					default:
+						break;
 				}
-				case cmn::BitstreamFormat::H265_ANNEXB:
-				{
-					// logtw("H265 is not supported yet");
-					return;
-				}
-				default:
-					break;
 			}
+
+			// Send outside the lock; OnFrame takes other locks and calls SendFrame.
+			for (auto &send_frame : frames_to_send)
+			{
+				OnFrame(track, send_frame);
+			}
+
+			return;
 		}
 
 		OnFrame(track, frame);

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -773,7 +773,9 @@ namespace pvd
 				cts_enabled = _cts_extmap_enabled == true;
 				{
 					std::lock_guard<std::mutex> lock(_sequence_header_lock);
-					if( _h26x_extradata_nalu.find(track->GetId()) == _h26x_extradata_nalu.end())
+					// Keep refreshing until the parameter sets are actually collected
+					auto it = _h26x_extradata_nalu.find(track->GetId());
+					if (it == _h26x_extradata_nalu.end() || it->second == nullptr)
 					{
 						_h26x_extradata_nalu[track->GetId()] = depacketizer->GetDecodingParameterSetsToAnnexB();
 					}
@@ -787,7 +789,9 @@ namespace pvd
 				cts_enabled = _cts_extmap_enabled == true;
 				{
 					std::lock_guard<std::mutex> lock(_sequence_header_lock);
-					if (_h26x_extradata_nalu.find(track->GetId()) == _h26x_extradata_nalu.end())
+					// Keep refreshing until the parameter sets are actually collected
+					auto it = _h26x_extradata_nalu.find(track->GetId());
+					if (it == _h26x_extradata_nalu.end() || it->second == nullptr)
 					{
 						_h26x_extradata_nalu[track->GetId()] = depacketizer->GetDecodingParameterSetsToAnnexB();
 					}
@@ -912,11 +916,13 @@ namespace pvd
 			// If the codec is H264/H265 and the sequence header has not been sent yet, prepend it.
 			if (is_h26x && !is_sent_sequence_header)
 			{
-				auto new_packet = media_packet->ClonePacket();
-
+				// Prepend only once the parameter sets are available; otherwise leave it
+				// unsent so a later frame can prepend after the depacketizer collects them.
 				auto it = _h26x_extradata_nalu.find(track_id);
 				if (it != _h26x_extradata_nalu.end() && it->second != nullptr)
 				{
+					auto new_packet = media_packet->ClonePacket();
+
 					// Since it is a NALU type, the data can simply be concatenated
 					auto prepend = std::make_shared<ov::Data>();
 					prepend->Append(it->second);			   // Decoding Parameter Sets (SPS/PPS/VPS)
@@ -925,10 +931,10 @@ namespace pvd
 					new_packet->SetData(prepend);
 
 					logtp("Prepend Decoding Parameter Sets. track_id(%d) codec_id(%d) original_data_length(%d) new_data_length(%d)", track_id, codec_id, media_packet->GetDataLength(), new_packet->GetDataLength());
-				}
 
-				packet_to_send = new_packet;
-				_sent_sequence_header[track_id] = true;
+					packet_to_send = new_packet;
+					_sent_sequence_header[track_id] = true;
+				}
 			}
 		}
 

--- a/src/projects/providers/webrtc/webrtc_stream.h
+++ b/src/projects/providers/webrtc/webrtc_stream.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include <base/provider/push_provider/stream.h>
 
 #include "modules/ice/ice_port.h"

--- a/src/projects/providers/webrtc/webrtc_stream.h
+++ b/src/projects/providers/webrtc/webrtc_stream.h
@@ -131,6 +131,12 @@ namespace pvd
 		std::map<uint32_t, std::shared_ptr<ov::Data>> _h26x_extradata_nalu;
 		std::map<uint32_t, bool> _sent_sequence_header;
 
+		// Guards the DTS reorder buffer and H264 bitstream parser (cts path)
+		mutable std::mutex _cts_reorder_lock;
+
+		// Guards _h26x_extradata_nalu and _sent_sequence_header
+		mutable std::mutex _sequence_header_lock;
+
 		// RID to track ID mapping
 		// Key: "mid:rid" when the SDP a=mid identifier is available (disambiguates across m= sections with reused RIDs),
 		// or just "rid" when no SDP MID is available. Each key is unique, so a single track ID per entry suffices.


### PR DESCRIPTION
## Problem
OME previously supported only a UDP candidate or a TCP relay (TURN) and did not allow switching between them. It recently started supporting UDP, TCP, and relay candidates together with dynamic switching. A switch can move a session's media to a different socket-pool worker, so the RTP/RTCP receive path can now run on two threads concurrently and races on the shared receive state.

## Solution
Guard each piece of shared receive state (ssrc map, receive statistics, jitter buffers, transport-cc generator, depacketizer parameter sets) with its own minimal-scope mutex, and keep per-call scratch local so only genuinely shared data sits under a lock.