### PR TITLE
fix: make socket and metrics timestamp fields atomic

### DIFF
--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -1932,22 +1932,22 @@ namespace ov
 
 	std::chrono::steady_clock::time_point Socket::GetLastRecvTime() const
 	{
-		return _last_recv_time;
+		return _last_recv_time.load(std::memory_order_relaxed);
 	}
 
 	std::chrono::steady_clock::time_point Socket::GetLastSentTime() const
 	{
-		return _last_sent_time;
+		return _last_sent_time.load(std::memory_order_relaxed);
 	}
 
 	void Socket::UpdateLastRecvTime()
 	{
-		_last_recv_time = std::chrono::steady_clock::now();
+		_last_recv_time.store(std::chrono::steady_clock::now(), std::memory_order_relaxed);
 	}
 
 	void Socket::UpdateLastSentTime()
 	{
-		_last_sent_time = std::chrono::steady_clock::now();
+		_last_sent_time.store(std::chrono::steady_clock::now(), std::memory_order_relaxed);
 	}
 
 	bool Socket::Flush()

--- a/src/projects/base/ovsocket/socket.h
+++ b/src/projects/base/ovsocket/socket.h
@@ -557,7 +557,7 @@ namespace ov
 		void UpdateLastRecvTime();
 		void UpdateLastSentTime();
 
-		std::chrono::steady_clock::time_point _last_recv_time = std::chrono::steady_clock::now();
-		std::chrono::steady_clock::time_point _last_sent_time = std::chrono::steady_clock::now();
+		std::atomic<std::chrono::steady_clock::time_point> _last_recv_time{std::chrono::steady_clock::now()};
+		std::atomic<std::chrono::steady_clock::time_point> _last_sent_time{std::chrono::steady_clock::now()};
 	};
 }  // namespace ov

--- a/src/projects/monitoring/common_metrics.cpp
+++ b/src/projects/monitoring/common_metrics.cpp
@@ -86,9 +86,9 @@ namespace mon
 		return _created_time;
 	}
 
-	const std::chrono::system_clock::time_point &CommonMetrics::GetLastUpdatedTime() const
+	std::chrono::system_clock::time_point CommonMetrics::GetLastUpdatedTime() const
 	{
-		return _last_updated_time;
+		return _last_updated_time.load(std::memory_order_relaxed);
 	}
 
 	uint64_t CommonMetrics::GetTotalBytesIn() const
@@ -141,27 +141,27 @@ namespace mon
 	}
 	std::chrono::system_clock::time_point CommonMetrics::GetMaxTotalConnectionsTime() const
 	{
-		return _max_total_connection_time;
+		return _max_total_connection_time.load(std::memory_order_relaxed);
 	}
 
 	std::chrono::system_clock::time_point CommonMetrics::GetLastRecvTime() const
 	{
-		return _last_recv_time;
+		return _last_recv_time.load(std::memory_order_relaxed);
 	}
 
 	std::chrono::system_clock::time_point CommonMetrics::GetLastSentTime() const
 	{
-		return _last_sent_time;
+		return _last_sent_time.load(std::memory_order_relaxed);
 	}
 
 	std::chrono::steady_clock::time_point CommonMetrics::GetLastRecvTimeSteady() const
 	{
-		return _last_recv_time_steady;
+		return _last_recv_time_steady.load(std::memory_order_relaxed);
 	}
 
 	std::chrono::steady_clock::time_point CommonMetrics::GetLastSentTimeSteady() const
 	{
-		return _last_sent_time_steady;
+		return _last_sent_time_steady.load(std::memory_order_relaxed);
 	}
 
 	uint64_t CommonMetrics::GetBytesOut(PublisherType type) const
@@ -185,8 +185,8 @@ namespace mon
 	void CommonMetrics::IncreaseBytesIn(uint64_t value)
 	{
 		_total_bytes_in += value;
-		_last_recv_time = std::chrono::system_clock::now();
-		_last_recv_time_steady = std::chrono::steady_clock::now();
+		_last_recv_time.store(std::chrono::system_clock::now(), std::memory_order_relaxed);
+		_last_recv_time_steady.store(std::chrono::steady_clock::now(), std::memory_order_relaxed);
 
 		// If there are no clients of the publisher, output throughput is not calculated.
 		// So, In/Oout throughput calculations are handled here.
@@ -204,8 +204,8 @@ namespace mon
 
 		_publisher_metrics[static_cast<int8_t>(type)]._bytes_out += value;
 		_total_bytes_out += value;
-		_last_sent_time = std::chrono::system_clock::now();
-		_last_sent_time_steady = std::chrono::steady_clock::now();
+		_last_sent_time.store(std::chrono::system_clock::now(), std::memory_order_relaxed);
+		_last_sent_time_steady.store(std::chrono::steady_clock::now(), std::memory_order_relaxed);
 
 		UpdateDate();
 	}
@@ -228,7 +228,7 @@ namespace mon
 		if (_total_connections.load() > _max_total_connections.load())
 		{
 			_max_total_connections.exchange(_total_connections);
-			_max_total_connection_time = std::chrono::system_clock::now();
+			_max_total_connection_time.store(std::chrono::system_clock::now(), std::memory_order_relaxed);
 		}
 
 		UpdateDate();
@@ -252,7 +252,7 @@ namespace mon
 	// Renew last updated time
 	void CommonMetrics::UpdateDate()
 	{
-		_last_updated_time = std::chrono::system_clock::now();
+		_last_updated_time.store(std::chrono::system_clock::now(), std::memory_order_relaxed);
 	}
 
 	void CommonMetrics::UpdateThroughput()

--- a/src/projects/monitoring/common_metrics.h
+++ b/src/projects/monitoring/common_metrics.h
@@ -17,7 +17,7 @@ namespace mon
 		virtual void ShowInfo(bool show_children = true);
 
 		const std::chrono::system_clock::time_point &GetCreatedTime() const;
-		const std::chrono::system_clock::time_point &GetLastUpdatedTime() const;
+		std::chrono::system_clock::time_point GetLastUpdatedTime() const;
 
 		virtual uint64_t GetTotalBytesIn() const;
 		virtual uint64_t GetTotalBytesOut() const;
@@ -56,7 +56,7 @@ namespace mon
 		void UpdateThroughput();
 
 		std::chrono::system_clock::time_point _created_time;
-		std::chrono::system_clock::time_point _last_updated_time;
+		std::atomic<std::chrono::system_clock::time_point> _last_updated_time;
 
 		// From Provider
 		std::atomic<uint64_t> _total_bytes_in;
@@ -67,12 +67,11 @@ namespace mon
 		std::atomic<uint32_t> _total_connections;
 		std::atomic<uint32_t> _max_total_connections;
 		// Time to reach maximum number of connections.
-		// TODO(Getroot): Does it need mutex? Check!
-		std::chrono::system_clock::time_point _max_total_connection_time;
-		std::chrono::system_clock::time_point _last_recv_time;
-		std::chrono::system_clock::time_point _last_sent_time;
-		std::chrono::steady_clock::time_point _last_recv_time_steady;
-		std::chrono::steady_clock::time_point _last_sent_time_steady;
+		std::atomic<std::chrono::system_clock::time_point> _max_total_connection_time;
+		std::atomic<std::chrono::system_clock::time_point> _last_recv_time;
+		std::atomic<std::chrono::system_clock::time_point> _last_sent_time;
+		std::atomic<std::chrono::steady_clock::time_point> _last_recv_time_steady;
+		std::atomic<std::chrono::steady_clock::time_point> _last_sent_time_steady;
 
 		// Throughput from Provider
 		std::atomic<uint64_t> _avg_throughtput_in;


### PR DESCRIPTION
ThreadSanitizer reports data races on timestamp fields that are read and written across threads without synchronization: ov::Socket last recv/sent time (timeout timer vs socket worker) and mon::CommonMetrics last update/recv/sent time (provider input vs publisher output threads).

Make those time_point members std::atomic, matching the atomic counters CommonMetrics already uses, with relaxed loads and stores since each field is only an independent timestamp snapshot and guards no other state.