### PR TITLE
feat(bitstream): add AV1 OBU parser and codec configuration record

### DIFF
--- a/src/projects/modules/bitstream/AMS.mk
+++ b/src/projects/modules/bitstream/AMS.mk
@@ -10,6 +10,7 @@ LOCAL_SOURCE_FILES := $(LOCAL_SOURCE_FILES) \
 	$(call get_sub_source_list,nalu) \
     $(call get_sub_source_list,h264) \
 	$(call get_sub_source_list,h265) \
+	$(call get_sub_source_list,av1) \
 	$(call get_sub_source_list,mp3)
 
 LOCAL_HEADER_FILES := $(LOCAL_HEADER_FILES) \
@@ -19,6 +20,7 @@ LOCAL_HEADER_FILES := $(LOCAL_HEADER_FILES) \
 	$(call get_sub_header_list,nalu) \
     $(call get_sub_header_list,h264) \
 	$(call get_sub_header_list,h265) \
+	$(call get_sub_header_list,av1) \
 	$(call get_sub_header_list,mp3)
 
 $(call add_pkg_config,srt)

--- a/src/projects/modules/bitstream/CMakeLists.txt
+++ b/src/projects/modules/bitstream/CMakeLists.txt
@@ -6,6 +6,7 @@ ome_add_static_library(bitstream
         nalu
         h264
         h265
+        av1
         mp3
     DEPS ovlibrary
 )

--- a/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.cpp
+++ b/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.cpp
@@ -53,6 +53,17 @@ uint8_t AV1DecoderConfigurationRecord::BitDepth() const
 
 bool AV1DecoderConfigurationRecord::Parse(const uint8_t *data, size_t length)
 {
+	// Invalidate any prior parse state up front.
+	// A re-parse on a reused instance must not leave the previous result observable:
+	// without this, a failure at any point below would leave `_parsed` (hence `IsValid()`) `true`
+	// and `GetData()` returning bytes cached by an earlier successful parse.
+	// `UpdateData()` drops the cached serialized buffer so `GetData()` no longer returns stale bytes.
+	// `_config_obus` is only assigned after the fixed header is fully read, so an early failure would
+	// otherwise leave the previous parse's OBU buffer reachable through `ConfigObus()`; clear it too.
+	_parsed		 = false;
+	_config_obus = nullptr;
+	UpdateData();
+
 	if ((data == nullptr) || (length < MIN_AV1DECODERCONFIGURATIONRECORD_SIZE))
 	{
 		return false;

--- a/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.cpp
+++ b/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.cpp
@@ -1,0 +1,469 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include "av1_decoder_configuration_record.h"
+
+#include <cstring>
+
+#include <base/common_types.h>
+#include <base/ovlibrary/ovlibrary.h>
+
+#include "av1_parser.h"
+#include "av1_types.h"
+
+#define OV_LOG_TAG "AV1DecoderConfigurationRecord"
+
+bool AV1DecoderConfigurationRecord::IsValid() const
+{
+	return _parsed && _marker == 1 && _version == 1;
+}
+
+ov::String AV1DecoderConfigurationRecord::GetCodecsParameter() const
+{
+	// RFC 6381 / AV1 ISO BMFF spec:
+	// `av01.<profile>.<level_idx><tier>.<bitDepth>`
+	// `tier`: `'M'` (main) or `'H'` (high)
+	// `bitDepth`: `08`, `10`, or `12`
+
+	const char tier_char = (_seq_tier_0 == 0) ? 'M' : 'H';
+	const uint8_t bit_depth = BitDepth();
+
+	return ov::String::FormatString(
+		"av01.%u.%02u%c.%02u",
+		static_cast<uint32_t>(_seq_profile),
+		static_cast<uint32_t>(_seq_level_idx_0),
+		tier_char,
+		static_cast<uint32_t>(bit_depth));
+}
+
+uint8_t AV1DecoderConfigurationRecord::BitDepth() const
+{
+	if (_seq_profile == 2 && _high_bitdepth == 1)
+	{
+		return _twelve_bit ? 12 : 10;
+	}
+
+	return _high_bitdepth ? 10 : 8;
+}
+
+bool AV1DecoderConfigurationRecord::Parse(const uint8_t *data, size_t length)
+{
+	if ((data == nullptr) || (length < MIN_AV1DECODERCONFIGURATIONRECORD_SIZE))
+	{
+		return false;
+	}
+
+	BitReader parser(data, length);
+
+	// AV1 ISOBMFF binding `AV1CodecConfigurationRecord` (`av1C` box).
+	_marker = parser.ReadBits<uint8_t>(1);							// marker
+	_version = parser.ReadBits<uint8_t>(7);							// version
+
+	if (_marker != 1 || _version != 1)
+	{
+		return false;
+	}
+
+	_seq_profile = parser.ReadBits<uint8_t>(3);						// seq_profile
+	_seq_level_idx_0 = parser.ReadBits<uint8_t>(5);					// seq_level_idx_0
+
+	// AV1 spec 6.4.1 `seq_profile` semantics: "seq_profile shall be in the range of 0 to 2." The
+	// values 3..7 are reserved (Table 4 of section 6.4.1). Reject reserved encodings.
+	if (_seq_profile > 2)
+	{
+		return false;
+	}
+
+	_seq_tier_0 = parser.ReadBits<uint8_t>(1);						// seq_tier_0
+	_high_bitdepth = parser.ReadBits<uint8_t>(1);					// high_bitdepth
+	_twelve_bit = parser.ReadBits<uint8_t>(1);						// twelve_bit
+	_monochrome = parser.ReadBits<uint8_t>(1);						// monochrome
+	_chroma_subsampling_x = parser.ReadBits<uint8_t>(1);			// chroma_subsampling_x
+	_chroma_subsampling_y = parser.ReadBits<uint8_t>(1);			// chroma_subsampling_y
+	_chroma_sample_position = parser.ReadBits<uint8_t>(2);			// chroma_sample_position
+
+	// AV1 spec 6.4.2 Table 8 `chroma_sample_position` semantics: value 3 (CSP_RESERVED) is reserved
+	// for future use. Reject any record that encodes the reserved chroma sample position.
+	if (_chroma_sample_position == 3)
+	{
+		return false;
+	}
+
+	// AV1 ISOBMFF binding v1.2.0 section 2.3.1: the 3-bit `reserved` field SHALL be 0. Reject any
+	// av1C blob that carries non-zero reserved bits so the strict parser does not silently accept
+	// malformed records (same policy as the OBU header reserved-bit reject in `av1_parser.cpp`).
+	const uint8_t reserved_3 = parser.ReadBits<uint8_t>(3);			// reserved
+	if (reserved_3 != 0)
+	{
+		return false;
+	}
+
+	_initial_presentation_delay_present = parser.ReadBits<uint8_t>(1);	// initial_presentation_delay_present
+	if (_initial_presentation_delay_present)
+	{
+		_initial_presentation_delay_minus_one = parser.ReadBits<uint8_t>(4);	// initial_presentation_delay_minus_one
+	}
+	else
+	{
+		// AV1 ISOBMFF binding v1.2.0 section 2.3.1: the trailing 4-bit `reserved` field (present
+		// only when `initial_presentation_delay_present == 0`) SHALL be 0.
+		const uint8_t reserved_4 = parser.ReadBits<uint8_t>(4);		// reserved
+		if (reserved_4 != 0)
+		{
+			return false;
+		}
+		_initial_presentation_delay_minus_one = 0;
+	}
+
+	const auto remaining = parser.BytesRemained();
+	if (remaining > 0)
+	{
+		_config_obus = std::make_shared<ov::Data>(parser.CurrentPosition(), remaining);
+	}
+	else
+	{
+		_config_obus = nullptr;
+	}
+
+	// AV1 ISOBMFF binding v1.2.0 4.2.1:
+	//   "The `configOBUs` field SHALL contain zero or more OBUs..."
+	//   "At most one Sequence Header OBU SHALL be present..."
+	//   "If present, the Sequence Header OBU SHALL be the first OBU."
+	//   "If a Sequence Header OBU is present in `configOBUs`, the values of the fields in
+	//    `AV1CodecConfigurationRecord` SHALL match those of the Sequence Header OBU."
+	if (_config_obus != nullptr && _config_obus->GetLength() > 0)
+	{
+		if (ValidateConfigObus() == false)
+		{
+			return false;
+		}
+	}
+
+	_parsed = true;
+
+	return true;
+}
+
+bool AV1DecoderConfigurationRecord::ValidateConfigObus()
+{
+	const auto *base   = _config_obus->GetDataAs<uint8_t>();
+	const size_t total = _config_obus->GetLength();
+	size_t offset	   = 0;
+	size_t obu_index   = 0;
+	bool seen_seq_hdr  = false;
+
+	while (offset < total)
+	{
+		auto parsed = Av1Parser::ParseObuHeader(base + offset, total - offset);
+		if (parsed.has_value() == false)
+		{
+			return false;
+		}
+
+		const auto &header	  = parsed->header;
+		size_t payload_offset = offset + parsed->bytes_consumed;
+		size_t payload_size	  = 0;
+
+		// AV1 ISOBMFF binding v1.2.0: `configOBUs` is a size-delimited OBU sequence; every OBU
+		// in the field SHALL set `obu_has_size_field = 1`. This is distinct from the in-band
+		// low-overhead bitstream format walked by `Av1Parser::ExtractFirstSequenceHeaderObu()`,
+		// which tolerates a leading `obu_has_size_field = 0` `TemporalDelimiter` (spec 5.6:
+		// "Note: The temporal delimiter has an empty payload.") because its payload size is
+		// statically zero. Inside `configOBUs` there is no such heuristic - absorbing the
+		// remainder as one anonymous payload would silently swallow follow-up OBUs and bypass
+		// the cross-check rules below, so reject immediately.
+		if (header.has_size_field == false)
+		{
+			return false;
+		}
+
+		auto leb = Av1Parser::DecodeLeb128(base + payload_offset, total - payload_offset);
+		if (leb.has_value() == false)
+		{
+			return false;
+		}
+
+		payload_offset += leb->bytes_consumed;
+
+		if (leb->value > total - payload_offset)
+		{
+			return false;
+		}
+
+		payload_size = static_cast<size_t>(leb->value);
+
+		if (header.type == Av1ObuType::SequenceHeader)
+		{
+			// Ordering rule: must be the first OBU in `configOBUs`.
+			if (obu_index != 0)
+			{
+				return false;
+			}
+			// Cardinality rule: at most one Sequence Header OBU.
+			if (seen_seq_hdr)
+			{
+				return false;
+			}
+			seen_seq_hdr = true;
+
+			// Cross-check rule: Sequence Header OBU fields SHALL match the `av1C` fixed fields.
+			//
+			// AV1 ISOBMFF binding v1.2.0 section 2.3.2: "When the configOBUs field contains a
+			// Sequence Header OBU, the values of the AV1CodecConfigurationRecord fields shall
+			// match those of the OBU. Specifically: seq_profile, seq_level_idx_0, seq_tier_0,
+			// high_bitdepth, twelve_bit, monochrome, chroma_subsampling_x, chroma_subsampling_y,
+			// chroma_sample_position (when not zero), and initial_presentation_delay_minus_one,
+			// when present, all shall match."
+			auto summary = Av1Parser::ParseSequenceHeaderSummary(base + payload_offset, payload_size);
+			if (summary.has_value() == false)
+			{
+				return false;
+			}
+			if (summary->seq_profile != _seq_profile)
+			{
+				return false;
+			}
+			if (summary->seq_level_idx_0 != _seq_level_idx_0)
+			{
+				return false;
+			}
+			if (summary->seq_tier_0 != _seq_tier_0)
+			{
+				return false;
+			}
+			if (summary->high_bitdepth != _high_bitdepth)
+			{
+				return false;
+			}
+			if (summary->twelve_bit != _twelve_bit)
+			{
+				return false;
+			}
+			if (summary->monochrome != _monochrome)
+			{
+				return false;
+			}
+			if (summary->chroma_subsampling_x != _chroma_subsampling_x)
+			{
+				return false;
+			}
+			if (summary->chroma_subsampling_y != _chroma_subsampling_y)
+			{
+				return false;
+			}
+			// Spec exception "(when not zero)" - skip the cross-check whenever the av1C value is 0.
+			if ((_chroma_sample_position != 0) && (summary->chroma_sample_position != _chroma_sample_position))
+			{
+				return false;
+			}
+
+			// AV1 ISOBMFF binding v1.2.0 section 2.3.2: "initial_presentation_delay_minus_one,
+			// when present, all shall match." The av1C `initial_presentation_delay_present`
+			// flag must equal the Sequence Header's `initial_display_delay_present_for_op_0`,
+			// and when both are 1 the `_minus_one` value must match.
+			if (summary->initial_display_delay_present_for_op_0 != _initial_presentation_delay_present)
+			{
+				return false;
+			}
+			if ((_initial_presentation_delay_present != 0) &&
+				(summary->initial_display_delay_minus_1_for_op_0 != _initial_presentation_delay_minus_one))
+			{
+				return false;
+			}
+		}
+
+		offset = payload_offset + payload_size;
+		obu_index++;
+	}
+
+	return true;
+}
+
+bool AV1DecoderConfigurationRecord::Parse(const std::shared_ptr<const ov::Data> &data)
+{
+	if (data == nullptr)
+	{
+		return false;
+	}
+
+	if (Parse(data->GetDataAs<uint8_t>(), data->GetLength()) == false)
+	{
+		return false;
+	}
+
+	// Preserve the caller's original buffer as the backing store; raw-pointer overload does not
+	// touch `SetData()` so the conv layer is the single source of truth for `GetData()`.
+	SetData(data);
+
+	return true;
+}
+
+bool AV1DecoderConfigurationRecord::Equals(const std::shared_ptr<DecoderConfigurationRecord> &other)
+{
+	// AV1 ISOBMFF binding v1.2.0 section 2.3 defines `AV1CodecConfigurationRecord` as the
+	// canonical serialized form of the av1C box. Two records are equal iff they would emit
+	// identical bytes through that serialization, so compare the serialized buffer end-to-end
+	// rather than a hand-picked subset of fixed fields. This catches differences in any of
+	// `monochrome`, `chroma_subsampling_x/y`, `chroma_sample_position`,
+	// `initial_presentation_delay_present`, `initial_presentation_delay_minus_one`, and the
+	// `configOBUs` payload - all of which the previous weak comparison silently ignored.
+	if (other == nullptr)
+	{
+		return false;
+	}
+
+	auto other_config = std::dynamic_pointer_cast<AV1DecoderConfigurationRecord>(other);
+	if (other_config == nullptr)
+	{
+		return false;
+	}
+
+	auto self_data = GetData();
+	auto other_data = other_config->GetData();
+	if (self_data == nullptr || other_data == nullptr)
+	{
+		return false;
+	}
+
+	if (self_data->GetLength() != other_data->GetLength())
+	{
+		return false;
+	}
+
+	return std::memcmp(
+			   self_data->GetDataAs<uint8_t>(),
+			   other_data->GetDataAs<uint8_t>(),
+			   self_data->GetLength()) == 0;
+}
+
+std::shared_ptr<const ov::Data> AV1DecoderConfigurationRecord::Serialize()
+{
+	ov::BitWriter bit(MIN_AV1DECODERCONFIGURATIONRECORD_SIZE + (_config_obus ? _config_obus->GetLength() : 0));
+
+	bit.WriteBits(1, _marker);
+	bit.WriteBits(7, _version);
+
+	bit.WriteBits(3, _seq_profile);
+	bit.WriteBits(5, _seq_level_idx_0);
+
+	bit.WriteBits(1, _seq_tier_0);
+	bit.WriteBits(1, _high_bitdepth);
+	bit.WriteBits(1, _twelve_bit);
+	bit.WriteBits(1, _monochrome);
+	bit.WriteBits(1, _chroma_subsampling_x);
+	bit.WriteBits(1, _chroma_subsampling_y);
+	bit.WriteBits(2, _chroma_sample_position);
+
+	bit.WriteBits(3, 0);
+	bit.WriteBits(1, _initial_presentation_delay_present);
+
+	if (_initial_presentation_delay_present)
+	{
+		bit.WriteBits(4, _initial_presentation_delay_minus_one);
+	}
+	else
+	{
+		bit.WriteBits(4, 0);
+	}
+
+	if (_config_obus != nullptr && _config_obus->GetLength() > 0)
+	{
+		if (bit.WriteData(_config_obus->GetDataAs<uint8_t>(), _config_obus->GetLength()) == false)
+		{
+			return nullptr;
+		}
+	}
+
+	return bit.GetDataObject();
+}
+
+uint8_t AV1DecoderConfigurationRecord::Marker() const { return _marker; }
+uint8_t AV1DecoderConfigurationRecord::Version() const { return _version; }
+uint8_t AV1DecoderConfigurationRecord::SeqProfile() const { return _seq_profile; }
+uint8_t AV1DecoderConfigurationRecord::SeqLevelIdx0() const { return _seq_level_idx_0; }
+uint8_t AV1DecoderConfigurationRecord::SeqTier0() const { return _seq_tier_0; }
+uint8_t AV1DecoderConfigurationRecord::HighBitdepth() const { return _high_bitdepth; }
+uint8_t AV1DecoderConfigurationRecord::TwelveBit() const { return _twelve_bit; }
+uint8_t AV1DecoderConfigurationRecord::Monochrome() const { return _monochrome; }
+uint8_t AV1DecoderConfigurationRecord::ChromaSubsamplingX() const { return _chroma_subsampling_x; }
+uint8_t AV1DecoderConfigurationRecord::ChromaSubsamplingY() const { return _chroma_subsampling_y; }
+uint8_t AV1DecoderConfigurationRecord::ChromaSamplePosition() const { return _chroma_sample_position; }
+uint8_t AV1DecoderConfigurationRecord::InitialPresentationDelayPresent() const { return _initial_presentation_delay_present; }
+uint8_t AV1DecoderConfigurationRecord::InitialPresentationDelayMinusOne() const { return _initial_presentation_delay_minus_one; }
+
+std::shared_ptr<ov::Data> AV1DecoderConfigurationRecord::ConfigObus() const
+{
+	return _config_obus;
+}
+
+void AV1DecoderConfigurationRecord::SetSeqProfile(uint8_t value)
+{
+	_seq_profile = value;
+	UpdateData();
+}
+
+void AV1DecoderConfigurationRecord::SetSeqLevelIdx0(uint8_t value)
+{
+	_seq_level_idx_0 = value;
+	UpdateData();
+}
+
+void AV1DecoderConfigurationRecord::SetSeqTier0(uint8_t value)
+{
+	_seq_tier_0 = value;
+	UpdateData();
+}
+
+void AV1DecoderConfigurationRecord::SetHighBitdepth(uint8_t value)
+{
+	_high_bitdepth = value;
+	UpdateData();
+}
+
+void AV1DecoderConfigurationRecord::SetTwelveBit(uint8_t value)
+{
+	_twelve_bit = value;
+	UpdateData();
+}
+
+void AV1DecoderConfigurationRecord::SetMonochrome(uint8_t value)
+{
+	_monochrome = value;
+	UpdateData();
+}
+
+void AV1DecoderConfigurationRecord::SetChromaSubsamplingX(uint8_t value)
+{
+	_chroma_subsampling_x = value;
+	UpdateData();
+}
+
+void AV1DecoderConfigurationRecord::SetChromaSubsamplingY(uint8_t value)
+{
+	_chroma_subsampling_y = value;
+	UpdateData();
+}
+
+void AV1DecoderConfigurationRecord::SetChromaSamplePosition(uint8_t value)
+{
+	_chroma_sample_position = value;
+	UpdateData();
+}
+
+void AV1DecoderConfigurationRecord::SetInitialPresentationDelay(bool present, uint8_t minus_one)
+{
+	_initial_presentation_delay_present = present ? 1 : 0;
+	_initial_presentation_delay_minus_one = present ? (minus_one & 0x0F) : 0;
+	UpdateData();
+}
+
+void AV1DecoderConfigurationRecord::SetConfigObus(const std::shared_ptr<ov::Data> &config_obus)
+{
+	_config_obus = config_obus;
+	UpdateData();
+}

--- a/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.h
+++ b/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.h
@@ -1,0 +1,157 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include <base/common_types.h>
+#include <base/info/decoder_configuration_record.h>
+#include <base/ovlibrary/ovlibrary.h>
+
+// https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-syntax
+//
+// aligned(8) class AV1CodecConfigurationRecord {
+//     unsigned int(1) marker = 1;
+//     unsigned int(7) version = 1;
+//     unsigned int(3) seq_profile;
+//     unsigned int(5) seq_level_idx_0;
+//     unsigned int(1) seq_tier_0;
+//     unsigned int(1) high_bitdepth;
+//     unsigned int(1) twelve_bit;
+//     unsigned int(1) monochrome;
+//     unsigned int(1) chroma_subsampling_x;
+//     unsigned int(1) chroma_subsampling_y;
+//     unsigned int(2) chroma_sample_position;
+//     unsigned int(3) reserved = 0;
+//     unsigned int(1) initial_presentation_delay_present;
+//     if (initial_presentation_delay_present) {
+//         unsigned int(4) initial_presentation_delay_minus_one;
+//     } else {
+//         unsigned int(4) reserved = 0;
+//     }
+//     unsigned int(8) configOBUs[];
+// }
+
+#define MIN_AV1DECODERCONFIGURATIONRECORD_SIZE 4
+
+class AV1DecoderConfigurationRecord : public DecoderConfigurationRecord
+{
+public:
+	/// Test whether the record passes the mandatory `marker == 1` / `version == 1` checks per AV1 ISOBMFF binding.
+	///
+	/// @return `true` if the record is structurally well-formed.
+	bool IsValid() const override;
+
+	/// Build an RFC 6381 `codecs` parameter string for this record.
+	///
+	/// Example output: `av01.0.04M.08`.
+	///
+	/// @return The MIME `codecs` parameter.
+	ov::String GetCodecsParameter() const override;
+
+	/// Parse a serialized `AV1CodecConfigurationRecord` (`av1C` box) per AOMedia ISOBMFF binding.
+	///
+	/// @param data Pointer to the raw `av1C` blob bytes (first byte must be `0x81`).
+	///
+	/// @param length Number of bytes available at `data` (>= `MIN_AV1DECODERCONFIGURATIONRECORD_SIZE`).
+	///
+	/// @return `true` if the blob is well-formed and all fields were extracted.
+	bool Parse(const uint8_t *data, size_t length);
+
+	/// Convenience overload that accepts an `ov::Data`. Backing storage is preserved on success
+	/// so `GetData()` returns the caller's original buffer.
+	///
+	/// @param data Raw `av1C` blob; must not be `nullptr` and must satisfy the size minimum.
+	///
+	/// @return `true` if the blob is well-formed and all fields were extracted.
+	bool Parse(const std::shared_ptr<const ov::Data> &data) override;
+
+	/// Compare this record against another for byte-for-byte equality of the serialized form.
+	///
+	/// @param other Other configuration record.
+	///
+	/// @return `true` if both records would serialize to identical bytes.
+	bool Equals(const std::shared_ptr<DecoderConfigurationRecord> &other) override;
+
+	/// Serialize this record back to its `av1C` byte form per AOMedia ISOBMFF binding.
+	///
+	/// @return Newly allocated buffer holding the serialized `av1C` blob.
+	std::shared_ptr<const ov::Data> Serialize() override;
+
+	uint8_t Marker() const;
+	uint8_t Version() const;
+	uint8_t SeqProfile() const;
+	uint8_t SeqLevelIdx0() const;
+	uint8_t SeqTier0() const;
+	uint8_t HighBitdepth() const;
+	uint8_t TwelveBit() const;
+	uint8_t Monochrome() const;
+	uint8_t ChromaSubsamplingX() const;
+	uint8_t ChromaSubsamplingY() const;
+	uint8_t ChromaSamplePosition() const;
+	uint8_t InitialPresentationDelayPresent() const;
+	uint8_t InitialPresentationDelayMinusOne() const;
+
+	/// Return the `configOBUs` payload (zero or more concatenated AV1 OBUs).
+	///
+	/// The returned buffer may be empty when the muxer chose to deliver the sequence header OBU in-band
+	/// rather than inside the `av1C` box.
+	///
+	/// @return The `configOBUs` byte buffer (possibly empty); never `nullptr` when `Parse` has succeeded.
+	std::shared_ptr<ov::Data> ConfigObus() const;
+
+	void SetSeqProfile(uint8_t value);
+	void SetSeqLevelIdx0(uint8_t value);
+	void SetSeqTier0(uint8_t value);
+	void SetHighBitdepth(uint8_t value);
+	void SetTwelveBit(uint8_t value);
+	void SetMonochrome(uint8_t value);
+	void SetChromaSubsamplingX(uint8_t value);
+	void SetChromaSubsamplingY(uint8_t value);
+	void SetChromaSamplePosition(uint8_t value);
+
+	/// Set `initial_presentation_delay_present` and (when `present`) the associated `initial_presentation_delay_minus_one`.
+	///
+	/// @param present `true` to encode the optional delay field.
+	///
+	/// @param minus_one Delay value minus one (only used when `present`).
+	void SetInitialPresentationDelay(bool present, uint8_t minus_one);
+
+	/// Replace the `configOBUs` payload with the given buffer.
+	///
+	/// @param config_obus Buffer of zero or more concatenated AV1 OBUs. The pointer is stored as-is; pass `nullptr` to clear.
+	void SetConfigObus(const std::shared_ptr<ov::Data> &config_obus);
+
+	/// Derive the effective bit depth from `high_bitdepth` and `twelve_bit` per AV1 spec section 5.5.2.
+	///
+	/// @return `8`, `10`, or `12`.
+	uint8_t BitDepth() const;
+
+private:
+	/// Walk `_config_obus`, enforcing AV1 ISOBMFF binding v1.2.0 rules: valid OBU sequence, at most
+	/// one Sequence Header OBU, Sequence Header must be the first OBU, and Sequence Header fields
+	/// must match the fixed `av1C` fields (`seq_profile`, `seq_level_idx_0`).
+	bool ValidateConfigObus();
+
+	uint8_t _marker = 1;
+	uint8_t _version = 1;
+	uint8_t _seq_profile = 0;
+	uint8_t _seq_level_idx_0 = 0;
+	uint8_t _seq_tier_0 = 0;
+	uint8_t _high_bitdepth = 0;
+	uint8_t _twelve_bit = 0;
+	uint8_t _monochrome = 0;
+	uint8_t _chroma_subsampling_x = 1;
+	uint8_t _chroma_subsampling_y = 1;
+	uint8_t _chroma_sample_position = 0;
+	uint8_t _initial_presentation_delay_present = 0;
+	uint8_t _initial_presentation_delay_minus_one = 0;
+
+	std::shared_ptr<ov::Data> _config_obus;
+
+	bool _parsed = false;
+};

--- a/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.h
+++ b/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.h
@@ -98,10 +98,11 @@ public:
 
 	/// Return the `configOBUs` payload (zero or more concatenated AV1 OBUs).
 	///
-	/// The returned buffer may be empty when the muxer chose to deliver the sequence header OBU in-band
-	/// rather than inside the `av1C` box.
+	/// `nullptr` is returned when the record carries no `configOBUs` - e.g. a minimal `av1C` whose
+	/// sequence header OBU is delivered in-band rather than inside the box. A successful `Parse` does
+	/// NOT guarantee a non-null result.
 	///
-	/// @return The `configOBUs` byte buffer (possibly empty); never `nullptr` when `Parse` has succeeded.
+	/// @return The `configOBUs` byte buffer, or `nullptr` when the record has no `configOBUs`.
 	std::shared_ptr<ov::Data> ConfigObus() const;
 
 	void SetSeqProfile(uint8_t value);

--- a/src/projects/modules/bitstream/av1/av1_decoder_configuration_record_test.cpp
+++ b/src/projects/modules/bitstream/av1/av1_decoder_configuration_record_test.cpp
@@ -1,0 +1,939 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include <base/ovlibrary/data.h>
+#include <modules/bitstream/av1/av1_decoder_configuration_record.h>
+#include <modules/bitstream/av1/av1_types.h>
+
+namespace
+{
+	std::shared_ptr<ov::Data> MakeData(const std::vector<uint8_t> &bytes)
+	{
+		return std::make_shared<ov::Data>(bytes.data(), bytes.size());
+	}
+
+	std::vector<uint8_t> EncodeLeb128(uint64_t value)
+	{
+		std::vector<uint8_t> bytes;
+		do
+		{
+			uint8_t byte = value & 0x7F;
+			value >>= 7;
+			if (value != 0)
+			{
+				byte |= 0x80;
+			}
+			bytes.push_back(byte);
+		} while (value != 0);
+		return bytes;
+	}
+
+	// Build a spec-correct OBU: 1-byte header + LEB128 size + payload.
+	std::vector<uint8_t> BuildObu(Av1ObuType type, const std::vector<uint8_t> &payload)
+	{
+		std::vector<uint8_t> bytes;
+		uint8_t header = 0;
+		header |= (static_cast<uint8_t>(type) & 0x0F) << 3;
+		// `extension_flag = 0`, `has_size_field = 1`, `reserved_1bit = 0`.
+		header |= 1 << 1;
+		bytes.push_back(header);
+		auto leb = EncodeLeb128(payload.size());
+		bytes.insert(bytes.end(), leb.begin(), leb.end());
+		bytes.insert(bytes.end(), payload.begin(), payload.end());
+		return bytes;
+	}
+
+	// Build a minimal valid `OBU_SEQUENCE_HEADER` payload with the given
+	// `seq_profile` / `seq_level_idx_0` plus optional `color_config()` overrides.
+	// `reduced_still_picture_header = 1` (with `still_picture = 1` per AV1 spec 5.5.1) keeps the
+	// payload short while still serializing every field through `color_config()`.
+	struct ReducedSeqHeaderFields
+	{
+		uint8_t seq_profile				= 0;
+		uint8_t seq_level_idx_0			= 0;
+		uint8_t high_bitdepth			= 0;
+		uint8_t twelve_bit				= 0;
+		uint8_t monochrome				= 0;
+		uint8_t color_range				= 0;
+		// AV1 spec defaults under seq_profile 0 (8-bit, color_desc=0) - subsampling 4:2:0.
+		uint8_t chroma_subsampling_x	= 1;
+		uint8_t chroma_subsampling_y	= 1;
+		uint8_t chroma_sample_position	= 0;
+	};
+
+	std::vector<uint8_t> BuildReducedSeqHeaderPayloadEx(const ReducedSeqHeaderFields &f)
+	{
+		ov::BitWriter w(8);
+		w.WriteBits(3, f.seq_profile);
+		// AV1 spec 5.5.1: reduced_still_picture_header == 1 requires still_picture == 1.
+		w.WriteBits(1, 1);   // still_picture
+		w.WriteBits(1, 1);   // reduced_still_picture_header
+		w.WriteBits(5, f.seq_level_idx_0);
+		w.WriteBits(4, 0);   // frame_width_bits_minus_1 -> 1 bit
+		w.WriteBits(4, 0);   // frame_height_bits_minus_1 -> 1 bit
+		w.WriteBits(1, 0);   // max_frame_width_minus_1
+		w.WriteBits(1, 0);   // max_frame_height_minus_1
+		// AV1 spec 5.5.1 reduced branch continuation.
+		w.WriteBits(1, 0);   // use_128x128_superblock
+		w.WriteBits(1, 0);   // enable_filter_intra
+		w.WriteBits(1, 0);   // enable_intra_edge_filter
+		w.WriteBits(1, 0);   // enable_superres
+		w.WriteBits(1, 0);   // enable_cdef
+		w.WriteBits(1, 0);   // enable_restoration
+		// AV1 spec 5.5.2 `color_config()`.
+		w.WriteBits(1, f.high_bitdepth);
+		if ((f.seq_profile == 2) && (f.high_bitdepth != 0))
+		{
+			w.WriteBits(1, f.twelve_bit);
+		}
+		if (f.seq_profile != 1)
+		{
+			w.WriteBits(1, f.monochrome);
+		}
+		w.WriteBits(1, 0);   // color_description_present_flag = 0 -> CP/TC/MC defaults
+		if (f.monochrome != 0)
+		{
+			w.WriteBits(1, f.color_range);
+		}
+		else
+		{
+			w.WriteBits(1, f.color_range);
+			// seq_profile 0 -> subsampling 1,1 implicit; seq_profile 1 -> 0,0 implicit.
+			// seq_profile 2 with bit_depth != 12 -> 1,0 implicit; otherwise reads bits.
+			if (f.seq_profile == 2)
+			{
+				const uint8_t bit_depth = (f.high_bitdepth != 0) ? ((f.twelve_bit != 0) ? 12 : 10) : 8;
+				if (bit_depth == 12)
+				{
+					w.WriteBits(1, f.chroma_subsampling_x);
+					if (f.chroma_subsampling_x != 0)
+					{
+						w.WriteBits(1, f.chroma_subsampling_y);
+					}
+				}
+			}
+			uint8_t eff_x = f.chroma_subsampling_x;
+			uint8_t eff_y = f.chroma_subsampling_y;
+			if (f.seq_profile == 0)
+			{
+				eff_x = 1;
+				eff_y = 1;
+			}
+			else if (f.seq_profile == 1)
+			{
+				eff_x = 0;
+				eff_y = 0;
+			}
+			else if (f.seq_profile == 2)
+			{
+				const uint8_t bit_depth = (f.high_bitdepth != 0) ? ((f.twelve_bit != 0) ? 12 : 10) : 8;
+				if (bit_depth != 12)
+				{
+					eff_x = 1;
+					eff_y = 0;
+				}
+			}
+			if ((eff_x != 0) && (eff_y != 0))
+			{
+				w.WriteBits(2, f.chroma_sample_position);
+			}
+		}
+		return std::vector<uint8_t>(w.GetData(), w.GetData() + w.GetDataSize());
+	}
+
+	std::vector<uint8_t> BuildReducedSeqHeaderPayload(uint8_t seq_profile, uint8_t seq_level_idx_0)
+	{
+		ReducedSeqHeaderFields f;
+		f.seq_profile	  = seq_profile;
+		f.seq_level_idx_0 = seq_level_idx_0;
+		return BuildReducedSeqHeaderPayloadEx(f);
+	}
+
+	// Build a Sequence Header OBU payload that exercises the full (non-reduced) path with one
+	// operating point. AV1 spec 5.5.1 requires `seq_tier[0]` to be read only when
+	// `seq_level_idx[0] > 7`; this helper supports both branches via `seq_tier_0`.
+	std::vector<uint8_t> BuildFullSeqHeaderPayload(uint8_t seq_profile, uint8_t seq_level_idx_0, uint8_t seq_tier_0)
+	{
+		ov::BitWriter w(16);
+		w.WriteBits(3, seq_profile);
+		w.WriteBits(1, 0);	 // still_picture
+		w.WriteBits(1, 0);	 // reduced_still_picture_header
+		w.WriteBits(1, 0);	 // timing_info_present_flag
+		w.WriteBits(1, 0);	 // initial_display_delay_present_flag
+		w.WriteBits(5, 0);	 // operating_points_cnt_minus_1
+		w.WriteBits(12, 0);	 // operating_point_idc[0]
+		w.WriteBits(5, seq_level_idx_0);
+		if (seq_level_idx_0 > 7)
+		{
+			w.WriteBits(1, seq_tier_0);
+		}
+		w.WriteBits(4, 0);	 // frame_width_bits_minus_1 -> 1 bit
+		w.WriteBits(4, 0);	 // frame_height_bits_minus_1 -> 1 bit
+		w.WriteBits(1, 0);	 // max_frame_width_minus_1
+		w.WriteBits(1, 0);	 // max_frame_height_minus_1
+		// AV1 spec 5.5.1 non-reduced continuation.
+		w.WriteBits(1, 0);	 // frame_id_numbers_present_flag
+		w.WriteBits(1, 0);	 // use_128x128_superblock
+		w.WriteBits(1, 0);	 // enable_filter_intra
+		w.WriteBits(1, 0);	 // enable_intra_edge_filter
+		w.WriteBits(1, 0);	 // enable_interintra_compound
+		w.WriteBits(1, 0);	 // enable_masked_compound
+		w.WriteBits(1, 0);	 // enable_warped_motion
+		w.WriteBits(1, 0);	 // enable_dual_filter
+		w.WriteBits(1, 0);	 // enable_order_hint
+		w.WriteBits(1, 1);	 // seq_choose_screen_content_tools -> SELECT path
+		w.WriteBits(1, 1);	 // seq_choose_integer_mv -> SELECT path (force=2 > 0)
+		w.WriteBits(1, 0);	 // enable_superres
+		w.WriteBits(1, 0);	 // enable_cdef
+		w.WriteBits(1, 0);	 // enable_restoration
+		// AV1 spec 5.5.2 `color_config()` for seq_profile 0: 8-bit, 4:2:0.
+		w.WriteBits(1, 0);	 // high_bitdepth
+		// seq_profile != 1 -> read monochrome.
+		if (seq_profile != 1)
+		{
+			w.WriteBits(1, 0);	 // monochrome = 0
+		}
+		w.WriteBits(1, 0);	 // color_description_present_flag
+		w.WriteBits(1, 0);	 // color_range
+		// seq_profile 0 -> subsampling implicit (1, 1), chroma_sample_position read (2 bits).
+		// seq_profile 1 -> subsampling implicit (0, 0), no chroma_sample_position.
+		if (seq_profile == 0)
+		{
+			w.WriteBits(2, 0);	 // chroma_sample_position
+		}
+		return std::vector<uint8_t>(w.GetData(), w.GetData() + w.GetDataSize());
+	}
+
+	// Variant of `BuildFullSeqHeaderPayload` that exercises the
+	// `initial_display_delay_present_flag` branch. AV1 spec 5.5.1: when the global flag is 1, each
+	// operating point carries a 1-bit `initial_display_delay_present_for_this_op[i]`; when that bit
+	// is 1, a 4-bit `initial_display_delay_minus_1[i]` follows.
+	std::vector<uint8_t> BuildFullSeqHeaderPayloadWithInitialDisplayDelay(
+		uint8_t seq_profile,
+		uint8_t seq_level_idx_0,
+		uint8_t seq_tier_0,
+		uint8_t initial_display_delay_present_for_op_0,
+		uint8_t initial_display_delay_minus_1_for_op_0)
+	{
+		ov::BitWriter w(16);
+		w.WriteBits(3, seq_profile);
+		w.WriteBits(1, 0);	 // still_picture
+		w.WriteBits(1, 0);	 // reduced_still_picture_header
+		w.WriteBits(1, 0);	 // timing_info_present_flag
+		w.WriteBits(1, 1);	 // initial_display_delay_present_flag = 1 (enable per-op signaling)
+		w.WriteBits(5, 0);	 // operating_points_cnt_minus_1
+		w.WriteBits(12, 0);	 // operating_point_idc[0]
+		w.WriteBits(5, seq_level_idx_0);
+		if (seq_level_idx_0 > 7)
+		{
+			w.WriteBits(1, seq_tier_0);
+		}
+		// AV1 spec 5.5.1: per-op presence flag follows when global flag == 1.
+		w.WriteBits(1, initial_display_delay_present_for_op_0);
+		if (initial_display_delay_present_for_op_0 != 0)
+		{
+			w.WriteBits(4, initial_display_delay_minus_1_for_op_0 & 0x0F);
+		}
+		w.WriteBits(4, 0);	 // frame_width_bits_minus_1 -> 1 bit
+		w.WriteBits(4, 0);	 // frame_height_bits_minus_1 -> 1 bit
+		w.WriteBits(1, 0);	 // max_frame_width_minus_1
+		w.WriteBits(1, 0);	 // max_frame_height_minus_1
+		// AV1 spec 5.5.1 non-reduced continuation.
+		w.WriteBits(1, 0);	 // frame_id_numbers_present_flag
+		w.WriteBits(1, 0);	 // use_128x128_superblock
+		w.WriteBits(1, 0);	 // enable_filter_intra
+		w.WriteBits(1, 0);	 // enable_intra_edge_filter
+		w.WriteBits(1, 0);	 // enable_interintra_compound
+		w.WriteBits(1, 0);	 // enable_masked_compound
+		w.WriteBits(1, 0);	 // enable_warped_motion
+		w.WriteBits(1, 0);	 // enable_dual_filter
+		w.WriteBits(1, 0);	 // enable_order_hint
+		w.WriteBits(1, 1);	 // seq_choose_screen_content_tools -> SELECT path
+		w.WriteBits(1, 1);	 // seq_choose_integer_mv -> SELECT path (force=2 > 0)
+		w.WriteBits(1, 0);	 // enable_superres
+		w.WriteBits(1, 0);	 // enable_cdef
+		w.WriteBits(1, 0);	 // enable_restoration
+		// AV1 spec 5.5.2 `color_config()` for seq_profile 0: 8-bit, 4:2:0.
+		w.WriteBits(1, 0);	 // high_bitdepth
+		if (seq_profile != 1)
+		{
+			w.WriteBits(1, 0);	 // monochrome = 0
+		}
+		w.WriteBits(1, 0);	 // color_description_present_flag
+		w.WriteBits(1, 0);	 // color_range
+		if (seq_profile == 0)
+		{
+			w.WriteBits(2, 0);	 // chroma_sample_position
+		}
+		return std::vector<uint8_t>(w.GetData(), w.GetData() + w.GetDataSize());
+	}
+
+	std::vector<uint8_t> BuildSeqHeaderObu(uint8_t seq_profile, uint8_t seq_level_idx_0)
+	{
+		return BuildObu(Av1ObuType::SequenceHeader, BuildReducedSeqHeaderPayload(seq_profile, seq_level_idx_0));
+	}
+
+	// Build a minimal valid `av1C` blob for the given fields, no `configOBUs`.
+	//
+	// `byte0`: `marker(1)=1`, `version(7)=1`                              -> `0x81`
+	// `byte1`: `seq_profile(3)`, `seq_level_idx_0(5)`
+	// `byte2`: `seq_tier_0(1)`, `high_bitdepth(1)`, `twelve_bit(1)`,
+	//          `monochrome(1)`, `chroma_subsampling_x(1)`,
+	//          `chroma_subsampling_y(1)`, `chroma_sample_position(2)`
+	// `byte3`: `reserved(3)=0`, `initial_presentation_delay_present(1)`,
+	//          [`delay_minus_one(4)` | `reserved(4)=0`]
+	std::vector<uint8_t> BuildAv1cHeader(
+		uint8_t seq_profile,
+		uint8_t seq_level_idx_0,
+		uint8_t seq_tier_0,
+		uint8_t high_bitdepth,
+		uint8_t twelve_bit,
+		uint8_t monochrome,
+		uint8_t chroma_subsampling_x,
+		uint8_t chroma_subsampling_y,
+		uint8_t chroma_sample_position,
+		bool delay_present,
+		uint8_t delay_minus_one)
+	{
+		std::vector<uint8_t> bytes;
+		bytes.push_back(0x81);
+		bytes.push_back(static_cast<uint8_t>(((seq_profile & 0x07) << 5) | (seq_level_idx_0 & 0x1F)));
+
+		uint8_t b2 = 0;
+		b2 |= (seq_tier_0 & 0x01) << 7;
+		b2 |= (high_bitdepth & 0x01) << 6;
+		b2 |= (twelve_bit & 0x01) << 5;
+		b2 |= (monochrome & 0x01) << 4;
+		b2 |= (chroma_subsampling_x & 0x01) << 3;
+		b2 |= (chroma_subsampling_y & 0x01) << 2;
+		b2 |= (chroma_sample_position & 0x03);
+		bytes.push_back(b2);
+
+		uint8_t b3 = 0;
+		b3 |= (delay_present ? 0x10 : 0x00);
+		b3 |= (delay_present ? (delay_minus_one & 0x0F) : 0x00);
+		bytes.push_back(b3);
+
+		return bytes;
+	}
+}  // namespace
+
+TEST(AV1DecoderConfigurationRecord, ParseValidMainProfile8Bit)
+{
+	// `profile=0`, `level_idx=4` (=> `"04"`), `tier=0` (`M`), `high_bitdepth=0`,
+	// `twelve_bit=0`, `monochrome=0`, `sub_x=1`, `sub_y=1`, `csp=0`,
+	// no presentation delay.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+
+	AV1DecoderConfigurationRecord record;
+	ASSERT_TRUE(record.Parse(MakeData(bytes)));
+
+	EXPECT_EQ(record.Marker(), 1);
+	EXPECT_EQ(record.Version(), 1);
+	EXPECT_EQ(record.SeqProfile(), 0);
+	EXPECT_EQ(record.SeqLevelIdx0(), 4);
+	EXPECT_EQ(record.SeqTier0(), 0);
+	EXPECT_EQ(record.HighBitdepth(), 0);
+	EXPECT_EQ(record.TwelveBit(), 0);
+	EXPECT_EQ(record.Monochrome(), 0);
+	EXPECT_EQ(record.ChromaSubsamplingX(), 1);
+	EXPECT_EQ(record.ChromaSubsamplingY(), 1);
+	EXPECT_EQ(record.ChromaSamplePosition(), 0);
+	EXPECT_EQ(record.InitialPresentationDelayPresent(), 0);
+	EXPECT_EQ(record.BitDepth(), 8);
+	EXPECT_TRUE(record.IsValid());
+	EXPECT_EQ(record.GetCodecsParameter(), "av01.0.04M.08");
+}
+
+TEST(AV1DecoderConfigurationRecord, ParseHighTier10Bit)
+{
+	// `profile=2`, `level_idx=8`, `tier=1` (`H`), `high_bitdepth=1`,
+	// `twelve_bit=0` -> 10-bit
+	auto bytes = BuildAv1cHeader(2, 8, 1, 1, 0, 0, 1, 1, 0, false, 0);
+
+	AV1DecoderConfigurationRecord record;
+	ASSERT_TRUE(record.Parse(MakeData(bytes)));
+
+	EXPECT_EQ(record.SeqProfile(), 2);
+	EXPECT_EQ(record.SeqLevelIdx0(), 8);
+	EXPECT_EQ(record.SeqTier0(), 1);
+	EXPECT_EQ(record.BitDepth(), 10);
+	EXPECT_EQ(record.GetCodecsParameter(), "av01.2.08H.10");
+}
+
+TEST(AV1DecoderConfigurationRecord, ParseHighTier12Bit)
+{
+	// `profile=2`, `high_bitdepth=1`, `twelve_bit=1` -> 12-bit
+	auto bytes = BuildAv1cHeader(2, 13, 1, 1, 1, 0, 1, 1, 0, false, 0);
+
+	AV1DecoderConfigurationRecord record;
+	ASSERT_TRUE(record.Parse(MakeData(bytes)));
+
+	EXPECT_EQ(record.BitDepth(), 12);
+	EXPECT_EQ(record.GetCodecsParameter(), "av01.2.13H.12");
+}
+
+TEST(AV1DecoderConfigurationRecord, ParseWithInitialPresentationDelay)
+{
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, true, 7);
+
+	AV1DecoderConfigurationRecord record;
+	ASSERT_TRUE(record.Parse(MakeData(bytes)));
+
+	EXPECT_EQ(record.InitialPresentationDelayPresent(), 1);
+	EXPECT_EQ(record.InitialPresentationDelayMinusOne(), 7);
+}
+
+TEST(AV1DecoderConfigurationRecord, ParseWithConfigObus)
+{
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+	// Spec-valid `configOBUs`: a Sequence Header OBU whose `seq_profile` / `seq_level_idx_0`
+	// match the fixed `av1C` fields (cross-check rule).
+	const auto obus = BuildSeqHeaderObu(0, 4);
+	bytes.insert(bytes.end(), obus.begin(), obus.end());
+
+	AV1DecoderConfigurationRecord record;
+	ASSERT_TRUE(record.Parse(MakeData(bytes)));
+
+	auto config_obus = record.ConfigObus();
+	ASSERT_NE(config_obus, nullptr);
+	ASSERT_EQ(config_obus->GetLength(), obus.size());
+	EXPECT_EQ(std::memcmp(config_obus->GetDataAs<uint8_t>(), obus.data(), obus.size()), 0);
+}
+
+TEST(AV1DecoderConfigurationRecord, RoundTripSerialize)
+{
+	// av1C must encode values consistent with the embedded Sequence Header OBU:
+	//   seq_profile = 0  -> AV1 spec 5.5.2: subsampling 4:2:0 implicit (1, 1)
+	//   seq_level_idx_0 = 4 (<=7 -> seq_tier_0 inferred to 0)
+	//   high_bitdepth = 0, twelve_bit = 0, monochrome = 0
+	//   chroma_sample_position = 0 (CSP_UNKNOWN)
+	// AV1 ISOBMFF binding v1.2.0 section 2.3.2 also requires the embedded SH
+	// `initial_display_delay_present_for_op_0` / `_minus_1_for_op_0` to match the av1C fields, so
+	// use the full (non-reduced) SH builder that can carry initial_display_delay signaling.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, true, 5);
+	const auto sh = BuildFullSeqHeaderPayloadWithInitialDisplayDelay(
+		/*seq_profile=*/0, /*seq_level_idx_0=*/4, /*seq_tier_0=*/0,
+		/*initial_display_delay_present_for_op_0=*/1,
+		/*initial_display_delay_minus_1_for_op_0=*/5);
+	const auto obus = BuildObu(Av1ObuType::SequenceHeader, sh);
+	bytes.insert(bytes.end(), obus.begin(), obus.end());
+
+	AV1DecoderConfigurationRecord record;
+	ASSERT_TRUE(record.Parse(MakeData(bytes)));
+
+	auto serialized = record.GetData();
+	ASSERT_NE(serialized, nullptr);
+	ASSERT_EQ(serialized->GetLength(), bytes.size());
+	EXPECT_EQ(std::memcmp(serialized->GetDataAs<uint8_t>(), bytes.data(), bytes.size()), 0);
+
+	AV1DecoderConfigurationRecord reparsed;
+	ASSERT_TRUE(reparsed.Parse(serialized));
+	EXPECT_EQ(reparsed.SeqProfile(), 0);
+	EXPECT_EQ(reparsed.SeqLevelIdx0(), 4);
+	EXPECT_EQ(reparsed.SeqTier0(), 0);
+	EXPECT_EQ(reparsed.InitialPresentationDelayPresent(), 1);
+	EXPECT_EQ(reparsed.InitialPresentationDelayMinusOne(), 5);
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsInvalidMarker)
+{
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+	// Clear marker bit -> `byte0` becomes `0x01` (`marker=0`, `version=1`).
+	bytes[0] = 0x01;
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+	EXPECT_FALSE(record.IsValid());
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsInvalidVersion)
+{
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+	// `marker=1`, `version=2` -> `0x82`.
+	bytes[0] = 0x82;
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+	EXPECT_FALSE(record.IsValid());
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsTooShort)
+{
+	std::vector<uint8_t> bytes = {0x81, 0x00, 0x00};
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsNullData)
+{
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(nullptr));
+}
+
+// ffmpeg's `libaom-av1` muxer over enhanced-RTMP emits an empty
+// `AV1CodecConfigurationRecord` blob in its first `SequenceStart` message. The
+// strict ISO/BMFF spec requires at least a marker + version + base fields, so
+// `Parse()` returns false on empty input - the caller (`flv::VideoParser`) must
+// synthesize a defaults blob in that case (see `flv_video_parser.cpp`).
+//
+// This test guards the strict-parser behavior: a fully empty buffer must be
+// rejected (`Parse` returns false), and the synthesized defaults buffer used
+// by the lenient ffmpeg-compat branch must `Parse` successfully.
+TEST(AV1DecoderConfigurationRecord, RejectsEmptyBlob)
+{
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(std::make_shared<ov::Data>()));
+	EXPECT_FALSE(record.IsValid());
+}
+
+TEST(AV1DecoderConfigurationRecord, ParsesSynthesizedDefaults)
+{
+	// Matches the literal used in `flv_video_parser.cpp` `ParseAV1` lenient
+	// branch: `marker=1`, `version=1`, all other fields zero.
+	const std::vector<uint8_t> defaults = {0x81, 0x00, 0x00, 0x00};
+
+	AV1DecoderConfigurationRecord record;
+	ASSERT_TRUE(record.Parse(MakeData(defaults)));
+	EXPECT_TRUE(record.IsValid());
+	EXPECT_EQ(record.Marker(), 1);
+	EXPECT_EQ(record.Version(), 1);
+	EXPECT_EQ(record.ConfigObus(), nullptr);
+}
+
+TEST(AV1DecoderConfigurationRecord, ParsesFfmpegLibaomAv1Capture)
+{
+	// Exact 17-byte `av1C` blob captured from `ffmpeg n6.x -c:v libaom-av1`
+	// pushing to `OvenMediaEngine` over enhanced-RTMP. This is the SECOND
+	// `SequenceStart` payload that arrives ~1.8s after the empty placeholder;
+	// it must parse cleanly.
+	const std::vector<uint8_t> ffmpeg_av1c = {
+		0x81,
+		0x00,
+		0x0C,
+		0x00,
+		0x0A, 0x0B, 0x00, 0x00, 0x00, 0x04, 0x3C, 0xFF, 0xBC, 0xDA, 0xF9, 0x00, 0x40,
+	};
+
+	AV1DecoderConfigurationRecord record;
+	ASSERT_TRUE(record.Parse(MakeData(ffmpeg_av1c)));
+	EXPECT_TRUE(record.IsValid());
+
+	EXPECT_EQ(record.Marker(), 1);
+	EXPECT_EQ(record.Version(), 1);
+	EXPECT_EQ(record.SeqProfile(), 0);
+	EXPECT_EQ(record.SeqLevelIdx0(), 0);
+	EXPECT_EQ(record.SeqTier0(), 0);
+	EXPECT_EQ(record.HighBitdepth(), 0);
+	EXPECT_EQ(record.TwelveBit(), 0);
+	EXPECT_EQ(record.Monochrome(), 0);
+	EXPECT_EQ(record.ChromaSubsamplingX(), 1);
+	EXPECT_EQ(record.ChromaSubsamplingY(), 1);
+	EXPECT_EQ(record.ChromaSamplePosition(), 0);
+	EXPECT_EQ(record.InitialPresentationDelayPresent(), 0);
+	EXPECT_EQ(record.BitDepth(), 8);
+
+	auto config_obus = record.ConfigObus();
+	ASSERT_NE(config_obus, nullptr);
+	EXPECT_EQ(config_obus->GetLength(), 13U);
+}
+
+// AV1 ISOBMFF binding v1.2.0 section 2.3 defines `AV1CodecConfigurationRecord` as the
+// canonical serialized form of the av1C box. `Equals()` therefore promises byte-for-byte
+// equality of that form. Each case below differs by exactly ONE field and asserts the
+// expected `Equals()` result.
+TEST(AV1DecoderConfigurationRecord, EqualsByByteIdenticalSerializedForm)
+{
+	// Baseline: a fully-populated av1C blob.
+	auto baseline_bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, /*delay_present=*/true, /*delay_minus_one=*/3);
+
+	auto baseline = std::make_shared<AV1DecoderConfigurationRecord>();
+	ASSERT_TRUE(baseline->Parse(MakeData(baseline_bytes)));
+
+	// Identical clone -> Equals true.
+	{
+		auto clone = std::make_shared<AV1DecoderConfigurationRecord>();
+		ASSERT_TRUE(clone->Parse(MakeData(baseline_bytes)));
+		EXPECT_TRUE(baseline->Equals(clone));
+	}
+
+	// Differ only in `seq_profile` -> Equals false (regression check - old contract caught
+	// this too, but the new contract still must).
+	{
+		auto bytes	= BuildAv1cHeader(1, 4, 0, 0, 0, 0, 0, 0, 0, true, 3);
+		auto record = std::make_shared<AV1DecoderConfigurationRecord>();
+		ASSERT_TRUE(record->Parse(MakeData(bytes)));
+		EXPECT_FALSE(baseline->Equals(record));
+	}
+
+	// Differ only in `monochrome` -> Equals false. Old weak contract returned TRUE here.
+	// `monochrome = 1` with seq_profile != 1 is a spec-valid av1C fixed-header encoding when
+	// no configOBUs are attached (the cross-check only runs against an embedded SH).
+	{
+		auto bytes	= BuildAv1cHeader(0, 4, 0, 0, 0, 1, 1, 1, 0, true, 3);
+		auto record = std::make_shared<AV1DecoderConfigurationRecord>();
+		ASSERT_TRUE(record->Parse(MakeData(bytes)));
+		EXPECT_FALSE(baseline->Equals(record));
+	}
+
+	// Differ only in `chroma_subsampling_x` -> Equals false. Old weak contract returned TRUE.
+	{
+		auto bytes	= BuildAv1cHeader(0, 4, 0, 0, 0, 0, 0, 1, 0, true, 3);
+		auto record = std::make_shared<AV1DecoderConfigurationRecord>();
+		ASSERT_TRUE(record->Parse(MakeData(bytes)));
+		EXPECT_FALSE(baseline->Equals(record));
+	}
+
+	// Differ only in `chroma_sample_position` -> Equals false. Old weak contract returned TRUE.
+	{
+		auto bytes	= BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 2, true, 3);
+		auto record = std::make_shared<AV1DecoderConfigurationRecord>();
+		ASSERT_TRUE(record->Parse(MakeData(bytes)));
+		EXPECT_FALSE(baseline->Equals(record));
+	}
+
+	// Differ only in `initial_presentation_delay_minus_one` (delay_present stays 1, value
+	// changes) -> Equals false. Old weak contract returned TRUE.
+	{
+		auto bytes	= BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, true, 7);
+		auto record = std::make_shared<AV1DecoderConfigurationRecord>();
+		ASSERT_TRUE(record->Parse(MakeData(bytes)));
+		EXPECT_FALSE(baseline->Equals(record));
+	}
+
+	// Differ only in `configOBUs` payload -> Equals false. Old weak contract returned TRUE.
+	// Cross-check: both records share the same fixed-header fields but one attaches a
+	// spec-valid Sequence Header OBU while the other does not.
+	{
+		auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, true, 3);
+		const auto sh = BuildFullSeqHeaderPayloadWithInitialDisplayDelay(
+			/*seq_profile=*/0, /*seq_level_idx_0=*/4, /*seq_tier_0=*/0,
+			/*initial_display_delay_present_for_op_0=*/1,
+			/*initial_display_delay_minus_1_for_op_0=*/3);
+		const auto obus = BuildObu(Av1ObuType::SequenceHeader, sh);
+		bytes.insert(bytes.end(), obus.begin(), obus.end());
+		auto record = std::make_shared<AV1DecoderConfigurationRecord>();
+		ASSERT_TRUE(record->Parse(MakeData(bytes)));
+		EXPECT_FALSE(baseline->Equals(record));
+	}
+
+	// `dynamic_pointer_cast<AV1DecoderConfigurationRecord>` failure -> Equals false. A stub
+	// non-AV1 sibling exercises the runtime-type branch without pulling in H264/H265 deps.
+	{
+		class StubDecoderConfigurationRecord : public DecoderConfigurationRecord
+		{
+		public:
+			bool Parse(const std::shared_ptr<const ov::Data> & /*data*/) override { return true; }
+			bool IsValid() const override { return true; }
+			bool Equals(const std::shared_ptr<DecoderConfigurationRecord> & /*other*/) override { return false; }
+			ov::String GetCodecsParameter() const override { return ""; }
+
+		protected:
+			std::shared_ptr<const ov::Data> Serialize() override { return std::make_shared<ov::Data>(); }
+		};
+
+		auto stub = std::make_shared<StubDecoderConfigurationRecord>();
+		EXPECT_FALSE(baseline->Equals(stub));
+	}
+
+	// Null other -> Equals false (matches base-class contract).
+	{
+		EXPECT_FALSE(baseline->Equals(nullptr));
+	}
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsMalformedConfigObu)
+{
+	// `configOBUs` containing an OBU with `obu_reserved_1bit = 1` -> rejected at the
+	// OBU header walk per AV1 spec 5.3.2.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+	bytes.push_back(0x09);  // type=SequenceHeader, ext=0, has_size=0, reserved=1 (invalid)
+	bytes.push_back(0x00);
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsConfigObuSeqProfileMismatch)
+{
+	// AV1 ISOBMFF binding v1.2.0: Sequence Header OBU `seq_profile` must equal `av1C` field.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+	// Embedded sequence header says `seq_profile=1`, but `av1C` says `0`.
+	const auto obus = BuildSeqHeaderObu(1, 4);
+	bytes.insert(bytes.end(), obus.begin(), obus.end());
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsConfigObuSeqLevelMismatch)
+{
+	// AV1 ISOBMFF binding v1.2.0: `seq_level_idx_0` cross-check failure.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+	// Embedded sequence header says `seq_level_idx_0=7`, but `av1C` says `4`.
+	const auto obus = BuildSeqHeaderObu(0, 7);
+	bytes.insert(bytes.end(), obus.begin(), obus.end());
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsSequenceHeaderNotFirstObu)
+{
+	// AV1 ISOBMFF binding v1.2.0: "If present, the Sequence Header OBU SHALL be the first OBU."
+	auto bytes	   = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+	const auto td  = BuildObu(Av1ObuType::TemporalDelimiter, {});
+	const auto seq = BuildSeqHeaderObu(0, 4);
+	bytes.insert(bytes.end(), td.begin(), td.end());
+	bytes.insert(bytes.end(), seq.begin(), seq.end());
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsMultipleSequenceHeaders)
+{
+	// AV1 ISOBMFF binding v1.2.0: "At most one Sequence Header OBU SHALL be present."
+	// (Two sequence headers also violates the "first OBU" rule; either condition rejects.)
+	auto bytes		 = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+	const auto seq_a = BuildSeqHeaderObu(0, 4);
+	const auto seq_b = BuildSeqHeaderObu(0, 4);
+	bytes.insert(bytes.end(), seq_a.begin(), seq_a.end());
+	bytes.insert(bytes.end(), seq_b.begin(), seq_b.end());
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, AcceptsConfigObusWithoutSequenceHeader)
+{
+	// `configOBUs` containing only a Temporal Delimiter is valid (no cross-check needed).
+	auto bytes	  = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+	const auto td = BuildObu(Av1ObuType::TemporalDelimiter, {});
+	bytes.insert(bytes.end(), td.begin(), td.end());
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_TRUE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsSeqProfileReserved)
+{
+	// AV1 spec 6.4.1: "seq_profile shall be in the range of 0 to 2." Values 3..7 are reserved.
+	for (uint8_t profile : {3, 4, 5, 6, 7})
+	{
+		// `BuildAv1cHeader` packs `seq_profile` as the top 3 bits of byte 1; values <= 7 fit.
+		auto bytes = BuildAv1cHeader(profile, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+		AV1DecoderConfigurationRecord record;
+		EXPECT_FALSE(record.Parse(MakeData(bytes))) << "seq_profile=" << static_cast<int>(profile);
+	}
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsReservedChromaSamplePosition)
+{
+	// AV1 spec 6.4.2 Table 8: `chroma_sample_position = 3` (`CSP_RESERVED`) is reserved.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 3, false, 0);
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsConfigObuSeqTierMismatch)
+{
+	// AV1 ISOBMFF binding v1.2.0 section 2.3.2: `seq_tier_0` cross-check failure. Embedded SH has
+	// `seq_level_idx_0 = 8 > 7` and `seq_tier_0 = 1`, but av1C says `seq_tier_0 = 0`.
+	auto bytes	  = BuildAv1cHeader(0, 8, 0, 0, 0, 0, 1, 1, 0, false, 0);
+	const auto sh = BuildFullSeqHeaderPayload(0, 8, /*seq_tier_0=*/1);
+	const auto obus = BuildObu(Av1ObuType::SequenceHeader, sh);
+	bytes.insert(bytes.end(), obus.begin(), obus.end());
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsConfigObuHighBitDepthMismatch)
+{
+	// AV1 ISOBMFF binding v1.2.0 section 2.3.2: `high_bitdepth` cross-check failure. Embedded SH
+	// sets `high_bitdepth = 1`; av1C declares 0.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+	ReducedSeqHeaderFields f;
+	f.seq_profile	  = 0;
+	f.seq_level_idx_0 = 4;
+	f.high_bitdepth	  = 1;	// mismatch
+	const auto obus	  = BuildObu(Av1ObuType::SequenceHeader, BuildReducedSeqHeaderPayloadEx(f));
+	bytes.insert(bytes.end(), obus.begin(), obus.end());
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsConfigObuMonochromeMismatch)
+{
+	// AV1 ISOBMFF binding v1.2.0 section 2.3.2: `monochrome` cross-check failure. Embedded SH sets
+	// `monochrome = 1`; av1C declares 0. Monochrome forces subsampling (1, 1) implicitly so the
+	// other av1C fields stay consistent.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+	ReducedSeqHeaderFields f;
+	f.seq_profile	  = 0;
+	f.seq_level_idx_0 = 4;
+	f.monochrome	  = 1;	// mismatch
+	const auto obus	  = BuildObu(Av1ObuType::SequenceHeader, BuildReducedSeqHeaderPayloadEx(f));
+	bytes.insert(bytes.end(), obus.begin(), obus.end());
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsConfigObuChromaSubsamplingMismatch)
+{
+	// AV1 ISOBMFF binding v1.2.0 section 2.3.2: `chroma_subsampling_x` / `chroma_subsampling_y` must
+	// match. With `seq_profile = 1` the spec forces 4:4:4 (0, 0); but av1C declares (1, 1). The
+	// embedded SH (profile 1) yields (0, 0) -> cross-check rejects.
+	auto bytes = BuildAv1cHeader(1, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+	ReducedSeqHeaderFields f;
+	f.seq_profile	  = 1;
+	f.seq_level_idx_0 = 4;
+	const auto obus	  = BuildObu(Av1ObuType::SequenceHeader, BuildReducedSeqHeaderPayloadEx(f));
+	bytes.insert(bytes.end(), obus.begin(), obus.end());
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsConfigObuChromaSamplePositionMismatch)
+{
+	// AV1 ISOBMFF binding v1.2.0 section 2.3.2: "chroma_sample_position (when not zero) ... shall
+	// match." av1C declares `chroma_sample_position = 2`; SH yields 0 (default in our builder when
+	// not explicitly set) - mismatch must be rejected because av1C value is non-zero.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 2, false, 0);
+	ReducedSeqHeaderFields f;
+	f.seq_profile			 = 0;
+	f.seq_level_idx_0		 = 4;
+	f.chroma_sample_position = 0;	 // mismatch vs av1C's 2
+	const auto obus			 = BuildObu(Av1ObuType::SequenceHeader, BuildReducedSeqHeaderPayloadEx(f));
+	bytes.insert(bytes.end(), obus.begin(), obus.end());
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, AcceptsZeroChromaSamplePositionMismatch)
+{
+	// AV1 ISOBMFF binding v1.2.0 section 2.3.2 spec exception: when av1C `chroma_sample_position`
+	// is 0, the cross-check is skipped even if the embedded SH carries a non-zero value.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, false, 0);
+	ReducedSeqHeaderFields f;
+	f.seq_profile			 = 0;
+	f.seq_level_idx_0		 = 4;
+	f.chroma_sample_position = 2;	 // SH says 2, but av1C says 0 - spec allows.
+	const auto obus			 = BuildObu(Av1ObuType::SequenceHeader, BuildReducedSeqHeaderPayloadEx(f));
+	bytes.insert(bytes.end(), obus.begin(), obus.end());
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_TRUE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, AcceptsConfigObuInitialPresentationDelayMatch)
+{
+	// AV1 ISOBMFF binding v1.2.0 section 2.3.2: "initial_presentation_delay_minus_one, when present,
+	// all shall match." Positive case - av1C declares `present = 1`, `minus_one = 5`; the embedded
+	// Sequence Header carries the same per-op-0 values, so cross-check accepts.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, /*delay_present=*/true, /*delay_minus_one=*/5);
+	const auto sh = BuildFullSeqHeaderPayloadWithInitialDisplayDelay(
+		/*seq_profile=*/0, /*seq_level_idx_0=*/4, /*seq_tier_0=*/0,
+		/*initial_display_delay_present_for_op_0=*/1,
+		/*initial_display_delay_minus_1_for_op_0=*/5);
+	const auto obus = BuildObu(Av1ObuType::SequenceHeader, sh);
+	bytes.insert(bytes.end(), obus.begin(), obus.end());
+
+	AV1DecoderConfigurationRecord record;
+	ASSERT_TRUE(record.Parse(MakeData(bytes)));
+	EXPECT_EQ(record.InitialPresentationDelayPresent(), 1);
+	EXPECT_EQ(record.InitialPresentationDelayMinusOne(), 5);
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsConfigObuInitialPresentationDelayPresentMismatch)
+{
+	// AV1 ISOBMFF binding v1.2.0 section 2.3.2: presence-flag mismatch must reject. av1C says
+	// `initial_presentation_delay_present = 1`, but the embedded SH carries
+	// `initial_display_delay_present_for_op_0 = 0` -> reject.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, /*delay_present=*/true, /*delay_minus_one=*/3);
+	const auto sh = BuildFullSeqHeaderPayloadWithInitialDisplayDelay(
+		/*seq_profile=*/0, /*seq_level_idx_0=*/4, /*seq_tier_0=*/0,
+		/*initial_display_delay_present_for_op_0=*/0,
+		/*initial_display_delay_minus_1_for_op_0=*/0);
+	const auto obus = BuildObu(Av1ObuType::SequenceHeader, sh);
+	bytes.insert(bytes.end(), obus.begin(), obus.end());
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsConfigObuWithoutSizeField)
+{
+	// AV1 ISOBMFF binding v1.2.0: every OBU inside `configOBUs` SHALL set `obu_has_size_field = 1`.
+	// Build an av1C blob whose `configOBUs` contains a Sequence Header OBU with
+	// `obu_has_size_field = 0` (header byte = `0x08`: `forbidden_bit=0`, `obu_type=1`,
+	// `ext_flag=0`, `has_size=0`, `reserved_1bit=0`) -> strict parser must reject.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, /*delay_present=*/false, /*delay_minus_one=*/0);
+	// Manually craft the OBU since `BuildObu` always sets `has_size_field = 1`.
+	const auto sh_payload = BuildReducedSeqHeaderPayload(0, 4);
+	bytes.push_back(static_cast<uint8_t>(0x08));  // SH header, has_size_field = 0
+	bytes.insert(bytes.end(), sh_payload.begin(), sh_payload.end());
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsFixedHeaderReserved3BitsNonZero)
+{
+	// AV1 ISOBMFF binding v1.2.0 section 2.3.1: the 3-bit `reserved` field in the fixed av1C
+	// header SHALL be 0. `BuildAv1cHeader` always writes 0; inject a non-zero value into the top
+	// 3 bits of byte 3 to exercise the strict reject.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, /*delay_present=*/false, /*delay_minus_one=*/0);
+	ASSERT_EQ(bytes.size(), 4U);
+	// byte 3 layout: `reserved(3) | initial_presentation_delay_present(1) | [delay_minus_one(4) | reserved(4)]`.
+	// Set top 3 bits to 0b101 -> 0xA0.
+	bytes[3] = static_cast<uint8_t>((bytes[3] & 0x1F) | 0xA0);
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+	EXPECT_FALSE(record.IsValid());
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsFixedHeaderReserved4BitsNonZero)
+{
+	// AV1 ISOBMFF binding v1.2.0 section 2.3.1: when `initial_presentation_delay_present == 0`,
+	// the trailing 4-bit `reserved` field SHALL be 0. `BuildAv1cHeader` writes 0; inject a
+	// non-zero value into the low 4 bits of byte 3.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, /*delay_present=*/false, /*delay_minus_one=*/0);
+	ASSERT_EQ(bytes.size(), 4U);
+	// Keep top 3 reserved bits at 0, presence bit at 0, set low 4 bits to 0xB.
+	bytes[3] = static_cast<uint8_t>((bytes[3] & 0xF0) | 0x0B);
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+	EXPECT_FALSE(record.IsValid());
+}
+
+TEST(AV1DecoderConfigurationRecord, RejectsConfigObuInitialPresentationDelayValueMismatch)
+{
+	// AV1 ISOBMFF binding v1.2.0 section 2.3.2: when both sides set `present = 1`, the
+	// `_minus_one` values must match. av1C declares 5; SH declares 7 -> reject.
+	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, /*delay_present=*/true, /*delay_minus_one=*/5);
+	const auto sh = BuildFullSeqHeaderPayloadWithInitialDisplayDelay(
+		/*seq_profile=*/0, /*seq_level_idx_0=*/4, /*seq_tier_0=*/0,
+		/*initial_display_delay_present_for_op_0=*/1,
+		/*initial_display_delay_minus_1_for_op_0=*/7);
+	const auto obus = BuildObu(Av1ObuType::SequenceHeader, sh);
+	bytes.insert(bytes.end(), obus.begin(), obus.end());
+
+	AV1DecoderConfigurationRecord record;
+	EXPECT_FALSE(record.Parse(MakeData(bytes)));
+}

--- a/src/projects/modules/bitstream/av1/av1_parser.cpp
+++ b/src/projects/modules/bitstream/av1/av1_parser.cpp
@@ -1,0 +1,646 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include "av1_parser.h"
+
+#define OV_LOG_TAG "Av1Parser"
+
+#define AV1_READ_BITS(type, value, bits)           \
+	type value;                                    \
+	if (reader.ReadBits(bits, value) == false)     \
+	{                                              \
+		return std::nullopt;                       \
+	}
+
+std::optional<DecodedLeb128> Av1Parser::DecodeLeb128(const uint8_t *data, size_t size)
+{
+	if (data == nullptr)
+	{
+		return std::nullopt;
+	}
+
+	uint64_t result = 0;
+	size_t i		= 0;
+
+	// AV1 spec 4.10.5: at most 8 bytes; low 7 bits per byte; MSB (`0x80`) indicates continuation.
+	for (; i < 8; i++)
+	{
+		if (i >= size)
+		{
+			return std::nullopt;
+		}
+
+		const uint8_t byte = data[i];
+		result |= static_cast<uint64_t>(byte & 0x7F) << (i * 7);
+
+		if ((byte & 0x80) == 0)
+		{
+			DecodedLeb128 decoded;
+			decoded.value		   = result;
+			decoded.bytes_consumed = i + 1;
+			return decoded;
+		}
+	}
+
+	// Reached 8 bytes without a terminator.
+	return std::nullopt;
+}
+
+std::optional<Av1ObuHeader> Av1Parser::ParseObuHeader(BitReader &reader)
+{
+	if (reader.BytesRemained() < 1)
+	{
+		return std::nullopt;
+	}
+
+	// AV1 spec 5.3.2 `obu_header()`
+	AV1_READ_BITS(uint8_t, forbidden_bit, 1);		// obu_forbidden_bit
+	if (forbidden_bit != 0)
+	{
+		return std::nullopt;
+	}
+
+	AV1_READ_BITS(uint8_t, obu_type, 4);				// obu_type
+	AV1_READ_BITS(uint8_t, extension_flag, 1);		// obu_extension_flag
+	AV1_READ_BITS(uint8_t, has_size_field, 1);		// obu_has_size_field
+	AV1_READ_BITS(uint8_t, reserved_bit, 1);			// obu_reserved_1bit
+
+	// AV1 spec 5.3.2 Table 5: "It is a requirement of bitstream conformance that the value of obu_type
+	// is not equal to one of the reserved values." Reserved values per Table 5 are 0 and 9..14.
+	if (obu_type == 0 || (obu_type >= 9 && obu_type <= 14))
+	{
+		return std::nullopt;
+	}
+
+	// AV1 spec 5.3.2: "obu_reserved_1bit ... shall be set to 0." Reject any OBU header that violates
+	// this conformance requirement so the strict parser does not silently accept malformed bitstreams.
+	if (reserved_bit != 0)
+	{
+		return std::nullopt;
+	}
+
+	Av1ObuHeader out;
+	out.type			= static_cast<Av1ObuType>(obu_type);
+	out.extension_flag	= (extension_flag != 0);
+	out.has_size_field	= (has_size_field != 0);
+	out.temporal_id		= 0;
+	out.spatial_id		= 0;
+
+	if (out.extension_flag)
+	{
+		if (reader.BytesRemained() < 1)
+		{
+			return std::nullopt;
+		}
+
+		// AV1 spec 5.3.3 `obu_extension_header()`
+		AV1_READ_BITS(uint8_t, temporal_id, 3);				// temporal_id
+		AV1_READ_BITS(uint8_t, spatial_id, 2);				// spatial_id
+		AV1_READ_BITS(uint8_t, ext_reserved, 3);				// extension_header_reserved_3bits
+
+		// AV1 spec 5.3.3: "extension_header_reserved_3bits ... shall be set to 0." Reject when the
+		// reserved bits carry any non-zero value.
+		if (ext_reserved != 0)
+		{
+			return std::nullopt;
+		}
+
+		out.temporal_id = temporal_id;
+		out.spatial_id	= spatial_id;
+	}
+
+	return out;
+}
+
+std::optional<ParsedObuHeader> Av1Parser::ParseObuHeader(const uint8_t *data, size_t size)
+{
+	if (data == nullptr)
+	{
+		return std::nullopt;
+	}
+
+	BitReader reader(data, size);
+	auto header = ParseObuHeader(reader);
+	if (header.has_value() == false)
+	{
+		return std::nullopt;
+	}
+
+	ParsedObuHeader parsed;
+	parsed.header		  = *header;
+	parsed.bytes_consumed = reader.BytesConsumed();
+	return parsed;
+}
+
+std::shared_ptr<const ov::Data> Av1Parser::ExtractFirstSequenceHeaderObu(const std::shared_ptr<const ov::Data> &config_obus)
+{
+	if (config_obus == nullptr || config_obus->GetLength() == 0)
+	{
+		return nullptr;
+	}
+
+	const auto *base   = config_obus->GetDataAs<uint8_t>();
+	const size_t total = config_obus->GetLength();
+	size_t offset	   = 0;
+
+	while (offset < total)
+	{
+		auto parsed = ParseObuHeader(base + offset, total - offset);
+		if (parsed.has_value() == false)
+		{
+			return nullptr;
+		}
+
+		const auto &header	  = parsed->header;
+		size_t payload_offset = offset + parsed->bytes_consumed;
+		size_t payload_size	  = 0;
+
+		if (header.has_size_field)
+		{
+			auto leb = DecodeLeb128(base + payload_offset, total - payload_offset);
+			if (leb.has_value() == false)
+			{
+				return nullptr;
+			}
+
+			payload_offset += leb->bytes_consumed;
+
+			if (leb->value > total - payload_offset)
+			{
+				return nullptr;
+			}
+
+			payload_size = static_cast<size_t>(leb->value);
+		}
+		else
+		{
+			// AV1 ISO BMFF requires `obu_has_size_field=1` inside `configOBUs`. If we hit an OBU without
+			// a size field there's no way to know where the next one starts, so the remainder of the
+			// buffer is treated as this OBU's payload.
+			//
+			// AV1 spec 5.6 `temporal_delimiter_obu()` is defined as a NO-OP: "Note: The temporal delimiter
+			// has an empty payload." When the stream uses the low-overhead bitstream format
+			// (`obu_has_size_field = 0`) we can still walk past a leading TemporalDelimiter because its
+			// payload is guaranteed to be zero bytes. This lets `ExtractFirstSequenceHeaderObu()` reach a
+			// subsequent SequenceHeader OBU in an in-band scan.
+			if (header.type == Av1ObuType::TemporalDelimiter)
+			{
+				payload_size = 0;
+			}
+			else
+			{
+				payload_size = total - payload_offset;
+			}
+		}
+
+		if (header.type == Av1ObuType::SequenceHeader)
+		{
+			if (payload_size == 0)
+			{
+				return std::make_shared<ov::Data>();
+			}
+			return std::make_shared<ov::Data>(base + payload_offset, payload_size);
+		}
+
+		offset = payload_offset + payload_size;
+	}
+
+	return nullptr;
+}
+
+namespace
+{
+	// AV1 spec 4.10.3 `uvlc()`. Reads leading-zero count + value; treats `leadingZeros >= 32` as the
+	// "invalid" sentinel (still consumed so the bit offset stays accurate). Returns `false` only when
+	// the buffer runs out.
+	bool SkipUvlc(BitReader &reader)
+	{
+		uint8_t leading_zeros = 0;
+		while (true)
+		{
+			uint8_t done = 0;
+			if (reader.ReadBits<uint8_t>(1, done) == false)
+			{
+				return false;
+			}
+			if (done != 0)
+			{
+				break;
+			}
+			leading_zeros++;
+			if (leading_zeros >= 32)
+			{
+				// AV1 spec sentinel: value is `(1 << 32) - 1`, no further value bits to read.
+				return true;
+			}
+		}
+		if (leading_zeros == 0)
+		{
+			return true;
+		}
+		uint32_t value = 0;
+		return reader.ReadBits<uint32_t>(leading_zeros, value);
+	}
+
+	// AV1 spec 5.5.2 `timing_info()`. Returns `false` only on buffer underflow.
+	bool SkipTimingInfo(BitReader &reader)
+	{
+		uint32_t num_units_in_display_tick = 0;
+		if (reader.ReadBits<uint32_t>(32, num_units_in_display_tick) == false)
+		{
+			return false;
+		}
+		uint32_t time_scale = 0;
+		if (reader.ReadBits<uint32_t>(32, time_scale) == false)
+		{
+			return false;
+		}
+		uint8_t equal_picture_interval = 0;
+		if (reader.ReadBits<uint8_t>(1, equal_picture_interval) == false)
+		{
+			return false;
+		}
+		if (equal_picture_interval != 0)
+		{
+			if (SkipUvlc(reader) == false)
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	// AV1 spec 5.5.3 `decoder_model_info()`. The 5-bit `buffer_delay_length_minus_1` field controls
+	// per-op `operating_parameters_info()` sizing; the caller captures it via `buffer_delay_length`.
+	bool SkipDecoderModelInfo(BitReader &reader, uint8_t &buffer_delay_length)
+	{
+		uint8_t buffer_delay_length_minus_1 = 0;
+		if (reader.ReadBits<uint8_t>(5, buffer_delay_length_minus_1) == false)
+		{
+			return false;
+		}
+		buffer_delay_length = buffer_delay_length_minus_1 + 1;
+
+		uint32_t num_units_in_decoding_tick = 0;
+		if (reader.ReadBits<uint32_t>(32, num_units_in_decoding_tick) == false)
+		{
+			return false;
+		}
+		uint8_t buffer_removal_time_length_minus_1 = 0;
+		if (reader.ReadBits<uint8_t>(5, buffer_removal_time_length_minus_1) == false)
+		{
+			return false;
+		}
+		uint8_t frame_presentation_time_length_minus_1 = 0;
+		if (reader.ReadBits<uint8_t>(5, frame_presentation_time_length_minus_1) == false)
+		{
+			return false;
+		}
+		return true;
+	}
+
+	// AV1 spec 5.5.5 `operating_parameters_info(op)`: `decoder_buffer_delay(n)`,
+	// `encoder_buffer_delay(n)`, `low_delay_mode_flag(1)` where `n = buffer_delay_length`.
+	bool SkipOperatingParametersInfo(BitReader &reader, uint8_t buffer_delay_length)
+	{
+		uint32_t tmp = 0;
+		if (reader.ReadBits<uint32_t>(buffer_delay_length, tmp) == false)
+		{
+			return false;
+		}
+		if (reader.ReadBits<uint32_t>(buffer_delay_length, tmp) == false)
+		{
+			return false;
+		}
+		uint8_t low_delay_mode_flag = 0;
+		return reader.ReadBits<uint8_t>(1, low_delay_mode_flag);
+	}
+}  // namespace
+
+std::optional<Av1SequenceHeaderSummary> Av1Parser::ParseSequenceHeaderSummary(const uint8_t *payload, size_t size)
+{
+	if ((payload == nullptr) || (size == 0))
+	{
+		return std::nullopt;
+	}
+
+	BitReader reader(payload, size);
+	Av1SequenceHeaderSummary out;
+
+	// AV1 spec 5.5.1 `sequence_header_obu()`
+	AV1_READ_BITS(uint8_t, seq_profile, 3);						// seq_profile
+	AV1_READ_BITS(uint8_t, still_picture, 1);					// still_picture
+	AV1_READ_BITS(uint8_t, reduced_still_picture_header, 1);		// reduced_still_picture_header
+
+	out.seq_profile					 = seq_profile;
+	out.still_picture				 = (still_picture != 0);
+	out.reduced_still_picture_header = (reduced_still_picture_header != 0);
+
+	// AV1 spec 5.5.1: "It is a requirement of bitstream conformance that if reduced_still_picture_header
+	// is equal to 1, the value of still_picture shall be equal to 1." Reject the malformed combination.
+	if (out.reduced_still_picture_header && (still_picture == 0))
+	{
+		return std::nullopt;
+	}
+
+	uint8_t seq_level_idx_0_value = 0;
+	uint8_t seq_tier_0_value = 0;
+	if (out.reduced_still_picture_header)
+	{
+		AV1_READ_BITS(uint8_t, seq_level_idx_0, 5);				// seq_level_idx[0]
+		seq_level_idx_0_value = seq_level_idx_0;
+	}
+	else
+	{
+		AV1_READ_BITS(uint8_t, timing_info_present_flag, 1);		// timing_info_present_flag
+
+		uint8_t decoder_model_info_present_flag = 0;
+		uint8_t buffer_delay_length				= 0;
+		if (timing_info_present_flag != 0)
+		{
+			// Spec 5.5.2 `timing_info()` lives before `decoder_model_info_present_flag`. Skip it
+			// with exact bit count so subsequent fields stay aligned.
+			if (SkipTimingInfo(reader) == false)
+			{
+				return std::nullopt;
+			}
+
+			AV1_READ_BITS(uint8_t, dmip_flag, 1);				// decoder_model_info_present_flag
+			decoder_model_info_present_flag = dmip_flag;
+			if (decoder_model_info_present_flag != 0)
+			{
+				// Spec 5.5.3 `decoder_model_info()`. Captures `buffer_delay_length` for the
+				// per-operating-point `operating_parameters_info(i)` sub-tree below.
+				if (SkipDecoderModelInfo(reader, buffer_delay_length) == false)
+				{
+					return std::nullopt;
+				}
+			}
+		}
+
+		AV1_READ_BITS(uint8_t, initial_display_delay_present_flag, 1);	// initial_display_delay_present_flag
+		AV1_READ_BITS(uint8_t, operating_points_cnt_minus_1, 5);			// operating_points_cnt_minus_1
+
+		// Spec 5.5.1: walk every operating point so width/height bits are reached at the correct
+		// offset. Only the `i == 0` `seq_level_idx` is recorded (matches the `av1C` summary).
+		const uint32_t op_count = static_cast<uint32_t>(operating_points_cnt_minus_1) + 1;
+		for (uint32_t i = 0; i < op_count; i++)
+		{
+			AV1_READ_BITS(uint16_t, operating_point_idc, 12);	// operating_point_idc[i]
+			AV1_READ_BITS(uint8_t, seq_level_idx, 5);			// seq_level_idx[i]
+			(void)operating_point_idc;
+
+			if (i == 0)
+			{
+				seq_level_idx_0_value = seq_level_idx;
+			}
+
+			if (seq_level_idx > 7)
+			{
+				AV1_READ_BITS(uint8_t, seq_tier, 1);			// seq_tier[i]
+				if (i == 0)
+				{
+					seq_tier_0_value = seq_tier;
+				}
+			}
+			// AV1 spec 5.5.1: "seq_tier[ i ] ... If seq_level_idx[ i ] is less than 8, the value of
+			// seq_tier[ i ] is inferred to be 0." `seq_tier_0_value` is already initialized to 0.
+
+			if (decoder_model_info_present_flag != 0)
+			{
+				AV1_READ_BITS(uint8_t, decoder_model_present_for_this_op, 1);
+				if (decoder_model_present_for_this_op != 0)
+				{
+					if (SkipOperatingParametersInfo(reader, buffer_delay_length) == false)
+					{
+						return std::nullopt;
+					}
+				}
+			}
+
+			if (initial_display_delay_present_flag != 0)
+			{
+				AV1_READ_BITS(uint8_t, initial_display_delay_present_for_this_op, 1);
+				uint8_t initial_display_delay_minus_1_for_this_op = 0;
+				if (initial_display_delay_present_for_this_op != 0)
+				{
+					AV1_READ_BITS(uint8_t, initial_display_delay_minus_1, 4);
+					initial_display_delay_minus_1_for_this_op = initial_display_delay_minus_1;
+				}
+
+				// AV1 ISOBMFF binding v1.2.0 section 2.3.2 cross-check requires the `op_0`
+				// `initial_display_delay` signaling to match the `av1C` fixed header. Capture
+				// the per-op values for `i == 0` only; later operating points are still walked
+				// for bit alignment but their values are not recorded.
+				if (i == 0)
+				{
+					out.initial_display_delay_present_for_op_0 = initial_display_delay_present_for_this_op;
+					out.initial_display_delay_minus_1_for_op_0 = initial_display_delay_minus_1_for_this_op;
+				}
+			}
+		}
+	}
+
+	out.seq_level_idx_0 = seq_level_idx_0_value;
+	out.seq_tier_0		= seq_tier_0_value;
+
+	// `frame_width_bits_minus_1` (4), `frame_height_bits_minus_1` (4),
+	// `max_frame_width_minus_1` (n), `max_frame_height_minus_1` (n).
+	AV1_READ_BITS(uint8_t, frame_width_bits_minus_1, 4);			// frame_width_bits_minus_1
+	AV1_READ_BITS(uint8_t, frame_height_bits_minus_1, 4);		// frame_height_bits_minus_1
+
+	const uint8_t width_bits  = frame_width_bits_minus_1 + 1;
+	const uint8_t height_bits = frame_height_bits_minus_1 + 1;
+
+	AV1_READ_BITS(uint32_t, max_frame_width_minus_1, width_bits);	// max_frame_width_minus_1
+	AV1_READ_BITS(uint32_t, max_frame_height_minus_1, height_bits);	// max_frame_height_minus_1
+
+	out.max_frame_width	 = max_frame_width_minus_1 + 1;
+	out.max_frame_height = max_frame_height_minus_1 + 1;
+
+	// AV1 spec 5.5.1 `sequence_header_obu()`: continue past `max_frame_height_minus_1` so the
+	// `color_config()` sub-tree can be reached. Cross-checking the configOBUs requires the
+	// `color_config()` values per AV1 ISOBMFF binding v1.2.0 section 2.3.2.
+	if (out.reduced_still_picture_header == false)
+	{
+		AV1_READ_BITS(uint8_t, frame_id_numbers_present_flag, 1);
+		if (frame_id_numbers_present_flag != 0)
+		{
+			AV1_READ_BITS(uint8_t, delta_frame_id_length_minus_2, 4);
+			AV1_READ_BITS(uint8_t, additional_frame_id_length_minus_1, 3);
+			(void)delta_frame_id_length_minus_2;
+			(void)additional_frame_id_length_minus_1;
+		}
+	}
+	AV1_READ_BITS(uint8_t, use_128x128_superblock, 1);
+	AV1_READ_BITS(uint8_t, enable_filter_intra, 1);
+	AV1_READ_BITS(uint8_t, enable_intra_edge_filter, 1);
+	(void)use_128x128_superblock;
+	(void)enable_filter_intra;
+	(void)enable_intra_edge_filter;
+
+	if (out.reduced_still_picture_header == false)
+	{
+		AV1_READ_BITS(uint8_t, enable_interintra_compound, 1);
+		AV1_READ_BITS(uint8_t, enable_masked_compound, 1);
+		AV1_READ_BITS(uint8_t, enable_warped_motion, 1);
+		AV1_READ_BITS(uint8_t, enable_dual_filter, 1);
+		AV1_READ_BITS(uint8_t, enable_order_hint, 1);
+		(void)enable_interintra_compound;
+		(void)enable_masked_compound;
+		(void)enable_warped_motion;
+		(void)enable_dual_filter;
+
+		if (enable_order_hint != 0)
+		{
+			AV1_READ_BITS(uint8_t, enable_jnt_comp, 1);
+			AV1_READ_BITS(uint8_t, enable_ref_frame_mvs, 1);
+			(void)enable_jnt_comp;
+			(void)enable_ref_frame_mvs;
+		}
+
+		AV1_READ_BITS(uint8_t, seq_choose_screen_content_tools, 1);
+		uint8_t seq_force_screen_content_tools = 2;	// AV1 spec: SELECT_SCREEN_CONTENT_TOOLS
+		if (seq_choose_screen_content_tools == 0)
+		{
+			AV1_READ_BITS(uint8_t, sfsct, 1);
+			seq_force_screen_content_tools = sfsct;
+		}
+
+		if (seq_force_screen_content_tools > 0)
+		{
+			AV1_READ_BITS(uint8_t, seq_choose_integer_mv, 1);
+			if (seq_choose_integer_mv == 0)
+			{
+				AV1_READ_BITS(uint8_t, seq_force_integer_mv, 1);
+				(void)seq_force_integer_mv;
+			}
+		}
+
+		if (enable_order_hint != 0)
+		{
+			AV1_READ_BITS(uint8_t, order_hint_bits_minus_1, 3);
+			(void)order_hint_bits_minus_1;
+		}
+	}
+
+	AV1_READ_BITS(uint8_t, enable_superres, 1);
+	AV1_READ_BITS(uint8_t, enable_cdef, 1);
+	AV1_READ_BITS(uint8_t, enable_restoration, 1);
+	(void)enable_superres;
+	(void)enable_cdef;
+	(void)enable_restoration;
+
+	// AV1 spec 5.5.2 `color_config()` - capture every field needed by AV1 ISOBMFF binding v1.2.0
+	// section 2.3.2 cross-check.
+	AV1_READ_BITS(uint8_t, high_bitdepth, 1);
+	out.high_bitdepth = high_bitdepth;
+	if ((out.seq_profile == 2) && (high_bitdepth != 0))
+	{
+		AV1_READ_BITS(uint8_t, twelve_bit, 1);
+		out.twelve_bit = twelve_bit;
+	}
+	else
+	{
+		out.twelve_bit = 0;
+	}
+
+	if (out.seq_profile == 1)
+	{
+		// AV1 spec 5.5.2: "if ( seq_profile == 1 ) { monochrome = 0 }" - implicit, no bits read.
+		out.monochrome = 0;
+	}
+	else
+	{
+		AV1_READ_BITS(uint8_t, monochrome, 1);
+		out.monochrome = monochrome;
+	}
+
+	AV1_READ_BITS(uint8_t, color_description_present_flag, 1);
+	uint8_t color_primaries			= 2;	// AV1 spec: CP_UNSPECIFIED
+	uint8_t transfer_characteristics = 2;	// AV1 spec: TC_UNSPECIFIED
+	uint8_t matrix_coefficients		= 2;	// AV1 spec: MC_UNSPECIFIED
+	if (color_description_present_flag != 0)
+	{
+		AV1_READ_BITS(uint8_t, cp, 8);
+		AV1_READ_BITS(uint8_t, tc, 8);
+		AV1_READ_BITS(uint8_t, mc, 8);
+		color_primaries			 = cp;
+		transfer_characteristics = tc;
+		matrix_coefficients		 = mc;
+	}
+
+	if (out.monochrome != 0)
+	{
+		// AV1 spec 5.5.2 monochrome branch: read color_range, infer subsampling 4:0:0 mapped to (1,1)
+		// per spec, `chroma_sample_position = CSP_UNKNOWN (0)`.
+		AV1_READ_BITS(uint8_t, color_range_mono, 1);
+		(void)color_range_mono;
+		out.chroma_subsampling_x	= 1;
+		out.chroma_subsampling_y	= 1;
+		out.chroma_sample_position	= 0;
+	}
+	else if ((color_primaries == 1) && (transfer_characteristics == 13) && (matrix_coefficients == 0))
+	{
+		// AV1 spec 5.5.2: sRGB shortcut - color_range = 1, subsampling 4:4:4.
+		out.chroma_subsampling_x	= 0;
+		out.chroma_subsampling_y	= 0;
+		out.chroma_sample_position	= 0;
+	}
+	else
+	{
+		AV1_READ_BITS(uint8_t, color_range_full, 1);
+		(void)color_range_full;
+		if (out.seq_profile == 0)
+		{
+			out.chroma_subsampling_x = 1;
+			out.chroma_subsampling_y = 1;
+		}
+		else if (out.seq_profile == 1)
+		{
+			out.chroma_subsampling_x = 0;
+			out.chroma_subsampling_y = 0;
+		}
+		else	// seq_profile == 2
+		{
+			const uint8_t bit_depth = (high_bitdepth != 0) ? ((out.twelve_bit != 0) ? 12 : 10) : 8;
+			if (bit_depth == 12)
+			{
+				AV1_READ_BITS(uint8_t, ss_x, 1);
+				out.chroma_subsampling_x = ss_x;
+				if (ss_x != 0)
+				{
+					AV1_READ_BITS(uint8_t, ss_y, 1);
+					out.chroma_subsampling_y = ss_y;
+				}
+				else
+				{
+					out.chroma_subsampling_y = 0;
+				}
+			}
+			else
+			{
+				out.chroma_subsampling_x = 1;
+				out.chroma_subsampling_y = 0;
+			}
+		}
+
+		if ((out.chroma_subsampling_x != 0) && (out.chroma_subsampling_y != 0))
+		{
+			AV1_READ_BITS(uint8_t, csp, 2);
+			out.chroma_sample_position = csp;
+		}
+		else
+		{
+			out.chroma_sample_position = 0;
+		}
+	}
+
+	out.parsed = true;
+	return out;
+}

--- a/src/projects/modules/bitstream/av1/av1_parser.h
+++ b/src/projects/modules/bitstream/av1/av1_parser.h
@@ -1,0 +1,87 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include <base/ovlibrary/ovlibrary.h>
+#include <stdint.h>
+
+#include "av1_types.h"
+
+class Av1Parser
+{
+public:
+	/// Decode a `LEB128`-encoded unsigned integer per AV1 spec section 4.10.5.
+	///
+	/// Reads up to 8 bytes from `data`. The terminating byte is the first one whose continuation bit
+	/// (`0x80`) is clear.
+	///
+	/// @param data Pointer to the first `LEB128` byte.
+	///
+	/// @param size Number of bytes available at `data`.
+	///
+	/// @return `DecodedLeb128` on success, `std::nullopt` if the buffer was exhausted before a terminator.
+	static std::optional<DecodedLeb128> DecodeLeb128(const uint8_t *data, size_t size);
+
+	/// Parse `obu_header()` (and `obu_extension_header()` when `extension_flag` is set) per AV1 spec
+	/// sections 5.3.2 / 5.3.3.
+	///
+	/// The size field (when `has_size_field` is true) is NOT consumed here.
+	///
+	/// @param reader Must contain the OBU header byte (and the extension byte if `extension_flag` is set).
+	///
+	/// @return Populated `Av1ObuHeader` on success, `std::nullopt` on failure.
+	static std::optional<Av1ObuHeader> ParseObuHeader(BitReader &reader);
+
+	/// Convenience overload of `ParseObuHeader` operating on a raw byte pointer.
+	///
+	/// @param data Pointer to the first OBU header byte.
+	///
+	/// @param size Number of bytes available at `data`.
+	///
+	/// @return `ParsedObuHeader` (header + bytes consumed, 1 or 2) on success, `std::nullopt` on failure.
+	static std::optional<ParsedObuHeader> ParseObuHeader(const uint8_t *data, size_t size);
+
+	/// Walk an AV1 OBU bytestream and return the payload of the first `OBU_SEQUENCE_HEADER`.
+	///
+	/// Accepts both the `configOBUs` payload of an `AV1CodecConfigurationBox` (per AV1 ISOBMFF binding)
+	/// and a raw in-band OBU bytestream from a media packet. The returned buffer contains only the bytes
+	/// AFTER the OBU header and optional `obu_size` field.
+	///
+	/// @param config_obus Buffer containing one or more concatenated AV1 OBUs.
+	///
+	/// @return Payload bytes of the first sequence header OBU, or `nullptr` if absent or buffer is malformed.
+	static std::shared_ptr<const ov::Data> ExtractFirstSequenceHeaderObu(const std::shared_ptr<const ov::Data> &config_obus);
+
+	/// Parse the leading mandatory fields of a `sequence_header_obu()` payload per AV1 spec section 5.5.1.
+	///
+	/// Only diagnostic-friendly fields are populated (`seq_profile`, `seq_level_idx_0`,
+	/// `max_frame_width`, `max_frame_height`, ...).
+	///
+	/// @param payload Pointer to the OBU payload (bytes after `obu_header` / `obu_size`).
+	///
+	/// @param size Number of bytes available at `payload`.
+	///
+	/// @return `std::nullopt` if the buffer is shorter than the mandatory prefix.
+	static std::optional<Av1SequenceHeaderSummary> ParseSequenceHeaderSummary(const uint8_t *payload, size_t size);
+
+	/// Convenience overload of `ParseSequenceHeaderSummary` operating on a raw byte pointer.
+	///
+	/// @param payload Buffer containing the OBU payload (bytes after `obu_header` / `obu_size`).
+	///
+	/// @return `std::nullopt` if the buffer is shorter than the mandatory prefix.
+	static std::optional<Av1SequenceHeaderSummary> ParseSequenceHeaderSummary(const std::shared_ptr<const ov::Data> &payload)
+	{
+		if (payload == nullptr)
+		{
+			return std::nullopt;
+		}
+
+		return ParseSequenceHeaderSummary(payload->GetDataAs<uint8_t>(), payload->GetLength());
+	}
+};

--- a/src/projects/modules/bitstream/av1/av1_parser_test.cpp
+++ b/src/projects/modules/bitstream/av1/av1_parser_test.cpp
@@ -1,0 +1,758 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include <base/ovlibrary/data.h>
+#include <modules/bitstream/av1/av1_parser.h>
+
+#include <cstring>
+#include <vector>
+
+namespace
+{
+	std::vector<uint8_t> EncodeLeb128(uint64_t value)
+	{
+		std::vector<uint8_t> bytes;
+		do
+		{
+			uint8_t byte = value & 0x7F;
+			value >>= 7;
+			if (value != 0)
+			{
+				byte |= 0x80;
+			}
+			bytes.push_back(byte);
+		} while (value != 0);
+		return bytes;
+	}
+
+	uint8_t MakeObuHeaderByte(Av1ObuType type, bool extension_flag, bool has_size_field, uint8_t reserved_1bit = 0)
+	{
+		uint8_t b = 0;
+		// `forbidden_bit(1)` | `type(4)` | `ext_flag(1)` | `has_size(1)` | `reserved(1)`
+		b |= (static_cast<uint8_t>(type) & 0x0F) << 3;
+		b |= (extension_flag ? 1 : 0) << 2;
+		b |= (has_size_field ? 1 : 0) << 1;
+		b |= (reserved_1bit & 0x01);
+		return b;
+	}
+
+	uint8_t MakeObuExtensionByte(uint8_t temporal_id, uint8_t spatial_id, uint8_t reserved_3bits = 0)
+	{
+		uint8_t b = 0;
+		b |= (temporal_id & 0x07) << 5;
+		b |= (spatial_id & 0x03) << 3;
+		b |= (reserved_3bits & 0x07);
+		return b;
+	}
+
+	// Build a spec-correct sequence header OBU payload with the given top-level structural fields.
+	// Always emits `frame_width_bits_minus_1 = 0`, `frame_height_bits_minus_1 = 0`,
+	// `max_frame_width_minus_1` / `max_frame_height_minus_1` 1 bit each so the resulting `width`,
+	// `height` come out as `width_minus_1 + 1` / `height_minus_1 + 1`.
+	struct SeqHeaderBuilder
+	{
+		uint8_t seq_profile							  = 0;
+		bool still_picture							  = false;
+		bool reduced_still_picture_header			  = false;
+		bool timing_info_present_flag				  = false;
+		// `timing_info()` sub-fields (only used when `timing_info_present_flag`).
+		uint32_t num_units_in_display_tick			  = 1;
+		uint32_t time_scale							  = 30;
+		bool equal_picture_interval					  = false;
+		bool decoder_model_info_present_flag		  = false;
+		uint8_t buffer_delay_length_minus_1			  = 0;
+		bool initial_display_delay_present_flag		  = false;
+		// Per-operating-point `initial_display_delay_present_for_this_op[i]` and
+		// `initial_display_delay_minus_1[i]`. Only consulted when
+		// `initial_display_delay_present_flag == true`. Defaults to all zeros which keeps the
+		// builder backward-compatible with existing tests.
+		std::vector<uint8_t> initial_display_delay_present_for_this_op;
+		std::vector<uint8_t> initial_display_delay_minus_1;
+		uint8_t operating_points_cnt_minus_1		  = 0;
+		std::vector<uint16_t> operating_point_idc;
+		std::vector<uint8_t> seq_level_idx;
+		std::vector<uint8_t> seq_tier;	// only consulted when `seq_level_idx[i] > 7`
+		uint8_t frame_width_bits_minus_1			  = 0;	// 1 bit
+		uint8_t frame_height_bits_minus_1			  = 0;	// 1 bit
+		uint32_t max_frame_width_minus_1			  = 0;
+		uint32_t max_frame_height_minus_1			  = 0;
+
+		// Spec-correct serialization of the post-`max_frame_height_minus_1` preamble (AV1 spec 5.5.1)
+		// and the `color_config()` (AV1 spec 5.5.2) sub-tree. Defaults mirror the smallest-bitstream
+		// path: no frame-id numbers, all enable_* flags 0, no screen-content tools, no jnt_comp, etc.
+		bool frame_id_numbers_present_flag			  = false;
+		uint8_t delta_frame_id_length_minus_2		  = 0;
+		uint8_t additional_frame_id_length_minus_1	  = 0;
+		uint8_t use_128x128_superblock				  = 0;
+		uint8_t enable_filter_intra					  = 0;
+		uint8_t enable_intra_edge_filter			  = 0;
+		uint8_t enable_interintra_compound			  = 0;
+		uint8_t enable_masked_compound				  = 0;
+		uint8_t enable_warped_motion				  = 0;
+		uint8_t enable_dual_filter					  = 0;
+		uint8_t enable_order_hint					  = 0;
+		uint8_t enable_jnt_comp						  = 0;
+		uint8_t enable_ref_frame_mvs				  = 0;
+		uint8_t seq_choose_screen_content_tools		  = 1;	// `SELECT_SCREEN_CONTENT_TOOLS` path - skips force flag
+		uint8_t seq_force_screen_content_tools_when_chosen = 0;
+		uint8_t seq_choose_integer_mv				  = 1;
+		uint8_t seq_force_integer_mv_when_chosen	  = 0;
+		uint8_t order_hint_bits_minus_1				  = 0;
+		uint8_t enable_superres						  = 0;
+		uint8_t enable_cdef							  = 0;
+		uint8_t enable_restoration					  = 0;
+
+		// AV1 spec 5.5.2 `color_config()` fields.
+		uint8_t high_bitdepth						  = 0;
+		uint8_t twelve_bit							  = 0;
+		uint8_t monochrome							  = 0;
+		uint8_t color_description_present_flag		  = 0;
+		uint8_t color_primaries						  = 2;	// CP_UNSPECIFIED
+		uint8_t transfer_characteristics			  = 2;	// TC_UNSPECIFIED
+		uint8_t matrix_coefficients					  = 2;	// MC_UNSPECIFIED
+		uint8_t color_range							  = 0;
+		// 4:2:0 default for non-monochrome.
+		uint8_t chroma_subsampling_x				  = 1;
+		uint8_t chroma_subsampling_y				  = 1;
+		uint8_t chroma_sample_position				  = 0;
+	};
+
+	std::vector<uint8_t> BuildSequenceHeaderObuPayload(const SeqHeaderBuilder &b)
+	{
+		ov::BitWriter w(64);
+		w.WriteBits(3, b.seq_profile);
+		w.WriteBits(1, b.still_picture ? 1 : 0);
+		w.WriteBits(1, b.reduced_still_picture_header ? 1 : 0);
+		if (b.reduced_still_picture_header)
+		{
+			// `seq_level_idx[0]` (5 bits) only.
+			w.WriteBits(5, b.seq_level_idx.empty() ? 0 : b.seq_level_idx[0]);
+		}
+		else
+		{
+			w.WriteBits(1, b.timing_info_present_flag ? 1 : 0);
+			if (b.timing_info_present_flag)
+			{
+				// AV1 spec 5.5.2 `timing_info()`
+				w.WriteBits(32, b.num_units_in_display_tick);
+				w.WriteBits(32, b.time_scale);
+				w.WriteBits(1, b.equal_picture_interval ? 1 : 0);
+				if (b.equal_picture_interval)
+				{
+					// uvlc value 0 -> single `1` bit.
+					w.WriteBits(1, 1);
+				}
+				w.WriteBits(1, b.decoder_model_info_present_flag ? 1 : 0);
+				if (b.decoder_model_info_present_flag)
+				{
+					// AV1 spec 5.5.3 `decoder_model_info()`
+					w.WriteBits(5, b.buffer_delay_length_minus_1);
+					w.WriteBits(32, 1u);  // num_units_in_decoding_tick
+					w.WriteBits(5, 0u);   // buffer_removal_time_length_minus_1
+					w.WriteBits(5, 0u);   // frame_presentation_time_length_minus_1
+				}
+			}
+			w.WriteBits(1, b.initial_display_delay_present_flag ? 1 : 0);
+			w.WriteBits(5, b.operating_points_cnt_minus_1);
+			const uint32_t op_count = static_cast<uint32_t>(b.operating_points_cnt_minus_1) + 1;
+			for (uint32_t i = 0; i < op_count; i++)
+			{
+				const uint16_t op_idc = (i < b.operating_point_idc.size()) ? b.operating_point_idc[i] : 0;
+				const uint8_t lvl	  = (i < b.seq_level_idx.size()) ? b.seq_level_idx[i] : 0;
+				w.WriteBits(12, op_idc);
+				w.WriteBits(5, lvl);
+				if (lvl > 7)
+				{
+					const uint8_t tier = (i < b.seq_tier.size()) ? b.seq_tier[i] : 0;
+					w.WriteBits(1, tier);
+				}
+				if (b.decoder_model_info_present_flag)
+				{
+					// `decoder_model_present_for_this_op[i] = 0` for the test fixture.
+					w.WriteBits(1, 0);
+				}
+				if (b.initial_display_delay_present_flag)
+				{
+					const uint8_t op_present = (i < b.initial_display_delay_present_for_this_op.size())
+												   ? b.initial_display_delay_present_for_this_op[i]
+												   : 0;
+					w.WriteBits(1, op_present);
+					if (op_present != 0)
+					{
+						const uint8_t op_delay = (i < b.initial_display_delay_minus_1.size())
+													 ? b.initial_display_delay_minus_1[i]
+													 : 0;
+						w.WriteBits(4, op_delay & 0x0F);
+					}
+				}
+			}
+		}
+		w.WriteBits(4, b.frame_width_bits_minus_1);
+		w.WriteBits(4, b.frame_height_bits_minus_1);
+		const uint8_t width_bits  = static_cast<uint8_t>(b.frame_width_bits_minus_1 + 1);
+		const uint8_t height_bits = static_cast<uint8_t>(b.frame_height_bits_minus_1 + 1);
+		w.WriteBits(width_bits, b.max_frame_width_minus_1);
+		w.WriteBits(height_bits, b.max_frame_height_minus_1);
+
+		// AV1 spec 5.5.1 continuation past `max_frame_height_minus_1`.
+		if (b.reduced_still_picture_header == false)
+		{
+			w.WriteBits(1, b.frame_id_numbers_present_flag ? 1 : 0);
+			if (b.frame_id_numbers_present_flag)
+			{
+				w.WriteBits(4, b.delta_frame_id_length_minus_2);
+				w.WriteBits(3, b.additional_frame_id_length_minus_1);
+			}
+		}
+		w.WriteBits(1, b.use_128x128_superblock);
+		w.WriteBits(1, b.enable_filter_intra);
+		w.WriteBits(1, b.enable_intra_edge_filter);
+		if (b.reduced_still_picture_header == false)
+		{
+			w.WriteBits(1, b.enable_interintra_compound);
+			w.WriteBits(1, b.enable_masked_compound);
+			w.WriteBits(1, b.enable_warped_motion);
+			w.WriteBits(1, b.enable_dual_filter);
+			w.WriteBits(1, b.enable_order_hint);
+			if (b.enable_order_hint)
+			{
+				w.WriteBits(1, b.enable_jnt_comp);
+				w.WriteBits(1, b.enable_ref_frame_mvs);
+			}
+			w.WriteBits(1, b.seq_choose_screen_content_tools);
+			uint8_t seq_force_screen_content_tools = 2;	 // SELECT_SCREEN_CONTENT_TOOLS
+			if (b.seq_choose_screen_content_tools == 0)
+			{
+				w.WriteBits(1, b.seq_force_screen_content_tools_when_chosen);
+				seq_force_screen_content_tools = b.seq_force_screen_content_tools_when_chosen;
+			}
+			if (seq_force_screen_content_tools > 0)
+			{
+				w.WriteBits(1, b.seq_choose_integer_mv);
+				if (b.seq_choose_integer_mv == 0)
+				{
+					w.WriteBits(1, b.seq_force_integer_mv_when_chosen);
+				}
+			}
+			if (b.enable_order_hint)
+			{
+				w.WriteBits(3, b.order_hint_bits_minus_1);
+			}
+		}
+		w.WriteBits(1, b.enable_superres);
+		w.WriteBits(1, b.enable_cdef);
+		w.WriteBits(1, b.enable_restoration);
+
+		// AV1 spec 5.5.2 `color_config()`.
+		w.WriteBits(1, b.high_bitdepth);
+		if ((b.seq_profile == 2) && (b.high_bitdepth != 0))
+		{
+			w.WriteBits(1, b.twelve_bit);
+		}
+		if (b.seq_profile != 1)
+		{
+			w.WriteBits(1, b.monochrome);
+		}
+		w.WriteBits(1, b.color_description_present_flag);
+		if (b.color_description_present_flag)
+		{
+			w.WriteBits(8, b.color_primaries);
+			w.WriteBits(8, b.transfer_characteristics);
+			w.WriteBits(8, b.matrix_coefficients);
+		}
+		const bool srgb_shortcut = (b.monochrome == 0) &&
+								   (b.color_primaries == 1) &&
+								   (b.transfer_characteristics == 13) &&
+								   (b.matrix_coefficients == 0);
+		if (b.monochrome != 0)
+		{
+			w.WriteBits(1, b.color_range);
+		}
+		else if (srgb_shortcut)
+		{
+			// color_range, subsampling inferred per spec; no bits written.
+		}
+		else
+		{
+			w.WriteBits(1, b.color_range);
+			if (b.seq_profile == 2)
+			{
+				const uint8_t bit_depth = (b.high_bitdepth != 0) ? ((b.twelve_bit != 0) ? 12 : 10) : 8;
+				if (bit_depth == 12)
+				{
+					w.WriteBits(1, b.chroma_subsampling_x);
+					if (b.chroma_subsampling_x != 0)
+					{
+						w.WriteBits(1, b.chroma_subsampling_y);
+					}
+				}
+			}
+			// For seq_profile 0 / 1 subsampling is implicit per spec.
+			uint8_t eff_ss_x = b.chroma_subsampling_x;
+			uint8_t eff_ss_y = b.chroma_subsampling_y;
+			if (b.seq_profile == 0)
+			{
+				eff_ss_x = 1;
+				eff_ss_y = 1;
+			}
+			else if (b.seq_profile == 1)
+			{
+				eff_ss_x = 0;
+				eff_ss_y = 0;
+			}
+			else if (b.seq_profile == 2)
+			{
+				const uint8_t bit_depth = (b.high_bitdepth != 0) ? ((b.twelve_bit != 0) ? 12 : 10) : 8;
+				if (bit_depth != 12)
+				{
+					eff_ss_x = 1;
+					eff_ss_y = 0;
+				}
+			}
+			if ((eff_ss_x != 0) && (eff_ss_y != 0))
+			{
+				w.WriteBits(2, b.chroma_sample_position);
+			}
+		}
+
+		return std::vector<uint8_t>(w.GetData(), w.GetData() + w.GetDataSize());
+	}
+
+	std::vector<uint8_t> MakeObu(Av1ObuType type, const std::vector<uint8_t> &payload, bool has_size_field = true)
+	{
+		std::vector<uint8_t> bytes;
+		bytes.push_back(MakeObuHeaderByte(type, false, has_size_field));
+		if (has_size_field)
+		{
+			auto leb = EncodeLeb128(payload.size());
+			bytes.insert(bytes.end(), leb.begin(), leb.end());
+		}
+		bytes.insert(bytes.end(), payload.begin(), payload.end());
+		return bytes;
+	}
+}  // namespace
+
+TEST(Av1ParserLeb128, RoundTripBoundaries)
+{
+	const uint64_t values[] = {0, 0x7F, 0x80, 0x3FFF, 0x4000, 0x1FFFFF, 0x200000};
+	for (uint64_t v : values)
+	{
+		auto enc = EncodeLeb128(v);
+		auto decoded = Av1Parser::DecodeLeb128(enc.data(), enc.size());
+		ASSERT_TRUE(decoded.has_value()) << "value=" << v;
+		EXPECT_EQ(decoded->value, v);
+		EXPECT_EQ(decoded->bytes_consumed, enc.size());
+	}
+}
+
+TEST(Av1ParserLeb128, RejectsTruncatedContinuation)
+{
+	const uint8_t bytes[] = {0x80};  // continuation bit (`0x80`) set but no follow byte
+	EXPECT_FALSE(Av1Parser::DecodeLeb128(bytes, sizeof(bytes)).has_value());
+}
+
+TEST(Av1ParserLeb128, RejectsOverlong)
+{
+	uint8_t bytes[9];
+	std::memset(bytes, 0x80, sizeof(bytes));
+	EXPECT_FALSE(Av1Parser::DecodeLeb128(bytes, sizeof(bytes)).has_value());
+}
+
+TEST(Av1ParserObuHeader, SequenceHeaderNoExtensionNoSize)
+{
+	const uint8_t bytes[] = {MakeObuHeaderByte(Av1ObuType::SequenceHeader, false, false)};
+	auto parsed = Av1Parser::ParseObuHeader(bytes, sizeof(bytes));
+	ASSERT_TRUE(parsed.has_value());
+	EXPECT_EQ(parsed->header.type, Av1ObuType::SequenceHeader);
+	EXPECT_FALSE(parsed->header.extension_flag);
+	EXPECT_FALSE(parsed->header.has_size_field);
+	EXPECT_EQ(parsed->bytes_consumed, 1u);
+}
+
+TEST(Av1ParserObuHeader, TemporalDelimiter)
+{
+	const uint8_t bytes[] = {MakeObuHeaderByte(Av1ObuType::TemporalDelimiter, false, true)};
+	auto parsed = Av1Parser::ParseObuHeader(bytes, sizeof(bytes));
+	ASSERT_TRUE(parsed.has_value());
+	EXPECT_EQ(parsed->header.type, Av1ObuType::TemporalDelimiter);
+	EXPECT_TRUE(parsed->header.has_size_field);
+	EXPECT_EQ(parsed->bytes_consumed, 1u);
+}
+
+TEST(Av1ParserObuHeader, FrameWithSizeField)
+{
+	const uint8_t bytes[] = {MakeObuHeaderByte(Av1ObuType::Frame, false, true)};
+	auto parsed = Av1Parser::ParseObuHeader(bytes, sizeof(bytes));
+	ASSERT_TRUE(parsed.has_value());
+	EXPECT_EQ(parsed->header.type, Av1ObuType::Frame);
+	EXPECT_FALSE(parsed->header.extension_flag);
+	EXPECT_TRUE(parsed->header.has_size_field);
+}
+
+TEST(Av1ParserObuHeader, ExtensionByteCarriesTemporalAndSpatialId)
+{
+	const uint8_t bytes[] = {
+		MakeObuHeaderByte(Av1ObuType::Frame, true, true),
+		MakeObuExtensionByte(5, 2),
+	};
+	auto parsed = Av1Parser::ParseObuHeader(bytes, sizeof(bytes));
+	ASSERT_TRUE(parsed.has_value());
+	EXPECT_EQ(parsed->header.type, Av1ObuType::Frame);
+	EXPECT_TRUE(parsed->header.extension_flag);
+	EXPECT_EQ(parsed->header.temporal_id, 5u);
+	EXPECT_EQ(parsed->header.spatial_id, 2u);
+	EXPECT_EQ(parsed->bytes_consumed, 2u);
+}
+
+TEST(Av1ParserObuHeader, RejectsForbiddenBitSet)
+{
+	// `forbidden_bit(1)=1`
+	const uint8_t bytes[] = {static_cast<uint8_t>(0x80 | MakeObuHeaderByte(Av1ObuType::SequenceHeader, false, false))};
+	EXPECT_FALSE(Av1Parser::ParseObuHeader(bytes, sizeof(bytes)).has_value());
+}
+
+TEST(Av1ParserObuHeader, RejectsTruncatedExtensionByte)
+{
+	const uint8_t bytes[] = {MakeObuHeaderByte(Av1ObuType::Frame, true, false)};
+	EXPECT_FALSE(Av1Parser::ParseObuHeader(bytes, sizeof(bytes)).has_value());
+}
+
+TEST(Av1ParserExtractSequenceHeader, ReturnsFirstSequenceHeaderPayload)
+{
+	const std::vector<uint8_t> td_payload = {};
+	const std::vector<uint8_t> seq_payload = {0x11, 0x22, 0x33, 0x44, 0x55};
+	const std::vector<uint8_t> fh_payload = {0xAA, 0xBB};
+
+	std::vector<uint8_t> blob;
+	auto td = MakeObu(Av1ObuType::TemporalDelimiter, td_payload);
+	auto seq = MakeObu(Av1ObuType::SequenceHeader, seq_payload);
+	auto fh = MakeObu(Av1ObuType::FrameHeader, fh_payload);
+	blob.insert(blob.end(), td.begin(), td.end());
+	blob.insert(blob.end(), seq.begin(), seq.end());
+	blob.insert(blob.end(), fh.begin(), fh.end());
+
+	auto data = std::make_shared<ov::Data>(blob.data(), blob.size());
+	auto extracted = Av1Parser::ExtractFirstSequenceHeaderObu(data);
+	ASSERT_NE(extracted, nullptr);
+	ASSERT_EQ(extracted->GetLength(), seq_payload.size());
+	EXPECT_EQ(std::memcmp(extracted->GetDataAs<uint8_t>(), seq_payload.data(), seq_payload.size()), 0);
+}
+
+TEST(Av1ParserExtractSequenceHeader, ReturnsNullWhenAbsent)
+{
+	const std::vector<uint8_t> td_payload = {};
+	const std::vector<uint8_t> fh_payload = {0xAA, 0xBB};
+
+	std::vector<uint8_t> blob;
+	auto td = MakeObu(Av1ObuType::TemporalDelimiter, td_payload);
+	auto fh = MakeObu(Av1ObuType::FrameHeader, fh_payload);
+	blob.insert(blob.end(), td.begin(), td.end());
+	blob.insert(blob.end(), fh.begin(), fh.end());
+
+	auto data = std::make_shared<ov::Data>(blob.data(), blob.size());
+	auto extracted = Av1Parser::ExtractFirstSequenceHeaderObu(data);
+	EXPECT_EQ(extracted, nullptr);
+}
+
+TEST(Av1ParserExtractSequenceHeader, ReturnsNullOnTruncatedSizeField)
+{
+	std::vector<uint8_t> blob;
+	blob.push_back(MakeObuHeaderByte(Av1ObuType::SequenceHeader, false, true));
+	blob.push_back(0x80);  // `LEB128` says "more bytes follow" but none do.
+	auto data = std::make_shared<ov::Data>(blob.data(), blob.size());
+	EXPECT_EQ(Av1Parser::ExtractFirstSequenceHeaderObu(data), nullptr);
+}
+
+TEST(Av1ParserObuHeader, RejectsReservedBitNonZero)
+{
+	// `obu_reserved_1bit = 1` violates AV1 spec 5.3.2.
+	const uint8_t bytes[] = {MakeObuHeaderByte(Av1ObuType::SequenceHeader, false, false, 1)};
+	EXPECT_FALSE(Av1Parser::ParseObuHeader(bytes, sizeof(bytes)).has_value());
+}
+
+TEST(Av1ParserObuHeader, RejectsExtensionReservedBitsNonZero)
+{
+	// `extension_header_reserved_3bits != 0` violates AV1 spec 5.3.3.
+	const uint8_t bytes[] = {
+		MakeObuHeaderByte(Av1ObuType::Frame, true, true),
+		MakeObuExtensionByte(1, 0, 0x01),
+	};
+	EXPECT_FALSE(Av1Parser::ParseObuHeader(bytes, sizeof(bytes)).has_value());
+}
+
+TEST(Av1ParserSequenceHeaderSummary, ParsesReducedStillPictureHeader)
+{
+	// `seq_profile=0` (3), `still_picture=1` (1), `reduced_still_picture_header=1` (1),
+	// `seq_level_idx_0=5` (5), `frame_width_bits_minus_1=7` (4 -> 8 bits),
+	// `frame_height_bits_minus_1=7` (4 -> 8 bits), `max_frame_width_minus_1=0x4F` (8 -> 80),
+	// `max_frame_height_minus_1=0x2F` (8 -> 48). Then byte-align padding.
+	//
+	// Bit layout:
+	//   `[000][1][1][00101][0111][0111][01001111][00101111] ...`
+	// Build with a bit writer for clarity.
+	ov::BitWriter bw(64);
+	bw.WriteBits(3, 0);   // seq_profile
+	bw.WriteBits(1, 1);   // still_picture
+	bw.WriteBits(1, 1);   // reduced_still_picture_header
+	bw.WriteBits(5, 5);   // seq_level_idx_0
+	bw.WriteBits(4, 7);   // frame_width_bits_minus_1
+	bw.WriteBits(4, 7);   // frame_height_bits_minus_1
+	bw.WriteBits(8, 79);  // max_frame_width_minus_1 -> width 80
+	bw.WriteBits(8, 47);  // max_frame_height_minus_1 -> height 48
+	// AV1 spec 5.5.1 continuation: reduced_still_picture_header branch skips frame-id, jumps directly
+	// to use_128x128_superblock / enable_filter_intra / enable_intra_edge_filter / enable_superres /
+	// enable_cdef / enable_restoration, then `color_config()`.
+	bw.WriteBits(1, 0);   // use_128x128_superblock
+	bw.WriteBits(1, 0);   // enable_filter_intra
+	bw.WriteBits(1, 0);   // enable_intra_edge_filter
+	bw.WriteBits(1, 0);   // enable_superres
+	bw.WriteBits(1, 0);   // enable_cdef
+	bw.WriteBits(1, 0);   // enable_restoration
+	bw.WriteBits(1, 0);   // high_bitdepth
+	bw.WriteBits(1, 0);   // monochrome
+	bw.WriteBits(1, 0);   // color_description_present_flag
+	bw.WriteBits(1, 0);   // color_range
+	bw.WriteBits(2, 0);   // chroma_sample_position (profile 0 -> subsampling 1,1 implicit)
+
+	auto bytes = bw.GetData();
+	auto summary = Av1Parser::ParseSequenceHeaderSummary(bytes, bw.GetDataSize());
+	ASSERT_TRUE(summary.has_value());
+	EXPECT_TRUE(summary->parsed);
+	EXPECT_EQ(summary->seq_profile, 0);
+	EXPECT_TRUE(summary->still_picture);
+	EXPECT_TRUE(summary->reduced_still_picture_header);
+	EXPECT_EQ(summary->seq_level_idx_0, 5);
+	EXPECT_EQ(summary->max_frame_width, 80u);
+	EXPECT_EQ(summary->max_frame_height, 48u);
+}
+
+TEST(Av1ParserSequenceHeaderSummary, ParsesFullSequenceHeaderNoTimingInfo)
+{
+	// `reduced_still_picture_header == 0` happy path: one operating point, no timing info,
+	// no decoder model, no initial display delay. Verifies bit offset alignment of the
+	// `12 + 5 = 17` per-op bits matches the previously hand-rolled "fast path".
+	SeqHeaderBuilder b;
+	b.seq_profile				   = 1;
+	b.timing_info_present_flag	   = false;
+	b.operating_points_cnt_minus_1 = 0;
+	b.operating_point_idc		   = {0};
+	b.seq_level_idx				   = {6};
+	b.frame_width_bits_minus_1	   = 9;	 // 10 bits
+	b.frame_height_bits_minus_1	   = 8;	 // 9 bits
+	b.max_frame_width_minus_1	   = 639;
+	b.max_frame_height_minus_1	   = 479;
+
+	auto payload = BuildSequenceHeaderObuPayload(b);
+	auto summary = Av1Parser::ParseSequenceHeaderSummary(payload.data(), payload.size());
+	ASSERT_TRUE(summary.has_value());
+	EXPECT_FALSE(summary->reduced_still_picture_header);
+	EXPECT_EQ(summary->seq_profile, 1);
+	EXPECT_EQ(summary->seq_level_idx_0, 6);
+	EXPECT_EQ(summary->max_frame_width, 640u);
+	EXPECT_EQ(summary->max_frame_height, 480u);
+}
+
+TEST(Av1ParserSequenceHeaderSummary, ParsesTimingInfoPresent)
+{
+	// AV1 ISOBMFF binding allows `timing_info_present_flag == 1`. The summary parser must
+	// consume the `timing_info()` sub-tree and still recover width/height correctly.
+	SeqHeaderBuilder b;
+	b.seq_profile				   = 0;
+	b.timing_info_present_flag	   = true;
+	b.num_units_in_display_tick	   = 1001;
+	b.time_scale				   = 60000;
+	b.equal_picture_interval	   = false;
+	b.operating_points_cnt_minus_1 = 0;
+	b.operating_point_idc		   = {0};
+	b.seq_level_idx				   = {4};
+	b.frame_width_bits_minus_1	   = 10;
+	b.frame_height_bits_minus_1	   = 10;
+	b.max_frame_width_minus_1	   = 1919;
+	b.max_frame_height_minus_1	   = 1079;
+
+	auto payload = BuildSequenceHeaderObuPayload(b);
+	auto summary = Av1Parser::ParseSequenceHeaderSummary(payload.data(), payload.size());
+	ASSERT_TRUE(summary.has_value());
+	EXPECT_EQ(summary->seq_level_idx_0, 4);
+	EXPECT_EQ(summary->max_frame_width, 1920u);
+	EXPECT_EQ(summary->max_frame_height, 1080u);
+}
+
+TEST(Av1ParserSequenceHeaderSummary, ParsesSeqTierBranch)
+{
+	// `seq_level_idx[0] > 7` triggers the `seq_tier[0]` bit per AV1 spec 5.5.1.
+	SeqHeaderBuilder b;
+	b.seq_profile				   = 0;
+	b.operating_points_cnt_minus_1 = 0;
+	b.operating_point_idc		   = {0};
+	b.seq_level_idx				   = {8};
+	b.seq_tier					   = {1};
+	b.frame_width_bits_minus_1	   = 10;
+	b.frame_height_bits_minus_1	   = 10;
+	b.max_frame_width_minus_1	   = 1919;
+	b.max_frame_height_minus_1	   = 1079;
+
+	auto payload = BuildSequenceHeaderObuPayload(b);
+	auto summary = Av1Parser::ParseSequenceHeaderSummary(payload.data(), payload.size());
+	ASSERT_TRUE(summary.has_value());
+	EXPECT_EQ(summary->seq_level_idx_0, 8);
+	EXPECT_EQ(summary->max_frame_width, 1920u);
+	EXPECT_EQ(summary->max_frame_height, 1080u);
+}
+
+TEST(Av1ParserSequenceHeaderSummary, ParsesMultipleOperatingPoints)
+{
+	// `operating_points_cnt_minus_1 = 1` -> 2 operating points. Only `i == 0` `seq_level_idx`
+	// is recorded; the parser must still consume the extra op-point bits exactly.
+	SeqHeaderBuilder b;
+	b.seq_profile				   = 0;
+	b.operating_points_cnt_minus_1 = 1;
+	b.operating_point_idc		   = {0x1FF, 0x0FF};
+	b.seq_level_idx				   = {6, 9};
+	b.seq_tier					   = {0, 1};
+	b.frame_width_bits_minus_1	   = 10;
+	b.frame_height_bits_minus_1	   = 10;
+	b.max_frame_width_minus_1	   = 1919;
+	b.max_frame_height_minus_1	   = 1079;
+
+	auto payload = BuildSequenceHeaderObuPayload(b);
+	auto summary = Av1Parser::ParseSequenceHeaderSummary(payload.data(), payload.size());
+	ASSERT_TRUE(summary.has_value());
+	EXPECT_EQ(summary->seq_level_idx_0, 6);
+	EXPECT_EQ(summary->max_frame_width, 1920u);
+	EXPECT_EQ(summary->max_frame_height, 1080u);
+}
+
+TEST(Av1ParserSequenceHeaderSummary, RejectsTruncatedTimingInfo)
+{
+	// `timing_info_present_flag = 1` but only 1 byte of payload after the leading bits ->
+	// `timing_info()` cannot be consumed, parser must fail cleanly.
+	ov::BitWriter bw(8);
+	bw.WriteBits(3, 0);	 // seq_profile
+	bw.WriteBits(1, 0);	 // still_picture
+	bw.WriteBits(1, 0);	 // reduced_still_picture_header
+	bw.WriteBits(1, 1);	 // timing_info_present_flag
+	bw.WriteBits(2, 0);	 // pad to byte boundary
+	auto payload = bw.GetData();
+	auto summary = Av1Parser::ParseSequenceHeaderSummary(payload, bw.GetDataSize());
+	EXPECT_FALSE(summary.has_value());
+}
+
+TEST(Av1ParserObuHeader, RejectsReservedObuType)
+{
+	// AV1 spec 5.3.2 Table 5: obu_type values 0 and 9..14 are reserved. Per the spec,
+	// "It is a requirement of bitstream conformance that the value of obu_type is not equal to one
+	// of the reserved values."
+	for (uint8_t reserved : {0, 9, 10, 11, 12, 13, 14})
+	{
+		// `forbidden_bit(1)=0`, `obu_type(4)=reserved`, `ext_flag(1)=0`, `has_size(1)=0`, `reserved(1)=0`
+		const uint8_t byte = static_cast<uint8_t>((reserved & 0x0F) << 3);
+		EXPECT_FALSE(Av1Parser::ParseObuHeader(&byte, 1).has_value())
+			<< "obu_type=" << static_cast<int>(reserved);
+	}
+}
+
+TEST(Av1ParserSequenceHeaderSummary, RejectsReducedStillPictureWithoutStillPicture)
+{
+	// AV1 spec 5.5.1: "It is a requirement of bitstream conformance that if
+	// reduced_still_picture_header is equal to 1, the value of still_picture shall be equal to 1."
+	ov::BitWriter bw(8);
+	bw.WriteBits(3, 0);   // seq_profile
+	bw.WriteBits(1, 0);   // still_picture = 0
+	bw.WriteBits(1, 1);   // reduced_still_picture_header = 1 (mismatch)
+	bw.WriteBits(5, 0);   // seq_level_idx_0
+	bw.WriteBits(2, 0);   // pad
+	auto payload = bw.GetData();
+	auto summary = Av1Parser::ParseSequenceHeaderSummary(payload, bw.GetDataSize());
+	EXPECT_FALSE(summary.has_value());
+}
+
+TEST(Av1ParserExtractSequenceHeader, HandlesTemporalDelimiterWithoutSizeField)
+{
+	// AV1 spec 5.6 `temporal_delimiter_obu()`: empty payload. When the stream uses the low-overhead
+	// bitstream format (`obu_has_size_field = 0`), the in-band scan must walk past the leading
+	// TemporalDelimiter (0-byte payload) and still find a subsequent SequenceHeader OBU.
+	std::vector<uint8_t> blob;
+	// TemporalDelimiter, has_size_field = 0.
+	blob.push_back(MakeObuHeaderByte(Av1ObuType::TemporalDelimiter, false, false));
+	// SequenceHeader with has_size_field = 1 to delimit the payload.
+	const std::vector<uint8_t> seq_payload = {0xAB, 0xCD, 0xEF};
+	auto seq = MakeObu(Av1ObuType::SequenceHeader, seq_payload, true);
+	blob.insert(blob.end(), seq.begin(), seq.end());
+
+	auto data	   = std::make_shared<ov::Data>(blob.data(), blob.size());
+	auto extracted = Av1Parser::ExtractFirstSequenceHeaderObu(data);
+	ASSERT_NE(extracted, nullptr);
+	ASSERT_EQ(extracted->GetLength(), seq_payload.size());
+	EXPECT_EQ(std::memcmp(extracted->GetDataAs<uint8_t>(), seq_payload.data(), seq_payload.size()), 0);
+}
+
+TEST(Av1ParserSequenceHeaderSummary, CapturesColorConfigFields)
+{
+	// AV1 spec 5.5.2 `color_config()`: with `seq_profile = 2` + `high_bitdepth = 1` + `twelve_bit = 1`
+	// + 12-bit depth, the subsampling bits are explicitly read; `monochrome = 0`, `color_range = 0`,
+	// `chroma_subsampling_x = 1`, `chroma_subsampling_y = 0` (4:2:2). When subsampling is not (1, 1),
+	// `chroma_sample_position` is not present in the bitstream and the parser yields 0.
+	SeqHeaderBuilder b;
+	b.seq_profile				   = 2;
+	b.operating_points_cnt_minus_1 = 0;
+	b.operating_point_idc		   = {0};
+	b.seq_level_idx				   = {10};
+	b.seq_tier					   = {1};
+	b.frame_width_bits_minus_1	   = 10;
+	b.frame_height_bits_minus_1	   = 10;
+	b.max_frame_width_minus_1	   = 1919;
+	b.max_frame_height_minus_1	   = 1079;
+	b.high_bitdepth				   = 1;
+	b.twelve_bit				   = 1;
+	b.monochrome				   = 0;
+	b.color_range				   = 0;
+	b.chroma_subsampling_x		   = 1;
+	b.chroma_subsampling_y		   = 0;
+
+	auto payload = BuildSequenceHeaderObuPayload(b);
+	auto summary = Av1Parser::ParseSequenceHeaderSummary(payload.data(), payload.size());
+	ASSERT_TRUE(summary.has_value());
+	EXPECT_EQ(summary->seq_profile, 2);
+	EXPECT_EQ(summary->seq_level_idx_0, 10);
+	EXPECT_EQ(summary->seq_tier_0, 1);
+	EXPECT_EQ(summary->high_bitdepth, 1);
+	EXPECT_EQ(summary->twelve_bit, 1);
+	EXPECT_EQ(summary->monochrome, 0);
+	EXPECT_EQ(summary->chroma_subsampling_x, 1);
+	EXPECT_EQ(summary->chroma_subsampling_y, 0);
+	EXPECT_EQ(summary->chroma_sample_position, 0);
+}
+
+TEST(Av1ParserSequenceHeaderSummary, CapturesInitialDisplayDelayForOp0)
+{
+	// AV1 spec 5.5.1: when `initial_display_delay_present_flag == 1` and the per-op presence flag
+	// for `op_0` is 1, a 4-bit `initial_display_delay_minus_1[0]` is read. AV1 ISOBMFF binding
+	// v1.2.0 section 2.3.2 cross-checks these against the `av1C` fixed header, so the summary
+	// parser must record both values for `op_0`.
+	SeqHeaderBuilder b;
+	b.seq_profile							= 0;
+	b.initial_display_delay_present_flag	= true;
+	b.operating_points_cnt_minus_1			= 0;
+	b.operating_point_idc					= {0};
+	b.seq_level_idx							= {4};
+	b.initial_display_delay_present_for_this_op = {1};
+	b.initial_display_delay_minus_1			= {9};
+	b.frame_width_bits_minus_1				= 10;
+	b.frame_height_bits_minus_1				= 10;
+	b.max_frame_width_minus_1				= 1919;
+	b.max_frame_height_minus_1				= 1079;
+
+	auto payload = BuildSequenceHeaderObuPayload(b);
+	auto summary = Av1Parser::ParseSequenceHeaderSummary(payload.data(), payload.size());
+	ASSERT_TRUE(summary.has_value());
+	EXPECT_EQ(summary->initial_display_delay_present_for_op_0, 1);
+	EXPECT_EQ(summary->initial_display_delay_minus_1_for_op_0, 9);
+}

--- a/src/projects/modules/bitstream/av1/av1_types.h
+++ b/src/projects/modules/bitstream/av1/av1_types.h
@@ -1,0 +1,105 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include <base/ovlibrary/ovlibrary.h>
+#include <stdint.h>
+
+// AV1 Bitstream & Decoding Process Specification, section 6.2.1
+// (https://aomediacodec.github.io/av1-spec/av1-spec.pdf)
+enum class Av1ObuType : uint8_t
+{
+	Reserved = 0,
+	SequenceHeader = 1,
+	TemporalDelimiter = 2,
+	FrameHeader = 3,
+	TileGroup = 4,
+	Metadata = 5,
+	Frame = 6,
+	RedundantFrameHeader = 7,
+	TileList = 8,
+	Padding = 15,
+};
+
+constexpr const char *EnumToString(Av1ObuType obu_type)
+{
+	switch (obu_type)
+	{
+		OV_CASE_RETURN_ENUM_STRING(Av1ObuType, Reserved);
+		OV_CASE_RETURN_ENUM_STRING(Av1ObuType, SequenceHeader);
+		OV_CASE_RETURN_ENUM_STRING(Av1ObuType, TemporalDelimiter);
+		OV_CASE_RETURN_ENUM_STRING(Av1ObuType, FrameHeader);
+		OV_CASE_RETURN_ENUM_STRING(Av1ObuType, TileGroup);
+		OV_CASE_RETURN_ENUM_STRING(Av1ObuType, Metadata);
+		OV_CASE_RETURN_ENUM_STRING(Av1ObuType, Frame);
+		OV_CASE_RETURN_ENUM_STRING(Av1ObuType, RedundantFrameHeader);
+		OV_CASE_RETURN_ENUM_STRING(Av1ObuType, TileList);
+		OV_CASE_RETURN_ENUM_STRING(Av1ObuType, Padding);
+	}
+
+	return "(Unknown)";
+}
+
+// AV1 spec 5.3.2 `obu_header()`
+struct Av1ObuHeader
+{
+	Av1ObuType type = Av1ObuType::Reserved;
+	bool extension_flag = false;
+	bool has_size_field = false;
+	uint8_t temporal_id = 0;
+	uint8_t spatial_id = 0;
+};
+
+/// Result of `Av1Parser::DecodeLeb128()` - decoded value plus byte count.
+struct DecodedLeb128
+{
+	uint64_t value = 0;
+	size_t bytes_consumed = 0;
+};
+
+/// Result of the raw-byte `Av1Parser::ParseObuHeader()` overload - parsed header plus the number of bytes consumed
+/// (1 byte for the base header, 2 bytes when `obu_extension_flag` is set).
+struct ParsedObuHeader
+{
+	Av1ObuHeader header;
+	size_t bytes_consumed = 0;
+};
+
+// AV1 spec 5.5.1 `sequence_header_obu()` - only the diagnostic-friendly leading fields, plus the
+// `color_config()` (spec 5.5.2) values needed for the `configOBUs` cross-check defined by AV1 ISOBMFF
+// binding v1.2.0 section 2.3.2.
+struct Av1SequenceHeaderSummary
+{
+	uint8_t seq_profile = 0;
+	bool still_picture = false;
+	bool reduced_still_picture_header = false;
+	uint8_t seq_level_idx_0 = 0;
+	uint8_t seq_tier_0 = 0;
+	uint32_t max_frame_width = 0;
+	uint32_t max_frame_height = 0;
+
+	// AV1 spec 5.5.2 `color_config()` fields used by AV1 ISOBMFF binding v1.2.0 section 2.3.2
+	// "When the configOBUs field contains a Sequence Header OBU, the values of the
+	// AV1CodecConfigurationRecord fields shall match those of the OBU."
+	uint8_t high_bitdepth = 0;
+	uint8_t twelve_bit = 0;
+	uint8_t monochrome = 0;
+	uint8_t chroma_subsampling_x = 0;
+	uint8_t chroma_subsampling_y = 0;
+	uint8_t chroma_sample_position = 0;
+
+	// AV1 spec 5.5.1 `sequence_header_obu()` operating-point `i == 0` initial display delay signaling.
+	// Recorded so AV1 ISOBMFF binding v1.2.0 section 2.3.2 can cross-check
+	// `initial_presentation_delay_minus_one` from the `av1C` fixed header:
+	//   "initial_presentation_delay_minus_one, when present, all shall match."
+	uint8_t initial_display_delay_present_for_op_0 = 0;
+	uint8_t initial_display_delay_minus_1_for_op_0 = 0;
+
+	bool parsed = false;
+};

--- a/src/projects/modules/bitstream/decoder_configuration_record_parser.h
+++ b/src/projects/modules/bitstream/decoder_configuration_record_parser.h
@@ -4,6 +4,7 @@
 
 #include "h264/h264_decoder_configuration_record.h"
 #include "h265/h265_decoder_configuration_record.h"
+#include "av1/av1_decoder_configuration_record.h"
 #include "aac/audio_specific_config.h"
 
 enum class DecoderConfigurationRecordType : uint8_t
@@ -11,7 +12,8 @@ enum class DecoderConfigurationRecordType : uint8_t
 	UNKNOWN = 0,
 	AVCConfigurationRecord,
 	HEVCConfigurationRecord,
-	AudioSpecificConfig
+	AudioSpecificConfig,
+	AV1ConfigurationRecord
 };
 
 class DecoderConfigurationRecordParser
@@ -28,6 +30,9 @@ public:
 			break;
 		case cmn::MediaCodecId::H265:
 			type = DecoderConfigurationRecordType::HEVCConfigurationRecord;
+			break;
+		case cmn::MediaCodecId::Av1:
+			type = DecoderConfigurationRecordType::AV1ConfigurationRecord;
 			break;
 		case cmn::MediaCodecId::Aac:
 			type = DecoderConfigurationRecordType::AudioSpecificConfig;
@@ -55,6 +60,9 @@ public:
 			break;
 		case DecoderConfigurationRecordType::HEVCConfigurationRecord:
 			decoder_configuration_record = std::make_shared<HEVCDecoderConfigurationRecord>();
+			break;
+		case DecoderConfigurationRecordType::AV1ConfigurationRecord:
+			decoder_configuration_record = std::make_shared<AV1DecoderConfigurationRecord>();
 			break;
 		case DecoderConfigurationRecordType::AudioSpecificConfig:
 			decoder_configuration_record = std::make_shared<AudioSpecificConfig>();


### PR DESCRIPTION
## What

Add an AV1 bitstream module under `modules/bitstream/av1`, covering the parsing primitives needed to handle AV1 in the codec configuration layer:

- `Av1Parser`: LEB128 decoding (spec 4.10.5), OBU header parsing (spec 5.3.2/5.3.3), first Sequence Header OBU extraction from both `configOBUs` and in-band low-overhead bytestreams, and a Sequence Header summary parser (spec 5.5.1/color_config 5.5.2).
- `AV1DecoderConfigurationRecord`: parse/serialize the `av1C` box per the AV1 ISOBMFF binding, RFC 6381 `codecs` parameter generation (e.g. `av01.0.04M.08`), and `configOBUs` validation (single Sequence Header, ordering, and field cross-check against the fixed `av1C` fields).
- `av1_types.h`: OBU type enum and parsing result structs.

Wire the module into the build (`CMakeLists.txt`, `AMS.mk`) and route `MediaCodecId::Av1` through `DecoderConfigurationRecordParser`.

## Scope

This is module-level integration only. Downstream wiring (packetizers, RTP payloaders, transcoder paths) is intentionally not connected yet and will follow in separate PRs.

## Tests

Adds unit tests for the parser and the configuration record (`av1_parser_test.cpp`, `av1_decoder_configuration_record_test.cpp`), picked up automatically by the `ome_test_modules` target.
