### PR TITLE
refactor: use find()/iterator instead of map operator[] under shared_lock

### DIFF
--- a/src/projects/base/publisher/stream.cpp
+++ b/src/projects/base/publisher/stream.cpp
@@ -117,13 +117,14 @@ namespace pub
 	std::shared_ptr<Session> StreamWorker::GetSession(session_id_t id)
 	{
 		std::shared_lock<std::shared_mutex> lock(_session_map_mutex);
-		if (_sessions.count(id) <= 0)
+		auto it = _sessions.find(id);
+		if (it == _sessions.end())
 		{
 			// logte("Cannot find session : %u", id);
 			return nullptr;
 		}
 
-		return _sessions[id];
+		return it->second;
 	}
 
 	void StreamWorker::SendPacket(const std::any &packet)

--- a/src/projects/modules/ice/ice_port.cpp
+++ b/src/projects/modules/ice/ice_port.cpp
@@ -710,14 +710,15 @@ void IcePort::OnDisconnected(const std::shared_ptr<ov::Socket> &remote, Physical
 void IcePort::OnDataReceived(const std::shared_ptr<ov::Socket> &remote, const ov::SocketAddress &address, const std::shared_ptr<const ov::Data> &data)
 {
 	std::shared_lock<std::shared_mutex> lock(_demultiplexers_lock);
-	if (_demultiplexers.find(remote->GetNativeHandle()) == _demultiplexers.end())
+	auto it = _demultiplexers.find(remote->GetNativeHandle());
+	if (it == _demultiplexers.end())
 	{
 		// If the client disconnects at this time, it cannot be found.
 		logtt("TCP packet input but cannot find the demultiplexer of %s.", remote->ToString().CStr());
 		return;
 	}
 
-	auto demultiplexer = _demultiplexers[remote->GetNativeHandle()];
+	auto demultiplexer = it->second;
 	lock.unlock();
 
 	ov::SocketAddressPair address_pair(*remote->GetLocalAddress(), address);

--- a/src/projects/publishers/hls/hls_stream.cpp
+++ b/src/projects/publishers/hls/hls_stream.cpp
@@ -331,8 +331,13 @@ bool HlsStream::SendBufferedPackets()
 bool HlsStream::AppendMediaPacket(const std::shared_ptr<MediaPacket> &media_packet)
 {
 	std::shared_lock<std::shared_mutex> lock(_ts_packetizers_guard);
-	auto& packetizers = _track_packetizers[media_packet->GetTrackId()];
-	for (auto& packetizer : packetizers)
+	auto it = _track_packetizers.find(media_packet->GetTrackId());
+	if (it == _track_packetizers.end())
+	{
+		return true;
+	}
+
+	for (auto& packetizer : it->second)
 	{
 		packetizer->AppendFrame(media_packet);
 	}

--- a/src/projects/publishers/webrtc/rtc_stream.cpp
+++ b/src/projects/publishers/webrtc/rtc_stream.cpp
@@ -1041,12 +1041,13 @@ void RtcStream::AddPacketizer(const std::shared_ptr<const MediaTrack> &track)
 std::shared_ptr<RtpPacketizer> RtcStream::GetPacketizer(uint32_t id)
 {
 	std::shared_lock<std::shared_mutex> lock(_packetizers_lock);
-	if (!_packetizers.count(id))
+	auto it = _packetizers.find(id);
+	if (it == _packetizers.end())
 	{
 		return nullptr;
 	}
 
-	return _packetizers[id];
+	return it->second;
 }
 
 ov::String RtcStream::GetRtpHistoryKey(uint32_t track_id, uint8_t payload_type)

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -1259,12 +1259,13 @@ bool TranscoderStream::CreateDecoder(MediaTrackId decoder_id, std::shared_ptr<in
 std::shared_ptr<TranscodeDecoder> TranscoderStream::GetDecoder(MediaTrackId decoder_id)
 {
 	std::shared_lock<std::shared_mutex> decoder_lock(_decoder_map_mutex);
-	if (_decoders.find(decoder_id) == _decoders.end())
+	auto it = _decoders.find(decoder_id);
+	if (it == _decoders.end())
 	{
 		return nullptr;
 	}
 
-	return _decoders[decoder_id];
+	return it->second;
 }
 
 void TranscoderStream::SetDecoder(MediaTrackId decoder_id, std::shared_ptr<TranscodeDecoder> decoder)
@@ -1455,34 +1456,37 @@ bool TranscoderStream::CreateEncoder(MediaTrackId encoder_id, std::shared_ptr<in
 std::optional<std::pair<std::shared_ptr<TranscodeFilter>, std::shared_ptr<TranscodeEncoder>>> TranscoderStream::GetEncoderSet(MediaTrackId encoder_id)
 {
 	std::shared_lock<std::shared_mutex> encoder_lock(_encoder_map_mutex);
-	if (_encoders.find(encoder_id) == _encoders.end())
+	auto it = _encoders.find(encoder_id);
+	if (it == _encoders.end())
 	{
 		return std::nullopt;
 	}
 
-	return _encoders[encoder_id];
+	return it->second;
 }
 
 std::shared_ptr<TranscodeFilter> TranscoderStream::GetEncoderFilter(MediaTrackId encoder_id)
 {
 	std::shared_lock<std::shared_mutex> encoder_lock(_encoder_map_mutex);
-	if (_encoders.find(encoder_id) == _encoders.end())
+	auto it = _encoders.find(encoder_id);
+	if (it == _encoders.end())
 	{
 		return nullptr;
 	}
 
-	return _encoders[encoder_id].first;
+	return it->second.first;
 }
 
 std::shared_ptr<TranscodeEncoder> TranscoderStream::GetEncoder(MediaTrackId encoder_id)
 {
 	std::shared_lock<std::shared_mutex> encoder_lock(_encoder_map_mutex);
-	if (_encoders.find(encoder_id) == _encoders.end())
+	auto it = _encoders.find(encoder_id);
+	if (it == _encoders.end())
 	{
 		return nullptr;
 	}
 
-	return _encoders[encoder_id].second;
+	return it->second.second;
 }
 
 void TranscoderStream::SetEncoderWithFilter(MediaTrackId encoder_id, std::shared_ptr<TranscodeFilter> filter, std::shared_ptr<TranscodeEncoder> encoder)
@@ -1558,12 +1562,13 @@ bool TranscoderStream::CreateFilter(MediaTrackId filter_id, std::shared_ptr<info
 std::shared_ptr<TranscodeFilter> TranscoderStream::GetFilter(MediaTrackId filter_id)
 {
 	std::shared_lock<std::shared_mutex> lock(_filter_map_mutex);
-	if (_filters.find(filter_id) == _filters.end())
+	auto it = _filters.find(filter_id);
+	if (it == _filters.end())
 	{
 		return nullptr;
 	}
 
-	return _filters[filter_id];
+	return it->second;
 }
 
 void TranscoderStream::SetFilter(MediaTrackId filter_id, std::shared_ptr<TranscodeFilter> filter)
@@ -1865,10 +1870,12 @@ void TranscoderStream::OnDecodedFrame(TranscodeResult result, MediaTrackId decod
 			bool _has_last_decoded_frame_pts	   = false;
 			{
 				std::shared_lock<std::shared_mutex> lock(_last_decoded_frame_mutex);
-				if (_last_decoded_frame_pts.find(decoder_id) != _last_decoded_frame_pts.end())
+				auto pts_it = _last_decoded_frame_pts.find(decoder_id);
+				if (pts_it != _last_decoded_frame_pts.end())
 				{
-					last_decoded_frame_time_us	   = _last_decoded_frame_pts[decoder_id];
-					last_decoded_frame_duration_us = _last_decoded_frame_duration[decoder_id];
+					last_decoded_frame_time_us	   = pts_it->second;
+					auto duration_it			   = _last_decoded_frame_duration.find(decoder_id);
+					last_decoded_frame_duration_us = (duration_it != _last_decoded_frame_duration.end()) ? duration_it->second : 0;
 					_has_last_decoded_frame_pts	   = true;
 				}
 			}
@@ -1993,9 +2000,10 @@ void TranscoderStream::SetLastDecodedFrame(MediaTrackId decoder_id, std::shared_
 std::shared_ptr<MediaFrame> TranscoderStream::GetLastDecodedFrame(MediaTrackId decoder_id)
 {
 	std::shared_lock<std::shared_mutex> lock(_last_decoded_frame_mutex);
-	if (_last_decoded_frames.find(decoder_id) != _last_decoded_frames.end())
+	auto it = _last_decoded_frames.find(decoder_id);
+	if (it != _last_decoded_frames.end())
 	{
-		auto frame = _last_decoded_frames[decoder_id]->CloneFrame();
+		auto frame = it->second->CloneFrame();
 		frame->SetTrackId(decoder_id);
 		return frame;
 	}


### PR DESCRIPTION
Several read paths held a std::shared_lock on a shared_mutex but indexed a guarded std::map with operator[], which inserts a default element when the key is absent, so a missing key turned a read into a concurrent write. In HlsStream::AppendMediaPacket and TranscoderStream::OnDecodedFrame the key can genuinely be missing (the latter indexed a different map than the one its guard checked).

Replace operator[] with find()/iterator access in these shared-lock sections so they are strictly read-only; an absent key now returns early or falls back to a default without mutating the map.

None of these are known to cause failures in practice (the missing-key paths are rare or effectively single-threaded), so this is closer to defensive hardening and cleanup than a critical fix.

The rtp_rtcp module has the same class of issue but is intentionally left out here, since its receive-path thread-safety is handled in #2177.
