### PR TITLE
feat: add AV1 media type support

### DIFF
--- a/src/projects/base/info/media_track.cpp
+++ b/src/projects/base/info/media_track.cpp
@@ -535,8 +535,19 @@ bool MediaTrack::IsValid()
 			}
 		}
 		break;
+		case MediaCodecId::Av1: {
+			// `GetCodecsParameter()` derives the AV1 codecs string from the decoder configuration record,
+			// and HLS/LL-HLS playlists consume it directly;
+			// require a non-null DCR so the track is not marked valid with an empty CODECS string
+			// (aligned with H264/H265).
+			if (IsValidResolution() && IsValidTimeBase() && GetDecoderConfigurationRecord() != nullptr)
+			{
+				_is_valid = true;
+				return true;
+			}
+		}
+		break;
 		case MediaCodecId::Vp9:
-		case MediaCodecId::Av1:
 		case MediaCodecId::Flv: {
 			if (IsValidResolution() && IsValidTimeBase())
 			{

--- a/src/projects/base/info/media_track.cpp
+++ b/src/projects/base/info/media_track.cpp
@@ -355,6 +355,7 @@ ov::String MediaTrack::GetCodecsParameter() const
 	{
 		case cmn::MediaCodecId::H264:
 		case cmn::MediaCodecId::H265:
+		case cmn::MediaCodecId::Av1:
 		case cmn::MediaCodecId::Aac:
 		{
 			auto config = GetDecoderConfigurationRecord();
@@ -535,6 +536,7 @@ bool MediaTrack::IsValid()
 		}
 		break;
 		case MediaCodecId::Vp9:
+		case MediaCodecId::Av1:
 		case MediaCodecId::Flv: {
 			if (IsValidResolution() && IsValidTimeBase())
 			{

--- a/src/projects/base/mediarouter/media_type.h
+++ b/src/projects/base/mediarouter/media_type.h
@@ -60,7 +60,10 @@ namespace cmn
 		SEI,	 // H.264/H.265 SEI
 		SCTE35,	 // SCTE35
 		WebVTT,	 // WebVTT (Web Video Text Tracks)
-		MP2
+		MP2,
+
+		// Backward compatibility: Logically part of Video Track. Do not change the order.
+		AV1_OBU
 	};
 
 	enum class PacketType : int8_t
@@ -391,6 +394,7 @@ namespace cmn
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, HVCC);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, VP8);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, VP8_RTP_RFC_7741);
+			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, AV1_OBU);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, AAC_RAW);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, AAC_MPEG4_GENERIC);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, AAC_ADTS);

--- a/src/projects/mediarouter/mediarouter_alert.cpp
+++ b/src/projects/mediarouter/mediarouter_alert.cpp
@@ -89,8 +89,11 @@ bool MediaRouterAlert::DetectBframes(const std::shared_ptr<info::Stream> &stream
 	switch (media_packet->GetBitstreamFormat())
 	{
 		case cmn::BitstreamFormat::H264_ANNEXB:
+			[[fallthrough]];
 		case cmn::BitstreamFormat::H264_AVCC:
+			[[fallthrough]];
 		case cmn::BitstreamFormat::H265_ANNEXB:
+			[[fallthrough]];
 		case cmn::BitstreamFormat::HVCC:
 			if (_alert_count_bframe < 1)	// Reduced the number of warning log outputs from 10 to 1
 			{
@@ -111,6 +114,10 @@ bool MediaRouterAlert::DetectBframes(const std::shared_ptr<info::Stream> &stream
 					_alert_count_bframe++;
 				}
 			}
+			break;
+		case cmn::BitstreamFormat::AV1_OBU:
+			// AV1 has no B-frames in the H.264/HEVC sense
+			// (uses reference frame indexes via `frame_header_obu`).
 			break;
 		default:
 			break;

--- a/src/projects/mediarouter/mediarouter_nomalize.cpp
+++ b/src/projects/mediarouter/mediarouter_nomalize.cpp
@@ -1154,7 +1154,13 @@ bool MediaRouterNormalize::ProcessAV1OBUStream(const std::shared_ptr<info::Strea
 				auto av1_config	 = std::dynamic_pointer_cast<AV1DecoderConfigurationRecord>(base_record);
 				if (av1_config != nullptr)
 				{
-					ApplyInBandSequenceHeaderToAv1Config(av1_config, *summary);
+					// The DCR is published via an atomic shared_ptr and read concurrently by publishers,
+					// so mutate a private copy and atomically swap it onto the track
+					// instead of editing the already-shared instance
+					// (consistent with how the H264/H265 paths always publish a freshly built record).
+					auto updated_config = std::make_shared<AV1DecoderConfigurationRecord>(*av1_config);
+					ApplyInBandSequenceHeaderToAv1Config(updated_config, *summary);
+					media_track->SetDecoderConfigurationRecord(updated_config);
 				}
 
 				media_track->SetResolution(

--- a/src/projects/mediarouter/mediarouter_nomalize.cpp
+++ b/src/projects/mediarouter/mediarouter_nomalize.cpp
@@ -1037,6 +1037,11 @@ void MediaRouterNormalize::ApplyInBandSequenceHeaderToAv1Config(
 	const std::shared_ptr<AV1DecoderConfigurationRecord> &av1_config,
 	const Av1SequenceHeaderSummary &summary)
 {
+	if (av1_config == nullptr)
+	{
+		return;
+	}
+
 	// Field set kept in lock-step with `AV1DecoderConfigurationRecord::ValidateConfigObus()`
 	// per AV1 ISOBMFF binding v1.2.0 section 2.3.2. The CodedFrames in-band path enters this
 	// helper only after `flv_video_parser::ParseAV1` synthesized the lenient default

--- a/src/projects/mediarouter/mediarouter_nomalize.cpp
+++ b/src/projects/mediarouter/mediarouter_nomalize.cpp
@@ -1044,7 +1044,7 @@ void MediaRouterNormalize::ApplyInBandSequenceHeaderToAv1Config(
 
 	// Field set kept in lock-step with `AV1DecoderConfigurationRecord::ValidateConfigObus()`
 	// per AV1 ISOBMFF binding v1.2.0 section 2.3.2. The CodedFrames in-band path enters this
-	// helper only after `flv_video_parser::ParseAV1` synthesized the lenient default
+	// helper only after the enhanced-RTMP (FLV) ingest path synthesized the lenient default
 	// `0x81 0x00 0x00 0x00` `av1C`; without copying these values through, every cross-checked
 	// field on the av1C stays at its default while the on-wire Sequence Header carries the
 	// real values, leaving the synthesized av1C stale.
@@ -1146,8 +1146,8 @@ bool MediaRouterNormalize::ProcessAV1OBUStream(const std::shared_ptr<info::Strea
 				// AV1 ISOBMFF binding v1.2.0 section 2.3.2: "When the configOBUs field contains a
 				// Sequence Header OBU, the values of the AV1CodecConfigurationRecord fields shall
 				// match those of the OBU." The CodedFrames branch only fires when the muxer has
-				// delivered the Sequence Header in-band - in that case `flv::VideoParser::ParseAV1`
-				// synthesized a default `av1C` (`0x81 0x00 0x00 0x00`), which is locked at level
+				// delivered the Sequence Header in-band - in that case the enhanced-RTMP (FLV)
+				// ingest path synthesized a default `av1C` (`0x81 0x00 0x00 0x00`), locked at level
 				// 2.0 / 4:4:4. Push the in-band Sequence Header values into the av1C so the codec
 				// string and downstream cross-check stay aligned with the actual bitstream.
 				auto base_record = media_track->GetDecoderConfigurationRecord();

--- a/src/projects/mediarouter/mediarouter_nomalize.cpp
+++ b/src/projects/mediarouter/mediarouter_nomalize.cpp
@@ -1147,7 +1147,7 @@ bool MediaRouterNormalize::ProcessAV1OBUStream(const std::shared_ptr<info::Strea
 				// Sequence Header OBU, the values of the AV1CodecConfigurationRecord fields shall
 				// match those of the OBU." The CodedFrames branch only fires when the muxer has
 				// delivered the Sequence Header in-band - in that case `flv::VideoParser::ParseAV1`
-				// synthesized a defaults `av1C` (`0x81 0x00 0x00 0x00`), which is locked at level
+				// synthesized a default `av1C` (`0x81 0x00 0x00 0x00`), which is locked at level
 				// 2.0 / 4:4:4. Push the in-band Sequence Header values into the av1C so the codec
 				// string and downstream cross-check stay aligned with the actual bitstream.
 				auto base_record = media_track->GetDecoderConfigurationRecord();

--- a/src/projects/mediarouter/mediarouter_nomalize.cpp
+++ b/src/projects/mediarouter/mediarouter_nomalize.cpp
@@ -1069,11 +1069,11 @@ void MediaRouterNormalize::ApplyInBandSequenceHeaderToAv1Config(
 bool MediaRouterNormalize::ProcessAV1OBUStream(const std::shared_ptr<info::Stream> &stream_info, std::shared_ptr<MediaTrack> &media_track, std::shared_ptr<MediaPacket> &media_packet)
 {
 	// AV1 OBU is delivered as a raw bytestream by the provider; no fragment-header conversion is required.
-	// Only two things must happen here, path-agnostic:
+	// Path-agnostic responsibilities here:
 	//   1. On `SEQUENCE_HEADER` packets, parse the `av1C` blob and store the `AV1DecoderConfigurationRecord` on the track.
-	//   2. Extract `max_frame_width` / `max_frame_height` from the first `OBU_SEQUENCE_HEADER`
-	//      (either inside `configOBUs` for `av1C` boxes, or in-band in the OBU bytestream when the provider has handed us OBUs directly)
-	//      and call `SetResolution` if not yet set.
+	//   2. From an in-band `OBU_SEQUENCE_HEADER` (key-frame TU or a separate TU), build/update the
+	//      `av1C` and resolution, applying mid-stream changes.
+	//   3. Mark key frames, and prepend the sequence header OBU to a key frame that lacks one in-band.
 
 	auto data = media_packet->GetData();
 	if ((data == nullptr) || data->IsEmpty())
@@ -1123,46 +1123,57 @@ bool MediaRouterNormalize::ProcessAV1OBUStream(const std::shared_ptr<info::Strea
 		return false;
 	}
 
-	// CodedFrames path: if the track still lacks a valid resolution, scan the OBU bytestream once for
-	// an in-band `OBU_SEQUENCE_HEADER`. Gate on `IsValidResolution()` rather than the broader
-	// `IsValid()` (which also requires a valid timebase) so we neither re-parse once the resolution
-	// is set nor tie resolution extraction to unrelated validity fields.
-	if (media_track->IsValidResolution() == false)
+	// CodedFrames path. Mark key frames (downstream GOP/segment handling needs it).
+	const bool is_key_frame = Av1Parser::IsKeyFrame(data);
+	media_packet->SetFlag(is_key_frame ? MediaPacketFlag::Key : MediaPacketFlag::NoFlag);
+
+	// Update resolution and the av1C from an in-band sequence header whenever one is present (it may
+	// arrive in its own temporal unit, not only in the key-frame TU), and re-apply when it changes.
+	// The av1C has no resolution field, so resolution is compared against the track directly.
+	auto seq_payload = Av1Parser::ExtractFirstSequenceHeaderObu(data);
+	if (seq_payload != nullptr)
 	{
-		// Wrap the packet data as a borrowed `ov::Data` view to feed `ExtractFirstSequenceHeaderObu`.
-		// `data` itself already implements the right interface; pass it through.
-		auto seq_payload = Av1Parser::ExtractFirstSequenceHeaderObu(data);
-		if (seq_payload != nullptr)
+		auto summary = Av1Parser::ParseSequenceHeaderSummary(seq_payload);
+		if (summary.has_value() && (summary->max_frame_width > 0) && (summary->max_frame_height > 0))
 		{
-			auto summary = Av1Parser::ParseSequenceHeaderSummary(seq_payload);
+			const int32_t width	 = static_cast<int32_t>(summary->max_frame_width);
+			const int32_t height = static_cast<int32_t>(summary->max_frame_height);
 
-			if (summary.has_value() &&
-				(summary->max_frame_width > 0) && (summary->max_frame_height > 0))
+			auto old_config = std::dynamic_pointer_cast<AV1DecoderConfigurationRecord>(media_track->GetDecoderConfigurationRecord());
+
+			// Build a fresh av1C (default fields + the sequence-header values). Fresh rather than a
+			// copy of the old record, so a stale configOBUs/presentation-delay is not carried into
+			// fields that now describe a different sequence header.
+			auto new_config = std::make_shared<AV1DecoderConfigurationRecord>();
+			ApplyInBandSequenceHeaderToAv1Config(new_config, *summary);
+
+			const auto resolution		  = media_track->GetResolution();
+			const bool resolution_changed = (resolution.width != width) || (resolution.height != height);
+			const bool config_changed	  = (old_config == nullptr) || (old_config->Equals(new_config) == false);
+
+			// Update only on change; publish a freshly built record (it is read concurrently).
+			if ((media_track->IsValidResolution() == false) || resolution_changed || config_changed)
 			{
-				// AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics): "When a Sequence Header OBU is contained
-				// within the configOBUs of the AV1CodecConfigurationRecord, the values present in the
-				// Sequence Header OBU contained within configOBUs SHALL match the values of the
-				// AV1CodecConfigurationRecord." The CodedFrames branch only fires when the muxer has
-				// delivered the Sequence Header in-band - in that case the enhanced-RTMP (FLV)
-				// ingest path synthesized a default `av1C` (`0x81 0x00 0x00 0x00`), locked at level
-				// 2.0 / 4:4:4. Push the in-band Sequence Header values into the av1C so the codec
-				// string and downstream cross-check stay aligned with the actual bitstream.
-				auto base_record = media_track->GetDecoderConfigurationRecord();
-				auto av1_config	 = std::dynamic_pointer_cast<AV1DecoderConfigurationRecord>(base_record);
-				if (av1_config != nullptr)
-				{
-					// The DCR is published via an atomic shared_ptr and read concurrently by publishers,
-					// so mutate a private copy and atomically swap it onto the track
-					// instead of editing the already-shared instance
-					// (consistent with how the H264/H265 paths always publish a freshly built record).
-					auto updated_config = std::make_shared<AV1DecoderConfigurationRecord>(*av1_config);
-					ApplyInBandSequenceHeaderToAv1Config(updated_config, *summary);
-					media_track->SetDecoderConfigurationRecord(updated_config);
-				}
+				media_track->SetResolution(width, height);
+				media_track->SetDecoderConfigurationRecord(new_config);
+			}
+		}
+	}
 
-				media_track->SetResolution(
-					static_cast<int32_t>(summary->max_frame_width),
-					static_cast<int32_t>(summary->max_frame_height));
+	// A key frame must carry a sequence header OBU to be independently decodable. If it has none
+	// in-band (e.g. delivered out-of-band in the av1C), prepend the sequence header OBU from the av1C.
+	if (is_key_frame && (Av1Parser::HasSequenceHeaderObu(data) == false))
+	{
+		auto av1_config = std::dynamic_pointer_cast<AV1DecoderConfigurationRecord>(media_track->GetDecoderConfigurationRecord());
+		if (av1_config != nullptr)
+		{
+			auto seq_obu = Av1Parser::ExtractFirstSequenceHeaderObuRaw(av1_config->ConfigObus());
+			if ((seq_obu != nullptr) && (seq_obu->GetLength() > 0))
+			{
+				auto merged = std::make_shared<ov::Data>(seq_obu->GetLength() + data->GetLength());
+				merged->Append(seq_obu);
+				merged->Append(data);
+				media_packet->SetData(merged);
 			}
 		}
 	}

--- a/src/projects/mediarouter/mediarouter_nomalize.cpp
+++ b/src/projects/mediarouter/mediarouter_nomalize.cpp
@@ -1149,8 +1149,9 @@ bool MediaRouterNormalize::ProcessAV1OBUStream(const std::shared_ptr<info::Strea
 			auto new_config = std::make_shared<AV1DecoderConfigurationRecord>();
 			ApplyInBandSequenceHeaderToAv1Config(new_config, *summary);
 
-			// The depacketized stream is low-overhead, so the sequence header OBU is already
-			// size-delimited as configOBUs requires.
+			// configOBUs needs a size-delimited sequence header OBU (obu_has_size_field == 1).
+			// ExtractFirstSequenceHeaderObuRaw returns one when present, else nullptr (configOBUs
+			// then stays empty).
 			auto seq_obu = Av1Parser::ExtractFirstSequenceHeaderObuRaw(data);
 			if (seq_obu != nullptr)
 			{

--- a/src/projects/mediarouter/mediarouter_nomalize.cpp
+++ b/src/projects/mediarouter/mediarouter_nomalize.cpp
@@ -13,6 +13,8 @@
 #include <modules/bitstream/aac/aac_adts.h>
 #include <modules/bitstream/aac/aac_converter.h>
 #include <modules/bitstream/aac/audio_specific_config.h>
+#include <modules/bitstream/av1/av1_decoder_configuration_record.h>
+#include <modules/bitstream/av1/av1_parser.h>
 #include <modules/bitstream/h264/h264_common.h>
 #include <modules/bitstream/h264/h264_decoder_configuration_record.h>
 #include <modules/bitstream/h264/h264_parser.h>
@@ -78,6 +80,9 @@ bool MediaRouterNormalize::NormalizeMediaPacket(const std::shared_ptr<info::Stre
 			break;
 		case cmn::BitstreamFormat::VP8:
 			result = media_packet->GetData() != nullptr && ProcessVP8Stream(stream_info, media_track, media_packet);
+			break;
+		case cmn::BitstreamFormat::AV1_OBU:
+			result = media_packet->GetData() != nullptr && ProcessAV1OBUStream(stream_info, media_track, media_packet);
 			break;
 		case cmn::BitstreamFormat::AAC_RAW:
 			result = media_packet->GetData() != nullptr && ProcessAACRawStream(stream_info, media_track, media_packet);
@@ -1024,6 +1029,135 @@ bool MediaRouterNormalize::ProcessVP8Stream(const std::shared_ptr<info::Stream> 
 	}
 
 	media_track->SetResolution(parser.GetWidth(), parser.GetHeight());
+
+	return true;
+}
+
+void MediaRouterNormalize::ApplyInBandSequenceHeaderToAv1Config(
+	const std::shared_ptr<AV1DecoderConfigurationRecord> &av1_config,
+	const Av1SequenceHeaderSummary &summary)
+{
+	// Field set kept in lock-step with `AV1DecoderConfigurationRecord::ValidateConfigObus()`
+	// per AV1 ISOBMFF binding v1.2.0 section 2.3.2. The CodedFrames in-band path enters this
+	// helper only after `flv_video_parser::ParseAV1` synthesized the lenient default
+	// `0x81 0x00 0x00 0x00` `av1C`; without copying these values through, every cross-checked
+	// field on the av1C stays at its default while the on-wire Sequence Header carries the
+	// real values, leaving the synthesized av1C stale.
+	av1_config->SetSeqProfile(summary.seq_profile);
+	av1_config->SetSeqLevelIdx0(summary.seq_level_idx_0);
+	av1_config->SetSeqTier0(summary.seq_tier_0);
+	av1_config->SetHighBitdepth(summary.high_bitdepth);
+	av1_config->SetTwelveBit(summary.twelve_bit);
+	av1_config->SetMonochrome(summary.monochrome);
+	av1_config->SetChromaSubsamplingX(summary.chroma_subsampling_x);
+	av1_config->SetChromaSubsamplingY(summary.chroma_subsampling_y);
+	av1_config->SetChromaSamplePosition(summary.chroma_sample_position);
+
+	// AV1 ISOBMFF binding v1.2.0 section 2.3.2:
+	//   "initial_presentation_delay_minus_one, when present, all shall match."
+	// `ParseSequenceHeaderSummary` captures `initial_display_delay_present_for_op_0` and
+	// `initial_display_delay_minus_1_for_op_0`; `ValidateConfigObus()` cross-checks them
+	// against `_initial_presentation_delay_present` / `_initial_presentation_delay_minus_one`.
+	// Without this call the synthesized av1C keeps the defaults (`present = 0`, `minus_one = 0`)
+	// and goes stale on any stream whose op-0 carries a non-zero presentation delay.
+	av1_config->SetInitialPresentationDelay(
+		summary.initial_display_delay_present_for_op_0 != 0,
+		summary.initial_display_delay_minus_1_for_op_0);
+}
+
+bool MediaRouterNormalize::ProcessAV1OBUStream(const std::shared_ptr<info::Stream> &stream_info, std::shared_ptr<MediaTrack> &media_track, std::shared_ptr<MediaPacket> &media_packet)
+{
+	// AV1 OBU is delivered as a raw bytestream by the provider; no fragment-header conversion is required.
+	// Only two things must happen here, path-agnostic:
+	//   1. On `SEQUENCE_HEADER` packets, parse the `av1C` blob and store the `AV1DecoderConfigurationRecord` on the track.
+	//   2. Extract `max_frame_width` / `max_frame_height` from the first `OBU_SEQUENCE_HEADER`
+	//      (either inside `configOBUs` for `av1C` boxes, or in-band in the OBU bytestream when the provider has handed us OBUs directly)
+	//      and call `SetResolution` if not yet set.
+
+	auto data = media_packet->GetData();
+	if ((data == nullptr) || data->IsEmpty())
+	{
+		return false;
+	}
+
+	if (media_packet->GetPacketType() == cmn::PacketType::SEQUENCE_HEADER)
+	{
+		auto av1_config = std::make_shared<AV1DecoderConfigurationRecord>();
+
+		if (av1_config->Parse(data) == false)
+		{
+			logte("Could not parse AV1 sequence header (`av1C`) of %s/%s/%s track",
+				  stream_info->GetApplicationName(), stream_info->GetName().CStr(), media_track->GetVariantName().CStr());
+
+			return false;
+		}
+
+		media_track->SetDecoderConfigurationRecord(av1_config);
+
+		// Try to populate resolution from `configOBUs` when the encoder embedded the sequence header OBU
+		// inside `av1C`. Some encoders (notably ffmpeg's libaom over enhanced-RTMP) leave `configOBUs`
+		// empty and deliver the sequence header OBU in-band; in that case resolution is filled by the
+		// CodedFrames branch below.
+		auto config_obus = av1_config->ConfigObus();
+
+		if ((config_obus != nullptr) && (config_obus->GetLength() > 0))
+		{
+			auto seq_payload = Av1Parser::ExtractFirstSequenceHeaderObu(config_obus);
+
+			if (seq_payload != nullptr)
+			{
+				auto summary = Av1Parser::ParseSequenceHeaderSummary(seq_payload);
+
+				if (summary.has_value() &&
+					summary->max_frame_width > 0 && summary->max_frame_height > 0)
+				{
+					media_track->SetResolution(
+						static_cast<int32_t>(summary->max_frame_width),
+						static_cast<int32_t>(summary->max_frame_height));
+				}
+			}
+		}
+
+		// Sequence header packets are not forwarded as media frames downstream.
+		return false;
+	}
+
+	// CodedFrames path: if the track still lacks a valid resolution, scan the OBU bytestream once for
+	// an in-band `OBU_SEQUENCE_HEADER`. Gate on `IsValidResolution()` rather than the broader
+	// `IsValid()` (which also requires a valid timebase) so we neither re-parse once the resolution
+	// is set nor tie resolution extraction to unrelated validity fields.
+	if (media_track->IsValidResolution() == false)
+	{
+		// Wrap the packet data as a borrowed `ov::Data` view to feed `ExtractFirstSequenceHeaderObu`.
+		// `data` itself already implements the right interface; pass it through.
+		auto seq_payload = Av1Parser::ExtractFirstSequenceHeaderObu(data);
+		if (seq_payload != nullptr)
+		{
+			auto summary = Av1Parser::ParseSequenceHeaderSummary(seq_payload);
+
+			if (summary.has_value() &&
+				(summary->max_frame_width > 0) && (summary->max_frame_height > 0))
+			{
+				// AV1 ISOBMFF binding v1.2.0 section 2.3.2: "When the configOBUs field contains a
+				// Sequence Header OBU, the values of the AV1CodecConfigurationRecord fields shall
+				// match those of the OBU." The CodedFrames branch only fires when the muxer has
+				// delivered the Sequence Header in-band - in that case `flv::VideoParser::ParseAV1`
+				// synthesized a defaults `av1C` (`0x81 0x00 0x00 0x00`), which is locked at level
+				// 2.0 / 4:4:4. Push the in-band Sequence Header values into the av1C so the codec
+				// string and downstream cross-check stay aligned with the actual bitstream.
+				auto base_record = media_track->GetDecoderConfigurationRecord();
+				auto av1_config	 = std::dynamic_pointer_cast<AV1DecoderConfigurationRecord>(base_record);
+				if (av1_config != nullptr)
+				{
+					ApplyInBandSequenceHeaderToAv1Config(av1_config, *summary);
+				}
+
+				media_track->SetResolution(
+					static_cast<int32_t>(summary->max_frame_width),
+					static_cast<int32_t>(summary->max_frame_height));
+			}
+		}
+	}
 
 	return true;
 }

--- a/src/projects/mediarouter/mediarouter_nomalize.cpp
+++ b/src/projects/mediarouter/mediarouter_nomalize.cpp
@@ -1141,11 +1141,21 @@ bool MediaRouterNormalize::ProcessAV1OBUStream(const std::shared_ptr<info::Strea
 
 			auto old_config = std::dynamic_pointer_cast<AV1DecoderConfigurationRecord>(media_track->GetDecoderConfigurationRecord());
 
-			// Build a fresh av1C (default fields + the sequence-header values). Fresh rather than a
-			// copy of the old record, so a stale configOBUs/presentation-delay is not carried into
-			// fields that now describe a different sequence header.
+			// Build a fresh av1C from this sequence header: the SH-derived fixed fields, plus the
+			// sequence header itself captured into configOBUs. Building from the current SH (rather
+			// than copying the previous record) keeps the fixed fields and configOBUs consistent, and
+			// populating configOBUs both keeps the av1C self-contained and lets the prepend path below
+			// recover the SH for key frames that arrive without one in-band.
 			auto new_config = std::make_shared<AV1DecoderConfigurationRecord>();
 			ApplyInBandSequenceHeaderToAv1Config(new_config, *summary);
+
+			// The depacketized stream is low-overhead, so the sequence header OBU is already
+			// size-delimited as configOBUs requires.
+			auto seq_obu = Av1Parser::ExtractFirstSequenceHeaderObuRaw(data);
+			if (seq_obu != nullptr)
+			{
+				new_config->SetConfigObus(std::make_shared<ov::Data>(seq_obu->GetData(), seq_obu->GetLength()));
+			}
 
 			const auto resolution		  = media_track->GetResolution();
 			const bool resolution_changed = (resolution.width != width) || (resolution.height != height);

--- a/src/projects/mediarouter/mediarouter_nomalize.cpp
+++ b/src/projects/mediarouter/mediarouter_nomalize.cpp
@@ -1058,16 +1058,12 @@ void MediaRouterNormalize::ApplyInBandSequenceHeaderToAv1Config(
 	av1_config->SetChromaSubsamplingY(summary.chroma_subsampling_y);
 	av1_config->SetChromaSamplePosition(summary.chroma_sample_position);
 
-	// AV1 ISOBMFF binding v1.2.0 section 2.3.2:
-	//   "initial_presentation_delay_minus_one, when present, all shall match."
-	// `ParseSequenceHeaderSummary` captures `initial_display_delay_present_for_op_0` and
-	// `initial_display_delay_minus_1_for_op_0`; `ValidateConfigObus()` cross-checks them
-	// against `_initial_presentation_delay_present` / `_initial_presentation_delay_minus_one`.
-	// Without this call the synthesized av1C keeps the defaults (`present = 0`, `minus_one = 0`)
-	// and goes stale on any stream whose op-0 carries a non-zero presentation delay.
-	av1_config->SetInitialPresentationDelay(
-		summary.initial_display_delay_present_for_op_0 != 0,
-		summary.initial_display_delay_minus_1_for_op_0);
+	// `initial_presentation_delay` is intentionally NOT copied from the Sequence Header. AV1
+	// ISOBMFF binding v1.3.0 section 2.3.4 (Semantics) defines it as an av1C-only field derived
+	// from a decoder-model procedure over all samples, distinct from the Sequence Header's
+	// `initial_display_delay_minus_1`; there is no "SHALL match" rule between them. The synthesized
+	// av1C keeps its default (`present = 0`), which is correct - it must not be forged from a
+	// single in-band Sequence Header's display-delay signaling.
 }
 
 bool MediaRouterNormalize::ProcessAV1OBUStream(const std::shared_ptr<info::Stream> &stream_info, std::shared_ptr<MediaTrack> &media_track, std::shared_ptr<MediaPacket> &media_packet)

--- a/src/projects/mediarouter/mediarouter_nomalize.cpp
+++ b/src/projects/mediarouter/mediarouter_nomalize.cpp
@@ -1043,7 +1043,7 @@ void MediaRouterNormalize::ApplyInBandSequenceHeaderToAv1Config(
 	}
 
 	// Field set kept in lock-step with `AV1DecoderConfigurationRecord::ValidateConfigObus()`
-	// per AV1 ISOBMFF binding v1.2.0 section 2.3.2. The CodedFrames in-band path enters this
+	// per AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics). The CodedFrames in-band path enters this
 	// helper only after the enhanced-RTMP (FLV) ingest path synthesized the lenient default
 	// `0x81 0x00 0x00 0x00` `av1C`; without copying these values through, every cross-checked
 	// field on the av1C stays at its default while the on-wire Sequence Header carries the
@@ -1143,9 +1143,10 @@ bool MediaRouterNormalize::ProcessAV1OBUStream(const std::shared_ptr<info::Strea
 			if (summary.has_value() &&
 				(summary->max_frame_width > 0) && (summary->max_frame_height > 0))
 			{
-				// AV1 ISOBMFF binding v1.2.0 section 2.3.2: "When the configOBUs field contains a
-				// Sequence Header OBU, the values of the AV1CodecConfigurationRecord fields shall
-				// match those of the OBU." The CodedFrames branch only fires when the muxer has
+				// AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics): "When a Sequence Header OBU is contained
+				// within the configOBUs of the AV1CodecConfigurationRecord, the values present in the
+				// Sequence Header OBU contained within configOBUs SHALL match the values of the
+				// AV1CodecConfigurationRecord." The CodedFrames branch only fires when the muxer has
 				// delivered the Sequence Header in-band - in that case the enhanced-RTMP (FLV)
 				// ingest path synthesized a default `av1C` (`0x81 0x00 0x00 0x00`), locked at level
 				// 2.0 / 4:4:4. Push the in-band Sequence Header values into the av1C so the codec

--- a/src/projects/mediarouter/mediarouter_nomalize.cpp
+++ b/src/projects/mediarouter/mediarouter_nomalize.cpp
@@ -1037,7 +1037,7 @@ void MediaRouterNormalize::ApplyInBandSequenceHeaderToAv1Config(
 	const std::shared_ptr<AV1DecoderConfigurationRecord> &av1_config,
 	const Av1SequenceHeaderSummary &summary)
 {
-	if (av1_config == nullptr)
+	if ((av1_config == nullptr) || (summary.parsed == false))
 	{
 		return;
 	}

--- a/src/projects/mediarouter/mediarouter_nomalize.h
+++ b/src/projects/mediarouter/mediarouter_nomalize.h
@@ -16,14 +16,33 @@
 
 #include "base/info/stream.h"
 #include "base/mediarouter/media_buffer.h"
-#include "base/mediarouter/mediarouter_application_connector.h"
 #include "base/mediarouter/media_type.h"
+#include "base/mediarouter/mediarouter_application_connector.h"
+#include "modules/bitstream/av1/av1_decoder_configuration_record.h"
+#include "modules/bitstream/av1/av1_types.h"
 #include "modules/managed_queue/managed_queue.h"
 
 class MediaRouterNormalize
 {
 public:
 	bool NormalizeMediaPacket(const std::shared_ptr<info::Stream> &stream_info, std::shared_ptr<MediaTrack> &media_track, std::shared_ptr<MediaPacket> &media_packet);
+
+	/// Copy every cross-checked field from an AV1 in-band Sequence Header summary onto the
+	/// `av1C` `AV1DecoderConfigurationRecord` that was synthesized by `flv_video_parser::ParseAV1`
+	/// (lenient `0x81 0x00 0x00 0x00` default) so the downstream
+	/// `AV1DecoderConfigurationRecord::ValidateConfigObus()` cross-check stays consistent with
+	/// the actual bitstream.
+	///
+	/// AV1 ISOBMFF binding v1.2.0 section 2.3.2:
+	///   "When the configOBUs field contains a Sequence Header OBU, the values of the
+	///    AV1CodecConfigurationRecord fields shall match those of the OBU. Specifically:
+	///    ... initial_presentation_delay_minus_one, when present, all shall match."
+	///
+	/// Exposed publicly (and as `static`) so the regression test in `mediarouter_test.cpp`
+	/// can exercise the field-mapping logic without standing up an Orchestrator fixture.
+	static void ApplyInBandSequenceHeaderToAv1Config(
+		const std::shared_ptr<AV1DecoderConfigurationRecord> &av1_config,
+		const Av1SequenceHeaderSummary &summary);
 
 	bool ProcessH264AVCCStream(const std::shared_ptr<info::Stream> &stream_info, std::shared_ptr<MediaTrack> &media_track, std::shared_ptr<MediaPacket> &media_packet);
 	bool ProcessH264AnnexBStream(const std::shared_ptr<info::Stream> &stream_info, std::shared_ptr<MediaTrack> &media_track, std::shared_ptr<MediaPacket> &media_packet);
@@ -37,6 +56,8 @@ public:
 	bool ProcessAACAdtsStream(const std::shared_ptr<info::Stream> &stream_info, std::shared_ptr<MediaTrack> &media_track, std::shared_ptr<MediaPacket> &media_packet);
 
 	bool ProcessVP8Stream(const std::shared_ptr<info::Stream> &stream_info, std::shared_ptr<MediaTrack> &media_track, std::shared_ptr<MediaPacket> &media_packet);
+
+	bool ProcessAV1OBUStream(const std::shared_ptr<info::Stream> &stream_info, std::shared_ptr<MediaTrack> &media_track, std::shared_ptr<MediaPacket> &media_packet);
 
 	bool ProcessOPUSStream(const std::shared_ptr<info::Stream> &stream_info, std::shared_ptr<MediaTrack> &media_track, std::shared_ptr<MediaPacket> &media_packet);
 

--- a/src/projects/mediarouter/mediarouter_nomalize.h
+++ b/src/projects/mediarouter/mediarouter_nomalize.h
@@ -28,7 +28,7 @@ public:
 	bool NormalizeMediaPacket(const std::shared_ptr<info::Stream> &stream_info, std::shared_ptr<MediaTrack> &media_track, std::shared_ptr<MediaPacket> &media_packet);
 
 	/// Copy every cross-checked field from an AV1 in-band Sequence Header summary onto the
-	/// `av1C` `AV1DecoderConfigurationRecord` that was synthesized by `flv_video_parser::ParseAV1`
+	/// `av1C` `AV1DecoderConfigurationRecord` synthesized by the enhanced-RTMP (FLV) ingest path
 	/// (lenient `0x81 0x00 0x00 0x00` default) so the downstream
 	/// `AV1DecoderConfigurationRecord::ValidateConfigObus()` cross-check stays consistent with
 	/// the actual bitstream.

--- a/src/projects/mediarouter/mediarouter_nomalize.h
+++ b/src/projects/mediarouter/mediarouter_nomalize.h
@@ -33,10 +33,11 @@ public:
 	/// `AV1DecoderConfigurationRecord::ValidateConfigObus()` cross-check stays consistent with
 	/// the actual bitstream.
 	///
-	/// AV1 ISOBMFF binding v1.2.0 section 2.3.2:
-	///   "When the configOBUs field contains a Sequence Header OBU, the values of the
-	///    AV1CodecConfigurationRecord fields shall match those of the OBU. Specifically:
-	///    ... initial_presentation_delay_minus_one, when present, all shall match."
+	/// AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics): "When a Sequence Header OBU is
+	/// contained within the configOBUs of the AV1CodecConfigurationRecord, the values present in
+	/// the Sequence Header OBU contained within configOBUs SHALL match the values of the
+	/// AV1CodecConfigurationRecord." (`initial_presentation_delay` is excluded - it is an av1C-only
+	/// field with no Sequence Header match rule.)
 	///
 	/// Exposed publicly (and as `static`) so the regression test in `mediarouter_test.cpp`
 	/// can exercise the field-mapping logic without standing up an Orchestrator fixture.

--- a/src/projects/mediarouter/mediarouter_test.cpp
+++ b/src/projects/mediarouter/mediarouter_test.cpp
@@ -70,8 +70,8 @@ TEST(MediaRouterNormalizeAv1InBandSh, InBandSequenceHeaderUpdatesAllAv1ConfigFie
 	summary.chroma_subsampling_x				   = 1;
 	summary.chroma_subsampling_y				   = 0;
 	summary.chroma_sample_position				   = 2;
-	// REGRESSION GUARD: op-0 initial display delay present + non-zero value
-	// must propagate to the av1C via SetInitialPresentationDelay().
+	// op-0 initial display delay is set here only to prove it is NOT copied into the av1C
+	// (it is a distinct field from av1C `initial_presentation_delay`, with no spec match rule).
 	summary.initial_display_delay_present_for_op_0 = 1;
 	summary.initial_display_delay_minus_1_for_op_0 = 7;
 
@@ -87,23 +87,19 @@ TEST(MediaRouterNormalizeAv1InBandSh, InBandSequenceHeaderUpdatesAllAv1ConfigFie
 	EXPECT_EQ(av1_config->ChromaSubsamplingY(), summary.chroma_subsampling_y);
 	EXPECT_EQ(av1_config->ChromaSamplePosition(), summary.chroma_sample_position);
 
-	// Regression: synthesized av1C must mirror the in-band SH op-0 delay signaling
-	// so the downstream AV1DecoderConfigurationRecord::ValidateConfigObus() cross-check
-	// (AV1 ISOBMFF binding v1.2.0 section 2.3.2 "initial_presentation_delay_minus_one,
-	// when present, all shall match") stays consistent with the actual bitstream.
-	EXPECT_EQ(av1_config->InitialPresentationDelayPresent(), 1);
-	EXPECT_EQ(av1_config->InitialPresentationDelayMinusOne(), 7);
+	// `initial_presentation_delay` must NOT be copied from the Sequence Header's
+	// `initial_display_delay` (distinct fields, no match rule per AV1 ISOBMFF binding v1.3.0
+	// section 2.3.4 (Semantics)); the av1C keeps its synthesized default of 0/0.
+	EXPECT_EQ(av1_config->InitialPresentationDelayPresent(), 0);
+	EXPECT_EQ(av1_config->InitialPresentationDelayMinusOne(), 0);
 }
 
-TEST(MediaRouterNormalizeAv1InBandSh, InBandSequenceHeaderClearsInitialPresentationDelayWhenAbsent)
+TEST(MediaRouterNormalizeAv1InBandSh, InBandSequenceHeaderLeavesInitialPresentationDelayUntouched)
 {
 	std::shared_ptr<AV1DecoderConfigurationRecord> av1_config;
 	ASSERT_NO_FATAL_FAILURE(MakeSynthesizedDefaultAv1Config(av1_config));
 
-	// Seed the av1C with a non-zero op-0 presentation delay BEFORE the helper runs.
-	// This forces the test to exercise the clear-from-non-zero path: a tautological
-	// 0/0 -> 0/0 assertion would also pass if the helper omitted the
-	// SetInitialPresentationDelay() call entirely, so it must not start from default.
+	// Seed the av1C with a non-zero presentation delay BEFORE the helper runs.
 	av1_config->SetInitialPresentationDelay(true, 5);
 	ASSERT_EQ(av1_config->InitialPresentationDelayPresent(), 1);
 	ASSERT_EQ(av1_config->InitialPresentationDelayMinusOne(), 5);
@@ -119,16 +115,14 @@ TEST(MediaRouterNormalizeAv1InBandSh, InBandSequenceHeaderClearsInitialPresentat
 	summary.chroma_subsampling_x				   = 1;
 	summary.chroma_subsampling_y				   = 1;
 	summary.chroma_sample_position				   = 0;
-	// op-0 delay absent in the in-band Sequence Header: helper must encode
-	// `present = 0` and wipe the stale `initial_presentation_delay_minus_one`
-	// back to 0 (av1_decoder_configuration_record.cpp:461 false branch).
 	summary.initial_display_delay_present_for_op_0 = 0;
 	summary.initial_display_delay_minus_1_for_op_0 = 0;
 
 	MediaRouterNormalize::ApplyInBandSequenceHeaderToAv1Config(av1_config, summary);
 
-	// Regression: the helper must reset the seeded 1/5 state back to 0/0.
-	// If SetInitialPresentationDelay() is omitted the av1C keeps 1/5 and this fails.
-	EXPECT_EQ(av1_config->InitialPresentationDelayPresent(), 0);
-	EXPECT_EQ(av1_config->InitialPresentationDelayMinusOne(), 0);
+	// The helper must NOT touch `initial_presentation_delay` - it is a distinct field from the
+	// Sequence Header's `initial_display_delay` with no spec match rule (AV1 ISOBMFF binding
+	// v1.3.0 section 2.3.4 (Semantics)). The seeded 1/5 is preserved.
+	EXPECT_EQ(av1_config->InitialPresentationDelayPresent(), 1);
+	EXPECT_EQ(av1_config->InitialPresentationDelayMinusOne(), 5);
 }

--- a/src/projects/mediarouter/mediarouter_test.cpp
+++ b/src/projects/mediarouter/mediarouter_test.cpp
@@ -10,9 +10,125 @@
 //        writing real tests here.
 //
 //==============================================================================
+#include <base/ovlibrary/data.h>
 #include <gtest/gtest.h>
+#include <modules/bitstream/av1/av1_decoder_configuration_record.h>
+#include <modules/bitstream/av1/av1_types.h>
+
+#include "mediarouter_nomalize.h"
 
 TEST(MediaRouterPlaceholder, TodoImplementTests)
 {
 	GTEST_SKIP() << "MediaRouter tests not yet implemented - see tests/mediarouter/";
+}
+
+// ---------------------------------------------------------------------------
+// Regression coverage for the in-band Sequence Header to av1C field sync.
+//
+// The CodedFrames branch of `MediaRouterNormalize::ProcessAV1OBUStream` enters
+// `ApplyInBandSequenceHeaderToAv1Config` after `flv_video_parser::ParseAV1`
+// synthesized the lenient default av1C blob `0x81 0x00 0x00 0x00`. The helper
+// must copy every cross-checked field (per AV1 ISOBMFF binding v1.2.0 section
+// 2.3.2) from the in-band Sequence Header summary onto the av1C - including
+// the `initial_presentation_delay_*` pair that was historically missed and
+// caused the synthesized av1C to go stale on streams with op-0 delay != 0.
+// ---------------------------------------------------------------------------
+namespace
+{
+	// Returns via out-param so the parse can be a hard precondition: gtest `ASSERT_*` expands to
+	// `return;` and is only usable in a void-returning function. Call through
+	// `ASSERT_NO_FATAL_FAILURE` so a parse failure stops the test instead of cascading.
+	void MakeSynthesizedDefaultAv1Config(std::shared_ptr<AV1DecoderConfigurationRecord> &out)
+	{
+		const std::vector<uint8_t> bytes = {0x81, 0x00, 0x00, 0x00};
+		auto data						 = std::make_shared<ov::Data>(bytes.data(), bytes.size());
+		auto record						 = std::make_shared<AV1DecoderConfigurationRecord>();
+		ASSERT_TRUE(record->Parse(data));
+		out = record;
+	}
+}  // namespace
+
+TEST(MediaRouterNormalizeAv1InBandSh, InBandSequenceHeaderUpdatesAllAv1ConfigFields)
+{
+	std::shared_ptr<AV1DecoderConfigurationRecord> av1_config;
+	ASSERT_NO_FATAL_FAILURE(MakeSynthesizedDefaultAv1Config(av1_config));
+
+	// Pre-condition: synthesized lenient defaults.
+	ASSERT_EQ(av1_config->SeqProfile(), 0);
+	ASSERT_EQ(av1_config->SeqLevelIdx0(), 0);
+	ASSERT_EQ(av1_config->InitialPresentationDelayPresent(), 0);
+	ASSERT_EQ(av1_config->InitialPresentationDelayMinusOne(), 0);
+
+	Av1SequenceHeaderSummary summary;
+	summary.parsed								   = true;
+	summary.seq_profile							   = 1;
+	summary.seq_level_idx_0						   = 8;
+	summary.seq_tier_0							   = 1;
+	summary.high_bitdepth						   = 1;
+	summary.twelve_bit							   = 0;
+	summary.monochrome							   = 1;
+	summary.chroma_subsampling_x				   = 1;
+	summary.chroma_subsampling_y				   = 0;
+	summary.chroma_sample_position				   = 2;
+	// REGRESSION GUARD: op-0 initial display delay present + non-zero value
+	// must propagate to the av1C via SetInitialPresentationDelay().
+	summary.initial_display_delay_present_for_op_0 = 1;
+	summary.initial_display_delay_minus_1_for_op_0 = 7;
+
+	MediaRouterNormalize::ApplyInBandSequenceHeaderToAv1Config(av1_config, summary);
+
+	EXPECT_EQ(av1_config->SeqProfile(), summary.seq_profile);
+	EXPECT_EQ(av1_config->SeqLevelIdx0(), summary.seq_level_idx_0);
+	EXPECT_EQ(av1_config->SeqTier0(), summary.seq_tier_0);
+	EXPECT_EQ(av1_config->HighBitdepth(), summary.high_bitdepth);
+	EXPECT_EQ(av1_config->TwelveBit(), summary.twelve_bit);
+	EXPECT_EQ(av1_config->Monochrome(), summary.monochrome);
+	EXPECT_EQ(av1_config->ChromaSubsamplingX(), summary.chroma_subsampling_x);
+	EXPECT_EQ(av1_config->ChromaSubsamplingY(), summary.chroma_subsampling_y);
+	EXPECT_EQ(av1_config->ChromaSamplePosition(), summary.chroma_sample_position);
+
+	// Regression: synthesized av1C must mirror the in-band SH op-0 delay signaling
+	// so the downstream AV1DecoderConfigurationRecord::ValidateConfigObus() cross-check
+	// (AV1 ISOBMFF binding v1.2.0 section 2.3.2 "initial_presentation_delay_minus_one,
+	// when present, all shall match") stays consistent with the actual bitstream.
+	EXPECT_EQ(av1_config->InitialPresentationDelayPresent(), 1);
+	EXPECT_EQ(av1_config->InitialPresentationDelayMinusOne(), 7);
+}
+
+TEST(MediaRouterNormalizeAv1InBandSh, InBandSequenceHeaderClearsInitialPresentationDelayWhenAbsent)
+{
+	std::shared_ptr<AV1DecoderConfigurationRecord> av1_config;
+	ASSERT_NO_FATAL_FAILURE(MakeSynthesizedDefaultAv1Config(av1_config));
+
+	// Seed the av1C with a non-zero op-0 presentation delay BEFORE the helper runs.
+	// This forces the test to exercise the clear-from-non-zero path: a tautological
+	// 0/0 -> 0/0 assertion would also pass if the helper omitted the
+	// SetInitialPresentationDelay() call entirely, so it must not start from default.
+	av1_config->SetInitialPresentationDelay(true, 5);
+	ASSERT_EQ(av1_config->InitialPresentationDelayPresent(), 1);
+	ASSERT_EQ(av1_config->InitialPresentationDelayMinusOne(), 5);
+
+	Av1SequenceHeaderSummary summary;
+	summary.parsed								   = true;
+	summary.seq_profile							   = 0;
+	summary.seq_level_idx_0						   = 4;
+	summary.seq_tier_0							   = 0;
+	summary.high_bitdepth						   = 0;
+	summary.twelve_bit							   = 0;
+	summary.monochrome							   = 0;
+	summary.chroma_subsampling_x				   = 1;
+	summary.chroma_subsampling_y				   = 1;
+	summary.chroma_sample_position				   = 0;
+	// op-0 delay absent in the in-band Sequence Header: helper must encode
+	// `present = 0` and wipe the stale `initial_presentation_delay_minus_one`
+	// back to 0 (av1_decoder_configuration_record.cpp:461 false branch).
+	summary.initial_display_delay_present_for_op_0 = 0;
+	summary.initial_display_delay_minus_1_for_op_0 = 0;
+
+	MediaRouterNormalize::ApplyInBandSequenceHeaderToAv1Config(av1_config, summary);
+
+	// Regression: the helper must reset the seeded 1/5 state back to 0/0.
+	// If SetInitialPresentationDelay() is omitted the av1C keeps 1/5 and this fails.
+	EXPECT_EQ(av1_config->InitialPresentationDelayPresent(), 0);
+	EXPECT_EQ(av1_config->InitialPresentationDelayMinusOne(), 0);
 }

--- a/src/projects/mediarouter/mediarouter_test.cpp
+++ b/src/projects/mediarouter/mediarouter_test.cpp
@@ -27,11 +27,11 @@ TEST(MediaRouterPlaceholder, TodoImplementTests)
 //
 // The CodedFrames branch of `MediaRouterNormalize::ProcessAV1OBUStream` enters
 // `ApplyInBandSequenceHeaderToAv1Config` after the enhanced-RTMP (FLV) ingest path
-// synthesized the lenient default av1C blob `0x81 0x00 0x00 0x00`. The helper
-// must copy every cross-checked field (per AV1 ISOBMFF binding v1.3.0 section
-// 2.3.4 (Semantics)) from the in-band Sequence Header summary onto the av1C - including
-// the `initial_presentation_delay_*` pair that was historically missed and
-// caused the synthesized av1C to go stale on streams with op-0 delay != 0.
+// synthesized the lenient default av1C blob `0x81 0x00 0x00 0x00`. The helper copies the
+// matchable fields (per AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics)) from the
+// in-band Sequence Header summary onto the av1C. `initial_presentation_delay_*` is NOT
+// among them: it is an av1C-only field with no Sequence Header "SHALL match" rule, so the
+// helper must leave it untouched - the tests below pin down both behaviours.
 // ---------------------------------------------------------------------------
 namespace
 {

--- a/src/projects/mediarouter/mediarouter_test.cpp
+++ b/src/projects/mediarouter/mediarouter_test.cpp
@@ -28,8 +28,8 @@ TEST(MediaRouterPlaceholder, TodoImplementTests)
 // The CodedFrames branch of `MediaRouterNormalize::ProcessAV1OBUStream` enters
 // `ApplyInBandSequenceHeaderToAv1Config` after the enhanced-RTMP (FLV) ingest path
 // synthesized the lenient default av1C blob `0x81 0x00 0x00 0x00`. The helper
-// must copy every cross-checked field (per AV1 ISOBMFF binding v1.2.0 section
-// 2.3.2) from the in-band Sequence Header summary onto the av1C - including
+// must copy every cross-checked field (per AV1 ISOBMFF binding v1.3.0 section
+// 2.3.4 (Semantics)) from the in-band Sequence Header summary onto the av1C - including
 // the `initial_presentation_delay_*` pair that was historically missed and
 // caused the synthesized av1C to go stale on streams with op-0 delay != 0.
 // ---------------------------------------------------------------------------

--- a/src/projects/mediarouter/mediarouter_test.cpp
+++ b/src/projects/mediarouter/mediarouter_test.cpp
@@ -26,7 +26,7 @@ TEST(MediaRouterPlaceholder, TodoImplementTests)
 // Regression coverage for the in-band Sequence Header to av1C field sync.
 //
 // The CodedFrames branch of `MediaRouterNormalize::ProcessAV1OBUStream` enters
-// `ApplyInBandSequenceHeaderToAv1Config` after `flv_video_parser::ParseAV1`
+// `ApplyInBandSequenceHeaderToAv1Config` after the enhanced-RTMP (FLV) ingest path
 // synthesized the lenient default av1C blob `0x81 0x00 0x00 0x00`. The helper
 // must copy every cross-checked field (per AV1 ISOBMFF binding v1.2.0 section
 // 2.3.2) from the in-band Sequence Header summary onto the av1C - including

--- a/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.cpp
+++ b/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.cpp
@@ -105,7 +105,7 @@ bool AV1DecoderConfigurationRecord::Parse(const uint8_t *data, size_t length)
 		return false;
 	}
 
-	// AV1 ISOBMFF binding v1.2.0 section 2.3.1: the 3-bit `reserved` field SHALL be 0. Reject any
+	// AV1 ISOBMFF binding v1.3.0 section 2.3.3 (Syntax) declares `unsigned int(3) reserved = 0`. Reject any
 	// av1C blob that carries non-zero reserved bits so the strict parser does not silently accept
 	// malformed records (same policy as the OBU header reserved-bit reject in `av1_parser.cpp`).
 	const uint8_t reserved_3 = parser.ReadBits<uint8_t>(3);			// reserved
@@ -121,8 +121,8 @@ bool AV1DecoderConfigurationRecord::Parse(const uint8_t *data, size_t length)
 	}
 	else
 	{
-		// AV1 ISOBMFF binding v1.2.0 section 2.3.1: the trailing 4-bit `reserved` field (present
-		// only when `initial_presentation_delay_present == 0`) SHALL be 0.
+		// AV1 ISOBMFF binding v1.3.0 section 2.3.3 (Syntax) declares the trailing 4-bit `reserved = 0`
+		// (present only when `initial_presentation_delay_present == 0`).
 		const uint8_t reserved_4 = parser.ReadBits<uint8_t>(4);		// reserved
 		if (reserved_4 != 0)
 		{
@@ -141,12 +141,13 @@ bool AV1DecoderConfigurationRecord::Parse(const uint8_t *data, size_t length)
 		_config_obus = nullptr;
 	}
 
-	// AV1 ISOBMFF binding v1.2.0 4.2.1:
-	//   "The `configOBUs` field SHALL contain zero or more OBUs..."
-	//   "At most one Sequence Header OBU SHALL be present..."
-	//   "If present, the Sequence Header OBU SHALL be the first OBU."
-	//   "If a Sequence Header OBU is present in `configOBUs`, the values of the fields in
-	//    `AV1CodecConfigurationRecord` SHALL match those of the Sequence Header OBU."
+	// AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics):
+	//   "The configOBUs field contains zero or more OBUs."
+	//   "the configOBUs field SHALL contain at most one Sequence Header OBU and if present, it
+	//    SHALL be the first OBU."
+	//   "When a Sequence Header OBU is contained within the configOBUs of the
+	//    AV1CodecConfigurationRecord, the values present in the Sequence Header OBU contained
+	//    within configOBUs SHALL match the values of the AV1CodecConfigurationRecord."
 	if (_config_obus != nullptr && _config_obus->GetLength() > 0)
 	{
 		if (ValidateConfigObus() == false)
@@ -180,8 +181,8 @@ bool AV1DecoderConfigurationRecord::ValidateConfigObus()
 		size_t payload_offset = offset + parsed->bytes_consumed;
 		size_t payload_size	  = 0;
 
-		// AV1 ISOBMFF binding v1.2.0: `configOBUs` is a size-delimited OBU sequence; every OBU
-		// in the field SHALL set `obu_has_size_field = 1`. This is distinct from the in-band
+		// AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics): `configOBUs` is a size-delimited OBU sequence;
+		// "The flag obu_has_size_field SHALL be set to 1". This is distinct from the in-band
 		// low-overhead bitstream format walked by `Av1Parser::ExtractFirstSequenceHeaderObu()`,
 		// which tolerates a leading `obu_has_size_field = 0` `TemporalDelimiter` (spec 5.6:
 		// "Note: The temporal delimiter has an empty payload.") because its payload size is
@@ -316,7 +317,7 @@ bool AV1DecoderConfigurationRecord::Parse(const std::shared_ptr<const ov::Data> 
 
 bool AV1DecoderConfigurationRecord::Equals(const std::shared_ptr<DecoderConfigurationRecord> &other)
 {
-	// AV1 ISOBMFF binding v1.2.0 section 2.3 defines `AV1CodecConfigurationRecord` as the
+	// AV1 ISOBMFF binding v1.3.0 section 2.3.3 (Syntax) defines `AV1CodecConfigurationRecord` as the
 	// canonical serialized form of the av1C box. Two records are equal iff they would emit
 	// identical bytes through that serialization, so compare the serialized buffer end-to-end
 	// rather than a hand-picked subset of fixed fields. This catches differences in any of

--- a/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.cpp
+++ b/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.cpp
@@ -20,7 +20,7 @@
 
 bool AV1DecoderConfigurationRecord::IsValid() const
 {
-	return _parsed && _marker == 1 && _version == 1;
+	return _valid && _marker == 1 && _version == 1;
 }
 
 ov::String AV1DecoderConfigurationRecord::GetCodecsParameter() const
@@ -55,12 +55,12 @@ bool AV1DecoderConfigurationRecord::Parse(const uint8_t *data, size_t length)
 {
 	// Invalidate any prior parse state up front.
 	// A re-parse on a reused instance must not leave the previous result observable:
-	// without this, a failure at any point below would leave `_parsed` (hence `IsValid()`) `true`
+	// without this, a failure at any point below would leave `_valid` (hence `IsValid()`) `true`
 	// and `GetData()` returning bytes cached by an earlier successful parse.
 	// `UpdateData()` drops the cached serialized buffer so `GetData()` no longer returns stale bytes.
 	// `_config_obus` is only assigned after the fixed header is fully read, so an early failure would
 	// otherwise leave the previous parse's OBU buffer reachable through `ConfigObus()`; clear it too.
-	_parsed		 = false;
+	_valid		 = false;
 	_config_obus = nullptr;
 	UpdateData();
 
@@ -156,7 +156,7 @@ bool AV1DecoderConfigurationRecord::Parse(const uint8_t *data, size_t length)
 		}
 	}
 
-	_parsed = true;
+	_valid = true;
 
 	return true;
 }
@@ -169,45 +169,26 @@ bool AV1DecoderConfigurationRecord::ValidateConfigObus()
 	size_t obu_index   = 0;
 	bool seen_seq_hdr  = false;
 
+	Av1ObuSpan obu;
 	while (offset < total)
 	{
-		auto parsed = Av1Parser::ParseObuHeader(base + offset, total - offset);
-		if (parsed.has_value() == false)
+		if (Av1Parser::ReadObu(base, total, offset, obu) == false)
 		{
 			return false;
 		}
 
-		const auto &header	  = parsed->header;
-		size_t payload_offset = offset + parsed->bytes_consumed;
-		size_t payload_size	  = 0;
-
-		// AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics): `configOBUs` is a size-delimited OBU sequence;
-		// "The flag obu_has_size_field SHALL be set to 1". This is distinct from the in-band
-		// low-overhead bitstream format walked by `Av1Parser::ExtractFirstSequenceHeaderObu()`,
-		// which tolerates a leading `obu_has_size_field = 0` `TemporalDelimiter` (spec 5.6:
-		// "Note: The temporal delimiter has an empty payload.") because its payload size is
-		// statically zero. Inside `configOBUs` there is no such heuristic - absorbing the
-		// remainder as one anonymous payload would silently swallow follow-up OBUs and bypass
-		// the cross-check rules below, so reject immediately.
-		if (header.has_size_field == false)
+		// AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics): `configOBUs` is a size-delimited OBU
+		// sequence; "The flag obu_has_size_field SHALL be set to 1". Unlike the tolerant in-band scan
+		// in `Av1Parser::ReadObu()`, a missing size field here would let the remainder be swallowed as
+		// one anonymous payload and bypass the cross-check rules below, so reject immediately.
+		if (obu.header.has_size_field == false)
 		{
 			return false;
 		}
 
-		auto leb = Av1Parser::DecodeLeb128(base + payload_offset, total - payload_offset);
-		if (leb.has_value() == false)
-		{
-			return false;
-		}
-
-		payload_offset += leb->bytes_consumed;
-
-		if (leb->value > total - payload_offset)
-		{
-			return false;
-		}
-
-		payload_size = static_cast<size_t>(leb->value);
+		const auto &header	  = obu.header;
+		size_t payload_offset = obu.payload_offset;
+		size_t payload_size	  = obu.payload_size;
 
 		if (header.type == Av1ObuType::SequenceHeader)
 		{

--- a/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.cpp
+++ b/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.cpp
@@ -225,12 +225,11 @@ bool AV1DecoderConfigurationRecord::ValidateConfigObus()
 
 			// Cross-check rule: Sequence Header OBU fields SHALL match the `av1C` fixed fields.
 			//
-			// AV1 ISOBMFF binding v1.2.0 section 2.3.2: "When the configOBUs field contains a
-			// Sequence Header OBU, the values of the AV1CodecConfigurationRecord fields shall
-			// match those of the OBU. Specifically: seq_profile, seq_level_idx_0, seq_tier_0,
-			// high_bitdepth, twelve_bit, monochrome, chroma_subsampling_x, chroma_subsampling_y,
-			// chroma_sample_position (when not zero), and initial_presentation_delay_minus_one,
-			// when present, all shall match."
+			// AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics): "When a Sequence Header OBU is
+			// contained within the configOBUs of the AV1CodecConfigurationRecord, the values present
+			// in the Sequence Header OBU contained within configOBUs SHALL match the values of the
+			// AV1CodecConfigurationRecord." Each fixed field below has its own "SHALL be equal to
+			// ... from the Sequence Header OBU" clause in section 2.3.4.
 			auto summary = Av1Parser::ParseSequenceHeaderSummary(base + payload_offset, payload_size);
 			if (summary.has_value() == false)
 			{
@@ -274,19 +273,11 @@ bool AV1DecoderConfigurationRecord::ValidateConfigObus()
 				return false;
 			}
 
-			// AV1 ISOBMFF binding v1.2.0 section 2.3.2: "initial_presentation_delay_minus_one,
-			// when present, all shall match." The av1C `initial_presentation_delay_present`
-			// flag must equal the Sequence Header's `initial_display_delay_present_for_op_0`,
-			// and when both are 1 the `_minus_one` value must match.
-			if (summary->initial_display_delay_present_for_op_0 != _initial_presentation_delay_present)
-			{
-				return false;
-			}
-			if ((_initial_presentation_delay_present != 0) &&
-				(summary->initial_display_delay_minus_1_for_op_0 != _initial_presentation_delay_minus_one))
-			{
-				return false;
-			}
+			// NOTE: `initial_presentation_delay` is deliberately NOT cross-checked against the
+			// Sequence Header. AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics) gives no
+			// "SHALL match" rule for it; it is an av1C-only field derived from a decoder-model
+			// procedure over all samples, and the spec explicitly notes it differs from the
+			// Sequence Header's `initial_display_delay_minus_1`.
 		}
 
 		offset = payload_offset + payload_size;

--- a/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.h
+++ b/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.h
@@ -133,9 +133,11 @@ public:
 	uint8_t BitDepth() const;
 
 private:
-	/// Walk `_config_obus`, enforcing AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics) rules: valid OBU sequence, at most
-	/// one Sequence Header OBU, Sequence Header must be the first OBU, and Sequence Header fields
-	/// must match the fixed `av1C` fields (`seq_profile`, `seq_level_idx_0`).
+	/// Walk `_config_obus`, enforcing AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics) rules: a
+	/// valid OBU sequence, at most one Sequence Header OBU, the Sequence Header (if present) as the
+	/// first OBU, and its fields matching the fixed `av1C` fields (`seq_profile`, `seq_level_idx_0`,
+	/// `seq_tier_0`, `high_bitdepth`, `twelve_bit`, `monochrome`, `chroma_subsampling_x/y`, and
+	/// `chroma_sample_position` when non-zero).
 	bool ValidateConfigObus();
 
 	uint8_t _marker = 1;

--- a/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.h
+++ b/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.h
@@ -154,5 +154,8 @@ private:
 
 	std::shared_ptr<ov::Data> _config_obus;
 
-	bool _parsed = false;
+	// Valid by default: a default-constructed record holds the lenient `0x81 0x00 0x00 0x00` fields
+	// (marker/version = 1), which is a usable av1C. Parse() clears this on entry and sets it true
+	// only on success, so a failed parse is observable as invalid via IsValid().
+	bool _valid = true;
 };

--- a/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.h
+++ b/src/projects/modules/bitstream/av1/av1_decoder_configuration_record.h
@@ -133,7 +133,7 @@ public:
 	uint8_t BitDepth() const;
 
 private:
-	/// Walk `_config_obus`, enforcing AV1 ISOBMFF binding v1.2.0 rules: valid OBU sequence, at most
+	/// Walk `_config_obus`, enforcing AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics) rules: valid OBU sequence, at most
 	/// one Sequence Header OBU, Sequence Header must be the first OBU, and Sequence Header fields
 	/// must match the fixed `av1C` fields (`seq_profile`, `seq_level_idx_0`).
 	bool ValidateConfigObus();

--- a/src/projects/modules/bitstream/av1/av1_decoder_configuration_record_test.cpp
+++ b/src/projects/modules/bitstream/av1/av1_decoder_configuration_record_test.cpp
@@ -415,9 +415,10 @@ TEST(AV1DecoderConfigurationRecord, RoundTripSerialize)
 	//   seq_level_idx_0 = 4 (<=7 -> seq_tier_0 inferred to 0)
 	//   high_bitdepth = 0, twelve_bit = 0, monochrome = 0
 	//   chroma_sample_position = 0 (CSP_UNKNOWN)
-	// AV1 ISOBMFF binding v1.2.0 section 2.3.2 also requires the embedded SH
-	// `initial_display_delay_present_for_op_0` / `_minus_1_for_op_0` to match the av1C fields, so
-	// use the full (non-reduced) SH builder that can carry initial_display_delay signaling.
+	// The av1C also carries `initial_presentation_delay` (1/5 here), which must round-trip through
+	// serialize/reparse below. It is NOT cross-checked against the Sequence Header's
+	// `initial_display_delay` (distinct fields, no match rule - see `ValidateConfigObus`); the full
+	// SH builder is used only so the embedded OBU is well-formed.
 	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, true, 5);
 	const auto sh = BuildFullSeqHeaderPayloadWithInitialDisplayDelay(
 		/*seq_profile=*/0, /*seq_level_idx_0=*/4, /*seq_tier_0=*/0,
@@ -839,42 +840,6 @@ TEST(AV1DecoderConfigurationRecord, AcceptsZeroChromaSamplePositionMismatch)
 	EXPECT_TRUE(record.Parse(MakeData(bytes)));
 }
 
-TEST(AV1DecoderConfigurationRecord, AcceptsConfigObuInitialPresentationDelayMatch)
-{
-	// AV1 ISOBMFF binding v1.2.0 section 2.3.2: "initial_presentation_delay_minus_one, when present,
-	// all shall match." Positive case - av1C declares `present = 1`, `minus_one = 5`; the embedded
-	// Sequence Header carries the same per-op-0 values, so cross-check accepts.
-	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, /*delay_present=*/true, /*delay_minus_one=*/5);
-	const auto sh = BuildFullSeqHeaderPayloadWithInitialDisplayDelay(
-		/*seq_profile=*/0, /*seq_level_idx_0=*/4, /*seq_tier_0=*/0,
-		/*initial_display_delay_present_for_op_0=*/1,
-		/*initial_display_delay_minus_1_for_op_0=*/5);
-	const auto obus = BuildObu(Av1ObuType::SequenceHeader, sh);
-	bytes.insert(bytes.end(), obus.begin(), obus.end());
-
-	AV1DecoderConfigurationRecord record;
-	ASSERT_TRUE(record.Parse(MakeData(bytes)));
-	EXPECT_EQ(record.InitialPresentationDelayPresent(), 1);
-	EXPECT_EQ(record.InitialPresentationDelayMinusOne(), 5);
-}
-
-TEST(AV1DecoderConfigurationRecord, RejectsConfigObuInitialPresentationDelayPresentMismatch)
-{
-	// AV1 ISOBMFF binding v1.2.0 section 2.3.2: presence-flag mismatch must reject. av1C says
-	// `initial_presentation_delay_present = 1`, but the embedded SH carries
-	// `initial_display_delay_present_for_op_0 = 0` -> reject.
-	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, /*delay_present=*/true, /*delay_minus_one=*/3);
-	const auto sh = BuildFullSeqHeaderPayloadWithInitialDisplayDelay(
-		/*seq_profile=*/0, /*seq_level_idx_0=*/4, /*seq_tier_0=*/0,
-		/*initial_display_delay_present_for_op_0=*/0,
-		/*initial_display_delay_minus_1_for_op_0=*/0);
-	const auto obus = BuildObu(Av1ObuType::SequenceHeader, sh);
-	bytes.insert(bytes.end(), obus.begin(), obus.end());
-
-	AV1DecoderConfigurationRecord record;
-	EXPECT_FALSE(record.Parse(MakeData(bytes)));
-}
-
 TEST(AV1DecoderConfigurationRecord, RejectsConfigObuWithoutSizeField)
 {
 	// AV1 ISOBMFF binding v1.2.0: every OBU inside `configOBUs` SHALL set `obu_has_size_field = 1`.
@@ -920,20 +885,4 @@ TEST(AV1DecoderConfigurationRecord, RejectsFixedHeaderReserved4BitsNonZero)
 	AV1DecoderConfigurationRecord record;
 	EXPECT_FALSE(record.Parse(MakeData(bytes)));
 	EXPECT_FALSE(record.IsValid());
-}
-
-TEST(AV1DecoderConfigurationRecord, RejectsConfigObuInitialPresentationDelayValueMismatch)
-{
-	// AV1 ISOBMFF binding v1.2.0 section 2.3.2: when both sides set `present = 1`, the
-	// `_minus_one` values must match. av1C declares 5; SH declares 7 -> reject.
-	auto bytes = BuildAv1cHeader(0, 4, 0, 0, 0, 0, 1, 1, 0, /*delay_present=*/true, /*delay_minus_one=*/5);
-	const auto sh = BuildFullSeqHeaderPayloadWithInitialDisplayDelay(
-		/*seq_profile=*/0, /*seq_level_idx_0=*/4, /*seq_tier_0=*/0,
-		/*initial_display_delay_present_for_op_0=*/1,
-		/*initial_display_delay_minus_1_for_op_0=*/7);
-	const auto obus = BuildObu(Av1ObuType::SequenceHeader, sh);
-	bytes.insert(bytes.end(), obus.begin(), obus.end());
-
-	AV1DecoderConfigurationRecord record;
-	EXPECT_FALSE(record.Parse(MakeData(bytes)));
 }

--- a/src/projects/modules/bitstream/av1/av1_parser.cpp
+++ b/src/projects/modules/bitstream/av1/av1_parser.cpp
@@ -465,7 +465,7 @@ std::optional<Av1SequenceHeaderSummary> Av1Parser::ParseSequenceHeaderSummary(co
 
 	// AV1 spec 5.5.1 `sequence_header_obu()`: continue past `max_frame_height_minus_1` so the
 	// `color_config()` sub-tree can be reached. Cross-checking the configOBUs requires the
-	// `color_config()` values per AV1 ISOBMFF binding v1.2.0 section 2.3.2.
+	// `color_config()` values per AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics).
 	if (out.reduced_still_picture_header == false)
 	{
 		AV1_READ_BITS(uint8_t, frame_id_numbers_present_flag, 1);
@@ -536,8 +536,8 @@ std::optional<Av1SequenceHeaderSummary> Av1Parser::ParseSequenceHeaderSummary(co
 	(void)enable_cdef;
 	(void)enable_restoration;
 
-	// AV1 spec 5.5.2 `color_config()` - capture every field needed by AV1 ISOBMFF binding v1.2.0
-	// section 2.3.2 cross-check.
+	// AV1 spec 5.5.2 `color_config()` - capture every field needed by AV1 ISOBMFF binding v1.3.0
+	// section 2.3.4 (Semantics) cross-check.
 	AV1_READ_BITS(uint8_t, high_bitdepth, 1);
 	out.high_bitdepth = high_bitdepth;
 	if ((out.seq_profile == 2) && (high_bitdepth != 0))

--- a/src/projects/modules/bitstream/av1/av1_parser.cpp
+++ b/src/projects/modules/bitstream/av1/av1_parser.cpp
@@ -433,10 +433,11 @@ std::optional<Av1SequenceHeaderSummary> Av1Parser::ParseSequenceHeaderSummary(co
 					initial_display_delay_minus_1_for_this_op = initial_display_delay_minus_1;
 				}
 
-				// AV1 ISOBMFF binding v1.2.0 section 2.3.2 cross-check requires the `op_0`
-				// `initial_display_delay` signaling to match the `av1C` fixed header. Capture
-				// the per-op values for `i == 0` only; later operating points are still walked
-				// for bit alignment but their values are not recorded.
+				// Capture the `op_0` `initial_display_delay` signaling from the Sequence Header
+				// (AV1 spec 5.5.1) for `i == 0` only; later operating points are still walked for
+				// bit alignment but their values are not recorded. NOTE: this is NOT cross-checked
+				// against the av1C `initial_presentation_delay` - they are distinct fields with no
+				// "SHALL match" rule (AV1 ISOBMFF binding v1.3.0 section 2.3.4 (Semantics)).
 				if (i == 0)
 				{
 					out.initial_display_delay_present_for_op_0 = initial_display_delay_present_for_this_op;

--- a/src/projects/modules/bitstream/av1/av1_parser.cpp
+++ b/src/projects/modules/bitstream/av1/av1_parser.cpp
@@ -340,6 +340,13 @@ std::shared_ptr<const ov::Data> Av1Parser::ExtractFirstSequenceHeaderObuRaw(cons
 		}
 		if (obu.header.type == Av1ObuType::SequenceHeader)
 		{
+			// Only a size-delimited OBU is usable as a standalone / configOBUs sequence header (the
+			// AV1 ISOBMFF binding requires obu_has_size_field == 1). A size-less one carries no
+			// obu_size, so reject it rather than hand back a buffer that builds an invalid av1C.
+			if (obu.header.has_size_field == false)
+			{
+				return nullptr;
+			}
 			// Full OBU: header + obu_size + payload.
 			return std::make_shared<ov::Data>(base + obu.obu_offset, obu.next_offset - obu.obu_offset);
 		}

--- a/src/projects/modules/bitstream/av1/av1_parser.cpp
+++ b/src/projects/modules/bitstream/av1/av1_parser.cpp
@@ -208,9 +208,10 @@ std::shared_ptr<const ov::Data> Av1Parser::ExtractFirstSequenceHeaderObu(const s
 
 		if (obu.header.type == Av1ObuType::SequenceHeader)
 		{
+			// A sequence header with no payload is malformed; report it as absent.
 			if (obu.payload_size == 0)
 			{
-				return std::make_shared<ov::Data>();
+				return nullptr;
 			}
 			return std::make_shared<ov::Data>(base + obu.payload_offset, obu.payload_size);
 		}

--- a/src/projects/modules/bitstream/av1/av1_parser.cpp
+++ b/src/projects/modules/bitstream/av1/av1_parser.cpp
@@ -137,6 +137,57 @@ std::optional<ParsedObuHeader> Av1Parser::ParseObuHeader(const uint8_t *data, si
 	return parsed;
 }
 
+bool Av1Parser::ReadObu(const uint8_t *data, size_t size, size_t offset, Av1ObuSpan &out)
+{
+	if (data == nullptr || offset >= size)
+	{
+		return false;
+	}
+
+	auto parsed = ParseObuHeader(data + offset, size - offset);
+	if (parsed.has_value() == false)
+	{
+		return false;
+	}
+
+	size_t payload_offset = offset + parsed->bytes_consumed;
+	size_t payload_size	  = 0;
+
+	if (parsed->header.has_size_field)
+	{
+		auto leb = DecodeLeb128(data + payload_offset, size - payload_offset);
+		if (leb.has_value() == false)
+		{
+			return false;
+		}
+		payload_offset += leb->bytes_consumed;
+		if (leb->value > size - payload_offset)
+		{
+			return false;
+		}
+		payload_size = static_cast<size_t>(leb->value);
+	}
+	else if (parsed->header.type == Av1ObuType::TemporalDelimiter)
+	{
+		// AV1 spec 5.6: the temporal delimiter has an empty payload, so it can be walked past even
+		// in a low-overhead (`obu_has_size_field = 0`) in-band stream.
+		payload_size = 0;
+	}
+	else
+	{
+		// No size field and not a TemporalDelimiter: the remainder of the buffer is this OBU's
+		// payload. Callers that require a size field (e.g. `configOBUs`) reject on `has_size_field`.
+		payload_size = size - payload_offset;
+	}
+
+	out.header		   = parsed->header;
+	out.obu_offset	   = offset;
+	out.payload_offset = payload_offset;
+	out.payload_size   = payload_size;
+	out.next_offset	   = payload_offset + payload_size;
+	return true;
+}
+
 std::shared_ptr<const ov::Data> Av1Parser::ExtractFirstSequenceHeaderObu(const std::shared_ptr<const ov::Data> &config_obus)
 {
 	if (config_obus == nullptr || config_obus->GetLength() == 0)
@@ -147,67 +198,151 @@ std::shared_ptr<const ov::Data> Av1Parser::ExtractFirstSequenceHeaderObu(const s
 	const auto *base   = config_obus->GetDataAs<uint8_t>();
 	const size_t total = config_obus->GetLength();
 	size_t offset	   = 0;
-
+	Av1ObuSpan obu;
 	while (offset < total)
 	{
-		auto parsed = ParseObuHeader(base + offset, total - offset);
-		if (parsed.has_value() == false)
+		if (ReadObu(base, total, offset, obu) == false)
 		{
 			return nullptr;
 		}
 
-		const auto &header	  = parsed->header;
-		size_t payload_offset = offset + parsed->bytes_consumed;
-		size_t payload_size	  = 0;
-
-		if (header.has_size_field)
+		if (obu.header.type == Av1ObuType::SequenceHeader)
 		{
-			auto leb = DecodeLeb128(base + payload_offset, total - payload_offset);
-			if (leb.has_value() == false)
-			{
-				return nullptr;
-			}
-
-			payload_offset += leb->bytes_consumed;
-
-			if (leb->value > total - payload_offset)
-			{
-				return nullptr;
-			}
-
-			payload_size = static_cast<size_t>(leb->value);
-		}
-		else
-		{
-			// AV1 ISO BMFF requires `obu_has_size_field=1` inside `configOBUs`. If we hit an OBU without
-			// a size field there's no way to know where the next one starts, so the remainder of the
-			// buffer is treated as this OBU's payload.
-			//
-			// AV1 spec 5.6 `temporal_delimiter_obu()` is defined as a NO-OP: "Note: The temporal delimiter
-			// has an empty payload." When the stream uses the low-overhead bitstream format
-			// (`obu_has_size_field = 0`) we can still walk past a leading TemporalDelimiter because its
-			// payload is guaranteed to be zero bytes. This lets `ExtractFirstSequenceHeaderObu()` reach a
-			// subsequent SequenceHeader OBU in an in-band scan.
-			if (header.type == Av1ObuType::TemporalDelimiter)
-			{
-				payload_size = 0;
-			}
-			else
-			{
-				payload_size = total - payload_offset;
-			}
-		}
-
-		if (header.type == Av1ObuType::SequenceHeader)
-		{
-			if (payload_size == 0)
+			if (obu.payload_size == 0)
 			{
 				return std::make_shared<ov::Data>();
 			}
-			return std::make_shared<ov::Data>(base + payload_offset, payload_size);
+			return std::make_shared<ov::Data>(base + obu.payload_offset, obu.payload_size);
 		}
 
-		offset = payload_offset + payload_size;
+		offset = obu.next_offset;
+	}
+
+	return nullptr;
+}
+
+namespace
+{
+	// AV1 spec 5.9.2 `uncompressed_header()` key-frame prefix. With `reduced_still_picture_header`
+	// the frame is always a KEY_FRAME. Otherwise the first bit is `show_existing_frame` and the next
+	// 2 bits are `frame_type` (0 == KEY_FRAME).
+	bool FrameObuIsKeyFrame(const uint8_t *payload, size_t size, bool reduced)
+	{
+		if (reduced)
+		{
+			return true;
+		}
+
+		BitReader reader(payload, size);
+		uint8_t show_existing_frame = 0;
+		if (reader.ReadBits<uint8_t>(1, show_existing_frame) == false)
+		{
+			return false;
+		}
+		if (show_existing_frame != 0)
+		{
+			return false;  // displays an already-decoded frame, not a new key frame
+		}
+
+		uint8_t frame_type = 0;
+		if (reader.ReadBits<uint8_t>(2, frame_type) == false)
+		{
+			return false;
+		}
+		return frame_type == 0;  // 0 == KEY_FRAME
+	}
+}  // namespace
+
+bool Av1Parser::IsKeyFrame(const uint8_t *data, size_t size)
+{
+	if (data == nullptr)
+	{
+		return false;
+	}
+
+	bool reduced  = false;
+	size_t offset = 0;
+	Av1ObuSpan obu;
+	while (offset < size)
+	{
+		if (ReadObu(data, size, offset, obu) == false)
+		{
+			return false;
+		}
+
+		if (obu.header.type == Av1ObuType::SequenceHeader)
+		{
+			// Only `reduced_still_picture_header` is needed here (it decides how frame_type is read),
+			// so read just the leading bits instead of the full sequence header: AV1 spec 5.5.1
+			// seq_profile f(3), still_picture f(1), reduced_still_picture_header f(1).
+			BitReader reader(data + obu.payload_offset, obu.payload_size);
+			uint8_t seq_profile = 0, still_picture = 0, reduced_flag = 0;
+			if (reader.ReadBits<uint8_t>(3, seq_profile) &&
+				reader.ReadBits<uint8_t>(1, still_picture) &&
+				reader.ReadBits<uint8_t>(1, reduced_flag))
+			{
+				reduced = (reduced_flag != 0);
+			}
+		}
+		else if (obu.header.type == Av1ObuType::Frame || obu.header.type == Av1ObuType::FrameHeader)
+		{
+			return FrameObuIsKeyFrame(data + obu.payload_offset, obu.payload_size, reduced);
+		}
+
+		offset = obu.next_offset;
+	}
+
+	return false;
+}
+
+bool Av1Parser::HasSequenceHeaderObu(const uint8_t *data, size_t size)
+{
+	if (data == nullptr)
+	{
+		return false;
+	}
+
+	size_t offset = 0;
+	Av1ObuSpan obu;
+	while (offset < size)
+	{
+		if (ReadObu(data, size, offset, obu) == false)
+		{
+			return false;
+		}
+		if (obu.header.type == Av1ObuType::SequenceHeader)
+		{
+			return true;
+		}
+		offset = obu.next_offset;
+	}
+
+	return false;
+}
+
+std::shared_ptr<const ov::Data> Av1Parser::ExtractFirstSequenceHeaderObuRaw(const std::shared_ptr<const ov::Data> &config_obus)
+{
+	if (config_obus == nullptr || config_obus->GetLength() == 0)
+	{
+		return nullptr;
+	}
+
+	const auto *base   = config_obus->GetDataAs<uint8_t>();
+	const size_t total = config_obus->GetLength();
+	size_t offset	   = 0;
+	Av1ObuSpan obu;
+	while (offset < total)
+	{
+		if (ReadObu(base, total, offset, obu) == false)
+		{
+			return nullptr;
+		}
+		if (obu.header.type == Av1ObuType::SequenceHeader)
+		{
+			// Full OBU: header + obu_size + payload.
+			return std::make_shared<ov::Data>(base + obu.obu_offset, obu.next_offset - obu.obu_offset);
+		}
+		offset = obu.next_offset;
 	}
 
 	return nullptr;

--- a/src/projects/modules/bitstream/av1/av1_parser.h
+++ b/src/projects/modules/bitstream/av1/av1_parser.h
@@ -85,8 +85,10 @@ public:
 		return (data != nullptr) && HasSequenceHeaderObu(data->GetDataAs<uint8_t>(), data->GetLength());
 	}
 
-	/// Return the first `OBU_SEQUENCE_HEADER` as a complete OBU (header + `obu_size` + payload), e.g.
-	/// to prepend it to a key frame that has no in-band sequence header. `nullptr` if absent.
+	/// Return the first `OBU_SEQUENCE_HEADER` as a complete, size-delimited OBU (header + `obu_size` +
+	/// payload) - suitable for `configOBUs` or for prepending to a key frame that lacks an in-band
+	/// sequence header. Returns `nullptr` if absent, or if the OBU is not size-delimited
+	/// (`obu_has_size_field == 0`), since the AV1 ISOBMFF binding requires `obu_has_size_field == 1`.
 	static std::shared_ptr<const ov::Data> ExtractFirstSequenceHeaderObuRaw(const std::shared_ptr<const ov::Data> &config_obus);
 
 	/// Parse the leading mandatory fields of a `sequence_header_obu()` payload per AV1 spec section 5.5.1.

--- a/src/projects/modules/bitstream/av1/av1_parser.h
+++ b/src/projects/modules/bitstream/av1/av1_parser.h
@@ -47,6 +47,15 @@ public:
 	/// @return `ParsedObuHeader` (header + bytes consumed, 1 or 2) on success, `std::nullopt` on failure.
 	static std::optional<ParsedObuHeader> ParseObuHeader(const uint8_t *data, size_t size);
 
+	/// Read one OBU at `offset`: header (via `ParseObuHeader`), `obu_size` (via `DecodeLeb128`), and
+	/// the payload bounds / next-OBU offset. The single OBU-walk primitive reused by the scanners
+	/// below and by `AV1DecoderConfigurationRecord`. An OBU with `obu_has_size_field == 0` takes its
+	/// payload as the rest of the buffer (zero for a TemporalDelimiter); callers that require a size
+	/// field (e.g. `configOBUs`) check `out.header.has_size_field`.
+	///
+	/// @return `false` on a malformed header / `obu_size`, otherwise `true` with `out` populated.
+	static bool ReadObu(const uint8_t *data, size_t size, size_t offset, Av1ObuSpan &out);
+
 	/// Walk an AV1 OBU bytestream and return the payload of the first `OBU_SEQUENCE_HEADER`.
 	///
 	/// Accepts both the `configOBUs` payload of an `AV1CodecConfigurationBox` (per AV1 ISOBMFF binding)
@@ -57,6 +66,28 @@ public:
 	///
 	/// @return Payload bytes of the first sequence header OBU, or `nullptr` if absent or buffer is malformed.
 	static std::shared_ptr<const ov::Data> ExtractFirstSequenceHeaderObu(const std::shared_ptr<const ov::Data> &config_obus);
+
+	/// Return true if the OBU bytestream's coded frame is a `KEY_FRAME` (AV1 spec `frame_type`).
+	///
+	/// Uses the in-band sequence header (if present) for `reduced_still_picture_header`, then reads
+	/// `frame_type` from the first Frame / FrameHeader OBU. The presence of an `OBU_SEQUENCE_HEADER`
+	/// alone is NOT a valid key-frame test.
+	static bool IsKeyFrame(const uint8_t *data, size_t size);
+	static bool IsKeyFrame(const std::shared_ptr<const ov::Data> &data)
+	{
+		return (data != nullptr) && IsKeyFrame(data->GetDataAs<uint8_t>(), data->GetLength());
+	}
+
+	/// Return true if the OBU bytestream contains an `OBU_SEQUENCE_HEADER`.
+	static bool HasSequenceHeaderObu(const uint8_t *data, size_t size);
+	static bool HasSequenceHeaderObu(const std::shared_ptr<const ov::Data> &data)
+	{
+		return (data != nullptr) && HasSequenceHeaderObu(data->GetDataAs<uint8_t>(), data->GetLength());
+	}
+
+	/// Return the first `OBU_SEQUENCE_HEADER` as a complete OBU (header + `obu_size` + payload), e.g.
+	/// to prepend it to a key frame that has no in-band sequence header. `nullptr` if absent.
+	static std::shared_ptr<const ov::Data> ExtractFirstSequenceHeaderObuRaw(const std::shared_ptr<const ov::Data> &config_obus);
 
 	/// Parse the leading mandatory fields of a `sequence_header_obu()` payload per AV1 spec section 5.5.1.
 	///

--- a/src/projects/modules/bitstream/av1/av1_parser_test.cpp
+++ b/src/projects/modules/bitstream/av1/av1_parser_test.cpp
@@ -853,3 +853,12 @@ TEST(Av1ParserExtractSequenceHeaderRaw, NullWhenAbsent)
 	auto data  = std::make_shared<ov::Data>(frame.data(), frame.size());
 	EXPECT_EQ(Av1Parser::ExtractFirstSequenceHeaderObuRaw(data), nullptr);
 }
+
+// A sequence header OBU with a zero-length payload is malformed -> treated as absent (nullptr),
+// not a non-null empty buffer.
+TEST(Av1ParserExtractSequenceHeader, ReturnsNullForEmptySequenceHeader)
+{
+	auto seq  = MakeObu(Av1ObuType::SequenceHeader, {});
+	auto data = std::make_shared<ov::Data>(seq.data(), seq.size());
+	EXPECT_EQ(Av1Parser::ExtractFirstSequenceHeaderObu(data), nullptr);
+}

--- a/src/projects/modules/bitstream/av1/av1_parser_test.cpp
+++ b/src/projects/modules/bitstream/av1/av1_parser_test.cpp
@@ -734,9 +734,9 @@ TEST(Av1ParserSequenceHeaderSummary, CapturesColorConfigFields)
 TEST(Av1ParserSequenceHeaderSummary, CapturesInitialDisplayDelayForOp0)
 {
 	// AV1 spec 5.5.1: when `initial_display_delay_present_flag == 1` and the per-op presence flag
-	// for `op_0` is 1, a 4-bit `initial_display_delay_minus_1[0]` is read. AV1 ISOBMFF binding
-	// v1.2.0 section 2.3.2 cross-checks these against the `av1C` fixed header, so the summary
-	// parser must record both values for `op_0`.
+	// for `op_0` is 1, a 4-bit `initial_display_delay_minus_1[0]` is read. The summary parser
+	// records both values for `op_0` (diagnostics only - this Sequence Header field is NOT
+	// cross-checked against the av1C `initial_presentation_delay`; they are distinct fields).
 	SeqHeaderBuilder b;
 	b.seq_profile							= 0;
 	b.initial_display_delay_present_flag	= true;

--- a/src/projects/modules/bitstream/av1/av1_parser_test.cpp
+++ b/src/projects/modules/bitstream/av1/av1_parser_test.cpp
@@ -854,6 +854,14 @@ TEST(Av1ParserExtractSequenceHeaderRaw, NullWhenAbsent)
 	EXPECT_EQ(Av1Parser::ExtractFirstSequenceHeaderObuRaw(data), nullptr);
 }
 
+// A sequence header OBU without obu_has_size_field cannot be stored in configOBUs -> nullptr.
+TEST(Av1ParserExtractSequenceHeaderRaw, NullWhenNotSizeDelimited)
+{
+	auto seq  = MakeObu(Av1ObuType::SequenceHeader, {0xAA}, /*has_size_field=*/false);
+	auto data = std::make_shared<ov::Data>(seq.data(), seq.size());
+	EXPECT_EQ(Av1Parser::ExtractFirstSequenceHeaderObuRaw(data), nullptr);
+}
+
 // A sequence header OBU with a zero-length payload is malformed -> treated as absent (nullptr),
 // not a non-null empty buffer.
 TEST(Av1ParserExtractSequenceHeader, ReturnsNullForEmptySequenceHeader)

--- a/src/projects/modules/bitstream/av1/av1_parser_test.cpp
+++ b/src/projects/modules/bitstream/av1/av1_parser_test.cpp
@@ -756,3 +756,100 @@ TEST(Av1ParserSequenceHeaderSummary, CapturesInitialDisplayDelayForOp0)
 	EXPECT_EQ(summary->initial_display_delay_present_for_op_0, 1);
 	EXPECT_EQ(summary->initial_display_delay_minus_1_for_op_0, 9);
 }
+
+// frame OBU payload, uncompressed_header() prefix: show_existing_frame(1) | frame_type(2).
+//   {0x00} -> show_existing=0, frame_type=0 (KEY_FRAME)
+//   {0x20} -> show_existing=0, frame_type=1 (INTER_FRAME)
+//   {0x80} -> show_existing_frame=1
+
+TEST(Av1ParserIsKeyFrame, FrameObuKeyFrame)
+{
+	auto frame = MakeObu(Av1ObuType::Frame, {0x00});
+	auto data  = std::make_shared<ov::Data>(frame.data(), frame.size());
+	EXPECT_TRUE(Av1Parser::IsKeyFrame(data));
+}
+
+TEST(Av1ParserIsKeyFrame, FrameObuInterFrame)
+{
+	auto frame = MakeObu(Av1ObuType::Frame, {0x20});
+	auto data  = std::make_shared<ov::Data>(frame.data(), frame.size());
+	EXPECT_FALSE(Av1Parser::IsKeyFrame(data));
+}
+
+TEST(Av1ParserIsKeyFrame, ShowExistingFrameIsNotKey)
+{
+	auto frame = MakeObu(Av1ObuType::Frame, {0x80});
+	auto data  = std::make_shared<ov::Data>(frame.data(), frame.size());
+	EXPECT_FALSE(Av1Parser::IsKeyFrame(data));
+}
+
+TEST(Av1ParserIsKeyFrame, SequenceHeaderThenKeyFrame)
+{
+	SeqHeaderBuilder b;
+	auto seq   = MakeObu(Av1ObuType::SequenceHeader, BuildSequenceHeaderObuPayload(b));
+	auto frame = MakeObu(Av1ObuType::Frame, {0x00});
+
+	std::vector<uint8_t> blob;
+	blob.insert(blob.end(), seq.begin(), seq.end());
+	blob.insert(blob.end(), frame.begin(), frame.end());
+
+	auto data = std::make_shared<ov::Data>(blob.data(), blob.size());
+	EXPECT_TRUE(Av1Parser::IsKeyFrame(data));
+}
+
+// reduced_still_picture_header => frame_type is always KEY_FRAME, even when the frame OBU bits
+// would otherwise read as INTER.
+TEST(Av1ParserIsKeyFrame, ReducedStillPictureIsAlwaysKey)
+{
+	SeqHeaderBuilder b;
+	b.still_picture				   = true;
+	b.reduced_still_picture_header = true;
+	auto seq   = MakeObu(Av1ObuType::SequenceHeader, BuildSequenceHeaderObuPayload(b));
+	auto frame = MakeObu(Av1ObuType::Frame, {0x20});
+
+	std::vector<uint8_t> blob;
+	blob.insert(blob.end(), seq.begin(), seq.end());
+	blob.insert(blob.end(), frame.begin(), frame.end());
+
+	auto data = std::make_shared<ov::Data>(blob.data(), blob.size());
+	EXPECT_TRUE(Av1Parser::IsKeyFrame(data));
+}
+
+TEST(Av1ParserHasSequenceHeaderObu, PresentAndAbsent)
+{
+	auto seq   = MakeObu(Av1ObuType::SequenceHeader, {0x00});
+	auto frame = MakeObu(Av1ObuType::Frame, {0x00});
+
+	std::vector<uint8_t> with_seq;
+	with_seq.insert(with_seq.end(), seq.begin(), seq.end());
+	with_seq.insert(with_seq.end(), frame.begin(), frame.end());
+	auto d1 = std::make_shared<ov::Data>(with_seq.data(), with_seq.size());
+	EXPECT_TRUE(Av1Parser::HasSequenceHeaderObu(d1));
+
+	auto d2 = std::make_shared<ov::Data>(frame.data(), frame.size());
+	EXPECT_FALSE(Av1Parser::HasSequenceHeaderObu(d2));
+}
+
+TEST(Av1ParserExtractSequenceHeaderRaw, ReturnsFullObu)
+{
+	auto td  = MakeObu(Av1ObuType::TemporalDelimiter, {});
+	auto seq = MakeObu(Av1ObuType::SequenceHeader, {0xAA, 0xBB});
+
+	std::vector<uint8_t> blob;
+	blob.insert(blob.end(), td.begin(), td.end());
+	blob.insert(blob.end(), seq.begin(), seq.end());
+
+	auto data = std::make_shared<ov::Data>(blob.data(), blob.size());
+	auto raw  = Av1Parser::ExtractFirstSequenceHeaderObuRaw(data);
+	ASSERT_NE(raw, nullptr);
+	// The full OBU (header + obu_size + payload) equals the SequenceHeader OBU bytes.
+	ASSERT_EQ(raw->GetLength(), seq.size());
+	EXPECT_EQ(std::memcmp(raw->GetDataAs<uint8_t>(), seq.data(), seq.size()), 0);
+}
+
+TEST(Av1ParserExtractSequenceHeaderRaw, NullWhenAbsent)
+{
+	auto frame = MakeObu(Av1ObuType::Frame, {0x00});
+	auto data  = std::make_shared<ov::Data>(frame.data(), frame.size());
+	EXPECT_EQ(Av1Parser::ExtractFirstSequenceHeaderObuRaw(data), nullptr);
+}

--- a/src/projects/modules/bitstream/av1/av1_types.h
+++ b/src/projects/modules/bitstream/av1/av1_types.h
@@ -73,7 +73,7 @@ struct ParsedObuHeader
 
 // AV1 spec 5.5.1 `sequence_header_obu()` - only the diagnostic-friendly leading fields, plus the
 // `color_config()` (spec 5.5.2) values needed for the `configOBUs` cross-check defined by AV1 ISOBMFF
-// binding v1.2.0 section 2.3.2.
+// binding v1.3.0 section 2.3.4 (Semantics).
 struct Av1SequenceHeaderSummary
 {
 	uint8_t seq_profile = 0;
@@ -84,9 +84,10 @@ struct Av1SequenceHeaderSummary
 	uint32_t max_frame_width = 0;
 	uint32_t max_frame_height = 0;
 
-	// AV1 spec 5.5.2 `color_config()` fields used by AV1 ISOBMFF binding v1.2.0 section 2.3.2
-	// "When the configOBUs field contains a Sequence Header OBU, the values of the
-	// AV1CodecConfigurationRecord fields shall match those of the OBU."
+	// AV1 spec 5.5.2 `color_config()` fields used by the AV1 ISOBMFF binding v1.3.0 section 2.3.4
+	// (Semantics) cross-check: "When a Sequence Header OBU is contained within the configOBUs of the
+	// AV1CodecConfigurationRecord, the values present in the Sequence Header OBU contained within
+	// configOBUs SHALL match the values of the AV1CodecConfigurationRecord."
 	uint8_t high_bitdepth = 0;
 	uint8_t twelve_bit = 0;
 	uint8_t monochrome = 0;

--- a/src/projects/modules/bitstream/av1/av1_types.h
+++ b/src/projects/modules/bitstream/av1/av1_types.h
@@ -95,10 +95,11 @@ struct Av1SequenceHeaderSummary
 	uint8_t chroma_subsampling_y = 0;
 	uint8_t chroma_sample_position = 0;
 
-	// AV1 spec 5.5.1 `sequence_header_obu()` operating-point `i == 0` initial display delay signaling.
-	// Recorded so AV1 ISOBMFF binding v1.2.0 section 2.3.2 can cross-check
-	// `initial_presentation_delay_minus_one` from the `av1C` fixed header:
-	//   "initial_presentation_delay_minus_one, when present, all shall match."
+	// AV1 spec 5.5.1 `sequence_header_obu()` operating-point `i == 0` initial display delay
+	// signaling. Captured for diagnostics only. NOTE: this is a Sequence Header field and is
+	// distinct from the av1C `initial_presentation_delay_minus_one`; the AV1 ISOBMFF binding
+	// v1.3.0 section 2.3.4 (Semantics) defines no "SHALL match" rule between the two, so these
+	// values are not cross-checked against or copied into the av1C.
 	uint8_t initial_display_delay_present_for_op_0 = 0;
 	uint8_t initial_display_delay_minus_1_for_op_0 = 0;
 

--- a/src/projects/modules/bitstream/av1/av1_types.h
+++ b/src/projects/modules/bitstream/av1/av1_types.h
@@ -71,6 +71,17 @@ struct ParsedObuHeader
 	size_t bytes_consumed = 0;
 };
 
+/// One OBU located by `Av1Parser::ReadObu()` while walking an OBU bytestream: the header plus the
+/// payload bounds and the offset of the next OBU.
+struct Av1ObuSpan
+{
+	Av1ObuHeader header;
+	size_t obu_offset	  = 0;	// offset of the OBU header
+	size_t payload_offset = 0;	// offset of the payload (after the header and optional obu_size)
+	size_t payload_size	  = 0;
+	size_t next_offset	  = 0;	// offset of the next OBU
+};
+
 // AV1 spec 5.5.1 `sequence_header_obu()` - only the diagnostic-friendly leading fields, plus the
 // `color_config()` (spec 5.5.2) values needed for the `configOBUs` cross-check defined by AV1 ISOBMFF
 // binding v1.3.0 section 2.3.4 (Semantics).

--- a/src/projects/modules/ffmpeg/compat.cpp
+++ b/src/projects/modules/ffmpeg/compat.cpp
@@ -49,6 +49,7 @@ namespace ffmpeg
 			OV_CASE_RETURN(AV_CODEC_ID_H264, cmn::MediaCodecId::H264);
 			OV_CASE_RETURN(AV_CODEC_ID_VP8, cmn::MediaCodecId::Vp8);
 			OV_CASE_RETURN(AV_CODEC_ID_VP9, cmn::MediaCodecId::Vp9);
+			OV_CASE_RETURN(AV_CODEC_ID_AV1, cmn::MediaCodecId::Av1);
 			OV_CASE_RETURN(AV_CODEC_ID_FLV1, cmn::MediaCodecId::Flv);
 			OV_CASE_RETURN(AV_CODEC_ID_AAC, cmn::MediaCodecId::Aac);
 			OV_CASE_RETURN(AV_CODEC_ID_MP2, cmn::MediaCodecId::Mp2);

--- a/src/projects/modules/ffmpeg/compat.h
+++ b/src/projects/modules/ffmpeg/compat.h
@@ -35,6 +35,7 @@ extern "C"
 #include <base/mediarouter/media_type.h>
 #include <base/ovlibrary/ovlibrary.h>
 #include <modules/bitstream/aac/audio_specific_config.h>
+#include <modules/bitstream/av1/av1_decoder_configuration_record.h>
 #include <modules/bitstream/h264/h264_decoder_configuration_record.h>
 #include <modules/bitstream/h265/h265_decoder_configuration_record.h>
 #include <modules/bitstream/opus/opus_specific_config.h>
@@ -131,6 +132,22 @@ namespace ffmpeg
 						}
 
 						media_track->SetDecoderConfigurationRecord(hevc_config);
+					}
+
+					break;
+				}
+				case cmn::MediaCodecId::Av1: {
+					if (stream->codecpar->extradata_size > 0)
+					{
+						// `av1C` format per AOMedia ISOBMFF binding.
+						auto av1_config = std::make_shared<AV1DecoderConfigurationRecord>();
+
+						if (av1_config->Parse(stream->codecpar->extradata, stream->codecpar->extradata_size) == false)
+						{
+							return false;
+						}
+
+						media_track->SetDecoderConfigurationRecord(av1_config);
 					}
 
 					break;

--- a/src/projects/modules/ffmpeg/compat.h
+++ b/src/projects/modules/ffmpeg/compat.h
@@ -141,8 +141,9 @@ namespace ffmpeg
 					{
 						// `av1C` format per AOMedia ISOBMFF binding.
 						auto av1_config = std::make_shared<AV1DecoderConfigurationRecord>();
+						auto extra_data = std::make_shared<ov::Data>(stream->codecpar->extradata, stream->codecpar->extradata_size, true);
 
-						if (av1_config->Parse(stream->codecpar->extradata, stream->codecpar->extradata_size) == false)
+						if (av1_config->Parse(extra_data) == false)
 						{
 							return false;
 						}

--- a/src/projects/modules/segment_writer/writer.cpp
+++ b/src/projects/modules/segment_writer/writer.cpp
@@ -852,6 +852,8 @@ bool Writer::WritePacket(const std::shared_ptr<const MediaPacket> &packet)
 			[[fallthrough]];
 		case cmn::BitstreamFormat::VP8_RTP_RFC_7741:
 			[[fallthrough]];
+		case cmn::BitstreamFormat::AV1_OBU:
+			[[fallthrough]];
 		case cmn::BitstreamFormat::AAC_MPEG4_GENERIC:
 			[[fallthrough]];
 		case cmn::BitstreamFormat::AAC_LATM:

--- a/src/projects/transcoder/transcoder_stream_internal.cpp
+++ b/src/projects/transcoder/transcoder_stream_internal.cpp
@@ -114,6 +114,7 @@ cmn::Timebase TranscoderStreamInternal::GetDefaultTimebaseByCodecId(cmn::MediaCo
 	{
 		case cmn::MediaCodecId::H264:
 		case cmn::MediaCodecId::H265:
+		case cmn::MediaCodecId::Av1:
 		case cmn::MediaCodecId::Vp8:
 		case cmn::MediaCodecId::Vp9:
 		case cmn::MediaCodecId::Flv:


### PR DESCRIPTION
## Summary

Adds AV1 as a first-class media type across the media pipeline.
AV1 is carried as an OBU bytestream (`BitstreamFormat::AV1_OBU`).

## Changes

- **media type**: add `BitstreamFormat::AV1_OBU` (logically part of the video track; enum order preserved for backward compatibility) and wire it into the bitstream-format string helper.
- **mediarouter normalize**: add `ProcessAV1OBUStream`:
  - parse the `av1C` `AV1DecoderConfigurationRecord` on sequence-header packets,
  - populate resolution from `configOBUs`, or from an in-band `OBU_SEQUENCE_HEADER` on the CodedFrames path when the encoder delivers it in-band (e.g. ffmpeg's libaom over enhanced-RTMP),
  - sync the in-band sequence header values back into a synthesized lenient `av1C` so the codec string and downstream cross-checks stay aligned (AV1 ISOBMFF binding v1.2.0 section 2.3.2).
  - gate the in-band resolution scan on `IsValidResolution()` rather than the broader `IsValid()`.
- **ffmpeg compat**: map `AV_CODEC_ID_AV1` and parse `av1C` extradata into the decoder configuration record.
- **segment writer**: handle `AV1_OBU` muxing.
- **transcoder/mediarouter alert**: recognize the AV1 codec.
- **tests**: regression coverage for the in-band sequence-header to `av1C` field sync, including the `initial_presentation_delay_*` pair.

## Test plan

- Unit tests in `mediarouter_test.cpp` cover the in-band sequence-header sync, including the presentation-delay fields.
- AV1 parser/decoder-configuration-record unit tests pass.
