### PR TITLE
refactor(tsa): adopt `ov::Mutex` wrappers and thread-safety annotations across modules

### DIFF
--- a/src/projects/base/info/audio_track.cpp
+++ b/src/projects/base/info/audio_track.cpp
@@ -12,7 +12,7 @@ using namespace cmn;
 
 AudioTrack::AudioTrack()
 {
-	std::scoped_lock lock(_audio_mutex);
+	ov::ScopedLock lock(_audio_mutex);
 	_channel_layout.SetLayout(AudioChannel::Layout::LayoutUnknown);
 
 	// The default frame size of the audio frame is fixed to 1024. 
@@ -22,44 +22,44 @@ AudioTrack::AudioTrack()
 
 void AudioTrack::SetSampleRate(int32_t sample_rate)
 {
-	std::scoped_lock lock(_audio_mutex);
+	ov::ScopedLock lock(_audio_mutex);
 	_sample.SetRate((AudioSample::Rate)sample_rate);
 }
 
 void AudioTrack::SetSampleFormat(AudioSample::Format format)
 {
-	std::scoped_lock lock(_audio_mutex);
+	ov::ScopedLock lock(_audio_mutex);
 	_sample.SetFormat(format);
 }
 
 int32_t AudioTrack::GetSampleRate() const
 {
-	std::shared_lock lock(_audio_mutex);
+	ov::SharedLockGuard lock(_audio_mutex);
 	return ov::ToUnderlyingType(_sample.GetRate());
 }
 
 AudioSample AudioTrack::GetSample() const
 {
-	std::shared_lock lock(_audio_mutex);
+	ov::SharedLockGuard lock(_audio_mutex);
 	return _sample;
 }
 
 
 AudioChannel AudioTrack::GetChannel() const
 {
-	std::shared_lock lock(_audio_mutex);
+	ov::SharedLockGuard lock(_audio_mutex);
 	return _channel_layout;
 }
 
 void AudioTrack::SetChannel(AudioChannel channel)
 {
-	std::scoped_lock lock(_audio_mutex);
+	ov::ScopedLock lock(_audio_mutex);
 	_channel_layout = channel;
 }
 
 void AudioTrack::SetChannelCount(uint32_t channel_count)
 {
-	std::scoped_lock lock(_audio_mutex);
+	ov::ScopedLock lock(_audio_mutex);
 
 	switch (channel_count)
 	{
@@ -77,13 +77,13 @@ void AudioTrack::SetChannelCount(uint32_t channel_count)
 
 void AudioTrack::SetChannelLayout(AudioChannel::Layout channel_layout)
 {
-	std::scoped_lock lock(_audio_mutex);
+	ov::ScopedLock lock(_audio_mutex);
 	_channel_layout.SetLayout(channel_layout);
 }
 
 bool AudioTrack::IsValidChannel() const
 {
-	std::shared_lock lock(_audio_mutex);
+	ov::SharedLockGuard lock(_audio_mutex);
 	return _channel_layout.IsValid();
 }
 

--- a/src/projects/base/info/audio_track.h
+++ b/src/projects/base/info/audio_track.h
@@ -9,9 +9,9 @@
 #pragma once
 
 #include <modules/bitstream/aac/audio_specific_config.h>
-#include <shared_mutex>
 
 #include "base/common_types.h"
+#include "base/ovlibrary/tsa/mutex.h"
 
 class AudioTrack
 {
@@ -34,12 +34,12 @@ public:
 	int GetAudioSamplesPerFrame() const;
 
 protected:
-	mutable std::shared_mutex _audio_mutex;	
+	mutable ov::SharedMutex _audio_mutex;	
 
 	// sample format, sample rate
-	cmn::AudioSample _sample;
+	cmn::AudioSample _sample OV_GUARDED_BY(_audio_mutex);
 
-	cmn::AudioChannel _channel_layout;
+	cmn::AudioChannel _channel_layout OV_GUARDED_BY(_audio_mutex);
 
 	// time_scale
 	std::atomic<double> _audio_timescale;

--- a/src/projects/base/info/managed_queue.h
+++ b/src/projects/base/info/managed_queue.h
@@ -10,9 +10,9 @@
 
 #include <base/info/vhost_app_name.h>
 
-#include <shared_mutex>
 
 #include "base/ovlibrary/ovlibrary.h"
+#include "base/ovlibrary/tsa/mutex.h"
 
 namespace info
 {
@@ -181,7 +181,7 @@ namespace info
 		// Set threshold in count-based mode.
 		void SetThreshold(size_t threshold)
 		{
-			auto lock_guard = std::lock_guard(_name_mutex);
+			ov::LockGuard lock_guard(_name_mutex);
 
 			_threshold_mode = ThresholdMode::CountBased;
 			_threshold_value = threshold;
@@ -193,7 +193,7 @@ namespace info
 		// Effective count is estimated from input_message_per_second * time_ms 
 		void SetThresholdByTime(size_t time_ms)
 		{
-			auto lock_guard = std::lock_guard(_name_mutex);
+			ov::LockGuard lock_guard(_name_mutex);
 
 			_threshold_mode = ThresholdMode::TimeBased;
 			_threshold_value = time_ms;
@@ -256,7 +256,7 @@ namespace info
 
 		void SetUrn(std::shared_ptr<URN> urn, const char* type_name)
 		{
-			auto lock_guard = std::lock_guard(_name_mutex);
+			ov::LockGuard lock_guard(_name_mutex);
 
 			_type_name = type_name;
 			_urn = urn;
@@ -289,11 +289,11 @@ namespace info
 		managed_queue_id_t _id = 0;
 
 		// Name of the queue
-		std::shared_mutex _name_mutex;
-		std::shared_ptr<URN> _urn;
+		ov::SharedMutex _name_mutex;
+		std::shared_ptr<URN> _urn OV_GUARDED_BY(_name_mutex);
 
 		// Type of template
-		ov::String _type_name;
+		ov::String _type_name OV_GUARDED_BY(_name_mutex);
 
 		// Peak size of the queue
 		size_t _peak = 0;
@@ -303,13 +303,13 @@ namespace info
 
 		// Threshold value computed according to the Threshold Mode.
 		// 0 : No threshold
-		size_t _threshold = 0;
+		size_t _threshold OV_GUARDED_BY(_name_mutex) = 0;
 
 		// Threshold mode
-		ThresholdMode _threshold_mode = ThresholdMode::CountBased;
+		ThresholdMode _threshold_mode OV_GUARDED_BY(_name_mutex) = ThresholdMode::CountBased;
 
 		// Threshold value: count (CountBased) or milliseconds (TimeBased)
-		size_t _threshold_value = 0;
+		size_t _threshold_value OV_GUARDED_BY(_name_mutex) = 0;
 
 		// threshold_exceeded_time increases from the point the queue is exceeded
 		std::atomic<int64_t> _threshold_exceeded_time_ms{0};

--- a/src/projects/base/info/media_track.cpp
+++ b/src/projects/base/info/media_track.cpp
@@ -44,7 +44,7 @@ MediaTrack::~MediaTrack()
 // Same ID required
 bool MediaTrack::Update(const MediaTrack &media_track)
 {
-	std::scoped_lock lock(
+	ov::ScopedLock lock(
 		_media_mutex, media_track._media_mutex,
 		_video_mutex, media_track._video_mutex,
 		_audio_mutex, media_track._audio_mutex,
@@ -123,13 +123,13 @@ uint32_t MediaTrack::GetId() const
 // Track Name (used for Renditions)
 void MediaTrack::SetVariantName(const ov::String &name)
 {
-	std::scoped_lock lock(_media_mutex);
+	ov::ScopedLock lock(_media_mutex);
 	_variant_name = name;
 }
 
 ov::String MediaTrack::GetVariantName() const
 {
-	std::shared_lock lock(_media_mutex);
+	ov::SharedLockGuard lock(_media_mutex);
 	if (_variant_name.IsEmpty())
 	{
 		// If variant name is not set, return media type string
@@ -152,37 +152,37 @@ int MediaTrack::GetGroupIndex() const
 // Public Name (used for multiple audio/video tracks. e.g. multilingual audio)
 void MediaTrack::SetPublicName(const ov::String &name)
 {
-	std::scoped_lock lock(_media_mutex);
+	ov::ScopedLock lock(_media_mutex);
 	_public_name = name;
 }
 ov::String MediaTrack::GetPublicName() const
 {
-	std::shared_lock lock(_media_mutex);
+	ov::SharedLockGuard lock(_media_mutex);
 	return _public_name;
 }
 
 // Language (rfc5646)
 void MediaTrack::SetLanguage(const ov::String &language)
 {
-	std::scoped_lock lock(_media_mutex);
+	ov::ScopedLock lock(_media_mutex);
 	_language = language;
 }
 ov::String MediaTrack::GetLanguage() const
 {
-	std::shared_lock lock(_media_mutex);
+	ov::SharedLockGuard lock(_media_mutex);
 	return _language;
 }
 
 // Characteristics (e.g. "main", "sign", "visually-impaired")
 void MediaTrack::SetCharacteristics(const ov::String &characteristics)
 {
-	std::scoped_lock lock(_media_mutex);
+	ov::ScopedLock lock(_media_mutex);
 	_characteristics = characteristics;
 }
 
 ov::String MediaTrack::GetCharacteristics() const
 {
-	std::shared_lock lock(_media_mutex);
+	ov::SharedLockGuard lock(_media_mutex);
 	return _characteristics;
 }
 
@@ -228,13 +228,13 @@ cmn::DeviceId MediaTrack::GetCodecDeviceId() const
 
 void MediaTrack::SetCodecModules(ov::String modules)
 {
-	std::scoped_lock lock(_media_mutex);
+	ov::ScopedLock lock(_media_mutex);
 	_codec_modules = modules;
 }
 
 ov::String MediaTrack::GetCodecModules() const
 {
-	std::shared_lock lock(_media_mutex);
+	ov::SharedLockGuard lock(_media_mutex);
 	return _codec_modules;
 }
 
@@ -250,25 +250,25 @@ cmn::BitstreamFormat MediaTrack::GetOriginBitstream() const
 
 cmn::Timebase MediaTrack::GetTimeBase() const
 {
-	std::shared_lock lock(_media_mutex);
+	ov::SharedLockGuard lock(_media_mutex);
 	return _time_base;
 }
 
 void MediaTrack::SetTimeBase(int32_t num, int32_t den)
 {
-	std::scoped_lock lock(_media_mutex);
+	ov::ScopedLock lock(_media_mutex);
 	_time_base.Set(num, den);
 }
 
 void MediaTrack::SetTimeBase(const cmn::Timebase &time_base)
 {
-	std::scoped_lock lock(_media_mutex);
+	ov::ScopedLock lock(_media_mutex);
 	_time_base = time_base;
 }
 
 bool MediaTrack::IsValidTimeBase() const
 {
-	std::shared_lock lock(_media_mutex);
+	ov::SharedLockGuard lock(_media_mutex);
 	return _time_base.IsValid();
 }
 
@@ -329,13 +329,13 @@ cmn::CodecStatus MediaTrack::GetCodecStatus() const
 
 void MediaTrack::SetExtraInfo(const ov::String &info)
 {
-	std::scoped_lock lock(_media_mutex);
+	ov::ScopedLock lock(_media_mutex);
 	_extra_info = info;
 }
 
 ov::String MediaTrack::GetExtraInfo() const
 {
-	std::shared_lock lock(_media_mutex);
+	ov::SharedLockGuard lock(_media_mutex);
 	return _extra_info;
 }
 
@@ -601,7 +601,7 @@ bool MediaTrack::IsValid()
 
 bool MediaTrack::HasQualityMeasured()
 {
-	std::scoped_lock lock(_media_mutex, _video_mutex);
+	ov::ScopedLock lock(_media_mutex, _video_mutex);
 	
 	if (_has_quality_measured == true)
 	{

--- a/src/projects/base/info/media_track.h
+++ b/src/projects/base/info/media_track.h
@@ -13,8 +13,8 @@
 #include "subtitle_track.h"
 
 #include "decoder_configuration_record.h"
+#include "base/ovlibrary/tsa/mutex.h"
 
-#include <shared_mutex>
 
 #define VALID_BITRATE_CALCULATION_THRESHOLD_MSEC (1000)
 
@@ -156,7 +156,7 @@ public:
 	bool IsEssentialTrack() const;
 
 protected:
-	mutable std::shared_mutex _media_mutex;
+	mutable ov::SharedMutex _media_mutex;
 
 	// Track ID
 	std::atomic<uint32_t> _id;
@@ -168,23 +168,23 @@ protected:
 	std::atomic<cmn::MediaCodecId> _codec_id;
 	std::atomic<cmn::MediaCodecModuleId> _codec_module_id;
 	std::atomic<cmn::DeviceId> _codec_device_id;
-	ov::String _codec_modules;
+	ov::String _codec_modules OV_GUARDED_BY(_media_mutex);
 
 	// Variant Name : Original encoder profile that made this track 
 	// from <OutputProfile><Encodes>(<Video> || <Audio> || <Image>)<Name>
-	ov::String _variant_name;
+	ov::String _variant_name OV_GUARDED_BY(_media_mutex);
 	std::atomic<int> _group_index = -1;
 
 	// Set by AudioMap or VideoMap or SubtitleMap
-	ov::String _public_name;
-	ov::String _language;
-	ov::String _characteristics;
+	ov::String _public_name OV_GUARDED_BY(_media_mutex);
+	ov::String _language OV_GUARDED_BY(_media_mutex);
+	ov::String _characteristics OV_GUARDED_BY(_media_mutex);
 
 	// Bitstream format 
 	std::atomic<cmn::BitstreamFormat> _origin_bitstream_format = cmn::BitstreamFormat::Unknown;
 
 	// Timebase
-	cmn::Timebase _time_base;
+	cmn::Timebase _time_base OV_GUARDED_BY(_media_mutex);
 
 	// Bitrate
 	std::atomic<int32_t> _bitrate;
@@ -235,7 +235,7 @@ protected:
 
 	// Codec status and extra info
 	std::atomic<cmn::CodecStatus> _codec_status = cmn::CodecStatus::Unknown;
-	ov::String _extra_info;
+	ov::String _extra_info OV_GUARDED_BY(_media_mutex);
 
 	// If false, encoder failure for this track is non-fatal and the stream continues without it.
 	std::atomic<bool> _essential_track = true;

--- a/src/projects/base/info/session.cpp
+++ b/src/projects/base/info/session.cpp
@@ -64,14 +64,14 @@ namespace info
 
 		auto name_path = _stream_info->GetNamePath().Append("%s(%u)", _name.value_or("[unnamed]").CStr(), _id);
 		{
-			std::lock_guard lock_guard(_name_path_mutex);
+			ov::LockGuard lock_guard(_name_path_mutex);
 			_name_path = name_path;
 		}
 	}
 
 	NamePath Session::GetNamePath() const
 	{
-		std::lock_guard lock_guard(_name_path_mutex);
+		ov::LockGuard lock_guard(_name_path_mutex);
 		return _name_path;
 	}
 

--- a/src/projects/base/info/session.h
+++ b/src/projects/base/info/session.h
@@ -8,6 +8,7 @@
 #include "./stream.h"
 #include "base/common_types.h"
 #include "base/ovlibrary/enable_shared_from_this.h"
+#include "base/ovlibrary/tsa/mutex.h"
 
 typedef uint32_t session_id_t;
 
@@ -62,8 +63,8 @@ namespace info
 		void SetIds(const info::Stream &stream);
 
 	private:
-		mutable std::mutex _name_path_mutex;
-		NamePath _name_path;
+		mutable ov::Mutex _name_path_mutex;
+		NamePath _name_path OV_GUARDED_BY(_name_path_mutex);
 
 		session_id_t _id;
 		std::optional<ov::String> _name;

--- a/src/projects/base/info/stream.cpp
+++ b/src/projects/base/info/stream.cpp
@@ -98,7 +98,7 @@ namespace info
 
 	NamePath Stream::GetNamePath() const
 	{
-		std::lock_guard lock_guard(_name_path_mutex);
+		ov::LockGuard lock_guard(_name_path_mutex);
 		return _name_path;
 	}
 
@@ -142,7 +142,7 @@ namespace info
 
 	void Stream::UpdateNamePath(const info::VHostAppName &vhost_app_name)
 	{
-		std::lock_guard lock_guard(_name_path_mutex);
+		ov::LockGuard lock_guard(_name_path_mutex);
 		_name_path = vhost_app_name.GetNamePath().Append("%s(%u)", GetName().CStr(), _id);
 	}
 

--- a/src/projects/base/info/stream.h
+++ b/src/projects/base/info/stream.h
@@ -6,6 +6,7 @@
 #include "base/info/media_track_group.h"
 #include "base/info/playlist.h"
 #include "base/info/track_set.h"
+#include "base/ovlibrary/tsa/mutex.h"
 #include "vhost_app_name.h"
 
 namespace info
@@ -194,8 +195,8 @@ namespace info
 		bool _from_origin_map_store = false;
 
 	private:
-		mutable std::mutex _name_path_mutex;
-		NamePath _name_path = NamePath::UnknownNamePath();
+		mutable ov::Mutex _name_path_mutex;
+		NamePath _name_path OV_GUARDED_BY(_name_path_mutex) = NamePath::UnknownNamePath();
 
 		std::chrono::system_clock::time_point _created_time;
 		std::chrono::system_clock::time_point _published_time;

--- a/src/projects/base/info/subtitle_track.cpp
+++ b/src/projects/base/info/subtitle_track.cpp
@@ -37,34 +37,34 @@ bool SubtitleTrack::IsForced() const
 
 ov::String SubtitleTrack::GetEngine() const
 {
-	std::shared_lock lock(_subtitle_mutex);
+	ov::SharedLockGuard lock(_subtitle_mutex);
 	return _engine;
 }
 void SubtitleTrack::SetEngine(const ov::String &engine)
 {
-	std::scoped_lock lock(_subtitle_mutex);
+	ov::ScopedLock lock(_subtitle_mutex);
 	_engine = engine;
 }
 
 void SubtitleTrack::SetModel(const ov::String &model)
 {
-	std::scoped_lock lock(_subtitle_mutex);
+	ov::ScopedLock lock(_subtitle_mutex);
 	_model = model;
 }
 ov::String SubtitleTrack::GetModel() const
 {
-	std::shared_lock lock(_subtitle_mutex);
+	ov::SharedLockGuard lock(_subtitle_mutex);
 	return _model;
 }
 
 void SubtitleTrack::SetSourceLanguage(const ov::String &language)
 {
-	std::scoped_lock lock(_subtitle_mutex);
+	ov::ScopedLock lock(_subtitle_mutex);
 	_source_language = language;
 }
 ov::String SubtitleTrack::GetSourceLanguage() const
 {
-	std::shared_lock lock(_subtitle_mutex);
+	ov::SharedLockGuard lock(_subtitle_mutex);
 	return _source_language;
 }
 
@@ -79,12 +79,12 @@ bool SubtitleTrack::ShouldTranslate() const
 
 void SubtitleTrack::SetOutputLabel(const ov::String &label)
 {
-	std::scoped_lock lock(_subtitle_mutex);
+	ov::ScopedLock lock(_subtitle_mutex);
 	_output_track_label = label;
 }
 ov::String SubtitleTrack::GetOutputTrackLabel() const
 {
-	std::shared_lock lock(_subtitle_mutex);
+	ov::SharedLockGuard lock(_subtitle_mutex);
 	return _output_track_label;
 }
 

--- a/src/projects/base/info/subtitle_track.h
+++ b/src/projects/base/info/subtitle_track.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "base/common_types.h"
+#include "base/ovlibrary/tsa/mutex.h"
 
 class SubtitleTrack
 {
@@ -49,7 +50,7 @@ public:
 	void SetSttEnabled(bool enabled);
 	bool IsSttEnabled() const;
 
-	mutable std::shared_mutex _subtitle_mutex;
+	mutable ov::SharedMutex _subtitle_mutex;
 
 	// For subtitle 
 	std::atomic<bool> _auto_select = false;
@@ -58,11 +59,11 @@ public:
 
 	// AI Modules
 	// e.g. Speech to Text
-	ov::String _engine = "whisper"; // Whisper
-	ov::String _model = "small"; // tiny, base, small, medium, large
-	ov::String _source_language = "auto"; // input language
+	ov::String _engine OV_GUARDED_BY(_subtitle_mutex) = "whisper"; // Whisper
+	ov::String _model OV_GUARDED_BY(_subtitle_mutex) = "small"; // tiny, base, small, medium, large
+	ov::String _source_language OV_GUARDED_BY(_subtitle_mutex) = "auto"; // input language
 	std::atomic<bool> _translation = false; // whisper only supports english translation
-	ov::String _output_track_label = ""; // input audio track label for speech to text
+	ov::String _output_track_label OV_GUARDED_BY(_subtitle_mutex) = ""; // input audio track label for speech to text
 	std::atomic<int32_t> _step_ms = 2000;
 	std::atomic<int32_t> _length_ms = 10000;
 	std::atomic<int32_t> _keep_ms = 1500;

--- a/src/projects/base/info/video_track.cpp
+++ b/src/projects/base/info/video_track.cpp
@@ -35,7 +35,7 @@ void VideoTrack::SetResolution(int32_t width, int32_t height)
 
 void VideoTrack::SetResolution(const cmn::Resolution &resolution)
 {
-	std::scoped_lock lock(_video_mutex);
+	ov::ScopedLock lock(_video_mutex);
 
 	_resolution			   = resolution;
 	_max_resolution.width  = std::max(_max_resolution.width, _resolution.width);
@@ -47,7 +47,7 @@ void VideoTrack::SetResolution(const cmn::Resolution &resolution)
 
 cmn::Resolution VideoTrack::GetResolution() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 	return _resolution;
 }
 
@@ -58,7 +58,7 @@ void VideoTrack::SetMaxResolution(int32_t max_width, int32_t max_height)
 
 void VideoTrack::SetMaxResolution(const cmn::Resolution &max_resolution)
 {
-	std::scoped_lock lock(_video_mutex);
+	ov::ScopedLock lock(_video_mutex);
 
 	_max_resolution.width  = std::max(std::max(_max_resolution.width, _resolution.width), max_resolution.width);
 	_max_resolution.height = std::max(std::max(_max_resolution.height, _resolution.height), max_resolution.height);
@@ -69,7 +69,7 @@ void VideoTrack::SetMaxResolution(const cmn::Resolution &max_resolution)
 
 cmn::Resolution VideoTrack::GetMaxResolution() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 	return _max_resolution;
 }
 
@@ -80,19 +80,19 @@ void VideoTrack::SetResolutionByConfig(int32_t width, int32_t height)
 
 void VideoTrack::SetResolutionByConfig(const cmn::Resolution &resolution)
 {
-	std::scoped_lock lock(_video_mutex);
+	ov::ScopedLock lock(_video_mutex);
 	_resolution_conf = resolution;
 }
 
 cmn::Resolution VideoTrack::GetResolutionByConfig() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 	return _resolution_conf;
 }
 
 bool VideoTrack::IsValidResolution() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 
 	return (_resolution.width > 0) && (_resolution.height > 0);
 }
@@ -109,25 +109,25 @@ double VideoTrack::GetVideoTimestampScale() const
 
 void VideoTrack::SetPreset(ov::String preset)
 {
-	std::scoped_lock lock(_video_mutex);
+	ov::ScopedLock lock(_video_mutex);
 	_preset = preset;
 }
 
 ov::String VideoTrack::GetPreset() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 	return _preset;
 }
 
 void VideoTrack::SetProfile(ov::String profile)
 {
-	std::scoped_lock lock(_video_mutex);
+	ov::ScopedLock lock(_video_mutex);
 	_profile = profile;
 }
 
 ov::String VideoTrack::GetProfile() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 	return _profile;
 }
 
@@ -153,31 +153,31 @@ int VideoTrack::GetThreadCount()
 
 VideoTrack::FrameSnapshot VideoTrack::GetFrameSnapshot() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 	return _frame_snapshot;
 }
 
 double VideoTrack::GetKeyFrameInterval() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 	return _frame_snapshot.GetKeyFrameInterval();
 }
 
 void VideoTrack::SetKeyFrameIntervalByMeasured(double key_frame_interval)
 {
-	std::scoped_lock lock(_video_mutex);
+	ov::ScopedLock lock(_video_mutex);
 	_frame_snapshot.key_frame_interval = key_frame_interval;
 }
 
 double VideoTrack::GetKeyFrameIntervalByMeasured() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 	return _frame_snapshot.key_frame_interval;
 }
 
 void VideoTrack::AddToMeasuredFramerateWindow(double framerate)
 {
-	std::scoped_lock lock(_video_mutex);
+	ov::ScopedLock lock(_video_mutex);
 
 	size_t kAbnormalFpsCheckWindowSize = 60;
 
@@ -191,7 +191,7 @@ void VideoTrack::AddToMeasuredFramerateWindow(double framerate)
 
 std::deque<double> VideoTrack::GetMeasuredFramerateWindow() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 
 	return _measured_framerate_window;
 }
@@ -208,7 +208,7 @@ double VideoTrack::GetKeyFrameIntervalLatest() const
 
 void VideoTrack::SetKeyFrameIntervalByConfig(int32_t key_frame_interval)
 {
-	std::scoped_lock lock(_video_mutex);
+	ov::ScopedLock lock(_video_mutex);
 
 	if (key_frame_interval > 0)
 	{
@@ -222,7 +222,7 @@ void VideoTrack::SetKeyFrameIntervalByConfig(int32_t key_frame_interval)
 
 double VideoTrack::GetKeyFrameIntervalByConfig() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 	return _frame_snapshot.key_frame_interval_conf.value_or(0.0);
 }
 
@@ -273,26 +273,26 @@ cmn::VideoPixelFormatId VideoTrack::GetColorspace() const
 
 double VideoTrack::GetFrameRate() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 	return _frame_snapshot.framerate_conf.value_or(_frame_snapshot.framerate);
 }
 
 void VideoTrack::SetFrameRateByMeasured(double framerate)
 {
-	std::scoped_lock lock(_video_mutex);
+	ov::ScopedLock lock(_video_mutex);
 	_frame_snapshot.framerate = framerate;
 	_max_framerate = std::max(_max_framerate.load(), framerate);
 }
 
 double VideoTrack::GetFrameRateByMeasured() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 	return _frame_snapshot.framerate;
 }
 
 void VideoTrack::SetMaxFrameRate(double framerate)
 {
-	std::scoped_lock lock(_video_mutex);
+	ov::ScopedLock lock(_video_mutex);
 	_max_framerate = std::max(std::max(_max_framerate.load(), _frame_snapshot.framerate), framerate);
 }
 
@@ -313,7 +313,7 @@ double VideoTrack::GetFrameRateLastSecond() const
 
 void VideoTrack::SetFrameRateByConfig(double framerate)
 {
-	std::scoped_lock lock(_video_mutex);
+	ov::ScopedLock lock(_video_mutex);
 
 	if (framerate > 0)
 	{
@@ -328,7 +328,7 @@ void VideoTrack::SetFrameRateByConfig(double framerate)
 
 double VideoTrack::GetFrameRateByConfig() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 	return _frame_snapshot.framerate_conf.value_or(0.0);
 }
 
@@ -394,7 +394,7 @@ int32_t VideoTrack::GetLookaheadByConfig() const
 
 void VideoTrack::SetOverlays(const std::vector<std::shared_ptr<info::Overlay>> &overlays)
 {
-	std::scoped_lock lock(_overlay_mutex);
+	ov::ScopedLock lock(_overlay_mutex);
 
 	if (overlays.empty())
 	{
@@ -409,24 +409,24 @@ void VideoTrack::SetOverlays(const std::vector<std::shared_ptr<info::Overlay>> &
 
 std::vector<std::shared_ptr<info::Overlay>> VideoTrack::GetOverlays() const
 {
-	std::shared_lock lock(_overlay_mutex);
+	ov::SharedLockGuard lock(_overlay_mutex);
 	return _overlays;
 }
 
 size_t VideoTrack::GetOverlaySignature() const
 {
-	std::shared_lock lock(_overlay_mutex);
+	ov::SharedLockGuard lock(_overlay_mutex);
 	return _overlay_signature;
 }
 
 void VideoTrack::SetExtraEncoderOptionsByConfig(const ov::String &options)
 {
-	std::scoped_lock lock(_video_mutex);
+	ov::ScopedLock lock(_video_mutex);
 	_extra_encoder_options = options;
 }
 
 ov::String VideoTrack::GetExtraEncoderOptionsByConfig() const
 {
-	std::shared_lock lock(_video_mutex);
+	ov::SharedLockGuard lock(_video_mutex);
 	return _extra_encoder_options;
 }

--- a/src/projects/base/info/video_track.h
+++ b/src/projects/base/info/video_track.h
@@ -12,6 +12,7 @@
 #include <modules/bitstream/nalu/nal_unit_fragment_header.h>
 #include "base/info/overlay.h"
 #include "base/common_types.h"
+#include "base/ovlibrary/tsa/mutex.h"
 
 class VideoTrack
 {
@@ -142,9 +143,9 @@ protected:
 	FrameSnapshot GetFrameSnapshot() const;
 
 protected:
-	mutable std::shared_mutex _video_mutex;
+	mutable ov::SharedMutex _video_mutex;
 
-	FrameSnapshot _frame_snapshot;
+	FrameSnapshot _frame_snapshot OV_GUARDED_BY(_video_mutex);
 
 	// framerate last one second (measurement)
 	std::atomic<double> _framerate_last_second = 0;
@@ -155,9 +156,9 @@ protected:
 	std::atomic<double> _video_timescale;
 	
 	// Resolution
-	cmn::Resolution _resolution{0, 0};
-	cmn::Resolution _max_resolution{0, 0};
-	cmn::Resolution _resolution_conf{0, 0};
+	cmn::Resolution _resolution OV_GUARDED_BY(_video_mutex){0, 0};
+	cmn::Resolution _max_resolution OV_GUARDED_BY(_video_mutex){0, 0};
+	cmn::Resolution _resolution_conf OV_GUARDED_BY(_video_mutex){0, 0};
 
 	// Resolution (set by user)
 	// NOTE: kept as cmn::Resolution in _resolution_conf
@@ -184,10 +185,10 @@ protected:
 	std::atomic<cmn::VideoPixelFormatId> _colorspace = cmn::VideoPixelFormatId::None;	
 
 	// Preset for encoder (set by user)
-	ov::String _preset;
+	ov::String _preset OV_GUARDED_BY(_video_mutex);
 
 	// Profile (set by user, used for h264, h265 codec)
-	ov::String _profile;
+	ov::String _profile OV_GUARDED_BY(_video_mutex);
 	
 	// Thread count of codec (set by user)
 	std::atomic<int> _thread_count = 0;	
@@ -209,9 +210,9 @@ protected:
 
 	// Abnormal key frame interval detection
 	std::atomic<bool> _detect_abnormal_framerate = false;
-	std::deque<double> _measured_framerate_window;
+	std::deque<double> _measured_framerate_window OV_GUARDED_BY(_video_mutex);
 
-	ov::String _extra_encoder_options;
+	ov::String _extra_encoder_options OV_GUARDED_BY(_video_mutex);
 public:
 	// Overlay (set by user)
 	void SetOverlays(const std::vector<std::shared_ptr<info::Overlay>> &overlays);
@@ -219,7 +220,7 @@ public:
 	size_t GetOverlaySignature() const;
  
 protected:
-	std::vector<std::shared_ptr<info::Overlay>> _overlays;
-	size_t _overlay_signature; // Default is 0, meaning no overlay.
-	mutable std::shared_mutex _overlay_mutex;
+	std::vector<std::shared_ptr<info::Overlay>> _overlays OV_GUARDED_BY(_overlay_mutex);
+	size_t _overlay_signature OV_GUARDED_BY(_overlay_mutex); // Default is 0, meaning no overlay.
+	mutable ov::SharedMutex _overlay_mutex;
 };

--- a/src/projects/base/ovcrypto/certificate.cpp
+++ b/src/projects/base/ovcrypto/certificate.cpp
@@ -385,7 +385,8 @@ STACK_OF(X509) * Certificate::GetChainCertification() const
 
 ov::String Certificate::GetFingerprint(const ov::String &algorithm)
 {
-	std::unique_lock<std::mutex> lock(_digest_mutex);
+	{
+		ov::LockGuard lock(_digest_mutex);
 	// Create digest if not created yet
 	if (_digest.GetLength() <= 0)
 	{
@@ -394,7 +395,7 @@ ov::String Certificate::GetFingerprint(const ov::String &algorithm)
 			return "";
 		}
 	}
-	lock.unlock();
+	}
 
 	ov::String fingerprint = ov::ToHexStringWithDelimiter(&_digest, ':');
 	fingerprint.MakeUpper();

--- a/src/projects/base/ovcrypto/certificate.h
+++ b/src/projects/base/ovcrypto/certificate.h
@@ -145,7 +145,7 @@ private:
 	// Make Self-Signed Certificate
 	X509 *MakeCertificate(EVP_PKEY *pkey);
 	// Make Digest
-	bool ComputeDigest(const ov::String &algorithm);
+	bool ComputeDigest(const ov::String &algorithm) OV_REQUIRES(_digest_mutex);
 
 	bool GetDigestEVP(const ov::String &algorithm, const EVP_MD **mdp);
 
@@ -159,7 +159,7 @@ private:
 	ov::RaiiPtr<STACK_OF(X509)> _chain_certificate{nullptr, X509StackFree};
 	ov::String _chain_certificate_filename;
 
-	ov::Data _digest;
-	ov::String _digest_algorithm;
-	std::mutex _digest_mutex;
+	ov::Data _digest OV_GUARDED_BY(_digest_mutex);
+	ov::String _digest_algorithm OV_GUARDED_BY(_digest_mutex);
+	ov::Mutex _digest_mutex;
 };

--- a/src/projects/base/ovcrypto/openssl/ocsp_cache.cpp
+++ b/src/projects/base/ovcrypto/openssl/ocsp_cache.cpp
@@ -16,7 +16,7 @@ namespace ov
 {
 	std::shared_ptr<OcspContext> OcspCache::ContextForCert(SSL_CTX *ssl_ctx, X509 *cert)
 	{
-		std::lock_guard lock_guard(_cache_mutex);
+		LockGuard lock_guard(_cache_mutex);
 
 		auto item = _cache_map.find(cert);
 
@@ -71,7 +71,7 @@ namespace ov
 
 	OcspCache::~OcspCache()
 	{
-		std::lock_guard lock_guard(_cache_mutex);
+		LockGuard lock_guard(_cache_mutex);
 
 		for (auto item : _cache_map)
 		{

--- a/src/projects/base/ovcrypto/openssl/ocsp_cache.h
+++ b/src/projects/base/ovcrypto/openssl/ocsp_cache.h
@@ -8,8 +8,8 @@
 //==============================================================================
 #pragma once
 
+#include <base/ovlibrary/tsa/mutex.h>
 #include <map>
-#include <mutex>
 
 #include "./ocsp_context.h"
 
@@ -31,8 +31,8 @@ namespace ov
 		};
 
 	private:
-		std::mutex _cache_mutex;
+		Mutex _cache_mutex;
 		// We should call X509_free when we erase an item from the map
-		std::map<X509 *, std::shared_ptr<OcspContext>, Comparator> _cache_map;
+		std::map<X509 *, std::shared_ptr<OcspContext>, Comparator> _cache_map OV_GUARDED_BY(_cache_mutex);
 	};
 }  // namespace ov

--- a/src/projects/base/ovcrypto/openssl/tls.cpp
+++ b/src/projects/base/ovcrypto/openssl/tls.cpp
@@ -95,7 +95,7 @@ namespace ov
 			{
 				logtc(
 					"Could not allocate BIO_METHOD '%s'. "
-					"TLS BIO creation is permanently  disabled for this process; "
+					"TLS BIO creation is permanently disabled for this process; "
 					"a restart is required to recover.",
 					OV_TLS_BIO_METHOD_NAME);
 				return nullptr;

--- a/src/projects/base/ovcrypto/openssl/tls.cpp
+++ b/src/projects/base/ovcrypto/openssl/tls.cpp
@@ -70,38 +70,65 @@ namespace ov
 
 	BIO_METHOD *Tls::PrepareBioMethod()
 	{
-		static std::mutex bio_mutex;
-		static BIO_METHOD *bio_method = nullptr;
+		// We want a lock-free fast path for every TLS BIO creation after the first one,
+		// so the per-method singleton is bound to a function-local static.
+		// C++11 guarantees the initializer runs exactly once even under concurrent callers,
+		// and subsequent calls just load the already-published pointer.
+		//
+		// Whatever the lambda returns - including `nullptr` - is the cached value for the
+		// rest of the process lifetime; we deliberately do not retry on failure.
+		// The two failure modes here are
+		//   (1) `BIO_meth_new()` returning `nullptr`,
+		//       which OpenSSL only does under OOM or resource exhaustion, and
+		//   (2) `BIO_meth_set_*()` rejecting the configuration,
+		//       which would require process-wide OpenSSL state corruption
+		//       since the inputs are static function pointers.
+		// Neither is something a later call can recover from, so retrying would only cost
+		// CPU and re-acquire the same lock without ever changing the outcome.
+		// Caching the failed result keeps the hot path branch-free;
+		// the one-shot `logte` inside the lambda makes the failure visible to operators
+		// so the loss of TLS can be traced back to startup time instead of looking like a configuration mistake later.
+		static auto bio_method = []() -> BIO_METHOD * {
+			auto method = OpensslManager::GetInstance()->GetBioMethod(OV_TLS_BIO_METHOD_NAME);
 
-		if (bio_method == nullptr)
-		{
-			auto lock_guard = std::lock_guard(bio_mutex);
-
-			if (bio_method == nullptr)
+			if (method == nullptr)
 			{
-				bio_method = OpensslManager::GetInstance()->GetBioMethod(OV_TLS_BIO_METHOD_NAME);
-
-				if (bio_method != nullptr)
-				{
-					int result = 1;
-
-					result	   = result && ::BIO_meth_set_create(bio_method, TlsCreate);
-					result	   = result && ::BIO_meth_set_ctrl(bio_method, TlsCtrl);
-					result	   = result && ::BIO_meth_set_read(bio_method, TlsRead);
-					result	   = result && ::BIO_meth_set_write(bio_method, TlsWrite);
-					result	   = result && ::BIO_meth_set_puts(bio_method, TlsPuts);
-					result	   = result && ::BIO_meth_set_destroy(bio_method, TlsDestroy);
-
-					if (result == 0)
-					{
-						OpensslManager::GetInstance()->FreeBioMethod(OV_TLS_BIO_METHOD_NAME);
-						::BIO_meth_free(bio_method);
-
-						bio_method = nullptr;
-					}
-				}
+				logtc(
+					"Could not allocate BIO_METHOD '%s'. "
+					"TLS BIO creation is permanently  disabled for this process; "
+					"a restart is required to recover.",
+					OV_TLS_BIO_METHOD_NAME);
+				return nullptr;
 			}
-		}
+
+			int result = 1;
+
+			result	   = result && ::BIO_meth_set_create(method, TlsCreate);
+			result	   = result && ::BIO_meth_set_ctrl(method, TlsCtrl);
+			result	   = result && ::BIO_meth_set_read(method, TlsRead);
+			result	   = result && ::BIO_meth_set_write(method, TlsWrite);
+			result	   = result && ::BIO_meth_set_puts(method, TlsPuts);
+			result	   = result && ::BIO_meth_set_destroy(method, TlsDestroy);
+
+			if (result == 0)
+			{
+				// Roll back the partially-configured method
+				// (drop it from the manager registry and free the OpenSSL object)
+				// so we publish a clean `nullptr` instead of a half-built handle.
+				OpensslManager::GetInstance()->FreeBioMethod(OV_TLS_BIO_METHOD_NAME);
+				::BIO_meth_free(method);
+
+				logte(
+					"Could not configure BIO_METHOD '%s' "
+					"(one of BIO_meth_set_*() rejected the configuration). "
+					"TLS BIO creation is permanently disabled for this process; "
+					"a restart is required to recover.",
+					OV_TLS_BIO_METHOD_NAME);
+				return nullptr;
+			}
+
+			return method;
+		}();
 
 		OV_ASSERT2(bio_method != nullptr);
 
@@ -265,7 +292,7 @@ namespace ov
 	std::shared_ptr<ov::Data> Tls::Read()
 	{
 		// lock
-		std::lock_guard lock(_ssl_lock);
+		LockGuard lock(_ssl_lock);
 
 		auto data = std::make_shared<ov::Data>(65535);
 
@@ -352,7 +379,7 @@ namespace ov
 		OV_ASSERT2(_ssl != nullptr);
 
 		// lock
-		std::lock_guard lock(_ssl_lock);
+		LockGuard lock(_ssl_lock);
 
 		size_t write_size = 0;
 

--- a/src/projects/base/ovcrypto/openssl/tls.h
+++ b/src/projects/base/ovcrypto/openssl/tls.h
@@ -110,6 +110,6 @@ namespace ov
 
 		TlsBioCallback _callback;
 
-		std::mutex _ssl_lock;
+		Mutex _ssl_lock;
 	};
 }  // namespace ov

--- a/src/projects/base/ovcrypto/openssl/tls_server_data.cpp
+++ b/src/projects/base/ovcrypto/openssl/tls_server_data.cpp
@@ -51,7 +51,7 @@ namespace ov
 		logtt("Trying to decrypt the data for TLS\n%s", cipher_data->Dump(32).CStr());
 
 		{
-			std::lock_guard lock_guard(_cipher_data_mutex);
+			LockGuard lock_guard(_cipher_data_mutex);
 			if ((_cipher_data == nullptr) || _cipher_data->IsEmpty())
 			{
 				_cipher_data = cipher_data->Clone();
@@ -161,7 +161,7 @@ namespace ov
 		auto result = _tls.Write(plain_data, &written_bytes);
 		if (result == SSL_ERROR_NONE)
 		{
-			std::lock_guard lock_guard(_plain_data_mutex);
+			LockGuard lock_guard(_plain_data_mutex);
 			*cipher_data = std::move(_plain_data);
 			return true;
 		}
@@ -208,7 +208,7 @@ namespace ov
 
 	ssize_t TlsServerData::OnTlsRead(Tls *tls, void *buffer, size_t length)
 	{
-		std::lock_guard lock_guard(_cipher_data_mutex);
+		LockGuard lock_guard(_cipher_data_mutex);
 
 		if (_cipher_data == nullptr)
 		{
@@ -241,7 +241,7 @@ namespace ov
 		}
 		else
 		{
-			std::lock_guard lock_guard(_plain_data_mutex);
+			LockGuard lock_guard(_plain_data_mutex);
 			if (_plain_data == nullptr)
 			{
 				_plain_data = std::make_shared<Data>(data, length);

--- a/src/projects/base/ovcrypto/openssl/tls_server_data.h
+++ b/src/projects/base/ovcrypto/openssl/tls_server_data.h
@@ -76,7 +76,7 @@ namespace ov
 		size_t GetDataLength() const;
 		std::shared_ptr<const Data> GetData() const;
 
-		std::mutex& GetSequentialSendMutex()
+		Mutex& GetSequentialSendMutex()
 		{
 			return _tls_sequential_send_mutex;
 		}
@@ -100,15 +100,15 @@ namespace ov
 		Tls _tls;
 		WriteCallback _write_callback;
 
-		std::mutex _cipher_data_mutex;
-		std::shared_ptr<Data> _cipher_data;
+		Mutex _cipher_data_mutex;
+		std::shared_ptr<Data> _cipher_data OV_GUARDED_BY(_cipher_data_mutex);
 
-		std::mutex _plain_data_mutex;
-		std::shared_ptr<Data> _plain_data;
+		Mutex _plain_data_mutex;
+		std::shared_ptr<Data> _plain_data OV_GUARDED_BY(_plain_data_mutex);
 
 		AlpnProtocol _selected_alpn_protocol = AlpnProtocol::Http11;
 
 	private:
-		std::mutex _tls_sequential_send_mutex;	// for atomic send
+		Mutex _tls_sequential_send_mutex;	// for atomic send
 	};
 }  // namespace ov

--- a/src/projects/base/ovlibrary/bps_calculator.cpp
+++ b/src/projects/base/ovlibrary/bps_calculator.cpp
@@ -21,7 +21,7 @@ namespace ov
 				constexpr int BITS_COUNT = OV_COUNTOF(_bits);
 				int64_t bits = _current_bits.exchange(0L);
 
-				auto lock_guard = std::lock_guard(_mutex);
+				LockGuard lock_guard(_mutex);
 				_acc_bits -= _bits[0];
 				// Shift
 				::memmove(&(_bits[0]), &(_bits[1]), sizeof(_bits[0]) * (BITS_COUNT - 1));

--- a/src/projects/base/ovlibrary/bps_calculator.h
+++ b/src/projects/base/ovlibrary/bps_calculator.h
@@ -9,10 +9,10 @@
 #pragma once
 
 #include <atomic>
-#include <shared_mutex>
 
 #include "delay_queue.h"
 #include "stop_watch.h"
+#include "tsa/mutex.h"
 
 namespace ov
 {
@@ -32,9 +32,9 @@ namespace ov
 		DelayQueue _timer{"BpsCalc"};
 		StopWatch _stop_watch;
 
-		std::shared_mutex _mutex;
-		int64_t _bits[10]{0};
-		int _bits_count = 0;
+		SharedMutex _mutex;
+		int64_t _bits[10] OV_GUARDED_BY(_mutex){0};
+		int _bits_count OV_GUARDED_BY(_mutex) = 0;
 
 		// Cumulative number of bits of last second
 		std::atomic<int64_t> _current_bits{0L};

--- a/src/projects/base/ovlibrary/log_internal.cpp
+++ b/src/projects/base/ovlibrary/log_internal.cpp
@@ -77,7 +77,7 @@ namespace ov
 			return;
 		}
 
-		std::lock_guard<std::mutex> lock(_mutex);
+		LockGuard<Mutex> lock(_mutex);
 
 		_enable_map.clear();
 		_enable_list.clear();
@@ -90,7 +90,7 @@ namespace ov
 			return false;
 		}
 
-		std::lock_guard<std::mutex> lock(_mutex);
+		LockGuard<Mutex> lock(_mutex);
 
 		auto item = _enable_map.find(tag);
 
@@ -145,7 +145,7 @@ namespace ov
 			return false;
 		}
 
-		std::lock_guard<std::mutex> lock(_mutex);
+		LockGuard<Mutex> lock(_mutex);
 
 		_enable_map.clear();
 

--- a/src/projects/base/ovlibrary/log_internal.h
+++ b/src/projects/base/ovlibrary/log_internal.h
@@ -16,7 +16,6 @@
 #include <chrono>
 #include <cstdio>
 #include <ctime>
-#include <mutex>
 #include <regex>
 #include <unordered_map>
 
@@ -24,6 +23,7 @@
 #include "./log.h"
 #include "./log_write.h"
 #include "./string.h"
+#include "./tsa/mutex.h"
 
 #if DEBUG
 #	define OV_LOG_SHOW_FILE_NAME 1
@@ -78,7 +78,7 @@ namespace ov
 
 		OVLogLevel _level;
 
-		std::mutex _mutex;
+		Mutex _mutex;
 
 		LogWrite _log_file;
 
@@ -90,11 +90,11 @@ namespace ov
 			ov::String regex_string;
 		};
 
-		std::vector<EnableItem> _enable_list;
+		std::vector<EnableItem> _enable_list OV_GUARDED_BY(_mutex);
 
 		// This map used for cache (It reduces regex matching cost)
 		// key: tag
 		// value: is_enabled
-		std::unordered_map<ov::String, EnableItem> _enable_map;
+		std::unordered_map<ov::String, EnableItem> _enable_map OV_GUARDED_BY(_mutex);
 	};
 }  // namespace ov

--- a/src/projects/base/ovlibrary/log_write.cpp
+++ b/src/projects/base/ovlibrary/log_write.cpp
@@ -63,7 +63,7 @@ namespace ov
 			return;
 		}
 
-		std::lock_guard<std::mutex> lock_guard(_log_stream_mutex);
+		LockGuard<Mutex> lock_guard(_log_stream_mutex);
 		_log_stream.close();
 		_log_stream.clear();
 
@@ -130,7 +130,7 @@ namespace ov
 			_last_day = local_time.tm_mday;
 		}
 
-		std::lock_guard<std::mutex> lock_guard(_log_stream_mutex);
+		LockGuard<Mutex> lock_guard(_log_stream_mutex);
 		_log_stream << log << std::endl;
 		_log_stream.flush();
 	}

--- a/src/projects/base/ovlibrary/log_write.h
+++ b/src/projects/base/ovlibrary/log_write.h
@@ -10,7 +10,7 @@
 
 #include <atomic>
 #include <fstream>
-#include <mutex>
+#include "./tsa/mutex.h"
 
 #define OV_LOG_DIR "logs"
 #define OV_LOG_DIR_SVC "/var/log/ovenmediaengine"
@@ -33,8 +33,8 @@ namespace ov
 	private:
 		void OpenNewFile(std::time_t time = 0);
 
-		std::mutex _log_stream_mutex;
-		std::ofstream _log_stream;
+		Mutex _log_stream_mutex;
+		std::ofstream _log_stream OV_GUARDED_BY(_log_stream_mutex);
 		int _last_day;
 		std::string _log_path;
 		std::string _log_file_name;

--- a/src/projects/base/ovlibrary/logger/logger.cpp
+++ b/src/projects/base/ovlibrary/logger/logger.cpp
@@ -14,6 +14,7 @@
 
 #include <memory>
 
+#include "../tsa/mutex.h"
 #include "sinks/sinks.h"
 
 #define OV_LOG_COLOR_RESET "\x1B[0m"
@@ -94,10 +95,10 @@ namespace ov::logger
 
 	std::shared_ptr<Logger> GetLogger(const char *tag, const LogOptions &options)
 	{
-		static std::mutex logger_map_mutex;
-		static std::map<std::string, std::shared_ptr<Logger>> logger_map;
+		static Mutex logger_map_mutex;
+		static std::map<std::string, std::shared_ptr<Logger>> logger_map OV_GUARDED_BY(logger_map_mutex);
 
-		std::lock_guard lock_guard(logger_map_mutex);
+		LockGuard lock_guard(logger_map_mutex);
 
 		{
 			auto logger = logger_map.find(tag);

--- a/src/projects/base/ovlibrary/logger/thread_helper.cpp
+++ b/src/projects/base/ovlibrary/logger/thread_helper.cpp
@@ -11,6 +11,7 @@
 #include <spdlog/details/os.h>
 
 #include "../assert.h"
+#include "../tsa/mutex.h"
 
 namespace ov::logger
 {
@@ -21,13 +22,13 @@ namespace ov::logger
 		public:
 			void AppendThreadInfo(size_t thread_id, pthread_t pthread_id)
 			{
-				std::lock_guard lock(_thread_id_map_mutex);
+				LockGuard lock(_thread_id_map_mutex);
 				(*_thread_id_map)[thread_id] = pthread_id;
 			}
 
 			void RemoveThreadInfo(size_t thread_id)
 			{
-				std::lock_guard lock(_thread_id_map_mutex);
+				LockGuard lock(_thread_id_map_mutex);
 
 #if DEBUG
 				if (_thread_id_map->find(thread_id) == _thread_id_map->end())
@@ -41,7 +42,7 @@ namespace ov::logger
 
 			pthread_t GetPthreadId(size_t thread_id)
 			{
-				std::shared_lock lock(_thread_id_map_mutex);
+				SharedLockGuard lock(_thread_id_map_mutex);
 
 				auto it = _thread_id_map->find(thread_id);
 
@@ -58,10 +59,10 @@ namespace ov::logger
 			}
 
 		private:
-			std::shared_mutex _thread_id_map_mutex;
+			SharedMutex _thread_id_map_mutex;
 			// key: `thread_id` - This is obtained by calling `thread_id()` of `spdlog`.
 			// value: `pthread_id`
-			std::shared_ptr<std::unordered_map<size_t, pthread_t>> _thread_id_map = std::make_shared<std::unordered_map<size_t, pthread_t>>();
+			std::shared_ptr<std::unordered_map<size_t, pthread_t>> _thread_id_map OV_GUARDED_BY(_thread_id_map_mutex) = std::make_shared<std::unordered_map<size_t, pthread_t>>();
 		};
 
 		static std::shared_ptr<Helper> &GetHelper()

--- a/src/projects/base/ovlibrary/queue.h
+++ b/src/projects/base/ovlibrary/queue.h
@@ -102,7 +102,7 @@ namespace ov
 		// Timeout in milliseconds
 		std::optional<T> Front(int timeout = Infinite)
 		{
-			LockGuard unique_lock(_mutex);
+			LockGuard lock(_mutex);
 
 			if (_stop == false)
 			{
@@ -113,7 +113,7 @@ namespace ov
 					std::chrono::steady_clock::time_point expire =
 						(timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
-					result = _condition.WaitUntil(unique_lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
+					result = _condition.WaitUntil(lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
 						return ((_queue.empty() == false) || _stop);
 					});
 				}
@@ -144,7 +144,7 @@ namespace ov
 		// Timeout in milliseconds
 		std::optional<T> Back(int timeout = Infinite)
 		{
-			LockGuard unique_lock(_mutex);
+			LockGuard lock(_mutex);
 
 			if (_stop == false)
 			{
@@ -156,7 +156,7 @@ namespace ov
 					std::chrono::steady_clock::time_point expire =
 						(timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
-					result = _condition.WaitUntil(unique_lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
+					result = _condition.WaitUntil(lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
 						return ((_queue.empty() == false) || _stop);
 					});
 				}
@@ -188,7 +188,7 @@ namespace ov
 		// Timeout in milliseconds
 		std::optional<T> Dequeue(int timeout = Infinite)
 		{
-			LockGuard unique_lock(_mutex);
+			LockGuard lock(_mutex);
 
 			if (_stop == false)
 			{
@@ -202,7 +202,7 @@ namespace ov
 						std::chrono::steady_clock::time_point expire =
 							(timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
-						result = _condition.WaitUntil(unique_lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
+						result = _condition.WaitUntil(lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
 							return ((_queue.empty() == false) || _stop);
 						});
 					}

--- a/src/projects/base/ovlibrary/queue.h
+++ b/src/projects/base/ovlibrary/queue.h
@@ -8,16 +8,15 @@
 //==============================================================================
 #pragma once
 
-#include <condition_variable>
 #include <optional>
 #include <queue>
-#include <shared_mutex>
 
 #include "./dump_utilities.h"
 #include "./log.h"
 #include "./ovdata_structure.h"
 #include "./stop_watch.h"
 #include "./string.h"
+#include "./tsa/mutex.h"
 
 namespace ov
 {
@@ -38,25 +37,25 @@ namespace ov
 
 			_last_log_time.Start();
 
-			auto shared_lock = std::shared_lock(_name_mutex);
+			SharedLockGuard shared_lock(_name_mutex);
 			logt("ov.Queue", "[%p] %s is created with threshold: %zu, interval: %d", this, _queue_name.CStr(), threshold, log_interval_in_msec);
 		}
 
 		~Queue()
 		{
-			auto shared_lock = std::shared_lock(_name_mutex);
+			SharedLockGuard shared_lock(_name_mutex);
 			logt("ov.Queue", "[%p] %s is destroyed", this, _queue_name.CStr());
 		}
 
 		String GetAlias() const
 		{
-			auto shared_lock = std::shared_lock(_name_mutex);
+			SharedLockGuard shared_lock(_name_mutex);
 			return _queue_name;
 		}
 
 		void SetAlias(const char *alias)
 		{
-			auto lock_guard = std::lock_guard(_name_mutex);
+			LockGuard lock_guard(_name_mutex);
 
 			if ((alias != nullptr) && (alias[0] != '\0'))
 			{
@@ -72,7 +71,7 @@ namespace ov
 
 		void SetThreshold(size_t threshold)
 		{
-			auto lock_guard = std::lock_guard(_name_mutex);
+			LockGuard lock_guard(_name_mutex);
 
 			_threshold = threshold;
 			logt("ov.Queue", "[%p] The threshold is changed to %d", this, _threshold);
@@ -80,30 +79,30 @@ namespace ov
 
 		void Enqueue(const T &item)
 		{
-			auto lock_guard = std::lock_guard(_mutex);
+			LockGuard lock_guard(_mutex);
 
 			_queue.push(item);
 
 			CheckThreshold();
 
-			_condition.notify_all();
+			_condition.NotifyAll();
 		}
 
 		void Enqueue(T &&item)
 		{
-			auto lock_guard = std::lock_guard(_mutex);
+			LockGuard lock_guard(_mutex);
 
 			_queue.push(std::move(item));
 
 			CheckThreshold();
 
-			_condition.notify_all();
+			_condition.NotifyAll();
 		}
 
 		// Timeout in milliseconds
 		std::optional<T> Front(int timeout = Infinite)
 		{
-			auto unique_lock = std::unique_lock(_mutex);
+			LockGuard unique_lock(_mutex);
 
 			if (_stop == false)
 			{
@@ -114,7 +113,7 @@ namespace ov
 					std::chrono::steady_clock::time_point expire =
 						(timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
-					result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
+					result = _condition.WaitUntil(unique_lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
 						return ((_queue.empty() == false) || _stop);
 					});
 				}
@@ -145,7 +144,7 @@ namespace ov
 		// Timeout in milliseconds
 		std::optional<T> Back(int timeout = Infinite)
 		{
-			auto unique_lock = std::unique_lock(_mutex);
+			LockGuard unique_lock(_mutex);
 
 			if (_stop == false)
 			{
@@ -157,7 +156,7 @@ namespace ov
 					std::chrono::steady_clock::time_point expire =
 						(timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
-					result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
+					result = _condition.WaitUntil(unique_lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
 						return ((_queue.empty() == false) || _stop);
 					});
 				}
@@ -189,7 +188,7 @@ namespace ov
 		// Timeout in milliseconds
 		std::optional<T> Dequeue(int timeout = Infinite)
 		{
-			auto unique_lock = std::unique_lock(_mutex);
+			LockGuard unique_lock(_mutex);
 
 			if (_stop == false)
 			{
@@ -203,7 +202,7 @@ namespace ov
 						std::chrono::steady_clock::time_point expire =
 							(timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
-						result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
+						result = _condition.WaitUntil(unique_lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
 							return ((_queue.empty() == false) || _stop);
 						});
 					}
@@ -242,14 +241,14 @@ namespace ov
 
 		bool IsEmpty() const
 		{
-			auto lock_guard = std::lock_guard(_mutex);
+			LockGuard lock_guard(_mutex);
 
 			return _queue.empty();
 		}
 
 		void Clear()
 		{
-			auto lock_guard = std::lock_guard(_mutex);
+			LockGuard lock_guard(_mutex);
 
 			// empty the queue
 			_queue = {};
@@ -257,7 +256,7 @@ namespace ov
 
 		size_t Size() const
 		{
-			auto lock_guard = std::lock_guard(_mutex);
+			LockGuard lock_guard(_mutex);
 
 			return _queue.size();
 		}
@@ -269,21 +268,21 @@ namespace ov
 
 		void Start()
 		{
-			auto lock_guard = std::lock_guard(_mutex);
+			LockGuard lock_guard(_mutex);
 
 			_stop = false;
 		}
 
 		void Stop()
 		{
-			auto lock_guard = std::lock_guard(_mutex);
+			LockGuard lock_guard(_mutex);
 
 			_stop = true;
-			_condition.notify_all();
+			_condition.NotifyAll();
 		}
 
 	protected:
-		inline void CheckThreshold()
+		inline void CheckThreshold() OV_REQUIRES(_mutex)
 		{
 			if (_peak < _queue.size())
 			{
@@ -294,7 +293,7 @@ namespace ov
 			{
 				if (_last_log_time.IsElapsed(_log_interval) && _last_log_time.Update())
 				{
-					auto shared_lock = std::shared_lock(_name_mutex);
+					SharedLockGuard shared_lock(_name_mutex);
 					logw("ov.Queue", "[%p] %s size has exceeded the threshold: queue: %zu, threshold: %zu, peak: %zu", this, _queue_name.CStr(), _queue.size(), _threshold, _peak);
 				}
 			}
@@ -303,17 +302,17 @@ namespace ov
 	private:
 		StopWatch _last_log_time;
 
-		std::shared_mutex _name_mutex;
-		String _queue_name;
+		SharedMutex _name_mutex;
+		String _queue_name OV_GUARDED_BY(_name_mutex);
 
 		size_t _threshold = 0;
-		size_t _peak = 0;
+		size_t _peak OV_GUARDED_BY(_mutex) = 0;
 		int _log_interval = 0;
 
-		std::queue<T> _queue;
-		mutable std::mutex _mutex;
-		std::condition_variable _condition;
-		bool _stop = false;
+		std::queue<T> _queue OV_GUARDED_BY(_mutex);
+		mutable Mutex _mutex;
+		ConditionVariable _condition;
+		bool _stop OV_GUARDED_BY(_mutex) = false;
 	};
 
 }  // namespace ov

--- a/src/projects/base/ovlibrary/thread_checker.h
+++ b/src/projects/base/ovlibrary/thread_checker.h
@@ -10,11 +10,11 @@
 
 #include <pthread.h>
 
-#include <mutex>
 #include <thread>
 
 #include "./assert.h"
 #include "./log.h"
+#include "./tsa/mutex.h"
 
 namespace ov
 {
@@ -131,7 +131,7 @@ namespace ov
 		// Returns `true` if the current thread matches the bound thread.
 		bool IsCurrent() const
 		{
-			std::scoped_lock lock(_mutex);
+			ScopedLock lock(_mutex);
 
 			if (_attached == false)
 			{
@@ -151,7 +151,7 @@ namespace ov
 		// no need to call Detach() first.
 		void Bind(ThreadLocation loc = {})
 		{
-			std::scoped_lock lock(_mutex);
+			ScopedLock lock(_mutex);
 			_bound_thread  = ::pthread_self();
 			_attached	   = true;
 			_bind_location = {loc, ov::StackTrace::GetStackTrace()};
@@ -163,7 +163,7 @@ namespace ov
 		// another.
 		void Detach()
 		{
-			std::scoped_lock lock(_mutex);
+			ScopedLock lock(_mutex);
 			_attached = false;
 		}
 
@@ -217,10 +217,10 @@ namespace ov
 			ov::String stack_trace;
 		};
 
-		mutable std::mutex _mutex;
-		mutable bool _attached = true;
-		mutable pthread_t _bound_thread;
-		mutable BindLocation _bind_location;
+		mutable Mutex _mutex;
+		mutable bool _attached OV_GUARDED_BY(_mutex) = true;
+		mutable pthread_t _bound_thread OV_GUARDED_BY(_mutex);
+		mutable BindLocation _bind_location OV_GUARDED_BY(_mutex);
 
 		inline static bool _main_initialized	   = false;
 		inline static ThreadChecker *_main_checker = nullptr;

--- a/src/projects/base/ovlibrary/url.cpp
+++ b/src/projects/base/ovlibrary/url.cpp
@@ -404,7 +404,6 @@ namespace ov
 		// DCL
 		if (_query_parsed.load(std::memory_order_relaxed))
 		{
-			// The query is parsed in another thread
 			return;
 		}
 

--- a/src/projects/base/ovlibrary/url.cpp
+++ b/src/projects/base/ovlibrary/url.cpp
@@ -198,7 +198,7 @@ namespace ov
 			_path_components.clear();
 			_query_string	  = "";
 			_has_query_string = false;
-			_query_parsed	  = false;
+			_query_parsed.store(false, std::memory_order_release);
 
 			_app			  = "";
 			_stream			  = "";
@@ -222,7 +222,7 @@ namespace ov
 		}
 		_query_string	  = group_list["qs"].GetValue();
 		_has_query_string = (_query_string.IsEmpty() == false);
-		_query_parsed	  = false;
+		_query_parsed.store(false, std::memory_order_release);
 
 		return true;
 	}
@@ -248,7 +248,7 @@ namespace ov
 
 		_query_string.Append(key);
 		_has_query_string = true;
-		_query_parsed	  = false;
+		_query_parsed.store(false, std::memory_order_release);
 
 		return true;
 	}
@@ -262,7 +262,7 @@ namespace ov
 
 		_query_string.AppendFormat("%s=%s", key.CStr(), Encode(value).CStr());
 		_has_query_string = true;
-		_query_parsed	  = false;
+		_query_parsed.store(false, std::memory_order_release);
 
 		return true;
 	}
@@ -284,7 +284,7 @@ namespace ov
 		}
 
 		_has_query_string = true;
-		_query_parsed	  = false;
+		_query_parsed.store(false, std::memory_order_release);
 
 		return true;
 	}
@@ -333,7 +333,7 @@ namespace ov
 		}
 
 		_query_string = new_query_string;
-		_query_parsed = false;
+		_query_parsed.store(false, std::memory_order_release);
 
 		return true;
 	}
@@ -394,42 +394,43 @@ namespace ov
 
 	void Url::ParseQueryIfNeeded() const
 	{
-		if ((_has_query_string == false) || _query_parsed)
+		if ((_has_query_string == false) || _query_parsed.load(std::memory_order_acquire))
 		{
 			return;
 		}
 
-		auto lock_guard = std::lock_guard(_query_map_mutex);
+		LockGuard lock_guard(_query_map_mutex);
 
 		// DCL
-		if (_query_parsed == false)
+		if (_query_parsed.load(std::memory_order_relaxed))
 		{
-			_query_parsed = true;
+			// The query is parsed in another thread
+			return;
+		}
 
-			// Split the query string into the map
-			if (_query_string.IsEmpty() == false)
+		// Split the query string into the map
+		if (_query_string.IsEmpty() == false)
+		{
+			const auto &query_list = _query_string.Split("&");
+
+			for (auto &query : query_list)
 			{
-				const auto &query_list = _query_string.Split("&");
+				auto tokens = query.Split("=", 2);
 
-				for (auto &query : query_list)
+				if (tokens.size() == 2)
 				{
-					auto tokens = query.Split("=", 2);
-
-					if (tokens.size() == 2)
-					{
-						_query_map[tokens[0]] = Decode(tokens[1]);
-					}
-					else
-					{
-						_query_map[query] = "";
-					}
+					_query_map[tokens[0]] = Decode(tokens[1]);
+				}
+				else
+				{
+					_query_map[query] = "";
 				}
 			}
 		}
-		else
-		{
-			// The query is parsed in another thread
-		}
+
+		// Publish AFTER population so the lock-free fast path that observes `true` via
+		// acquire is guaranteed to see the fully built _query_map.
+		_query_parsed.store(true, std::memory_order_release);
 	}
 
 	bool Url::HasQueryString() const
@@ -482,7 +483,7 @@ namespace ov
 		_path_components  = other._path_components;
 		_has_query_string = other._has_query_string;
 		_query_string	  = other._query_string;
-		_query_parsed	  = other._query_parsed;
+		_query_parsed.store(other._query_parsed.load(std::memory_order_acquire), std::memory_order_release);
 		_query_map		  = other._query_map;
 		_app			  = other._app;
 		_stream			  = other._stream;

--- a/src/projects/base/ovlibrary/url.h
+++ b/src/projects/base/ovlibrary/url.h
@@ -8,8 +8,11 @@
 //==============================================================================
 #pragma once
 
+#include <atomic>
+
 #include "./ovlibrary.h"
 #include "./string.h"
+#include "./tsa/mutex.h"
 
 namespace ov
 {
@@ -111,10 +114,11 @@ namespace ov
 		std::vector<ov::String> _path_components;
 		ov::String _query_string;
 		bool _has_query_string = false;
-		// To reduce the cost of parsing the query map, parsing the query only when Query() or QueryMap() is called
-		mutable bool _query_parsed = false;
-		mutable std::mutex _query_map_mutex;
-		mutable std::map<ov::String, ov::String> _query_map;
+		// To reduce the cost of parsing the query map, parsing the query only when Query() or QueryMap() is called.
+		// Atomic acquire/release publishes _query_map so the lock-free fast path in ParseQueryIfNeeded is race-free.
+		mutable std::atomic<bool> _query_parsed{false};
+		mutable Mutex _query_map_mutex;
+		mutable std::map<ov::String, ov::String> _query_map OV_GUARDED_BY(_query_map_mutex);
 
 		// Valid for URLs of the form: <scheme>://<domain>[:<port>]/<app>/<stream>[<file>[/<remaining>]][?<query string>]
 		ov::String _app;

--- a/src/projects/base/ovsocket/client_socket.h
+++ b/src/projects/base/ovsocket/client_socket.h
@@ -42,7 +42,7 @@ namespace ov
 		void OnReadable() override;
 		void OnClosed() override;
 
-		bool CloseInternal(SocketState close_reason) override;
+		bool CloseInternal(SocketState close_reason) override OV_REQUIRES(_dispatch_queue_lock);
 
 		std::weak_ptr<ServerSocket> _server_socket;
 	};

--- a/src/projects/base/ovsocket/datagram_socket.h
+++ b/src/projects/base/ovsocket/datagram_socket.h
@@ -48,7 +48,7 @@ namespace ov
 		//--------------------------------------------------------------------
 		// Overriding of Socket
 		//--------------------------------------------------------------------
-		bool CloseInternal(SocketState close_reason) override;
+		bool CloseInternal(SocketState close_reason) override OV_REQUIRES(_dispatch_queue_lock);
 
 		//--------------------------------------------------------------------
 		// Implementation of SocketAsyncInterface

--- a/src/projects/base/ovsocket/server_socket.h
+++ b/src/projects/base/ovsocket/server_socket.h
@@ -70,7 +70,7 @@ namespace ov
 		//--------------------------------------------------------------------
 		// Overriding of Socket
 		//--------------------------------------------------------------------
-		bool CloseInternal(SocketState close_reason) override;
+		bool CloseInternal(SocketState close_reason) override OV_REQUIRES(_dispatch_queue_lock);
 
 		//--------------------------------------------------------------------
 		// Implementation of SocketAsyncInterface

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -172,7 +172,7 @@ namespace ov
 		{
 			auto state = _state.load();
 
-			std::lock_guard lock_guard(_dispatch_queue_lock);
+			LockGuard lock_guard(_dispatch_queue_lock);
 			if (CloseInternal(state))
 			{
 				SetState(SocketState::Closed);
@@ -237,7 +237,7 @@ namespace ov
 	bool Socket::AppendCommand(DispatchCommand command, bool dispatch_immediately)
 	{
 		SOCKET_PROFILER_INIT();
-		std::lock_guard lock_guard(_dispatch_queue_lock);
+		LockGuard lock_guard(_dispatch_queue_lock);
 		SOCKET_PROFILER_AFTER_LOCK();
 
 		SOCKET_PROFILER_POST_HANDLER([&](int64_t lock_elapsed, int64_t total_elapsed) {
@@ -271,7 +271,7 @@ namespace ov
 	bool Socket::AddToWorker(bool need_to_wait_first_epoll_event)
 	{
 		{
-			std::lock_guard lock_guard(_worker_mutex);
+			LockGuard lock_guard(_worker_mutex);
 
 			if (_added_to_worker)
 			{
@@ -310,7 +310,7 @@ namespace ov
 
 	bool Socket::DeleteFromWorker()
 	{
-		std::lock_guard lock_guard(_worker_mutex);
+		LockGuard lock_guard(_worker_mutex);
 
 		if (_added_to_worker)
 		{
@@ -1002,7 +1002,7 @@ namespace ov
 		{
 			SOCKET_PROFILER_AFTER_LOCK();
 
-			std::lock_guard lock_guard(_dispatch_queue_lock);
+			LockGuard lock_guard(_dispatch_queue_lock);
 
 			[[maybe_unused]] auto count = _dispatch_queue.size();
 			SOCKET_PROFILER_POST_HANDLER([&](int64_t lock_elapsed, int64_t total_elapsed) {
@@ -1082,7 +1082,7 @@ namespace ov
 			case BlockingMode::Blocking:
 #if DEBUG
 			{
-				std::lock_guard lock_guard(_dispatch_queue_lock);
+				LockGuard lock_guard(_dispatch_queue_lock);
 				[[maybe_unused]] auto count = _dispatch_queue.size();
 				OV_ASSERT2(count == 0);
 			}
@@ -1091,7 +1091,7 @@ namespace ov
 
 			case BlockingMode::NonBlocking: {
 				// Due to the connection callback point, the DispatchEventsInternal() specifically performs mutex.lock inside.
-				// std::lock_guard lock_guard(_dispatch_queue_lock);
+				// LockGuard lock_guard(_dispatch_queue_lock);
 				auto result = DispatchEventsInternal();
 
 				CallCloseCallbackIfNeeded();
@@ -2011,7 +2011,7 @@ namespace ov
 
 				// Close regardless of result
 				{
-					std::lock_guard lock_guard(_dispatch_queue_lock);
+					LockGuard lock_guard(_dispatch_queue_lock);
 
 					if (CloseInternal(new_state))
 					{
@@ -2028,7 +2028,7 @@ namespace ov
 
 			case BlockingMode::NonBlocking: {
 				SOCKET_PROFILER_INIT();
-				std::lock_guard lock_guard(_dispatch_queue_lock);
+				LockGuard lock_guard(_dispatch_queue_lock);
 				SOCKET_PROFILER_AFTER_LOCK();
 
 				SOCKET_PROFILER_POST_HANDLER([&](int64_t lock_elapsed, int64_t total_elapsed) {
@@ -2076,7 +2076,7 @@ namespace ov
 		bool result = false;
 
 		{
-			std::lock_guard lock_guard(_dispatch_queue_lock);
+			LockGuard lock_guard(_dispatch_queue_lock);
 
 			result = CloseInternal(_state);
 		}
@@ -2091,7 +2091,7 @@ namespace ov
 		bool result = false;
 
 		{
-			std::lock_guard lock_guard(_dispatch_queue_lock);
+			LockGuard lock_guard(_dispatch_queue_lock);
 
 			result = CloseInternal(new_state);
 

--- a/src/projects/base/ovsocket/socket.h
+++ b/src/projects/base/ovsocket/socket.h
@@ -10,6 +10,7 @@
 
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <base/ovlibrary/tsa/mutex.h>
 
 #include "socket_address.h"
 #include "socket_address_pair.h"
@@ -227,7 +228,7 @@ namespace ov
 
 		bool HasExpiredCommand() const
 		{
-			std::lock_guard lock_guard(_dispatch_queue_lock);
+			LockGuard lock_guard(_dispatch_queue_lock);
 
 			if (HasCommand())
 			{
@@ -439,7 +440,7 @@ namespace ov
 		void OnDataAvailableEvent() override;
 		//--------------------------------------------------------------------
 
-		DispatchResult DispatchEventInternal(DispatchCommand &command);
+		DispatchResult DispatchEventInternal(DispatchCommand &command) OV_REQUIRES(_dispatch_queue_lock);
 
 		bool IsSendable() const;
 		ssize_t HandleSendError(const ssize_t result, const size_t total_sent);
@@ -462,7 +463,7 @@ namespace ov
 
 		// CloseInternal() doesn't call the _callback directly
 		// So, we need to call CallCloseCallbackIfNeeded() after calling this api to do connection callback
-		virtual bool CloseInternal(SocketState close_reason);
+		virtual bool CloseInternal(SocketState close_reason) OV_REQUIRES(_dispatch_queue_lock);
 
 		// Since the resource is usually cleaned inside the OnClosed() callback,
 		// callback is performed outside the lock_guard to prevent acquiring the lock.
@@ -527,8 +528,8 @@ namespace ov
 		// This is a software-side retry marker, not a real pending kernel read event.
 		std::atomic<bool> _has_pending_events = false;
 
-		std::mutex _worker_mutex;
-		bool _added_to_worker = false;
+		Mutex _worker_mutex;
+		bool _added_to_worker OV_GUARDED_BY(_worker_mutex) = false;
 
 		std::atomic<bool> _need_to_wait_first_epoll_event{true};
 		Event _first_epoll_event_received{true};
@@ -538,8 +539,8 @@ namespace ov
 		std::shared_ptr<SocketAddress> _local_address = nullptr;
 		std::shared_ptr<SocketAddress> _remote_address = nullptr;
 
-		mutable std::recursive_mutex _dispatch_queue_lock;
-		std::deque<DispatchCommand> _dispatch_queue;
+		mutable RecursiveMutex _dispatch_queue_lock;
+		std::deque<DispatchCommand> _dispatch_queue OV_GUARDED_BY(_dispatch_queue_lock);
 		std::atomic<bool> _has_close_command = false;
 
 		std::atomic<bool> _connection_event_fired{false};

--- a/src/projects/base/ovsocket/socket_pool/socket_pool.cpp
+++ b/src/projects/base/ovsocket/socket_pool/socket_pool.cpp
@@ -25,7 +25,7 @@ namespace ov
 	SocketPool::~SocketPool()
 	{
 		// Verify that the epoll is closed normally
-		std::lock_guard lock_guard(_worker_list_mutex);
+		LockGuard lock_guard(_worker_list_mutex);
 
 #if DEBUG
 		for (auto &worker : _worker_list)
@@ -58,7 +58,7 @@ namespace ov
 					decltype(_worker_list) release_worker_list;
 
 					{
-						std::lock_guard lock_guard(_worker_list_mutex);
+						LockGuard lock_guard(_worker_list_mutex);
 
 						for (auto iterator = _worker_list.begin(); iterator != _worker_list.end();)
 						{
@@ -125,7 +125,7 @@ namespace ov
 			if (succeeded)
 			{
 				{
-					std::lock_guard lock_guard(_worker_list_mutex);
+					LockGuard lock_guard(_worker_list_mutex);
 					_worker_list.insert(
 						_worker_list.end(),
 						std::make_move_iterator(worker_list.begin()),
@@ -164,7 +164,7 @@ namespace ov
 		std::vector<std::shared_ptr<SocketPoolWorker>> worker_list;
 
 		{
-			std::lock_guard lock_guard(_worker_list_mutex);
+			LockGuard lock_guard(_worker_list_mutex);
 			worker_list = std::move(_worker_list);
 		}
 
@@ -175,7 +175,7 @@ namespace ov
 	{
 		String description;
 
-		std::lock_guard lock_guard(_worker_list_mutex);
+		LockGuard lock_guard(_worker_list_mutex);
 
 		description.AppendFormat(
 			"<SocketPool: %p, workers: %zu",

--- a/src/projects/base/ovsocket/socket_pool/socket_pool.h
+++ b/src/projects/base/ovsocket/socket_pool/socket_pool.h
@@ -8,6 +8,7 @@
 //==============================================================================
 #pragma once
 
+#include <base/ovlibrary/tsa/mutex.h>
 #include <stdexcept>
 
 #include "socket_pool_worker.h"
@@ -84,7 +85,7 @@ namespace ov
 
 		int GetWorkerCount() const
 		{
-			std::lock_guard lock_guard(_worker_list_mutex);
+			LockGuard lock_guard(_worker_list_mutex);
 			return static_cast<int>(_worker_list.size());
 		}
 
@@ -126,7 +127,7 @@ namespace ov
 		// This method will increase the number of sockets for that worker by 1
 		std::shared_ptr<SocketPoolWorker> GetLeastBusyWorker()
 		{
-			std::lock_guard lock_guard(_worker_list_mutex);
+			LockGuard lock_guard(_worker_list_mutex);
 
 			if (_thread_per_socket)
 			{
@@ -178,8 +179,8 @@ namespace ov
 
 		bool _initialized		= false;
 
-		mutable std::mutex _worker_list_mutex;
-		std::vector<std::shared_ptr<SocketPoolWorker>> _worker_list;
+		mutable Mutex _worker_list_mutex;
+		std::vector<std::shared_ptr<SocketPoolWorker>> _worker_list OV_GUARDED_BY(_worker_list_mutex);
 
 		// Worker releaser
 		ov::DelayQueue _timer{"SocketPoolWorkerReleaser"};

--- a/src/projects/base/provider/pull_provider/stream.cpp
+++ b/src/projects/base/provider/pull_provider/stream.cpp
@@ -42,7 +42,7 @@ namespace pvd
 
 	bool PullStream::Start()
 	{
-		std::lock_guard<std::mutex> lock(_start_stop_stream_lock);
+		ov::LockGuard<ov::Mutex> lock(_start_stop_stream_lock);
 		_restart_count = 0;
 		while (true)
 		{
@@ -68,7 +68,7 @@ namespace pvd
 
 	bool PullStream::Stop()
 	{
-		std::lock_guard<std::mutex> lock(_start_stop_stream_lock);
+		ov::LockGuard<ov::Mutex> lock(_start_stop_stream_lock);
 		StopStream();
 		return Stream::Stop();
 	}

--- a/src/projects/base/provider/pull_provider/stream.h
+++ b/src/projects/base/provider/pull_provider/stream.h
@@ -12,6 +12,7 @@
 #include "base/info/stream.h"
 #include "base/provider/stream.h"
 #include "monitoring/monitoring.h"
+#include <base/ovlibrary/tsa/mutex.h>
 
 namespace pvd
 {
@@ -64,14 +65,14 @@ namespace pvd
 		}
 
 	private:
-		uint32_t	_restart_count = 0;
+		uint32_t	_restart_count OV_GUARDED_BY(_start_stop_stream_lock) = 0;
 		std::vector<std::shared_ptr<const ov::Url>> _url_list;
-		int _curr_url_index = 0;
+		int _curr_url_index OV_GUARDED_BY(_start_stop_stream_lock) = 0;
 
 		std::shared_ptr<pvd::PullStreamProperties> _properties;
 
 		// It can be called by multiple thread
-		std::mutex _start_stop_stream_lock;
+		ov::Mutex _start_stop_stream_lock;
 
 	public:
 		const std::shared_ptr<const ov::Url> GetNextURL();

--- a/src/projects/base/provider/stream.cpp
+++ b/src/projects/base/provider/stream.cpp
@@ -92,7 +92,7 @@ namespace pvd
 	// Consider the reconnection time and add it to the base timestamp
 	void Stream::UpdateReconnectTimeToBasetime()
 	{
-		std::scoped_lock lock(_source_stream_timestamp_mutex);
+		ov::ScopedLock lock(_source_stream_timestamp_mutex);
 
 		auto last_pkt_received_time_us = _last_pkt_received_time_us.load();
 		if (last_pkt_received_time_us >= 0)
@@ -119,7 +119,7 @@ namespace pvd
 
 	int64_t Stream::GetCurrentTimestampMs()
 	{
-		std::lock_guard<std::mutex> lock(_timestamp_mutex);
+		ov::LockGuard<ov::Mutex> lock(_timestamp_mutex);
 
 		// Not yet started
 		if (_last_media_timestamp_ms == -1)
@@ -368,7 +368,7 @@ namespace pvd
 
 		if (master_clock_track != nullptr && packet->GetTrackId() == master_clock_track->GetId())
 		{
-			std::lock_guard<std::mutex> lock(_timestamp_mutex);
+			ov::LockGuard<ov::Mutex> lock(_timestamp_mutex);
 			_last_media_timestamp_ms = packet->GetPts() / GetTrack(packet->GetTrackId())->GetTimeBase().GetTimescale() * 1000.0;
 			_elapsed_from_last_media_timestamp.Restart();
 		}
@@ -390,7 +390,7 @@ namespace pvd
 
 	void Stream::ResetSourceStreamTimestamp()
 	{
-		std::scoped_lock lock(_source_stream_timestamp_mutex);
+		ov::ScopedLock lock(_source_stream_timestamp_mutex);
 
 		// Set the last timestamp of the highest value of all tracks
 		// In this algorithm, the timestamp of A or V jumps for synchronization.
@@ -530,7 +530,7 @@ namespace pvd
 		const auto us_scale					 = AV_TIME_BASE * num_tb;
 		const auto &track_scale				 = den_tb;	// An alias of `den_tb` for clarity
 
-		std::scoped_lock lock(_source_stream_timestamp_mutex);
+		ov::ScopedLock lock(_source_stream_timestamp_mutex);
 
 		// 1. Get the start timestamp and base timebase of this stream.
 		if (_start_timestamp_us == -1LL)
@@ -657,7 +657,7 @@ namespace pvd
 
 		int64_t base_timestamp = 0;
 		{
-			std::scoped_lock lock(_source_stream_timestamp_mutex);
+			ov::ScopedLock lock(_source_stream_timestamp_mutex);
 			if (_base_timestamp_us != -1)
 			{
 				base_timestamp = _base_timestamp_us;
@@ -672,7 +672,7 @@ namespace pvd
 	// This is a method of generating a PTS with an increment value (delta) when it cannot be used as a PTS because the start value of the timestamp is random like the RTP timestamp.
 	int64_t Stream::AdjustTimestampByDelta(uint32_t track_id, int64_t timestamp, int64_t max_timestamp)
 	{
-		std::scoped_lock lock(_source_stream_timestamp_mutex);
+		ov::ScopedLock lock(_source_stream_timestamp_mutex);
 
 		int64_t curr_timestamp;
 

--- a/src/projects/base/provider/stream.h
+++ b/src/projects/base/provider/stream.h
@@ -16,6 +16,7 @@
 #include <base/mediarouter/media_buffer.h>
 #include <base/event/media_event.h>
 #include <base/mediarouter/mediarouter_interface.h>
+#include <base/ovlibrary/tsa/mutex.h>
 
 namespace pvd
 {
@@ -128,7 +129,7 @@ namespace pvd
 
 	private:
 		void ResetSourceStreamTimestamp();
-		int64_t GetDeltaTimestamp(uint32_t track_id, int64_t timestamp, int64_t max_timestamp);
+		int64_t GetDeltaTimestamp(uint32_t track_id, int64_t timestamp, int64_t max_timestamp) OV_REQUIRES(_source_stream_timestamp_mutex);
 		void UpdateReconnectTimeToBasetime();
 
 		// Processing events
@@ -136,19 +137,19 @@ namespace pvd
 
 		// TrackID : Timestamp(us)
 		// For the by delta update method
-		std::map<uint32_t, int64_t>			_source_timestamp_map;
+		std::map<uint32_t, int64_t>			_source_timestamp_map OV_GUARDED_BY(_source_stream_timestamp_mutex);
 
 		// For the by base timestamp method
-		std::map<uint32_t, int64_t>			_last_timestamp_us_map;
-		std::map<uint32_t, int64_t>			_last_duration_us_map;
+		std::map<uint32_t, int64_t>			_last_timestamp_us_map OV_GUARDED_BY(_source_stream_timestamp_mutex);
+		std::map<uint32_t, int64_t>			_last_duration_us_map OV_GUARDED_BY(_source_stream_timestamp_mutex);
 
-		int64_t 							_base_timestamp_us = -1;
+		int64_t 							_base_timestamp_us OV_GUARDED_BY(_source_stream_timestamp_mutex) = -1;
 
 		// For Wraparound
-		std::map<uint32_t, int64_t>			_last_origin_ts_map[2];
-		std::map<uint32_t, int64_t>			_wraparound_count_map[2]; // 0 : pts 1: dts
+		std::map<uint32_t, int64_t>			_last_origin_ts_map[2] OV_GUARDED_BY(_source_stream_timestamp_mutex);
+		std::map<uint32_t, int64_t>			_wraparound_count_map[2] OV_GUARDED_BY(_source_stream_timestamp_mutex); // 0 : pts 1: dts
 
-		int64_t								_start_timestamp_us = -1LL; // Make first timestamp to zero
+		int64_t								_start_timestamp_us OV_GUARDED_BY(_source_stream_timestamp_mutex) = -1LL; // Make first timestamp to zero
 
 		// `-1` means no media packet has been received yet.
 		std::atomic<int64_t> _last_pkt_received_time_us{-1};
@@ -163,11 +164,11 @@ namespace pvd
 		LipSyncClock 						_rtp_lip_sync_clock;
 		ov::StopWatch						_first_rtp_received_time;
 
-		mutable std::mutex _source_stream_timestamp_mutex;
-		mutable std::mutex _timestamp_mutex;
-		int64_t _last_media_timestamp_ms = -1LL;
-		ov::StopWatch _elapsed_from_last_media_timestamp;
-		int64_t _max_generated_timestamp_ms = -1LL;
+		mutable ov::Mutex _source_stream_timestamp_mutex;
+		mutable ov::Mutex _timestamp_mutex;
+		int64_t _last_media_timestamp_ms OV_GUARDED_BY(_timestamp_mutex) = -1LL;
+		ov::StopWatch _elapsed_from_last_media_timestamp OV_GUARDED_BY(_timestamp_mutex);
+		int64_t _max_generated_timestamp_ms OV_GUARDED_BY(_timestamp_mutex) = -1LL;
 
 		std::shared_ptr<pvd::Application> _application = nullptr;
 	};

--- a/src/projects/config/config_manager.cpp
+++ b/src/projects/config/config_manager.cpp
@@ -258,7 +258,7 @@ namespace cfg
 		logti("Trying to load configurations... (%s)", server_config_path.CStr());
 		DataSource data_source(DataType::Xml, config_path, CFG_MAIN_FILE_NAME, XML_ROOT_NAME);
 
-		std::unique_lock lock(_server_mutex);
+		ov::LockGuard lock(_server_mutex);
 
 		_server = std::make_shared<Server>();
 		_server->SetItemName(XML_ROOT_NAME);

--- a/src/projects/config/config_manager.h
+++ b/src/projects/config/config_manager.h
@@ -33,7 +33,7 @@ namespace cfg
 
 		std::shared_ptr<const Server> GetServer() const noexcept
 		{
-			std::shared_lock lock(_server_mutex);
+			ov::SharedLockGuard lock(_server_mutex);
 			return _server;
 		}
 
@@ -65,8 +65,8 @@ namespace cfg
 
 		ov::String _config_path;
 
-		mutable std::shared_mutex _server_mutex;
-		std::shared_ptr<Server> _server;
+		mutable ov::SharedMutex _server_mutex;
+		std::shared_ptr<Server> _server OV_GUARDED_BY(_server_mutex);
 		ov::String _server_id;
 		ov::String _license_key;
 		std::map<ov::String, ov::String> _macros;
@@ -77,7 +77,7 @@ namespace cfg
 		// value: compatible version numbers
 		std::map<ov::String, std::vector<int>> _supported_versions_map;
 
-		mutable std::mutex _config_mutex;
+		mutable ov::Mutex _config_mutex;
 
 	private:
 		std::tuple<bool, ov::String> LoadServerIDFromStorage(const ov::String &config_path) const;

--- a/src/projects/modules/containers/bmff/fmp4_packager/fmp4_packager.h
+++ b/src/projects/modules/containers/bmff/fmp4_packager/fmp4_packager.h
@@ -65,8 +65,5 @@ namespace bmff
 		double _target_chunk_duration_ms = 0.0;
 
 		std::queue<std::shared_ptr<const MediaPacket>> _reserved_data_packets;
-
-		std::map<int64_t, Marker> _markers;
-		mutable std::shared_mutex _markers_guard;
 	};
 }

--- a/src/projects/modules/dtls_srtp/dtls_transport.cpp
+++ b/src/projects/modules/dtls_srtp/dtls_transport.cpp
@@ -18,7 +18,7 @@ DtlsTransport::~DtlsTransport()
 
 bool DtlsTransport::Stop()
 {
-	std::lock_guard<std::mutex> lock(_tls_lock);
+	ov::LockGuard<ov::Mutex> lock(_tls_lock);
 
 	_tls.Uninitialize();
 
@@ -107,7 +107,7 @@ bool DtlsTransport::InitializeTlsLocked()
 
 bool DtlsTransport::StartDTLS()
 {
-	std::lock_guard<std::mutex> lock(_tls_lock);
+	ov::LockGuard<ov::Mutex> lock(_tls_lock);
 
 	/*
 	if(_ice_port->GetState() != IcePortConnectionState::Completed)
@@ -251,7 +251,7 @@ bool DtlsTransport::OnDataReceivedFromPrevNode(NodeType from_node, const std::sh
 			}
 			else
 			{
-				std::lock_guard<std::mutex> lock(_tls_lock);
+				ov::LockGuard<ov::Mutex> lock(_tls_lock);
 				// If it is not SRTP, it must be encrypted in DTLS.
 				// TODO: Currently, SCTP is not supported, so there is no need to encrypt,
 				// and it will be developed if it supports data channels in the future.
@@ -295,7 +295,7 @@ bool DtlsTransport::OnDataReceivedFromNextNode(NodeType from_node, const std::sh
 		case SSL_CONNECTED: {
 			if (IsDtlsPacket(data))
 			{
-				std::lock_guard<std::mutex> lock(_tls_lock);
+				ov::LockGuard<ov::Mutex> lock(_tls_lock);
 				logtt("Receive DTLS packet");
 				// Packet을 Queue에 쌓는다.
 				SaveDtlsPacket(data);

--- a/src/projects/modules/dtls_srtp/dtls_transport.h
+++ b/src/projects/modules/dtls_srtp/dtls_transport.h
@@ -47,24 +47,24 @@ public:
 
 protected:
 	// SSL에서 암호화 할 패킷을 읽어갈 때 호출한다. _packet_buffer에 쌓인 패킷을 준다.
-	ssize_t Read(ov::Tls *tls, void *buffer, size_t length);
+	ssize_t Read(ov::Tls *tls, void *buffer, size_t length) OV_NO_THREAD_SAFETY_ANALYSIS;
 
 	// SSL에서 복호화한 패킷의 전송을 요청할 때 호출한다. ice로 최종 전송한다.
 	ssize_t Write(ov::Tls *tls, const void *data, size_t length);
 
-	bool VerifyPeerCertificate();
+	bool VerifyPeerCertificate() OV_NO_THREAD_SAFETY_ANALYSIS;
 
 private:
-	bool ContinueSSL();
+	bool ContinueSSL() OV_REQUIRES(_tls_lock);
 	// Initializes the underlying TLS session and BIO and transitions to
 	// SSL_CONNECTING. Caller MUST hold _tls_lock.
-	bool InitializeTlsLocked();
+	bool InitializeTlsLocked() OV_REQUIRES(_tls_lock);
 	bool IsDtlsPacket(const std::shared_ptr<const ov::Data> data);
 	bool IsRtpPacket(const std::shared_ptr<const ov::Data> data);
-	bool SaveDtlsPacket(const std::shared_ptr<const ov::Data> data);
-	std::shared_ptr<const ov::Data> TakeDtlsPacket();
+	bool SaveDtlsPacket(const std::shared_ptr<const ov::Data> data) OV_REQUIRES(_tls_lock);
+	std::shared_ptr<const ov::Data> TakeDtlsPacket() OV_REQUIRES(_tls_lock);
 
-	bool MakeSrtpKey();
+	bool MakeSrtpKey() OV_REQUIRES(_tls_lock);
 
 	enum SSLState
 	{
@@ -76,24 +76,24 @@ private:
 		SSL_CLOSED
 	};
 
-	SSLState _state;
-	bool _peer_certificate_verified;
+	SSLState _state OV_GUARDED_BY(_tls_lock);
+	bool _peer_certificate_verified OV_GUARDED_BY(_tls_lock);
 	std::shared_ptr<info::Session> _session_info;
 	std::shared_ptr<IcePort> _ice_port;
 	std::shared_ptr<SrtpTransport> _srtp_transport;
 	std::shared_ptr<::Certificate> _local_certificate;
 	std::shared_ptr<ov::TlsContext> _tls_context;
-	std::shared_ptr<::Certificate> _peer_certificate;
+	std::shared_ptr<::Certificate> _peer_certificate OV_GUARDED_BY(_tls_lock);
 	ov::String _peer_fingerprint_algorithm;
 	ov::String _peer_fingerprint_value;
 
 	// SSL이 가져갈 패킷을 임시로 보관하는 버퍼, 동시에 1개만 저장한다.
-	std::deque<std::shared_ptr<const ov::Data>> _packet_buffer;
+	std::deque<std::shared_ptr<const ov::Data>> _packet_buffer OV_GUARDED_BY(_tls_lock);
 
 	// SSL *_ssl;
 	// SSL_CTX *_ssl_ctx;
 
-	std::mutex _tls_lock;
+	ov::Mutex _tls_lock;
 
-	ov::Tls _tls;
+	ov::Tls _tls OV_GUARDED_BY(_tls_lock);
 };

--- a/src/projects/modules/dtls_srtp/srtp_adapter.cpp
+++ b/src/projects/modules/dtls_srtp/srtp_adapter.cpp
@@ -26,7 +26,7 @@ SrtpAdapter::~SrtpAdapter()
 
 bool SrtpAdapter::Release()
 {
-	std::lock_guard<std::mutex> lock(_session_lock);
+	ov::LockGuard<ov::Mutex> lock(_session_lock);
 
 	if(_session != nullptr)
 	{
@@ -66,7 +66,7 @@ bool SrtpAdapter::SetKey(srtp_ssrc_type_t type, uint64_t crypto_suite, std::shar
 	policy.allow_repeat_tx = 1;
 	policy.next = nullptr;
 
-	std::lock_guard<std::mutex> lock(_session_lock);
+	ov::LockGuard<ov::Mutex> lock(_session_lock);
 	int err = srtp_create(&_session, &policy);
 	if(err != srtp_err_status_ok)
 	{
@@ -110,7 +110,7 @@ bool SrtpAdapter::ProtectRtp(std::shared_ptr<ov::Data> data)
 	uint8_t red_payload_type = byte_buffer[12];
 	uint16_t seq = ByteReader<uint16_t>::ReadBigEndian(&byte_buffer[2]);
 
-	std::lock_guard<std::mutex> lock(_session_lock);
+	ov::LockGuard<ov::Mutex> lock(_session_lock);
 	int err = srtp_protect(_session, buffer, &out_len);
 	if(err != srtp_err_status_ok)
 	{
@@ -141,7 +141,7 @@ bool SrtpAdapter::ProtectRtcp(std::shared_ptr<ov::Data> data)
     int out_len = static_cast<int>(data->GetLength());
     data->SetLength(need_len);
 
-	std::lock_guard<std::mutex> lock(_session_lock);
+	ov::LockGuard<ov::Mutex> lock(_session_lock);
     int err = srtp_protect_rtcp(_session, buffer, &out_len);
     if(err != srtp_err_status_ok)
     {
@@ -162,7 +162,7 @@ bool SrtpAdapter::UnprotectRtp(const std::shared_ptr<ov::Data> &data)
     auto buffer = data->GetWritableData();
     int out_len = static_cast<int>(data->GetLength());
 
-	std::lock_guard<std::mutex> lock(_session_lock);
+	ov::LockGuard<ov::Mutex> lock(_session_lock);
     int err = srtp_unprotect(_session, buffer, &out_len);
     if (err != srtp_err_status_ok)
     {
@@ -185,7 +185,7 @@ bool SrtpAdapter::UnprotectRtcp(const std::shared_ptr<ov::Data> &data)
     auto buffer = data->GetWritableData();
     int out_len = static_cast<int>(data->GetLength());
 
-	std::lock_guard<std::mutex> lock(_session_lock);
+	ov::LockGuard<ov::Mutex> lock(_session_lock);
     int err = srtp_unprotect_rtcp(_session, buffer, &out_len);
     if (err != srtp_err_status_ok)
     {

--- a/src/projects/modules/dtls_srtp/srtp_adapter.h
+++ b/src/projects/modules/dtls_srtp/srtp_adapter.h
@@ -27,9 +27,9 @@ public:
     bool	UnprotectRtcp(const std::shared_ptr<ov::Data> &data);
 
 private:
-	std::mutex		_session_lock;
-	srtp_ctx_t_* 	_session;
-	
-	uint32_t 		_rtp_auth_tag_len;
-    uint32_t 		_rtcp_auth_tag_len;
+	ov::Mutex		_session_lock;
+	srtp_ctx_t_* 	_session OV_GUARDED_BY(_session_lock);
+
+	uint32_t 		_rtp_auth_tag_len OV_GUARDED_BY(_session_lock);
+    uint32_t 		_rtcp_auth_tag_len OV_GUARDED_BY(_session_lock);
 };

--- a/src/projects/modules/http/client/http_client.cpp
+++ b/src/projects/modules/http/client/http_client.cpp
@@ -79,7 +79,7 @@ namespace http
 
 		void HttpClient::SetRequestHeader(const ov::String &key, const ov::String &value)
 		{
-			std::lock_guard lock_guard(_request_mutex);
+			ov::LockGuard lock_guard(_request_mutex);
 
 			if (_requested)
 			{
@@ -359,7 +359,7 @@ namespace http
 
 		void HttpClient::Request(const ov::String &url, ResponseHandler response_handler)
 		{
-			std::lock_guard lock_guard(_request_mutex);
+			ov::LockGuard lock_guard(_request_mutex);
 
 			ov::SocketAddress address;
 

--- a/src/projects/modules/http/client/http_client.h
+++ b/src/projects/modules/http/client/http_client.h
@@ -142,7 +142,7 @@ namespace http
 
 			prot::h1::HttpResponseParser _parser;
 
-			std::mutex _request_mutex;
+			ov::Mutex _request_mutex;
 			std::atomic<bool> _requested = false;
 
 			ov::String _url;

--- a/src/projects/modules/http/client/http_client_v2.cpp
+++ b/src/projects/modules/http/client/http_client_v2.cpp
@@ -79,7 +79,7 @@ namespace http
 
 		void HttpClientV2::SetRequestHeader(const ov::String &key, const ov::String &value)
 		{
-			std::lock_guard lock_guard(_request_mutex);
+			ov::LockGuard lock_guard(_request_mutex);
 
 			if (_requested)
 			{
@@ -92,7 +92,7 @@ namespace http
 
 		std::optional<ov::String> HttpClientV2::GetRequestHeader(const ov::String &key)
 		{
-			std::lock_guard lock_guard(_request_mutex);
+			ov::LockGuard lock_guard(_request_mutex);
 
 			auto iterator = _request_header_map.find(key);
 
@@ -106,14 +106,14 @@ namespace http
 
 		const HttpHeaderMap HttpClientV2::GetRequestHeaders() const
 		{
-			std::lock_guard lock_guard(_request_mutex);
+			ov::LockGuard lock_guard(_request_mutex);
 
 			return _request_header_map;
 		}
 
 		void HttpClientV2::RemoveRequestHeader(const ov::String &key)
 		{
-			std::lock_guard lock_guard(_request_mutex);
+			ov::LockGuard lock_guard(_request_mutex);
 
 			if (_requested)
 			{
@@ -143,7 +143,7 @@ namespace http
 				_connected_callback_called = true;
 
 				{
-					std::shared_lock lock(_interceptor_list_mutex);
+					ov::SharedLockGuard lock(_interceptor_list_mutex);
 					for (auto &interceptor : _interceptor_list)
 					{
 						auto error = interceptor->OnConnected();
@@ -260,7 +260,7 @@ namespace http
 				std::shared_ptr<const ov::Error> first_error;
 
 				{
-					std::shared_lock lock(_interceptor_list_mutex);
+					ov::SharedLockGuard lock(_interceptor_list_mutex);
 					for (auto &interceptor : _interceptor_list)
 					{
 						auto error = interceptor->OnRequestStarted(parsed_url);
@@ -360,7 +360,7 @@ namespace http
 
 		void HttpClientV2::CallCloseFinish()
 		{
-			std::shared_lock lock(_interceptor_list_mutex);
+			ov::SharedLockGuard lock(_interceptor_list_mutex);
 
 #ifdef DEBUG
 			OV_ASSERT2(_request_finished_callback_called == false);
@@ -448,14 +448,14 @@ namespace http
 			auto cancel_token = std::make_shared<CancelToken>();
 
 			{
-				std::shared_lock lock(_interceptor_list_mutex);
+				ov::SharedLockGuard lock(_interceptor_list_mutex);
 				for (auto &interceptor : _interceptor_list)
 				{
 					interceptor->SetCancelToken(cancel_token);
 				}
 			}
 
-			std::lock_guard lock_guard(_request_mutex);
+			ov::LockGuard lock_guard(_request_mutex);
 
 			ov::SocketAddress address;
 
@@ -610,7 +610,7 @@ namespace http
 			}
 
 			{
-				std::shared_lock lock(_interceptor_list_mutex);
+				ov::SharedLockGuard lock(_interceptor_list_mutex);
 				for (auto &interceptor : _interceptor_list)
 				{
 					interceptor->OnCompleted();
@@ -679,7 +679,7 @@ namespace http
 						auto bytes_to_copy = std::min(_chunk_length, remaining);
 
 						{
-							std::shared_lock lock(_interceptor_list_mutex);
+							ov::SharedLockGuard lock(_interceptor_list_mutex);
 							for (auto &interceptor : _interceptor_list)
 							{
 								_response_body_size += bytes_to_copy;
@@ -793,7 +793,7 @@ namespace http
 						else
 						{
 							{
-								std::shared_lock lock(_interceptor_list_mutex);
+								ov::SharedLockGuard lock(_interceptor_list_mutex);
 								for (auto &interceptor : _interceptor_list)
 								{
 									_response_body_size += sub_data->GetLength();
@@ -882,7 +882,7 @@ namespace http
 
 			{
 				auto response_info = ResponseInfo::From(_parser);
-				std::shared_lock lock(_interceptor_list_mutex);
+				ov::SharedLockGuard lock(_interceptor_list_mutex);
 				for (auto &interceptor : _interceptor_list)
 				{
 					auto error = interceptor->OnResponseInfo(response_info);
@@ -924,7 +924,7 @@ namespace http
 		void HttpClientV2::HandleError(std::shared_ptr<const ov::Error> error)
 		{
 			{
-				std::shared_lock lock(_interceptor_list_mutex);
+				ov::SharedLockGuard lock(_interceptor_list_mutex);
 				for (auto &interceptor : _interceptor_list)
 				{
 					interceptor->OnError(error);

--- a/src/projects/modules/http/client/http_client_v2.h
+++ b/src/projects/modules/http/client/http_client_v2.h
@@ -65,13 +65,13 @@ namespace http
 
 			void AddInterceptor(const std::shared_ptr<HttpClientInterceptor> &interceptor)
 			{
-				std::unique_lock lock(_interceptor_list_mutex);
+				ov::LockGuard lock(_interceptor_list_mutex);
 				_interceptor_list.push_back(interceptor);
 			}
 
 			void ClearInterceptors()
 			{
-				std::unique_lock lock(_interceptor_list_mutex);
+				ov::LockGuard lock(_interceptor_list_mutex);
 				_interceptor_list.clear();
 			}
 
@@ -168,8 +168,8 @@ namespace http
 			int _recv_timeout_msec			= 60 * 1000;
 			Method _method					= Method::Get;
 
-			std::shared_mutex _interceptor_list_mutex;
-			std::vector<std::shared_ptr<HttpClientInterceptor>> _interceptor_list;
+			ov::SharedMutex _interceptor_list_mutex;
+			std::vector<std::shared_ptr<HttpClientInterceptor>> _interceptor_list OV_GUARDED_BY(_interceptor_list_mutex);
 
 			bool _connected_callback_called = false;
 #ifdef DEBUG
@@ -187,7 +187,7 @@ namespace http
 
 			prot::h1::HttpResponseParser _parser;
 
-			mutable std::recursive_mutex _request_mutex;
+			mutable ov::RecursiveMutex _request_mutex;
 			std::atomic<bool> _requested = false;
 
 			ov::String _url;

--- a/src/projects/modules/http/cors/cors_manager.cpp
+++ b/src/projects/modules/http/cors/cors_manager.cpp
@@ -21,7 +21,7 @@ namespace http
 
 	void CorsManager::SetCrossDomains(const info::VHostAppName &vhost_app_name, const cfg::cmn::CrossDomains &cross_domain_cfg)
 	{
-		std::lock_guard lock_guard(_cors_mutex);
+		ov::LockGuard lock_guard(_cors_mutex);
 
 		auto url_list = cross_domain_cfg.GetUrls();
 		_cors_cfg_map[vhost_app_name] = cross_domain_cfg;
@@ -135,7 +135,7 @@ namespace http
 
 	bool CorsManager::SetupRtmpCorsXml(const std::shared_ptr<http::svr::HttpResponse> &response) const
 	{
-		std::lock_guard lock_guard(_cors_mutex);
+		ov::LockGuard lock_guard(_cors_mutex);
 
 		if (_cors_rtmp.IsEmpty() == false)
 		{
@@ -176,7 +176,7 @@ namespace http
 		std::unordered_map<info::VHostAppName, cfg::cmn::CrossDomains>::const_iterator cors_cfg_iterator;
 
 		{
-			std::lock_guard lock_guard(_cors_mutex);
+			ov::LockGuard lock_guard(_cors_mutex);
 
 			auto cors_policy_iterator = _cors_policy_map.find(vhost_app_name);
 			auto cors_regex_list_iterator = _cors_item_list_map.find(vhost_app_name);

--- a/src/projects/modules/http/cors/cors_manager.h
+++ b/src/projects/modules/http/cors/cors_manager.h
@@ -80,20 +80,20 @@ namespace http
 		};
 
 	protected:
-		mutable std::mutex _cors_mutex;
+		mutable ov::Mutex _cors_mutex;
 
-		std::unordered_map<info::VHostAppName, CorsPolicy> _cors_policy_map;
+		std::unordered_map<info::VHostAppName, CorsPolicy> _cors_policy_map OV_GUARDED_BY(_cors_mutex);
 
 		// CORS for HTTP
 		// key: VHostAppName, value: regex
-		std::unordered_map<info::VHostAppName, std::vector<CorsItem>> _cors_item_list_map;
+		std::unordered_map<info::VHostAppName, std::vector<CorsItem>> _cors_item_list_map OV_GUARDED_BY(_cors_mutex);
 
-		std::unordered_map<info::VHostAppName, cfg::cmn::CrossDomains> _cors_cfg_map;
+		std::unordered_map<info::VHostAppName, cfg::cmn::CrossDomains> _cors_cfg_map OV_GUARDED_BY(_cors_mutex);
 
 		// CORS for RTMP
 		//
 		// NOTE - The RTMP CORS setting follows the first declared <CrossDomains> setting,
 		//        because crossdomain.xml must be located / and cannot be declared per app.
-		ov::String _cors_rtmp;
+		ov::String _cors_rtmp OV_GUARDED_BY(_cors_mutex);
 	};
 }  // namespace http

--- a/src/projects/modules/http/hpack/decoder.cpp
+++ b/src/projects/modules/http/hpack/decoder.cpp
@@ -18,7 +18,7 @@ namespace http
 	{
 		bool Decoder::Decode(const std::shared_ptr<const ov::Data> &data, std::vector<HeaderField> &header_fields)
 		{
-			std::lock_guard<std::mutex> lock(_decoder_lock);
+			ov::LockGuard<ov::Mutex> lock(_decoder_lock);
 			auto reader = std::make_shared<BitReader>(data->GetDataAs<uint8_t>(), data->GetLength());
 
 			while (reader->BytesRemained() > 0)

--- a/src/projects/modules/http/hpack/decoder.h
+++ b/src/projects/modules/http/hpack/decoder.h
@@ -23,21 +23,21 @@ namespace http
 			bool Decode(const std::shared_ptr<const ov::Data> &data, std::vector<HeaderField> &header_fields);
 
 		private:
-			bool DecodeIndexedHeaderField(const std::shared_ptr<BitReader> &reader, std::vector<HeaderField> &header_fields);
-			bool DecodeLiteralHeaderFieldWithIndexing(const std::shared_ptr<BitReader> &reader, std::vector<HeaderField> &header_fields);
-			bool DecodeLiteralHeaderFieldWithoutIndexing(const std::shared_ptr<BitReader> &reader, std::vector<HeaderField> &header_fields);
-			bool DecodeLiteralHeaderFieldNeverIndexed(const std::shared_ptr<BitReader> &reader, std::vector<HeaderField> &header_fields);
+			bool DecodeIndexedHeaderField(const std::shared_ptr<BitReader> &reader, std::vector<HeaderField> &header_fields) OV_REQUIRES(_decoder_lock);
+			bool DecodeLiteralHeaderFieldWithIndexing(const std::shared_ptr<BitReader> &reader, std::vector<HeaderField> &header_fields) OV_REQUIRES(_decoder_lock);
+			bool DecodeLiteralHeaderFieldWithoutIndexing(const std::shared_ptr<BitReader> &reader, std::vector<HeaderField> &header_fields) OV_REQUIRES(_decoder_lock);
+			bool DecodeLiteralHeaderFieldNeverIndexed(const std::shared_ptr<BitReader> &reader, std::vector<HeaderField> &header_fields) OV_REQUIRES(_decoder_lock);
 
-			bool DecodeDynamicTableSizeUpdate(const std::shared_ptr<BitReader> &reader);
+			bool DecodeDynamicTableSizeUpdate(const std::shared_ptr<BitReader> &reader) OV_REQUIRES(_decoder_lock);
 
-			bool ReadLiteralHeaderField(uint8_t index_bits, const std::shared_ptr<BitReader> &reader, HeaderField &header_field);
+			bool ReadLiteralHeaderField(uint8_t index_bits, const std::shared_ptr<BitReader> &reader, HeaderField &header_field) OV_REQUIRES(_decoder_lock);
 
 			// Unsigned Little Endian Base 128
-			bool ReadULEB128(const std::shared_ptr<BitReader> &reader, uint64_t &value);
-			bool ReadString(const std::shared_ptr<BitReader> &reader, ov::String &value);
+			bool ReadULEB128(const std::shared_ptr<BitReader> &reader, uint64_t &value) OV_REQUIRES(_decoder_lock);
+			bool ReadString(const std::shared_ptr<BitReader> &reader, ov::String &value) OV_REQUIRES(_decoder_lock);
 
-			TableConnector	_table_connector;
-			std::mutex _decoder_lock;
+			TableConnector	_table_connector OV_GUARDED_BY(_decoder_lock);
+			ov::Mutex _decoder_lock;
 		};
 	} // namespace hpack
 } // namespace http

--- a/src/projects/modules/http/hpack/encoder.cpp
+++ b/src/projects/modules/http/hpack/encoder.cpp
@@ -16,7 +16,7 @@ namespace http
 	{
 		bool Encoder::UpdateDynamicTableSize(size_t size)
 		{
-			std::lock_guard<std::mutex> lock(_encoder_lock);
+			ov::LockGuard<ov::Mutex> lock(_encoder_lock);
 			if (_table_connector.UpdateDynamicTableSize(size) == false)
 			{
 				return false;
@@ -28,7 +28,7 @@ namespace http
 
 		std::shared_ptr<ov::Data> Encoder::Encode(const HeaderField &header_fields, EncodingType type)
 		{
-			std::lock_guard<std::mutex> lock(_encoder_lock);
+			ov::LockGuard<ov::Mutex> lock(_encoder_lock);
 
 			std::shared_ptr<ov::Data> encoded_data = std::make_shared<ov::Data>(header_fields.GetSize());
 			ov::ByteStream stream(encoded_data.get());

--- a/src/projects/modules/http/hpack/encoder.h
+++ b/src/projects/modules/http/hpack/encoder.h
@@ -32,24 +32,24 @@ namespace http
 			std::shared_ptr<ov::Data> Encode(const HeaderField &header_fields, EncodingType type);
 
 		private:
-			bool EncodeIndexedHeaderField(ov::ByteStream &stream, const HeaderField &header_fields, uint32_t index);
-			bool EncodeLiteralHeaderFieldWithIndexing(ov::ByteStream &stream, const HeaderField &header_fields, uint32_t name_index);
-			bool EncodeLiteralHeaderFieldWithoutIndexing(ov::ByteStream &stream, const HeaderField &header_fields, uint32_t name_index);
-			bool EncodeLiteralHeaderFieldNeverIndexed(ov::ByteStream &stream, const HeaderField &header_fields, uint32_t name_index);
+			bool EncodeIndexedHeaderField(ov::ByteStream &stream, const HeaderField &header_fields, uint32_t index) OV_REQUIRES(_encoder_lock);
+			bool EncodeLiteralHeaderFieldWithIndexing(ov::ByteStream &stream, const HeaderField &header_fields, uint32_t name_index) OV_REQUIRES(_encoder_lock);
+			bool EncodeLiteralHeaderFieldWithoutIndexing(ov::ByteStream &stream, const HeaderField &header_fields, uint32_t name_index) OV_REQUIRES(_encoder_lock);
+			bool EncodeLiteralHeaderFieldNeverIndexed(ov::ByteStream &stream, const HeaderField &header_fields, uint32_t name_index) OV_REQUIRES(_encoder_lock);
 
-			bool EncodeDynamicTableSizeUpdate(ov::ByteStream &stream, size_t size);
-			
-			bool WriteLiteralHeaderField(ov::ByteStream &stream, const HeaderField &header_fields, uint32_t name_index, uint8_t mask, uint8_t index_bits, bool huffman_encoding = true);
-			bool WriteInteger(ov::ByteStream &stream, uint8_t mask, uint8_t value_bits, uint64_t value);
-			bool WriteString(ov::ByteStream &stream, const ov::String &value, bool huffman_encoding);
+			bool EncodeDynamicTableSizeUpdate(ov::ByteStream &stream, size_t size) OV_REQUIRES(_encoder_lock);
+
+			bool WriteLiteralHeaderField(ov::ByteStream &stream, const HeaderField &header_fields, uint32_t name_index, uint8_t mask, uint8_t index_bits, bool huffman_encoding = true) OV_REQUIRES(_encoder_lock);
+			bool WriteInteger(ov::ByteStream &stream, uint8_t mask, uint8_t value_bits, uint64_t value) OV_REQUIRES(_encoder_lock);
+			bool WriteString(ov::ByteStream &stream, const ov::String &value, bool huffman_encoding) OV_REQUIRES(_encoder_lock);
 
 			// Unsigned Little Endian Base 128
-			bool WriteULEB128(ov::ByteStream &stream, const uint64_t &value);
+			bool WriteULEB128(ov::ByteStream &stream, const uint64_t &value) OV_REQUIRES(_encoder_lock);
 
-			TableConnector	_table_connector;
-			bool _need_signal_table_size_update = false;
+			TableConnector	_table_connector OV_GUARDED_BY(_encoder_lock);
+			bool _need_signal_table_size_update OV_GUARDED_BY(_encoder_lock) = false;
 
-			std::mutex _encoder_lock;
+			ov::Mutex _encoder_lock;
 		};
 	} // namespace hpack
 } // namespace http

--- a/src/projects/modules/http/server/http_response.cpp
+++ b/src/projects/modules/http/server/http_response.cpp
@@ -206,7 +206,7 @@ namespace http
 				return false;
 			}
 
-			std::lock_guard<decltype(_response_mutex)> lock(_response_mutex);
+			ov::LockGuard<decltype(_response_mutex)> lock(_response_mutex);
 
 			auto cloned_data = data->Clone();
 
@@ -303,7 +303,7 @@ namespace http
 
 		int32_t HttpResponse::Response()
 		{
-			std::lock_guard<decltype(_response_mutex)> lock(_response_mutex);
+			ov::LockGuard<decltype(_response_mutex)> lock(_response_mutex);
 			_response_time = std::chrono::system_clock::now();
 
 			uint32_t sent_size = 0;
@@ -402,7 +402,7 @@ namespace http
 			}
 			else
 			{
-				std::lock_guard<std::mutex> lock(_tls_data->GetSequentialSendMutex());
+				ov::LockGuard<ov::Mutex> lock(_tls_data->GetSequentialSendMutex());
 
 				if (_tls_data->Encrypt(data, &send_data) == false)
 				{

--- a/src/projects/modules/http/server/http_response.h
+++ b/src/projects/modules/http/server/http_response.h
@@ -96,7 +96,7 @@ namespace http
 			virtual int32_t SendHeader();
 			virtual int32_t SendPayload();
 
-			ov::String GetEtag();
+			ov::String GetEtag() OV_REQUIRES(_response_mutex);
 
 			std::shared_ptr<ov::ClientSocket> _client_socket;
 			std::shared_ptr<ov::TlsServerData> _tls_data;
@@ -104,10 +104,10 @@ namespace http
 			StatusCode _status_code = StatusCode::OK;
 			ov::String _reason = StringFromStatusCode(StatusCode::OK);
 
-			bool _is_header_sent = false;
-			
+			bool _is_header_sent OV_GUARDED_BY(_response_mutex) = false;
+
 			// FIXME(dimiden): It is supposed to be synchronized whenever a packet is sent, but performance needs to be improved
-			std::recursive_mutex _response_mutex;
+			ov::RecursiveMutex _response_mutex;
 
 			// https://www.rfc-editor.org/rfc/rfc7230#section-3.2
 			// Each header field consists of a case-insensitive field name followed
@@ -122,22 +122,22 @@ namespace http
 
 			// So _response_header is a map of case insentitive header key and value
 			std::unordered_map<ov::String, std::vector<ov::String>, ov::CaseInsensitiveHash, ov::CaseInsensitiveEqual> _response_header;
-			std::vector<std::shared_ptr<const ov::Data>> _response_data_list;
-			size_t _response_data_size = 0;
+			std::vector<std::shared_ptr<const ov::Data>> _response_data_list OV_GUARDED_BY(_response_mutex);
+			size_t _response_data_size OV_GUARDED_BY(_response_mutex) = 0;
 
 			std::vector<ov::String> _default_value{};
 
 			// Created time
 			std::chrono::system_clock::time_point _created_time;
 			// Responsed time
-			std::chrono::system_clock::time_point _response_time;
-			uint32_t _sent_size = 0;
+			std::chrono::system_clock::time_point _response_time OV_GUARDED_BY(_response_mutex);
+			uint32_t _sent_size OV_GUARDED_BY(_response_mutex) = 0;
 
 			Method _method = Method::Unknown;
 
 			bool _etag_enabled_by_config = false;
 			ov::String _if_none_match = "";
-			std::shared_ptr<ov::Data> _response_hash = nullptr;
+			std::shared_ptr<ov::Data> _response_hash OV_GUARDED_BY(_response_mutex) = nullptr;
 		};
 	}  // namespace svr
 }  // namespace http

--- a/src/projects/modules/http/server/http_server_manager.cpp
+++ b/src/projects/modules/http/server/http_server_manager.cpp
@@ -24,7 +24,7 @@ namespace http
 			auto http2_enabled = module_config.GetHttp2().IsEnabled();
 
 			{
-				auto lock_guard = std::lock_guard(_http_servers_mutex);
+				ov::LockGuard lock_guard(_http_servers_mutex);
 				auto item = _http_servers.find(address);
 
 				if (item != _http_servers.end())
@@ -136,7 +136,7 @@ namespace http
 				http2_enabled = false;
 			}
 
-			auto lock_guard = std::lock_guard(_http_servers_mutex);
+			ov::LockGuard lock_guard(_http_servers_mutex);
 			auto item = _http_servers.find(address);
 
 			if (item != _http_servers.end())
@@ -358,7 +358,7 @@ namespace http
 		{
 			std::shared_ptr<HttpsServer> https_server = nullptr;
 
-			auto lock_guard = std::lock_guard(_http_servers_mutex);
+			ov::LockGuard lock_guard(_http_servers_mutex);
 			auto item = _http_servers.find(address);
 
 			if (item != _http_servers.end())

--- a/src/projects/modules/http/server/http_server_manager.h
+++ b/src/projects/modules/http/server/http_server_manager.h
@@ -67,8 +67,8 @@ namespace http
 			}
 
 		protected:
-			std::mutex _http_servers_mutex;
-			std::map<ov::SocketAddress, std::shared_ptr<HttpServer>> _http_servers;
+			ov::Mutex _http_servers_mutex;
+			std::map<ov::SocketAddress, std::shared_ptr<HttpServer>> _http_servers OV_GUARDED_BY(_http_servers_mutex);
 
 			http::CorsManager _default_cors_manager;
 		};

--- a/src/projects/modules/http/server/https_server.cpp
+++ b/src/projects/modules/http/server/https_server.cpp
@@ -51,7 +51,7 @@ namespace http
 				return error;
 			}
 
-			std::lock_guard lock_guard(_https_certificate_map_mutex);
+			ov::LockGuard lock_guard(_https_certificate_map_mutex);
 
 			logtt("Append the certificate for host: %s", certificate->ToString().CStr());
 
@@ -64,7 +64,7 @@ namespace http
 
 		std::shared_ptr<const ov::Error> HttpsServer::RemoveCertificate(const std::shared_ptr<const info::Certificate> &certificate)
 		{
-			std::lock_guard lock_guard(_https_certificate_map_mutex);
+			ov::LockGuard lock_guard(_https_certificate_map_mutex);
 
 			logtt("Remove the certificate for host: %s", certificate->ToString().CStr());
 
@@ -94,7 +94,7 @@ namespace http
 			std::shared_ptr<HttpsCertificate> https_certificate;
 
 			{
-				std::lock_guard lock_guard(_https_certificate_map_mutex);
+				ov::LockGuard lock_guard(_https_certificate_map_mutex);
 				if (_https_certificate_map.empty())
 				{
 					logte("Could not handle connection event: there is no certificate");
@@ -180,7 +180,7 @@ namespace http
 			std::shared_ptr<HttpsCertificate> https_certificate;
 
 			{
-				std::lock_guard lock_guard(_https_certificate_map_mutex);
+				ov::LockGuard lock_guard(_https_certificate_map_mutex);
 				for (auto &[vhost_name, https_cert] : _https_certificate_map)
 				{
 					if (https_cert->certificate->IsCertificateForHost(server_name))

--- a/src/projects/modules/http/server/https_server.h
+++ b/src/projects/modules/http/server/https_server.h
@@ -55,10 +55,10 @@ namespace http
 			bool HandleSniCallback(ov::TlsContext *tls_context, SSL *ssl, const ov::String &server_name);
 
 		protected:
-			std::mutex _https_certificate_map_mutex;
+			ov::Mutex _https_certificate_map_mutex;
 
 			// Certificate Name : HttpsCertificate
-			std::map<ov::String, std::shared_ptr<HttpsCertificate>> _https_certificate_map;
+			std::map<ov::String, std::shared_ptr<HttpsCertificate>> _https_certificate_map OV_GUARDED_BY(_https_certificate_map_mutex);
 		};
 	}  // namespace svr
 }  // namespace http

--- a/src/projects/modules/ice/ice_candidate_pair.cpp
+++ b/src/projects/modules/ice/ice_candidate_pair.cpp
@@ -78,7 +78,7 @@ void IceCandidatePair::SetTurnDataChannel(uint16_t channel_number)
 void IceCandidatePair::SetTurnSendIndication(const ov::SocketAddress &turn_peer_address)
 {
     {
-        std::lock_guard<std::mutex> lock(_turn_peer_address_mutex);
+        ov::LockGuard<ov::Mutex> lock(_turn_peer_address_mutex);
         _turn_peer_address = turn_peer_address;
     }
     _transport_type.store(TransportType::TurnSendIndication);
@@ -96,6 +96,6 @@ uint16_t IceCandidatePair::GetTurnChannelNumber() const
 
 ov::SocketAddress IceCandidatePair::GetTurnPeerAddress() const
 {
-    std::lock_guard<std::mutex> lock(_turn_peer_address_mutex);
+    ov::LockGuard<ov::Mutex> lock(_turn_peer_address_mutex);
     return _turn_peer_address;
 }

--- a/src/projects/modules/ice/ice_candidate_pair.h
+++ b/src/projects/modules/ice/ice_candidate_pair.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <atomic>
-#include <mutex>
 
 #include <base/ovlibrary/ovlibrary.h>
 #include <base/ovsocket/ovsocket.h>
@@ -69,6 +68,6 @@ private:
 
 	std::atomic<TransportType> _transport_type{TransportType::Direct};
 	std::atomic<uint16_t> _turn_channel_number{0};
-	mutable std::mutex _turn_peer_address_mutex;
-	ov::SocketAddress _turn_peer_address;
+	mutable ov::Mutex _turn_peer_address_mutex;
+	ov::SocketAddress _turn_peer_address OV_GUARDED_BY(_turn_peer_address_mutex);
 };

--- a/src/projects/modules/ice/ice_session.cpp
+++ b/src/projects/modules/ice/ice_session.cpp
@@ -37,7 +37,7 @@ ov::String IceSession::ToString() const
 
 void IceSession::Refresh()
 {
-	std::scoped_lock lock(_expire_time_mutex);
+	ov::ScopedLock lock(_expire_time_mutex);
 	_expire_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(_expire_after_ms);
 }
 
@@ -48,7 +48,7 @@ bool IceSession::IsExpired() const
 		return true;
 	}
 
-	std::shared_lock lock(_expire_time_mutex);
+	ov::SharedLockGuard lock(_expire_time_mutex);
 	return (std::chrono::steady_clock::now() > _expire_time);
 }
 
@@ -123,7 +123,7 @@ void IceSession::SetCandidatePairTurnSendIndication(const ov::SocketAddressPair&
 
 std::shared_ptr<IceCandidatePair> IceSession::GetActiveCandidatePair() const
 {
-	std::shared_lock lock(_active_candidate_pair_mutex);
+	ov::SharedLockGuard lock(_active_candidate_pair_mutex);
 	return _active_candidate_pair;
 }
 
@@ -140,7 +140,7 @@ std::shared_ptr<ov::Socket> IceSession::GetActiveSocket() const
 
 std::shared_ptr<IceCandidatePair> IceSession::FindCandidatePair(const ov::SocketAddressPair& address_pair) const
 {
-	std::shared_lock lock(_candidate_pairs_mutex);
+	ov::SharedLockGuard lock(_candidate_pairs_mutex);
 
 	auto it = _candidate_pairs.find(address_pair);
 	if (it != _candidate_pairs.end())
@@ -153,7 +153,7 @@ std::shared_ptr<IceCandidatePair> IceSession::FindCandidatePair(const ov::Socket
 
 std::vector<std::shared_ptr<ov::Socket>> IceSession::GetCandidatePairSockets() const
 {
-	std::shared_lock lock(_candidate_pairs_mutex);
+	ov::SharedLockGuard lock(_candidate_pairs_mutex);
 
 	std::vector<std::shared_ptr<ov::Socket>> sockets;
 	for (const auto& [address_pair, candidate_pair] : _candidate_pairs)
@@ -187,7 +187,7 @@ std::vector<std::shared_ptr<ov::Socket>> IceSession::GetCandidatePairSockets() c
 
 std::shared_ptr<IceCandidatePair> IceSession::CreateAndAddCandidatePair(const ov::SocketAddressPair& address_pair, const std::shared_ptr<ov::Socket>& socket)
 {
-	std::scoped_lock lock(_candidate_pairs_mutex);
+	ov::ScopedLock lock(_candidate_pairs_mutex);
 
 	// Avoid TOCTOU: another thread may have inserted the same address_pair
 	// after FindCandidatePair() and before this function acquires the lock.
@@ -205,7 +205,7 @@ std::shared_ptr<IceCandidatePair> IceSession::CreateAndAddCandidatePair(const ov
 
 void IceSession::RemoveCandidatePair(const ov::SocketAddressPair& address_pair)
 {
-	std::scoped_lock lock(_candidate_pairs_mutex);
+	ov::ScopedLock lock(_candidate_pairs_mutex);
 
 	_candidate_pairs.erase(address_pair);
 }
@@ -319,7 +319,7 @@ bool IceSession::MarkNominated(const ov::SocketAddressPair& address_pair)
 // and switches if the peer moves.
 bool IceSession::SelectActiveCandidatePair(const ov::SocketAddressPair& address_pair)
 {
-	std::scoped_lock lock(_active_candidate_pair_mutex);
+	ov::ScopedLock lock(_active_candidate_pair_mutex);
 
 	if (_active_candidate_pair != nullptr && _active_candidate_pair->GetAddressPair() == address_pair)
 	{

--- a/src/projects/modules/ice/ice_session.h
+++ b/src/projects/modules/ice/ice_session.h
@@ -106,14 +106,14 @@ private:
     std::atomic<IceConnectionState> _state{IceConnectionState::New};
 
     // Candidate pairs
-	mutable std::shared_mutex _active_candidate_pair_mutex;
-    std::shared_ptr<IceCandidatePair> _active_candidate_pair;
+	mutable ov::SharedMutex _active_candidate_pair_mutex;
+    std::shared_ptr<IceCandidatePair> _active_candidate_pair OV_GUARDED_BY(_active_candidate_pair_mutex);
 
-	mutable std::shared_mutex _candidate_pairs_mutex;
-    std::map<ov::SocketAddressPair, std::shared_ptr<IceCandidatePair>> _candidate_pairs;
+	mutable ov::SharedMutex _candidate_pairs_mutex;
+    std::map<ov::SocketAddressPair, std::shared_ptr<IceCandidatePair>> _candidate_pairs OV_GUARDED_BY(_candidate_pairs_mutex);
 
-	mutable std::shared_mutex _expire_time_mutex;
-	std::chrono::time_point<std::chrono::steady_clock> _expire_time;
+	mutable ov::SharedMutex _expire_time_mutex;
+	std::chrono::time_point<std::chrono::steady_clock> _expire_time OV_GUARDED_BY(_expire_time_mutex);
 	const int _expire_after_ms;
 	const uint64_t _lifetime_epoch_ms;
 

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -116,7 +116,7 @@ namespace ov
 
 		std::optional<T> Front(int timeout = Infinite)
 		{
-			LockGuard unique_lock(_mutex);
+			LockGuard lock(_mutex);
 
 			if (_stop)
 			{
@@ -127,7 +127,7 @@ namespace ov
 			{
 				std::chrono::steady_clock::time_point expire = (timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
-				auto result = _condition.WaitUntil(unique_lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
+				auto result = _condition.WaitUntil(lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
 					return (((_size == 0) == false) || _stop);
 				});
 
@@ -150,7 +150,7 @@ namespace ov
 
 		std::optional<T> Back(int timeout = Infinite)
 		{
-			LockGuard unique_lock(_mutex);
+			LockGuard lock(_mutex);
 
 			if (_stop)
 			{
@@ -161,7 +161,7 @@ namespace ov
 			{
 				std::chrono::steady_clock::time_point expire = (timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
-				auto result = _condition.WaitUntil(unique_lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
+				auto result = _condition.WaitUntil(lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
 					return (((_size == 0) == false) || _stop);
 				});
 
@@ -176,7 +176,7 @@ namespace ov
 
 		std::optional<T> Dequeue(int timeout = Infinite)
 		{
-			LockGuard unique_lock(_mutex);
+			LockGuard lock(_mutex);
 
 			if (_stop)
 			{
@@ -241,7 +241,7 @@ namespace ov
 					}
 				}
 
-				_condition.WaitUntil(unique_lock, expire);
+				_condition.WaitUntil(lock, expire);
 
 				// Check the hard deadline after waking.
 				if (timeout != Infinite && std::chrono::steady_clock::now() >= deadline)
@@ -373,7 +373,7 @@ namespace ov
 		// Buffer keeps items for a certain amount of time
 		void SetBufferingDelay(int delay_ms)
 		{
-			LockGuard unique_lock(_mutex);
+			LockGuard lock(_mutex);
 			if(delay_ms < 0)
 			{
 				logw(LOG_TAG, "[%s] Invalid buffering delay value: %d. Setting to 0.", GetInfoString().CStr(), delay_ms);
@@ -433,7 +433,7 @@ namespace ov
 
 		void EnqueueInternal(ManagedQueueNode* node, int timeout, EnqueuePos push_method)
 		{
-			LockGuard unique_lock(_mutex);
+			LockGuard lock(_mutex);
 
 			// Update statistics of input message count
 			_input_message_count++;
@@ -442,7 +442,7 @@ namespace ov
 			if(_exceed_threshold_and_wait_enabled == true)
 			{
 				std::chrono::steady_clock::time_point expire = (timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
-				auto result = _condition.WaitUntil(unique_lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
+				auto result = _condition.WaitUntil(lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
 					return (!IsThresholdExceeded() || _stop);
 				});
 				if (_stop)

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -11,10 +11,8 @@
 
 #include <monitoring/monitoring.h>
 
-#include <condition_variable>
 #include <optional>
 #include <queue>
-#include <shared_mutex>
 
 #include "base/info/managed_queue.h"
 #include "base/ovlibrary/ovlibrary.h"
@@ -118,7 +116,7 @@ namespace ov
 
 		std::optional<T> Front(int timeout = Infinite)
 		{
-			auto unique_lock = std::unique_lock(_mutex);
+			LockGuard unique_lock(_mutex);
 
 			if (_stop)
 			{
@@ -129,7 +127,7 @@ namespace ov
 			{
 				std::chrono::steady_clock::time_point expire = (timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
-				auto result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
+				auto result = _condition.WaitUntil(unique_lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
 					return (((_size == 0) == false) || _stop);
 				});
 
@@ -145,14 +143,14 @@ namespace ov
 		// How long the first message has been buffered
 		int32_t GetBufferedTimeMs()
 		{
-			auto lock_guard = std::lock_guard(_mutex);
+			LockGuard lock_guard(_mutex);
 
 			return GetBufferedTimeMsInternal();
 		}
 
 		std::optional<T> Back(int timeout = Infinite)
 		{
-			auto unique_lock = std::unique_lock(_mutex);
+			LockGuard unique_lock(_mutex);
 
 			if (_stop)
 			{
@@ -163,7 +161,7 @@ namespace ov
 			{
 				std::chrono::steady_clock::time_point expire = (timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
-				auto result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
+				auto result = _condition.WaitUntil(unique_lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
 					return (((_size == 0) == false) || _stop);
 				});
 
@@ -178,7 +176,7 @@ namespace ov
 
 		std::optional<T> Dequeue(int timeout = Infinite)
 		{
-			auto unique_lock = std::unique_lock(_mutex);
+			LockGuard unique_lock(_mutex);
 
 			if (_stop)
 			{
@@ -243,7 +241,7 @@ namespace ov
 					}
 				}
 
-				_condition.wait_until(unique_lock, expire);
+				_condition.WaitUntil(unique_lock, expire);
 
 				// Check the hard deadline after waking.
 				if (timeout != Infinite && std::chrono::steady_clock::now() >= deadline)
@@ -280,7 +278,7 @@ namespace ov
 
 			if(_exceed_threshold_and_wait_enabled == true)
 			{
-				_condition.notify_all();
+				_condition.NotifyAll();
 			}
 
 			return value;
@@ -288,7 +286,7 @@ namespace ov
 
 		bool IsEmpty() const
 		{
-			auto lock_guard = std::lock_guard(_mutex);
+			LockGuard lock_guard(_mutex);
 
 			return (_size == 0);
 		}
@@ -303,7 +301,7 @@ namespace ov
 		// Cleared all items in the queue
 		void Clear()
 		{
-			auto lock_guard = std::lock_guard(_mutex);
+			LockGuard lock_guard(_mutex);
 
 			while (_front_node != nullptr)
 			{
@@ -323,20 +321,20 @@ namespace ov
 
 		size_t Size() const
 		{
-			auto lock_guard = std::lock_guard(_mutex);
+			LockGuard lock_guard(_mutex);
 
 			return _size;
 		}
 
 		void Stop()
 		{
-			auto lock_guard = std::lock_guard(_mutex);
+			LockGuard lock_guard(_mutex);
 
 			_stop = true;
 
 			ClearMetrics();
 
-			_condition.notify_all();
+			_condition.NotifyAll();
 		}
 
 		// Injects a one-shot wakeup so the consumer can re-evaluate its state.
@@ -350,11 +348,11 @@ namespace ov
 		// notify_all() keeps the wakeup reliable when Front()/Back() waiters coexist.
 		void InjectWakeup()
 		{
-			auto lock_guard = std::lock_guard(_mutex);
+			LockGuard lock_guard(_mutex);
 
 			_pending_wakeup = true;
 
-			_condition.notify_all();
+			_condition.NotifyAll();
 		}
 
 		bool IsStopped() const
@@ -375,7 +373,7 @@ namespace ov
 		// Buffer keeps items for a certain amount of time
 		void SetBufferingDelay(int delay_ms)
 		{
-			auto unique_lock = std::unique_lock(_mutex);
+			LockGuard unique_lock(_mutex);
 			if(delay_ms < 0)
 			{
 				logw(LOG_TAG, "[%s] Invalid buffering delay value: %d. Setting to 0.", GetInfoString().CStr(), delay_ms);
@@ -387,7 +385,7 @@ namespace ov
 
 		ov::String GetInfoString()
 		{
-			auto shared_lock = std::shared_lock(_name_mutex);
+			SharedLockGuard shared_lock(_name_mutex);
 
 			ov::String urn_str = (_urn != nullptr) ? _urn->ToString() : ov::String("NoUrn");
 
@@ -407,7 +405,7 @@ namespace ov
 
 	private:
 
-		int32_t GetBufferedTimeMsInternal()
+		int32_t GetBufferedTimeMsInternal() OV_REQUIRES(_mutex)
 		{
 			if (_front_node == nullptr)
 			{
@@ -435,7 +433,7 @@ namespace ov
 
 		void EnqueueInternal(ManagedQueueNode* node, int timeout, EnqueuePos push_method)
 		{
-			auto unique_lock = std::unique_lock(_mutex);
+			LockGuard unique_lock(_mutex);
 
 			// Update statistics of input message count
 			_input_message_count++;
@@ -444,7 +442,7 @@ namespace ov
 			if(_exceed_threshold_and_wait_enabled == true)
 			{
 				std::chrono::steady_clock::time_point expire = (timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
-				auto result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
+				auto result = _condition.WaitUntil(unique_lock, expire, [this]() OV_REQUIRES(_mutex) -> bool {
 					return (!IsThresholdExceeded() || _stop);
 				});
 				if (_stop)
@@ -475,10 +473,10 @@ namespace ov
 			// Always notify: when buffering_delay == 0 this is the normal signal;
 			// when buffering_delay != 0 this lets the Dequeue thread recalculate
 			// its timed wait based on the (possibly new) front node.
-			_condition.notify_all();
+			_condition.NotifyAll();
 		}
 
-		void PushBack(ManagedQueueNode* node)
+		void PushBack(ManagedQueueNode* node) OV_REQUIRES(_mutex)
 		{
 			if (_size == 0)
 			{
@@ -494,7 +492,7 @@ namespace ov
 			_size++;
 		}
 
-		void PushFront(ManagedQueueNode* node)
+		void PushFront(ManagedQueueNode* node) OV_REQUIRES(_mutex)
 		{
 			if (_size == 0)
 			{
@@ -512,7 +510,7 @@ namespace ov
 
 	protected:
 		// Update statistical metrics and send data to monitoring module.
-		void UpdateMetrics()
+		void UpdateMetrics() OV_REQUIRES(_mutex)
 		{
 			// Update the peak statistics
 			if (_peak < _size)
@@ -548,7 +546,7 @@ namespace ov
 					{
 						_last_logging_time = 0;
 
-						auto shared_lock = std::shared_lock(_name_mutex);
+						SharedLockGuard shared_lock(_name_mutex);
 						logw(LOG_TAG, "Exceeded. %s", GetInfoString().CStr());
 
 						_last_logged_peak = _peak;
@@ -566,7 +564,7 @@ namespace ov
 			}
 		}
 
-		void ClearMetrics()
+		void ClearMetrics() OV_REQUIRES(_mutex)
 		{
 			_peak = 0;
 			_input_message_per_second = 0;
@@ -589,14 +587,14 @@ namespace ov
 	private:
 		// Check if the queue has exceeded the threshold.
 		// _threshold == 0 means no threshold.
-		bool IsThresholdExceeded() const
+		bool IsThresholdExceeded() const OV_REQUIRES(_mutex)
 		{
 			if (_threshold == 0) return false;
 			return _size >= _threshold;
 		}
 
 		// Compute the threshold
-		void UpdateThreshold()
+		void UpdateThreshold() OV_REQUIRES(_mutex)
 		{
 			// Compute the delay buffer count
 			size_t delay_buffer_count = 0;
@@ -627,30 +625,30 @@ namespace ov
 			}
 		}
 
-		StopWatch _timer;
+		StopWatch _timer OV_GUARDED_BY(_mutex);
 
 		int _stats_metric_interval = 0;
 
 		int _log_interval = 0;
-		int64_t _last_logging_time = 0;
+		int64_t _last_logging_time OV_GUARDED_BY(_mutex) = 0;
 
 		// Linked list of the queue
-		ManagedQueueNode* _front_node;
-		ManagedQueueNode* _rear_node;
+		ManagedQueueNode* _front_node OV_GUARDED_BY(_mutex);
+		ManagedQueueNode* _rear_node OV_GUARDED_BY(_mutex);
 
 		// Mutex and condition variable for the queue
-		mutable std::mutex _mutex;
-		std::condition_variable _condition;
+		mutable Mutex _mutex;
+		ConditionVariable _condition;
 
 		// Stop flag
 		std::atomic<bool> _stop;
 
 		// Set by InjectWakeup(), consumed by Dequeue(). A pending one-shot
 		// wakeup. Unlike _stop, the queue stays usable.
-		bool _pending_wakeup = false;
+		bool _pending_wakeup OV_GUARDED_BY(_mutex) = false;
 
 		// Use to print logs when the peak value of the queue is increased.
-		size_t _last_logged_peak = 0;
+		size_t _last_logged_peak OV_GUARDED_BY(_mutex) = 0;
 
 		// Prevent exceed threshold. If true, the queue will not exceed the threshold
 		// Wait until the queue falls below the threshold

--- a/src/projects/modules/pacer/adaptive_delay_controller.cpp
+++ b/src/projects/modules/pacer/adaptive_delay_controller.cpp
@@ -59,7 +59,7 @@ void AdaptiveDelayController::RecordSample(uint32_t track_id, int64_t lateness_m
 	int warn_max_value		 = 0;
 
 	{
-		std::lock_guard<std::mutex> lock(_mu);
+		ov::LockGuard<ov::Mutex> lock(_mu);
 		_samples.push_back({now, lateness_ms, track_id});
 
 		while (!_samples.empty() && (now - _samples.front().ts) > kWindow)
@@ -132,7 +132,7 @@ void AdaptiveDelayController::RecordSample(uint32_t track_id, int64_t lateness_m
 
 int AdaptiveDelayController::GetCurrentDelayMs()
 {
-	std::lock_guard<std::mutex> lock(_mu);
+	ov::LockGuard<ov::Mutex> lock(_mu);
 	return _current_delay_ms;
 }
 

--- a/src/projects/modules/pacer/adaptive_delay_controller.h
+++ b/src/projects/modules/pacer/adaptive_delay_controller.h
@@ -9,7 +9,6 @@
 
 #include <chrono>
 #include <deque>
-#include <mutex>
 
 // Stream-scoped adaptive smoothing-delay controller.
 //
@@ -41,7 +40,7 @@ public:
 	int GetMaxDelayMs() const { return _max_delay_ms; }
 
 private:
-	void Recompute();
+	void Recompute() OV_REQUIRES(_mu);
 
 	struct Sample
 	{
@@ -54,17 +53,17 @@ private:
 	int _min_delay_ms;
 	int _max_delay_ms;
 
-	std::mutex _mu;
-	std::deque<Sample> _samples;
-	int _current_delay_ms;
-	std::chrono::steady_clock::time_point _last_recompute;
+	ov::Mutex _mu;
+	std::deque<Sample> _samples OV_GUARDED_BY(_mu);
+	int _current_delay_ms OV_GUARDED_BY(_mu);
+	std::chrono::steady_clock::time_point _last_recompute OV_GUARDED_BY(_mu);
 
 	// Warning state (rate-limited).
-	std::chrono::steady_clock::time_point _last_lateness_warn;
-	std::chrono::steady_clock::time_point _last_max_warn;
-	bool _at_max = false;
+	std::chrono::steady_clock::time_point _last_lateness_warn OV_GUARDED_BY(_mu);
+	std::chrono::steady_clock::time_point _last_max_warn OV_GUARDED_BY(_mu);
+	bool _at_max OV_GUARDED_BY(_mu) = false;
 
 	// Periodic measurement log (for tuning Min/Max defaults).
-	std::chrono::steady_clock::time_point _last_stats_log;
-	void LogPerTrackStats();
+	std::chrono::steady_clock::time_point _last_stats_log OV_GUARDED_BY(_mu);
+	void LogPerTrackStats() OV_REQUIRES(_mu);
 };

--- a/src/projects/modules/pacer/frame_pacer.cpp
+++ b/src/projects/modules/pacer/frame_pacer.cpp
@@ -73,7 +73,7 @@ void FramePacer::Push(const std::shared_ptr<MediaPacket> &packet,
 	uint32_t calib_track_id	   = 0;
 
 	{
-		std::lock_guard<std::mutex> lock(_mu);
+		ov::LockGuard<ov::Mutex> lock(_mu);
 
 		auto now = arrival_time;
 

--- a/src/projects/modules/pacer/frame_pacer.h
+++ b/src/projects/modules/pacer/frame_pacer.h
@@ -12,7 +12,6 @@
 #include <chrono>
 #include <functional>
 #include <memory>
-#include <mutex>
 #include <vector>
 
 #include "adaptive_delay_controller.h"
@@ -68,20 +67,20 @@ private:
 	std::shared_ptr<ov::DelayQueue> _scheduler;
 	DispatchFn _dispatcher;
 
-	std::mutex _mu;
-	bool _anchor_set = false;
-	int64_t _anchor_pts_us = 0;
-	std::chrono::steady_clock::time_point _anchor_arrival;
-	std::chrono::steady_clock::time_point _last_push;
-	std::chrono::steady_clock::time_point _last_drift_warn;
+	ov::Mutex _mu;
+	bool _anchor_set OV_GUARDED_BY(_mu) = false;
+	int64_t _anchor_pts_us OV_GUARDED_BY(_mu) = 0;
+	std::chrono::steady_clock::time_point _anchor_arrival OV_GUARDED_BY(_mu);
+	std::chrono::steady_clock::time_point _last_push OV_GUARDED_BY(_mu);
+	std::chrono::steady_clock::time_point _last_drift_warn OV_GUARDED_BY(_mu);
 
 	// Anchor calibration. The provisional anchor (first frame after reset)
 	// may sit at an extreme of the path-delay distribution; calibration
 	// collects N frames and shifts the anchor by their median so baseline
 	// lateness centers on zero.
-	bool _anchor_calibrated = false;
-	std::vector<int64_t> _calibration_samples_ms;
+	bool _anchor_calibrated OV_GUARDED_BY(_mu) = false;
+	std::vector<int64_t> _calibration_samples_ms OV_GUARDED_BY(_mu);
 	// Total frames since last (re)anchor including outliers, used as a
 	// timeout when valid samples don't accumulate.
-	size_t _calibration_attempts = 0;
+	size_t _calibration_attempts OV_GUARDED_BY(_mu) = 0;
 };

--- a/src/projects/modules/physical_port/physical_port_manager.cpp
+++ b/src/projects/modules/physical_port/physical_port_manager.cpp
@@ -27,7 +27,7 @@ std::shared_ptr<PhysicalPort> PhysicalPortManager::CreatePort(const char *name,
 															  int recv_buffer_size,
 															  const PhysicalPort::OnSocketCreated on_socket_created)
 {
-	auto lock_guard = std::lock_guard(_port_list_mutex);
+	ov::LockGuard lock_guard(_port_list_mutex);
 
 	auto key = std::make_pair(type, address);
 	auto item = _port_list.find(key);
@@ -77,7 +77,7 @@ bool PhysicalPortManager::DeletePort(std::shared_ptr<PhysicalPort> &port)
 		return false;
 	}
 
-	auto lock_guard = std::lock_guard(_port_list_mutex);
+	ov::LockGuard lock_guard(_port_list_mutex);
 
 	auto key = std::make_pair(port->GetType(), port->GetAddress());
 	auto item = _port_list.find(key);

--- a/src/projects/modules/physical_port/physical_port_manager.h
+++ b/src/projects/modules/physical_port/physical_port_manager.h
@@ -40,8 +40,8 @@ protected:
 
 	std::shared_ptr<ov::SocketPool> GetSocketPool(const std::pair<ov::SocketType, ov::SocketAddress> &socket_info, int socket_pool_count);
 
-	std::map<std::pair<ov::SocketType, ov::SocketAddress>, std::shared_ptr<PhysicalPort>> _port_list;
+	std::map<std::pair<ov::SocketType, ov::SocketAddress>, std::shared_ptr<PhysicalPort>> _port_list OV_GUARDED_BY(_port_list_mutex);
 	std::map<std::pair<ov::SocketType, ov::SocketAddress>, std::shared_ptr<ov::SocketPool>> _socket_pool_list;
 
-	std::mutex _port_list_mutex;
+	ov::Mutex _port_list_mutex;
 };

--- a/src/projects/modules/rtc_signalling/p2p/rtc_p2p_manager.cpp
+++ b/src/projects/modules/rtc_signalling/p2p/rtc_p2p_manager.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<RtcPeerInfo> RtcP2PManager::CreatePeerInfo(peer_id_t id, const s
 
 	if (IsEnabled())
 	{
-		auto lock_guard = std::lock_guard(_list_mutex);
+		ov::LockGuard lock_guard(_list_mutex);
 
 		auto previous_peer_info = _peer_list.find(id);
 
@@ -57,7 +57,7 @@ std::shared_ptr<RtcPeerInfo> RtcP2PManager::CreatePeerInfo(peer_id_t id, const s
 
 std::shared_ptr<RtcPeerInfo> RtcP2PManager::FindPeer(peer_id_t peer_id)
 {
-	auto lock_guard = std::lock_guard(_list_mutex);
+	ov::LockGuard lock_guard(_list_mutex);
 
 	auto peer_info = _peer_list.find(peer_id);
 
@@ -71,7 +71,7 @@ std::shared_ptr<RtcPeerInfo> RtcP2PManager::FindPeer(peer_id_t peer_id)
 
 bool RtcP2PManager::RemovePeer(const std::shared_ptr<RtcPeerInfo> &peer)
 {
-	auto lock_guard = std::lock_guard(_list_mutex);
+	ov::LockGuard lock_guard(_list_mutex);
 
 	if (peer->IsHost())
 	{
@@ -121,7 +121,7 @@ bool RtcP2PManager::RegisterAsHostPeer(const std::shared_ptr<RtcPeerInfo> &peer)
 		return false;
 	}
 
-	auto lock_guard = std::lock_guard(_list_mutex);
+	ov::LockGuard lock_guard(_list_mutex);
 
 	auto peer_info = FindPeer(peer->GetId());
 
@@ -162,7 +162,7 @@ std::shared_ptr<RtcPeerInfo> RtcP2PManager::TryToRegisterAsClientPeer(const std:
 		return nullptr;
 	}
 
-	auto lock_guard = std::lock_guard(_list_mutex);
+	ov::LockGuard lock_guard(_list_mutex);
 
 	for (const auto &host : _available_list)
 	{
@@ -208,7 +208,7 @@ std::shared_ptr<RtcPeerInfo> RtcP2PManager::GetClientPeerOf(const std::shared_pt
 {
 	if (host != nullptr)
 	{
-		auto lock_guard = std::lock_guard(_list_mutex);
+		ov::LockGuard lock_guard(_list_mutex);
 
 		auto &client_list = host->_client_list;
 		auto client = client_list.find(client_id);
@@ -238,7 +238,7 @@ std::map<peer_id_t, std::shared_ptr<RtcPeerInfo>> RtcP2PManager::GetClientPeerLi
 	}
 
 	{
-		auto lock_guard = std::lock_guard(_list_mutex);
+		ov::LockGuard lock_guard(_list_mutex);
 		list = host->_client_list;
 	}
 

--- a/src/projects/modules/rtc_signalling/p2p/rtc_p2p_manager.h
+++ b/src/projects/modules/rtc_signalling/p2p/rtc_p2p_manager.h
@@ -41,15 +41,15 @@ protected:
 
 	int _max_client_peers_per_host_peer = -1;
 
-	std::recursive_mutex _list_mutex;
+	ov::RecursiveMutex _list_mutex;
 
 	// All peer list
 	// key: peer id, value: peer info list
-	std::map<peer_id_t, std::shared_ptr<RtcPeerInfo>> _peer_list;
+	std::map<peer_id_t, std::shared_ptr<RtcPeerInfo>> _peer_list OV_GUARDED_BY(_list_mutex);
 
 	// List of hosts that can accept client
 	// key: host id, value: host info
-	std::map<peer_id_t, std::shared_ptr<RtcPeerInfo>> _available_list;
+	std::map<peer_id_t, std::shared_ptr<RtcPeerInfo>> _available_list OV_GUARDED_BY(_list_mutex);
 
-	int _total_client_count = 0;
+	int _total_client_count OV_GUARDED_BY(_list_mutex) = 0;
 };

--- a/src/projects/modules/rtmp/rtmp_chunk_parser_common.h
+++ b/src/projects/modules/rtmp/rtmp_chunk_parser_common.h
@@ -25,13 +25,13 @@ public:
 public:
 	info::NamePath GetNamePath() const
 	{
-		std::lock_guard lock_guard(_name_path_mutex);
+		ov::LockGuard lock_guard(_name_path_mutex);
 		return _name_path;
 	}
 
 	virtual void UpdateNamePath(const info::NamePath &stream_name_path)
 	{
-		std::lock_guard lock_guard(_name_path_mutex);
+		ov::LockGuard lock_guard(_name_path_mutex);
 		_name_path = stream_name_path;
 		_message_queue.SetAlias(ov::String::FormatString("RTMP queue for %s", _name_path.CStr()));
 	}
@@ -51,6 +51,6 @@ protected:
 	size_t _chunk_size = 0;
 
 private:
-	mutable std::mutex _name_path_mutex;
-	info::NamePath _name_path;
+	mutable ov::Mutex _name_path_mutex;
+	info::NamePath _name_path OV_GUARDED_BY(_name_path_mutex);
 };

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.cpp
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.cpp
@@ -56,7 +56,7 @@ bool RtcpTransportCcFeedbackGenerator::AddReceivedRtpPacket(const std::shared_pt
 	uint8_t delta_size = 0;
 
 	// _transport_cc and the running counters below are shared; lock from here.
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 
 	// first packet of feedback message
 	if (_transport_cc == nullptr)
@@ -168,7 +168,7 @@ bool RtcpTransportCcFeedbackGenerator::AddReceivedRtpPacket(const std::shared_pt
 
 std::shared_ptr<RtcpPacket> RtcpTransportCcFeedbackGenerator::GenerateTransportCcMessageIfElapsed(uint32_t milliseconds)
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 
 	// Check elapsed and build under one lock so concurrent receives can't both
 	// pass the interval check and emit feedback for the same window.

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.h
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.h
@@ -12,7 +12,6 @@
 #include "../rtp_packet.h"
 #include "transport_cc.h"
 
-#include <mutex>
 
 // https://datatracker.ietf.org/doc/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
 
@@ -65,7 +64,7 @@ public:
 	std::shared_ptr<RtcpPacket> GenerateTransportCcMessageIfElapsed(uint32_t milliseconds);
 	uint32_t GetPacketStatusCount() const
 	{
-		std::lock_guard<std::mutex> lock(_lock);
+		ov::LockGuard<ov::Mutex> lock(_lock);
 		if (_transport_cc == nullptr)
 		{
 			return 0;
@@ -78,18 +77,18 @@ private:
 	std::chrono::steady_clock::time_point _created_time;
 	uint8_t _extension_id = 0;
 	uint32_t _sender_ssrc = 0;
-	uint32_t _last_media_ssrc = 0;
+	uint32_t _last_media_ssrc OV_GUARDED_BY(_lock) = 0;
 
-	bool _is_first_packet = true;
-	uint16_t _last_wide_sequence_number = 0;
+	bool _is_first_packet OV_GUARDED_BY(_lock) = true;
+	uint16_t _last_wide_sequence_number OV_GUARDED_BY(_lock) = 0;
 
-	uint8_t _fb_pkt_count = 0;
+	uint8_t _fb_pkt_count OV_GUARDED_BY(_lock) = 0;
 
-	std::chrono::steady_clock::time_point _last_reference_time; // multiples of 64ms, now() - created_time base
-	std::chrono::steady_clock::time_point _last_rtp_received_time;
-	std::shared_ptr<TransportCc> _transport_cc = nullptr;
+	std::chrono::steady_clock::time_point _last_reference_time OV_GUARDED_BY(_lock); // multiples of 64ms, now() - created_time base
+	std::chrono::steady_clock::time_point _last_rtp_received_time OV_GUARDED_BY(_lock);
+	std::shared_ptr<TransportCc> _transport_cc OV_GUARDED_BY(_lock) = nullptr;
 
-	std::chrono::steady_clock::time_point _last_report_time;
+	std::chrono::steady_clock::time_point _last_report_time OV_GUARDED_BY(_lock);
 
-	mutable std::mutex _lock;
+	mutable ov::Mutex _lock;
 };

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizer_h264.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizer_h264.cpp
@@ -238,7 +238,7 @@ bool RtpDepacketizerH264::IsDecodingParmeterSets(uint8_t nal_unit_type)
 
 std::shared_ptr<ov::Data> RtpDepacketizerH264::GetDecodingParameterSetsToAnnexB()
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	uint8_t start_prefix[ANNEXB_START_PREFIX_LENGTH] = {0, 0, 0, 1};
 
 	if(GetDecodingParameterSets().size() < 2) // It must contatin SPS, PPS

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizer_h265.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizer_h265.cpp
@@ -395,7 +395,7 @@ bool RtpDepacketizerH265::IsDecodingParmeterSets(uint8_t nal_unit_type)
 
 std::shared_ptr<ov::Data> RtpDepacketizerH265::GetDecodingParameterSetsToAnnexB()
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	uint8_t start_prefix[ANNEXB_START_PREFIX_LENGTH] = {0, 0, 0, 1};
 
 	if(GetDecodingParameterSets().size() < 3) // It must contatin VPS, SPS, PPS

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizing_manager.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizing_manager.cpp
@@ -35,7 +35,7 @@ std::map<uint8_t, std::shared_ptr<ov::Data>>& RtpDepacketizingManager::GetDecodi
 
 void RtpDepacketizingManager::AddDecodingParameterSet(uint8_t type, const std::shared_ptr<ov::Data> &value)
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	_parameter_sets[type] = value;
 }
 

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizing_manager.h
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizing_manager.h
@@ -3,7 +3,6 @@
 #include "rtp_rtcp_defines.h"
 #include "rtp_packet.h"
 
-#include <mutex>
 
 class RtpDepacketizingManager
 {
@@ -26,14 +25,14 @@ public:
 
 protected:
 	// Internal accessor; returns the raw map, so call only while holding _lock
-	std::map<uint8_t, std::shared_ptr<ov::Data>>& GetDecodingParameterSets();
+	std::map<uint8_t, std::shared_ptr<ov::Data>>& GetDecodingParameterSets() OV_REQUIRES(_lock);
 
 	// Guards _parameter_sets (the only cross-call shared state). Locked in
 	// AddDecodingParameterSet (write) and GetDecodingParameterSetsToAnnexB (read);
 	// GetDecodingParameterSets runs under the latter's lock
-	mutable std::mutex _lock;
+	mutable ov::Mutex _lock;
 
 private:
-	std::map<uint8_t, std::shared_ptr<ov::Data>> _parameter_sets;
+	std::map<uint8_t, std::shared_ptr<ov::Data>> _parameter_sets OV_GUARDED_BY(_lock);
 
 };

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.cpp
@@ -219,7 +219,7 @@ void RtpFrameJitterBuffer::UpdateFrameIntervalEstimate(uint32_t rtp_ts)
 
 bool RtpFrameJitterBuffer::InsertPacket(const std::shared_ptr<RtpPacket> &packet)
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	auto timestamp = GetExtentedTimestamp(packet->Timestamp());
 
 	// Reject packets for an already-emitted/dropped frame. Without this a
@@ -336,7 +336,7 @@ void RtpFrameJitterBuffer::BurnOutExpiredFrames()
 
 bool RtpFrameJitterBuffer::HasAvailableFrame()
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	return HasAvailableFrameInternal();
 }
 
@@ -388,7 +388,7 @@ bool RtpFrameJitterBuffer::HasAvailableFrameInternal()
 
 std::shared_ptr<RtpFrame> RtpFrameJitterBuffer::PopAvailableFrame()
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	if (HasAvailableFrameInternal() == false)
 	{
 		return nullptr;

--- a/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.h
+++ b/src/projects/modules/rtp_rtcp/rtp_frame_jitter_buffer.h
@@ -5,7 +5,6 @@
 #include <functional>
 #include <optional>
 #include <unordered_map>
-#include <mutex>
 
 // One frame's worth of RTP packets, identified by a common RTP timestamp.
 // Completeness is decided from packet flags stamped by RtpFrameBoundaryDetector:
@@ -112,20 +111,20 @@ public:
 
 private:
 	// Non-locking core shared by HasAvailableFrame() and PopAvailableFrame()
-	bool HasAvailableFrameInternal();
-	void BurnOutExpiredFrames();
-	uint64_t GetExtentedTimestamp(uint32_t timestamp);
-	uint32_t CurrentHoldMs();
-	void UpdateFrameIntervalEstimate(uint32_t rtp_ts);
-	void AdvanceProcessedSeq(RtpFrame &frame);
+	bool HasAvailableFrameInternal() OV_REQUIRES(_lock);
+	void BurnOutExpiredFrames() OV_REQUIRES(_lock);
+	uint64_t GetExtentedTimestamp(uint32_t timestamp) OV_REQUIRES(_lock);
+	uint32_t CurrentHoldMs() OV_REQUIRES(_lock);
+	void UpdateFrameIntervalEstimate(uint32_t rtp_ts) OV_REQUIRES(_lock);
+	void AdvanceProcessedSeq(RtpFrame &frame) OV_REQUIRES(_lock);
 	// Records bookkeeping after a frame leaves the buffer (emitted or
 	// discarded): advances the processed timestamp/seq watermarks and
 	// updates the frame-interval estimate. Caller still has to erase the
 	// frame from `_rtp_frames`.
-	void MarkFrameProcessed(uint64_t extended_timestamp, RtpFrame &frame);
+	void MarkFrameProcessed(uint64_t extended_timestamp, RtpFrame &frame) OV_REQUIRES(_lock);
 
-	uint32_t _last_timestamp = 0;
-	uint32_t _timestamp_cycle = 0;
+	uint32_t _last_timestamp OV_GUARDED_BY(_lock) = 0;
+	uint32_t _timestamp_cycle OV_GUARDED_BY(_lock) = 0;
 
 	std::function<uint32_t()> _hold_ms_provider;
 	std::function<void(uint16_t)> _on_processed_seq_advance;
@@ -133,8 +132,8 @@ private:
 	uint32_t _clock_rate = 0;
 	uint32_t _max_hold_ms = 0;  // 0 = no cap
 
-	bool _has_processed_seq = false;
-	uint16_t _last_processed_max_seq = 0;
+	bool _has_processed_seq OV_GUARDED_BY(_lock) = false;
+	uint16_t _last_processed_max_seq OV_GUARDED_BY(_lock) = 0;
 
 	// Conservative seed for the frame-interval mean-deviation. Until the
 	// EWMA collects a few real samples we have no idea what fps / pacing
@@ -152,19 +151,19 @@ private:
 	// starts at 0 (first sample seeds it directly) but the deviation
 	// starts large so the very first frame (e.g. the initial keyframe)
 	// has enough hold for NACK retries before EWMA has caught up.
-	bool _has_last_processed_rtp_ts = false;
-	uint32_t _last_processed_rtp_ts = 0;
-	uint32_t _frame_interval_ms = 0;
-	uint32_t _frame_interval_dev_ms = INITIAL_FRAME_INTERVAL_DEV_GUESS_MS;
+	bool _has_last_processed_rtp_ts OV_GUARDED_BY(_lock) = false;
+	uint32_t _last_processed_rtp_ts OV_GUARDED_BY(_lock) = 0;
+	uint32_t _frame_interval_ms OV_GUARDED_BY(_lock) = 0;
+	uint32_t _frame_interval_dev_ms OV_GUARDED_BY(_lock) = INITIAL_FRAME_INTERVAL_DEV_GUESS_MS;
 
 	// Highest extended timestamp already emitted or dropped. Rejects packets
 	// for an older timestamp (typical for late RTX after a frame has been
 	// popped) so they don't create a phantom duplicate frame.
-	bool _has_processed_timestamp = false;
-	uint64_t _last_processed_timestamp = 0;
+	bool _has_processed_timestamp OV_GUARDED_BY(_lock) = false;
+	uint64_t _last_processed_timestamp OV_GUARDED_BY(_lock) = 0;
 
 	// timestamp : RtpFrameInfo (ordered, so std::map)
-	std::map<uint64_t, std::shared_ptr<RtpFrame>> _rtp_frames;
+	std::map<uint64_t, std::shared_ptr<RtpFrame>> _rtp_frames OV_GUARDED_BY(_lock);
 
-	mutable std::mutex _lock;
+	mutable ov::Mutex _lock;
 };

--- a/src/projects/modules/rtp_rtcp/rtp_minimal_jitter_buffer.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_minimal_jitter_buffer.cpp
@@ -4,7 +4,7 @@
 
 bool RtpMinimalJitterBuffer::InsertPacket(const std::shared_ptr<RtpPacket> &packet)
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	// Already it determined this packet was lost
 	if(packet->SequenceNumber() < _next_sequence_number)
 	{
@@ -17,7 +17,7 @@ bool RtpMinimalJitterBuffer::InsertPacket(const std::shared_ptr<RtpPacket> &pack
 
 bool RtpMinimalJitterBuffer::HasAvailablePacket()
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	if(_rtp_packets.size() <= 0)
 	{
 		return false;
@@ -28,7 +28,7 @@ bool RtpMinimalJitterBuffer::HasAvailablePacket()
 
 std::shared_ptr<RtpPacket> RtpMinimalJitterBuffer::PopAvailablePacket()
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	std::shared_ptr<RtpPacketBox> packet_box = nullptr;
 
 	// First packet

--- a/src/projects/modules/rtp_rtcp/rtp_minimal_jitter_buffer.h
+++ b/src/projects/modules/rtp_rtcp/rtp_minimal_jitter_buffer.h
@@ -3,7 +3,6 @@
 #include "base/ovlibrary/ovlibrary.h"
 #include "rtp_packet.h"
 #include <unordered_map>
-#include <mutex>
 
 #define DEFAULT_AUDIO_MAX_BUFFERING_TIME_MS	200
 
@@ -16,7 +15,7 @@ public:
 	std::shared_ptr<RtpPacket> PopAvailablePacket();
 	
 private:
-	uint16_t _next_sequence_number = 0;
+	uint16_t _next_sequence_number OV_GUARDED_BY(_lock) = 0;
 	uint32_t _max_buffering_time_ms = DEFAULT_AUDIO_MAX_BUFFERING_TIME_MS;
 
 	struct RtpPacketBox
@@ -33,7 +32,7 @@ private:
 
 	// sequence number : RtpFrameInfo
 	// it should be ordered, so use std::map
-	std::map<uint16_t, std::shared_ptr<RtpPacketBox>> _rtp_packets;
+	std::map<uint16_t, std::shared_ptr<RtpPacketBox>> _rtp_packets OV_GUARDED_BY(_lock);
 
-	mutable std::mutex _lock;
+	mutable ov::Mutex _lock;
 };

--- a/src/projects/modules/rtp_rtcp/rtp_nack_generator.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_nack_generator.cpp
@@ -32,7 +32,7 @@ std::optional<uint32_t> RtpNackGenerator::ExtendSeq(uint16_t seq) const
 
 void RtpNackGenerator::OnPacketReceived(uint16_t seq)
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	auto now = std::chrono::steady_clock::now();
 
 	_received_total++;
@@ -137,7 +137,7 @@ void RtpNackGenerator::OnPacketReceived(uint16_t seq)
 
 std::vector<uint16_t> RtpNackGenerator::BuildPendingNack()
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	auto now = std::chrono::steady_clock::now();
 
 	DiscardStale(now);
@@ -192,7 +192,7 @@ std::vector<uint16_t> RtpNackGenerator::BuildPendingNack()
 
 uint32_t RtpNackGenerator::GetRecommendedHoldMs() const
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	return GetRecommendedHoldMsInternal();
 }
 
@@ -229,7 +229,7 @@ uint32_t RtpNackGenerator::GetRecommendedHoldMsInternal() const
 
 std::optional<uint16_t> RtpNackGenerator::GetLowestPendingSeq() const
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	if (_pending.empty())
 	{
 		return std::nullopt;
@@ -239,7 +239,7 @@ std::optional<uint16_t> RtpNackGenerator::GetLowestPendingSeq() const
 
 void RtpNackGenerator::DropPendingUpTo(uint16_t max_seq)
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	if (_initialized == false)
 	{
 		return;

--- a/src/projects/modules/rtp_rtcp/rtp_nack_generator.h
+++ b/src/projects/modules/rtp_rtcp/rtp_nack_generator.h
@@ -3,7 +3,6 @@
 #include <base/ovlibrary/ovlibrary.h>
 #include <chrono>
 #include <map>
-#include <mutex>
 #include <optional>
 #include <vector>
 
@@ -90,43 +89,43 @@ private:
 		std::chrono::steady_clock::time_point inserted_at;
 	};
 
-	std::optional<uint32_t> ExtendSeq(uint16_t seq) const;
-	void UpdateLatencyStats(double sample_ms, std::chrono::steady_clock::time_point now);
-	void DiscardStale(std::chrono::steady_clock::time_point now);
-	void LogPeriodicStats(std::chrono::steady_clock::time_point now);
+	std::optional<uint32_t> ExtendSeq(uint16_t seq) const OV_REQUIRES(_lock);
+	void UpdateLatencyStats(double sample_ms, std::chrono::steady_clock::time_point now) OV_REQUIRES(_lock);
+	void DiscardStale(std::chrono::steady_clock::time_point now) OV_REQUIRES(_lock);
+	void LogPeriodicStats(std::chrono::steady_clock::time_point now) OV_REQUIRES(_lock);
 	// Hold recommendation core; assumes _lock is already held.
-	uint32_t GetRecommendedHoldMsInternal() const;
+	uint32_t GetRecommendedHoldMsInternal() const OV_REQUIRES(_lock);
 
 	uint32_t _track_id = 0;
 	uint32_t _media_ssrc = 0;
 	uint32_t _hold_max_ms = HOLD_MAX_MS_DEFAULT;
 
-	bool _initialized = false;
-	uint32_t _newest_extended = 0;	// last seq seen in extended (uint32) form
-	uint32_t _expected_next = 0;	// next extended seq we expect
+	bool _initialized OV_GUARDED_BY(_lock) = false;
+	uint32_t _newest_extended OV_GUARDED_BY(_lock) = 0;	// last seq seen in extended (uint32) form
+	uint32_t _expected_next OV_GUARDED_BY(_lock) = 0;	// next extended seq we expect
 
-	std::map<uint32_t /*extended seq*/, PendingEntry> _pending;
+	std::map<uint32_t /*extended seq*/, PendingEntry> _pending OV_GUARDED_BY(_lock);
 
 	// NACK->RTX latency stats (smoothed mean + mean-deviation, milliseconds).
 	// _ewma_ms doubles as the NACK retry interval. Seeded with the same
 	// initial RTT guess that GetRecommendedHoldMs falls back to, so retry
 	// timing and hold timing agree before the first sample lands.
-	bool _stats_initialized = false;
-	double _ewma_ms = INITIAL_RTT_GUESS_MS;
-	double _ewma_dev_ms = 0.0;
-	std::chrono::steady_clock::time_point _last_sample_at;
+	bool _stats_initialized OV_GUARDED_BY(_lock) = false;
+	double _ewma_ms OV_GUARDED_BY(_lock) = INITIAL_RTT_GUESS_MS;
+	double _ewma_dev_ms OV_GUARDED_BY(_lock) = 0.0;
+	std::chrono::steady_clock::time_point _last_sample_at OV_GUARDED_BY(_lock);
 
 	// Cumulative monitoring counters. Logged every STATS_LOG_INTERVAL_MS as
 	// deltas (loss / recovery snapshot) and as cumulative totals.
-	uint64_t _received_total = 0;
-	uint64_t _nacks_sent_total = 0;
-	uint64_t _recovered_total = 0;
-	uint64_t _lost_permanent_total = 0;
-	uint64_t _prev_received = 0;
-	uint64_t _prev_nacks_sent = 0;
-	uint64_t _prev_recovered = 0;
-	uint64_t _prev_lost_permanent = 0;
-	std::chrono::steady_clock::time_point _last_stats_log_at;
+	uint64_t _received_total OV_GUARDED_BY(_lock) = 0;
+	uint64_t _nacks_sent_total OV_GUARDED_BY(_lock) = 0;
+	uint64_t _recovered_total OV_GUARDED_BY(_lock) = 0;
+	uint64_t _lost_permanent_total OV_GUARDED_BY(_lock) = 0;
+	uint64_t _prev_received OV_GUARDED_BY(_lock) = 0;
+	uint64_t _prev_nacks_sent OV_GUARDED_BY(_lock) = 0;
+	uint64_t _prev_recovered OV_GUARDED_BY(_lock) = 0;
+	uint64_t _prev_lost_permanent OV_GUARDED_BY(_lock) = 0;
+	std::chrono::steady_clock::time_point _last_stats_log_at OV_GUARDED_BY(_lock);
 
-	mutable std::mutex _lock;
+	mutable ov::Mutex _lock;
 };

--- a/src/projects/modules/rtp_rtcp/rtp_receive_statistics.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_receive_statistics.cpp
@@ -15,7 +15,7 @@ RtpReceiveStatistics::RtpReceiveStatistics(uint32_t media_ssrc, uint32_t clock_r
 
 bool RtpReceiveStatistics::AddReceivedRtpPacket(const std::shared_ptr<RtpPacket> &packet)
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	if(_first == true)
 	{
 		_first = false;
@@ -34,7 +34,7 @@ bool RtpReceiveStatistics::AddReceivedRtpPacket(const std::shared_ptr<RtpPacket>
 
 bool RtpReceiveStatistics::AddReceivedRtcpSenderReport(const std::shared_ptr<SenderReport> &report)
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	_last_sr_received_time = std::chrono::steady_clock::now();
 
 	// the middle 32 bits out of 64 in the NTP timestamp
@@ -46,25 +46,25 @@ bool RtpReceiveStatistics::AddReceivedRtcpSenderReport(const std::shared_ptr<Sen
 
 uint32_t RtpReceiveStatistics::GetMediaSSRC()
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	return _media_ssrc;
 }
 
 uint32_t RtpReceiveStatistics::GetReceiverSSRC()
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	return _receiver_ssrc;
 }
 
 uint64_t RtpReceiveStatistics::GetNumberOfFirRequests()
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	return _fir_request_count;
 }
 
 void RtpReceiveStatistics::OnFirRequested()
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	_fir_request_count ++;
 }
 
@@ -132,19 +132,19 @@ bool RtpReceiveStatistics::UpdateStat(const std::shared_ptr<RtpPacket> &packet)
 
 bool RtpReceiveStatistics::HasElapsedSinceLastReportBlock(uint32_t milliseconds)
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	return _report_block_timer.IsElapsed(milliseconds);
 }
 
 bool RtpReceiveStatistics::IsSenderReportReceived()
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	return _last_sr_timestamp != 0;
 }
 
 std::shared_ptr<ReportBlock> RtpReceiveStatistics::GenerateReportBlock()
 {
-	std::lock_guard<std::mutex> lock(_lock);
+	ov::LockGuard<ov::Mutex> lock(_lock);
 	int32_t extented_highest_seq = _cycles + _highest_seq;
 	int32_t expected_packet_count = extented_highest_seq - _init_seq + 1;
 

--- a/src/projects/modules/rtp_rtcp/rtp_receive_statistics.h
+++ b/src/projects/modules/rtp_rtcp/rtp_receive_statistics.h
@@ -4,7 +4,6 @@
 #include "rtp_packet.h"
 #include "rtcp_info/sender_report.h"
 
-#include <mutex>
 
 #define RTP_SEQ_MOD	(1<<16)
 #define MAX_DROPOUT	3000
@@ -36,35 +35,35 @@ public:
 	bool UpdateStat(const std::shared_ptr<RtpPacket> &packet);
 
 private:
-	uint32_t	_media_ssrc = 0;
-	uint32_t	_receiver_ssrc = 0;		// random generated local ssrc, for ReceiverReport, FIR ... 
+	uint32_t	_media_ssrc OV_GUARDED_BY(_lock) = 0;
+	uint32_t	_receiver_ssrc = 0;		// random generated local ssrc, for ReceiverReport, FIR ...
 	uint32_t	_clock_rate = 0;
 
 	// From SR
-	std::chrono::steady_clock::time_point _last_sr_received_time;
-	uint32_t	_last_sr_timestamp = 0;
+	std::chrono::steady_clock::time_point _last_sr_received_time OV_GUARDED_BY(_lock);
+	uint32_t	_last_sr_timestamp OV_GUARDED_BY(_lock) = 0;
 
 	// For Receiver Report
-	bool		_first = true;
-	
+	bool		_first OV_GUARDED_BY(_lock) = true;
+
 	// https://tools.ietf.org/html/rfc3550#page-75
-	uint16_t	_highest_seq = 0;
-	uint32_t	_cycles = 0;
-	uint32_t	_init_seq = 0;
-	uint32_t	_received_packets = 0;
-	uint32_t	_expected_packets_prior = 0;
-	uint32_t	_received_packets_prior = 0;
-	uint32_t	_interarrival_jitter = 0;
+	uint16_t	_highest_seq OV_GUARDED_BY(_lock) = 0;
+	uint32_t	_cycles OV_GUARDED_BY(_lock) = 0;
+	uint32_t	_init_seq OV_GUARDED_BY(_lock) = 0;
+	uint32_t	_received_packets OV_GUARDED_BY(_lock) = 0;
+	uint32_t	_expected_packets_prior OV_GUARDED_BY(_lock) = 0;
+	uint32_t	_received_packets_prior OV_GUARDED_BY(_lock) = 0;
+	uint32_t	_interarrival_jitter OV_GUARDED_BY(_lock) = 0;
 
-	uint32_t 	_last_rtp_timestamp = 0;
-	std::chrono::steady_clock::time_point _last_rtp_received_time;
+	uint32_t 	_last_rtp_timestamp OV_GUARDED_BY(_lock) = 0;
+	std::chrono::steady_clock::time_point _last_rtp_received_time OV_GUARDED_BY(_lock);
 
-	uint32_t	_received_bytes = 0;
+	uint32_t	_received_bytes OV_GUARDED_BY(_lock) = 0;
 
-	uint64_t	_fir_request_count = 0;
+	uint64_t	_fir_request_count OV_GUARDED_BY(_lock) = 0;
 
-	ov::StopWatch	_report_block_timer;
+	ov::StopWatch	_report_block_timer OV_GUARDED_BY(_lock);
 
 	// Locked at the public methods; InitSeq/UpdateSeq/UpdateStat run under it
-	mutable std::mutex _lock;
+	mutable ov::Mutex _lock;
 };

--- a/src/projects/modules/segment_writer/writer.cpp
+++ b/src/projects/modules/segment_writer/writer.cpp
@@ -371,7 +371,7 @@ bool Writer::AddTrack(const std::shared_ptr<const MediaTrack> &media_track)
 		return false;
 	}
 
-	auto lock_guard = std::lock_guard(_track_mutex);
+	ov::LockGuard lock_guard(_track_mutex);
 
 	auto track = std::make_shared<Track>(_track_list.size(), RationalFromTimebase(media_track->GetTimeBase()), media_track);
 	_track_list.emplace_back(track);
@@ -400,7 +400,7 @@ bool Writer::Prepare(ov::String service_name)
 
 	// Prepare AVStreams
 	{
-		auto lock_guard = std::lock_guard(_track_mutex);
+		ov::LockGuard lock_guard(_track_mutex);
 		int index = 0;
 
 		for (auto &track : _track_list)
@@ -552,7 +552,7 @@ int Writer::DecideBufferSize() const
 bool Writer::ResetData(int track_id)
 {
 	{
-		auto lock_guard = std::lock_guard(_track_mutex);
+		ov::LockGuard lock_guard(_track_mutex);
 
 		if (_buffer_size == -1)
 		{
@@ -612,7 +612,7 @@ off_t Writer::GetCurrentOffset() const
 
 int64_t Writer::GetFirstPts(uint32_t track_id) const
 {
-	auto lock_guard = std::lock_guard(_track_mutex);
+	ov::LockGuard lock_guard(_track_mutex);
 	auto track_item = _track_map.find(track_id);
 
 	if (track_item != _track_map.end())
@@ -626,7 +626,7 @@ int64_t Writer::GetFirstPts(uint32_t track_id) const
 
 int64_t Writer::GetFirstPts(cmn::MediaType type) const
 {
-	auto lock_guard = std::lock_guard(_track_mutex);
+	ov::LockGuard lock_guard(_track_mutex);
 	for (auto &track_item : _track_list)
 	{
 		if (track_item->track->GetMediaType() == type)
@@ -640,7 +640,7 @@ int64_t Writer::GetFirstPts(cmn::MediaType type) const
 
 int64_t Writer::GetFirstPts() const
 {
-	auto lock_guard = std::lock_guard(_track_mutex);
+	ov::LockGuard lock_guard(_track_mutex);
 	if (_track_list.size() > 0)
 	{
 		auto &track = _track_list[0];
@@ -652,7 +652,7 @@ int64_t Writer::GetFirstPts() const
 
 int64_t Writer::GetDuration(uint32_t track_id) const
 {
-	auto lock_guard = std::lock_guard(_track_mutex);
+	ov::LockGuard lock_guard(_track_mutex);
 	auto track_item = _track_map.find(track_id);
 
 	if (track_item != _track_map.end())
@@ -665,7 +665,7 @@ int64_t Writer::GetDuration(uint32_t track_id) const
 
 int64_t Writer::GetDuration() const
 {
-	auto lock_guard = std::lock_guard(_track_mutex);
+	ov::LockGuard lock_guard(_track_mutex);
 	if (_track_list.size() > 0)
 	{
 		return _track_list[0]->duration;
@@ -681,7 +681,7 @@ bool Writer::WritePacket(const std::shared_ptr<const MediaPacket> &packet, const
 	std::shared_ptr<Writer::Track> track;
 
 	{
-		auto lock_guard = std::lock_guard(_track_mutex);
+		ov::LockGuard lock_guard(_track_mutex);
 		auto track_item = _track_map.find(packet->GetTrackId());
 
 		if (track_item == _track_map.end())

--- a/src/projects/modules/segment_writer/writer.h
+++ b/src/projects/modules/segment_writer/writer.h
@@ -117,7 +117,7 @@ protected:
 	};
 
 	// Needed mutex lock for _track_list before calling this method
-	int DecideBufferSize() const;
+	int DecideBufferSize() const OV_REQUIRES(_track_mutex);
 
 	int OnWrite(const uint8_t *buf, int buf_size);
 	static int OnWrite(void *opaque, uint8_t *buf, int buf_size)
@@ -147,11 +147,11 @@ protected:
 
 	std::shared_ptr<ov::ByteStream> _data_stream;
 
-	mutable std::mutex _track_mutex;
+	mutable ov::Mutex _track_mutex;
 	// Key: MediaPacket.GetTrackId()
 	// Value: Track.stream_index
-	std::map<int, std::shared_ptr<Track>> _track_map;
-	std::vector<std::shared_ptr<Track>> _track_list;
+	std::map<int, std::shared_ptr<Track>> _track_map OV_GUARDED_BY(_track_mutex);
+	std::vector<std::shared_ptr<Track>> _track_list OV_GUARDED_BY(_track_mutex);
 
 	std::atomic<int> _buffer_size{-1};
 };

--- a/src/projects/modules/srt/srt_stream_url_resolver.cpp
+++ b/src/projects/modules/srt/srt_stream_url_resolver.cpp
@@ -17,7 +17,7 @@ namespace modules::srt
 {
 	void StreamUrlResolver::Initialize(const std::vector<cfg::cmn::SrtStream> &stream_list)
 	{
-		std::unique_lock lock{_stream_map_mutex};
+		ov::LockGuard lock{_stream_map_mutex};
 		for (const auto &stream : stream_list)
 		{
 			_stream_map.emplace(stream.GetPort(), stream.GetStreamPath());
@@ -26,7 +26,7 @@ namespace modules::srt
 
 	std::optional<ov::String> StreamUrlResolver::GetStreamPath(int port)
 	{
-		std::shared_lock lock{_stream_map_mutex};
+		ov::SharedLockGuard lock{_stream_map_mutex};
 		auto it = _stream_map.find(port);
 
 		return (it != _stream_map.end()) ? std::optional<ov::String>(it->second) : std::nullopt;

--- a/src/projects/modules/srt/srt_stream_url_resolver.h
+++ b/src/projects/modules/srt/srt_stream_url_resolver.h
@@ -33,9 +33,9 @@ namespace modules::srt
 		std::optional<info::Host> GetHostInfo(const ov::String &host) const;
 
 	private:
-		std::shared_mutex _stream_map_mutex;
+		ov::SharedMutex _stream_map_mutex;
 		// Key: port, Value: stream_path
-		std::map<int, ov::String> _stream_map;
+		std::map<int, ov::String> _stream_map OV_GUARDED_BY(_stream_map_mutex);
 	};
 
 }  // namespace modules::srt

--- a/src/projects/modules/whip/whip_server.cpp
+++ b/src/projects/modules/whip/whip_server.cpp
@@ -199,7 +199,7 @@ bool WhipServer::Start(
 	{
 		if (PrepareForTCPRelay() && PrepareForExternalIceServer())
 		{
-			std::lock_guard lock_guard{_http_server_list_mutex};
+			ov::LockGuard lock_guard{_http_server_list_mutex};
 			_http_server_list = std::move(http_server_list);
 			_https_server_list = std::move(https_server_list);
 
@@ -254,7 +254,7 @@ bool WhipServer::InsertCertificate(const std::shared_ptr<const info::Certificate
 	// The cache replays in `Start()` if this is called before listeners exist.
 	//
 	// Lock order: this mutex (outer) -> `HttpsServer::_https_certificate_map_mutex` (inner).
-	std::lock_guard lock_guard{_http_server_list_mutex};
+	ov::LockGuard lock_guard{_http_server_list_mutex};
 
 	_certificate_map[certificate->GetName()] = certificate;
 
@@ -278,7 +278,7 @@ bool WhipServer::RemoveCertificate(const std::shared_ptr<const info::Certificate
 		return true;
 	}
 
-	std::lock_guard lock_guard{_http_server_list_mutex};
+	ov::LockGuard lock_guard{_http_server_list_mutex};
 
 	_certificate_map.erase(certificate->GetName());
 

--- a/src/projects/modules/whip/whip_server.h
+++ b/src/projects/modules/whip/whip_server.h
@@ -75,9 +75,9 @@ private:
 
 	std::shared_ptr<WhipObserver> _observer;
 
-	std::recursive_mutex _http_server_list_mutex;
-	std::vector<std::shared_ptr<http::svr::HttpServer>> _http_server_list;
-	std::vector<std::shared_ptr<http::svr::HttpsServer>> _https_server_list;
+	ov::RecursiveMutex _http_server_list_mutex;
+	std::vector<std::shared_ptr<http::svr::HttpServer>> _http_server_list OV_GUARDED_BY(_http_server_list_mutex);
+	std::vector<std::shared_ptr<http::svr::HttpsServer>> _https_server_list OV_GUARDED_BY(_http_server_list_mutex);
 
 	// Cached certificates that must be applied to every HTTPS server in `_https_server_list`.
 	// `InsertCertificate()` can be called before `Start()` constructs the HTTPS servers
@@ -86,7 +86,7 @@ private:
 	// Protected by `_http_server_list_mutex`.
 	//
 	// Lock order: this mutex (outer) -> `HttpsServer::_https_certificate_map_mutex` (inner).
-	std::map<ov::String, std::shared_ptr<const info::Certificate>> _certificate_map;
+	std::map<ov::String, std::shared_ptr<const info::Certificate>> _certificate_map OV_GUARDED_BY(_http_server_list_mutex);
 
 	std::set<ov::String> _link_headers;
 	bool _tcp_force = false;

--- a/src/projects/monitoring/alert/alert_rules_updater.cpp
+++ b/src/projects/monitoring/alert/alert_rules_updater.cpp
@@ -44,7 +44,7 @@ namespace mon::alrt
 	{
 		if (_is_dynamic_update)
 		{
-			std::shared_lock lock(_dynamic_rules_mutex);
+			ov::SharedLockGuard lock(_dynamic_rules_mutex);
 
 			return _rules;
 		}
@@ -134,7 +134,7 @@ namespace mon::alrt
 			rules->FromDataSource(item_name.GetName(data_source.GetType()), item_name, data_source);
 
 			{
-				std::lock_guard lock_guard(_dynamic_rules_mutex);
+				ov::LockGuard lock_guard(_dynamic_rules_mutex);
 				_rules = rules;
 			}
 

--- a/src/projects/monitoring/alert/alert_rules_updater.h
+++ b/src/projects/monitoring/alert/alert_rules_updater.h
@@ -31,7 +31,7 @@ namespace mon::alrt
 		std::atomic<uint64_t> _last_modified = 0;
 		ov::String _rules_file;
 
-		mutable std::shared_mutex _dynamic_rules_mutex;
-		std::shared_ptr<const cfg::alrt::rule::Rules> _rules = nullptr;
+		mutable ov::SharedMutex _dynamic_rules_mutex;
+		std::shared_ptr<const cfg::alrt::rule::Rules> _rules OV_GUARDED_BY(_dynamic_rules_mutex) = nullptr;
 	};
 }  // namespace mon::alrt

--- a/src/projects/monitoring/stream_metrics.cpp
+++ b/src/projects/monitoring/stream_metrics.cpp
@@ -36,14 +36,14 @@ namespace mon
 
 	void StreamMetrics::LinkOutputStreamMetrics(const std::shared_ptr<StreamMetrics> &stream)
 	{
-		std::scoped_lock lock(_output_stream_metrics_mutex);
+		ov::ScopedLock lock(_output_stream_metrics_mutex);
 
 		_output_stream_metrics.push_back(stream);
 	}
 
 	std::vector<std::shared_ptr<StreamMetrics>> StreamMetrics::GetLinkedOutputStreamMetrics() const
 	{
-		std::shared_lock lock(_output_stream_metrics_mutex);
+		ov::SharedLockGuard lock(_output_stream_metrics_mutex);
 
 		return _output_stream_metrics;
 	}
@@ -114,7 +114,7 @@ namespace mon
 			return;
 		}
 
-		std::lock_guard lock(_module_usage_count_map_mutex);
+		ov::LockGuard lock(_module_usage_count_map_mutex);
 
 		auto it = _module_usage_count_map.find(media_track->GetId());
 
@@ -147,7 +147,7 @@ namespace mon
 			return;
 		}
 
-		std::lock_guard lock(_module_usage_count_map_mutex);
+		ov::LockGuard lock(_module_usage_count_map_mutex);
 
 		auto it = _module_usage_count_map.find(media_track->GetId());
 

--- a/src/projects/monitoring/stream_metrics.h
+++ b/src/projects/monitoring/stream_metrics.h
@@ -68,12 +68,12 @@ namespace mon
 		std::atomic<int64_t> _subscribe_time_from_origin_msec = 0;
 
 		// If this stream is from Provider(input stream) it has multiple output streams
-		mutable std::shared_mutex _output_stream_metrics_mutex;
-		std::vector<std::shared_ptr<StreamMetrics>> _output_stream_metrics;
+		mutable ov::SharedMutex _output_stream_metrics_mutex;
+		std::vector<std::shared_ptr<StreamMetrics>> _output_stream_metrics OV_GUARDED_BY(_output_stream_metrics_mutex);
 
 		std::shared_ptr<ApplicationMetrics> _app_metrics;
 
-		std::mutex _module_usage_count_map_mutex;
-		std::unordered_map<MediaTrackId, std::shared_ptr<const MediaTrack>> _module_usage_count_map;
+		ov::Mutex _module_usage_count_map_mutex;
+		std::unordered_map<MediaTrackId, std::shared_ptr<const MediaTrack>> _module_usage_count_map OV_GUARDED_BY(_module_usage_count_map_mutex);
 	};
 }  // namespace mon

--- a/src/projects/providers/mpegts/mpegts_stream.cpp
+++ b/src/projects/providers/mpegts/mpegts_stream.cpp
@@ -93,7 +93,7 @@ namespace pvd
 			return false;
 		}
 
-		std::lock_guard<std::shared_mutex> lock(_depacketizer_lock);
+		ov::LockGuard<ov::SharedMutex> lock(_depacketizer_lock);
 		_depacketizer.AddPacket(data);
 
 		// Publish

--- a/src/projects/providers/mpegts/mpegts_stream.h
+++ b/src/projects/providers/mpegts/mpegts_stream.h
@@ -37,13 +37,13 @@ namespace pvd
 
 	private:
 		bool Start() override;	
-		bool Publish();
+		bool Publish() OV_REQUIRES(_depacketizer_lock);
 
 		// Client socket
 		std::shared_ptr<ov::Socket> _remote = nullptr;
 
-		std::shared_mutex _depacketizer_lock;
-		mpegts::MpegTsDepacketizer	_depacketizer;
+		ov::SharedMutex _depacketizer_lock;
+		mpegts::MpegTsDepacketizer	_depacketizer OV_GUARDED_BY(_depacketizer_lock);
 
 		info::VHostAppName _vhost_app_name;
 

--- a/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
+++ b/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
@@ -608,13 +608,13 @@ namespace pvd::rtmp
 
 	info::NamePath RtmpChunkHandler::GetNamePath() const
 	{
-		std::lock_guard lock_guard(_name_path_mutex);
+		ov::LockGuard lock_guard(_name_path_mutex);
 		return _name_path;
 	}
 
 	void RtmpChunkHandler::UpdateNamePath(const info::NamePath &stream_name_path)
 	{
-		std::lock_guard lock_guard(_name_path_mutex);
+		ov::LockGuard lock_guard(_name_path_mutex);
 		_name_path = stream_name_path;
 	}
 

--- a/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.h
+++ b/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.h
@@ -185,7 +185,7 @@ namespace pvd::rtmp
 
 		cfg::vhost::app::pvd::EventGenerator _event_generator_config;
 
-		mutable std::mutex _name_path_mutex;
-		info::NamePath _name_path;
+		mutable ov::Mutex _name_path_mutex;
+		info::NamePath _name_path OV_GUARDED_BY(_name_path_mutex);
 	};
 }  // namespace pvd::rtmp

--- a/src/projects/providers/rtsp/rtsp_server.cpp
+++ b/src/projects/providers/rtsp/rtsp_server.cpp
@@ -128,7 +128,7 @@ std::unique_ptr<T> CreateTrack(const RtspServer::StreamTrackInfo *stream_track, 
 
 void RtspServer::OnConnected(const std::shared_ptr<ov::Socket> &remote)
 {
-    std::lock_guard<std::mutex> lock(mutex_);
+    ov::LockGuard<ov::Mutex> lock(mutex_);
     auto request_iterator = requests_.find(remote.get());
     if (request_iterator != requests_.end())
     {
@@ -143,7 +143,7 @@ void RtspServer::OnDataReceived(const std::shared_ptr<ov::Socket> &remote,
 {
     std::shared_ptr<RtspConnection> rtsp_connection;
     {
-        std::lock_guard<std::mutex> lock(mutex_);
+        ov::LockGuard<ov::Mutex> lock(mutex_);
         auto request_iterator = requests_.find(remote.get());
         if (request_iterator != requests_.end())
         {
@@ -157,7 +157,7 @@ void RtspServer::OnDisconnected(const std::shared_ptr<ov::Socket> &remote,
                                 PhysicalPortDisconnectReason reason,
                                 const std::shared_ptr<const ov::Error> &error)
 {
-    std::lock_guard<std::mutex> lock(mutex_);
+    ov::LockGuard<ov::Mutex> lock(mutex_);
     auto request_iterator = requests_.find(remote.get());
     if (request_iterator != requests_.end())
     {
@@ -170,7 +170,7 @@ bool RtspServer::Disconnect(const ov::String &app_name, uint32_t stream_id)
     return true;
 }
 
-void RtspServer::DeleteStream(const std::lock_guard<std::mutex> &lock, std::unordered_map<std::string, uint32_t>::iterator &stream_id_iterator)
+void RtspServer::DeleteStream(const ov::LockGuard<ov::Mutex> &lock, std::unordered_map<std::string, uint32_t>::iterator &stream_id_iterator)
 
 {
     // Not sure if shut down the existing connections and continue or fail, currently erase everything
@@ -207,7 +207,7 @@ bool RtspServer::OnStreamAnnounced(const std::string_view &app_name,
     // Not sure if announce when the stream arrives or wait till all the tracks are set up, currently announce as soon as it shows up
     const auto stream_path = std::string(app_name.data(), app_name.size()).append("/").append(std::string(stream_name.data(), stream_name.size()));
     
-    std::lock_guard<std::mutex> lock(mutex_);
+    ov::LockGuard<ov::Mutex> lock(mutex_);
     {
         auto existing_stream_iterator = stream_ids_.find(stream_path);
         if (existing_stream_iterator != stream_ids_.end())
@@ -269,7 +269,7 @@ bool RtspServer::OnUdpStreamTrackSetup(const std::string_view &rtsp_uri,
 {
     const auto track_path = std::string(rtsp_uri.data(), rtsp_uri.size());
     
-    std::lock_guard<std::mutex> lock(mutex_);
+    ov::LockGuard<ov::Mutex> lock(mutex_);
     const auto *stream_track = FindTrackStream(lock, track_path);
     if (stream_track == nullptr)
     {
@@ -303,7 +303,7 @@ bool RtspServer::OnTcpStreamTrackSetup(const std::string_view &rtsp_uri,
 {
     const auto track_path = std::string(rtsp_uri.data(), rtsp_uri.size());
     
-    std::lock_guard<std::mutex> lock(mutex_);
+    ov::LockGuard<ov::Mutex> lock(mutex_);
     const auto *stream_track = FindTrackStream(lock, track_path);
     if (stream_track == nullptr)
     {
@@ -329,7 +329,7 @@ bool RtspServer::OnTcpStreamTrackSetup(const std::string_view &rtsp_uri,
     return true;
 }
 
-RtspServer::StreamTrackInfo *RtspServer::FindTrackStream(const std::lock_guard<std::mutex> &lock,
+RtspServer::StreamTrackInfo *RtspServer::FindTrackStream(const ov::LockGuard<ov::Mutex> &lock,
     const std::string &track_path)
 {
     auto stream_track_iterator = stream_tracks_.find(track_path);
@@ -341,7 +341,7 @@ RtspServer::StreamTrackInfo *RtspServer::FindTrackStream(const std::lock_guard<s
     return &stream_track_iterator->second;
 }
 
-std::vector<std::unique_ptr<RtpTrack>> *RtspServer::FindSessionTracks(const std::lock_guard<std::mutex> &lock,
+std::vector<std::unique_ptr<RtpTrack>> *RtspServer::FindSessionTracks(const ov::LockGuard<ov::Mutex> &lock,
     uint32_t stream_id)
 {
     auto stream_iterator = stream_contexts_.find(stream_id);
@@ -358,7 +358,7 @@ bool RtspServer::OnStreamTeardown(const std::string_view &app_name,
     const std::string_view &stream_name)
 {
     const auto stream_path = std::string(app_name.data(), app_name.size()).append("/").append(std::string(stream_name.data(), stream_name.size()));
-    std::lock_guard<std::mutex> lock(mutex_);
+    ov::LockGuard<ov::Mutex> lock(mutex_);
     auto stream_iterator = stream_ids_.find(stream_path);
     if (stream_iterator != stream_ids_.end())
     {
@@ -386,7 +386,7 @@ bool RtspServer::OnVideoData(uint32_t stream_id,
         uint8_t flags, 
         std::unique_ptr<FragmentationHeader> fragmentation_header)
 {
-    std::lock_guard<std::mutex> lock(mutex_);
+    ov::LockGuard<ov::Mutex> lock(mutex_);
     auto stream_context_iterator = stream_contexts_.find(stream_id);
     if (stream_context_iterator == stream_contexts_.end())
     {
@@ -404,7 +404,7 @@ bool RtspServer::OnAudioData(uint32_t stream_id,
         uint32_t timestamp,
         const std::shared_ptr<std::vector<uint8_t>> &data)
 {
-    std::lock_guard<std::mutex> lock(mutex_);
+    ov::LockGuard<ov::Mutex> lock(mutex_);
     auto stream_context_iterator = stream_contexts_.find(stream_id);
     if (stream_context_iterator == stream_contexts_.end())
     {
@@ -433,7 +433,7 @@ void RtspServer::OnRtcpSenderReport(uint32_t stream_id,
     uint8_t track_id,
     const RtcpSenderReport &rtcp_sender_report)
 {
-    std::lock_guard<std::mutex> lock(mutex_);
+    ov::LockGuard<ov::Mutex> lock(mutex_);
     auto stream_context_iterator = stream_contexts_.find(stream_id);
     if (stream_context_iterator == stream_contexts_.end())
     {

--- a/src/projects/providers/rtsp/rtsp_server.h
+++ b/src/projects/providers/rtsp/rtsp_server.h
@@ -15,7 +15,6 @@
 #include <modules/physical_port/physical_port_manager.h>
 
 #include <unordered_map>
-#include <mutex>
 
 class RtspServer : public ServerBase<RtspServer, ov::SocketType::Tcp>, public ObservableBase<RtspServer, RtspObserver>
 {
@@ -97,24 +96,24 @@ protected:
                         const std::shared_ptr<const ov::Error> &error) override;
 
 private:
-    std::vector<std::unique_ptr<RtpTrack>> *FindSessionTracks(const std::lock_guard<std::mutex> &lock, uint32_t stream_id);
-    StreamTrackInfo *FindTrackStream(const std::lock_guard<std::mutex> &lock, const std::string &track_path);
- 
-    void DeleteStream(const std::lock_guard<std::mutex> &lock, std::unordered_map<std::string, uint32_t>::iterator &stream_id_iterator);
+    std::vector<std::unique_ptr<RtpTrack>> *FindSessionTracks(const ov::LockGuard<ov::Mutex> &lock, uint32_t stream_id) OV_REQUIRES(mutex_);
+    StreamTrackInfo *FindTrackStream(const ov::LockGuard<ov::Mutex> &lock, const std::string &track_path) OV_REQUIRES(mutex_);
+
+    void DeleteStream(const ov::LockGuard<ov::Mutex> &lock, std::unordered_map<std::string, uint32_t>::iterator &stream_id_iterator) OV_REQUIRES(mutex_);
 
 private:
-    std::mutex mutex_;
-    std::unordered_map<ov::Socket *, std::shared_ptr<RtspConnection>> requests_;
+    ov::Mutex mutex_;
+    std::unordered_map<ov::Socket *, std::shared_ptr<RtspConnection>> requests_ OV_GUARDED_BY(mutex_);
     // Maps stream path (e.g. /app/live to an internal id)
-    std::unordered_map<std::string, uint32_t> stream_ids_;
+    std::unordered_map<std::string, uint32_t> stream_ids_ OV_GUARDED_BY(mutex_);
     // Holds the context for each stream (routes, RTSP session id, ...)
-    std::unordered_map<uint32_t, RtspStreamContext> stream_contexts_;
+    std::unordered_map<uint32_t, RtspStreamContext> stream_contexts_ OV_GUARDED_BY(mutex_);
     // Holds the tracks of a given session via an RtpTrack abstraction
-    std::unordered_map<uint32_t, std::vector<std::unique_ptr<RtpTrack>>> session_tracks_;
+    std::unordered_map<uint32_t, std::vector<std::unique_ptr<RtpTrack>>> session_tracks_ OV_GUARDED_BY(mutex_);
     // Maps track paths to stream id (e.g /app/live/audio_track -> 1),
     // this is needed since for UDP the control uri will be used to setup the track
     // and there is no other info to tie that setup request together with the actual stream from the setup request
-    std::unordered_map<std::string, StreamTrackInfo> stream_tracks_;
+    std::unordered_map<std::string, StreamTrackInfo> stream_tracks_ OV_GUARDED_BY(mutex_);
     // TODO(rubu): make these configurable
     ov::PortRange<ov::SocketType::Udp> rtp_udp_port_range_ = {2000, 3000};
 };

--- a/src/projects/providers/rtspc/rtspc_stream.cpp
+++ b/src/projects/providers/rtspc/rtspc_stream.cpp
@@ -788,14 +788,14 @@ namespace pvd
 
 	bool RtspcStream::SubscribeResponse(const std::shared_ptr<RtspMessage> &request_message)
 	{
-		std::lock_guard<std::mutex> lock(_response_subscriptions_lock);
+		ov::LockGuard<ov::Mutex> lock(_response_subscriptions_lock);
 		_response_subscriptions.emplace(request_message->GetCSeq(), std::make_shared<ResponseSubscription>(request_message));
 		return true;
 	}
 
 	std::shared_ptr<RtspcStream::ResponseSubscription> RtspcStream::PopResponseSubscription(uint32_t cseq)
 	{
-		std::lock_guard<std::mutex> lock(_response_subscriptions_lock);
+		ov::LockGuard<ov::Mutex> lock(_response_subscriptions_lock);
 		auto it = _response_subscriptions.find(cseq);
 		if (it == _response_subscriptions.end())
 		{

--- a/src/projects/providers/rtspc/rtspc_stream.h
+++ b/src/projects/providers/rtspc/rtspc_stream.h
@@ -151,8 +151,8 @@ namespace pvd
 		std::map<uint32_t, uint8_t> _ssrc_channel_id_map;
 
 		// CSeq : RequestMessage
-		std::mutex _response_subscriptions_lock;
-		std::unordered_map<uint32_t, std::shared_ptr<ResponseSubscription>> _response_subscriptions;
+		ov::Mutex _response_subscriptions_lock;
+		std::unordered_map<uint32_t, std::shared_ptr<ResponseSubscription>> _response_subscriptions OV_GUARDED_BY(_response_subscriptions_lock);
 		RtspDemuxer _rtsp_demuxer;
 
 		// Rtp

--- a/src/projects/publishers/ovt/ovt_session.cpp
+++ b/src/projects/publishers/ovt/ovt_session.cpp
@@ -86,7 +86,7 @@ void OvtSession::SendOutgoingData(const std::any &packet)
 	// TrackSet filter (applied only to media packets; signaling packets are payload type
 	// MESSAGE_RESPONSE and are sent via OvtPublisher::SendResponse, not this path).
 	{
-		std::scoped_lock lock(_track_set_filter_mutex);
+		ov::ScopedLock lock(_track_set_filter_mutex);
 
 		if (_track_set_filter_enabled &&
 			session_packet->PayloadType() == OVT_PAYLOAD_TYPE_MEDIA_PACKET)
@@ -146,7 +146,7 @@ void OvtSession::SendOutgoingData(const std::any &packet)
 
 void OvtSession::SetAllowedTrackIds(const std::set<uint32_t> &allowed_track_ids)
 {
-	std::scoped_lock lock(_track_set_filter_mutex);
+	ov::ScopedLock lock(_track_set_filter_mutex);
 
 	_allowed_track_ids		  = allowed_track_ids;
 	_track_set_filter_enabled = true;

--- a/src/projects/publishers/ovt/ovt_session.h
+++ b/src/projects/publishers/ovt/ovt_session.h
@@ -61,14 +61,14 @@ private:
 	// When `_track_set_filter_enabled` is `false`, no filtering is performed (full stream is forwarded).
 	// When `true`, only media packets whose track id is in `_allowed_track_ids` are forwarded;
 	// an empty `_allowed_track_ids` in this state drops every media packet.
-	mutable std::mutex _track_set_filter_mutex;
-	bool _track_set_filter_enabled = false;
-	std::set<uint32_t> _allowed_track_ids;
+	mutable ov::Mutex _track_set_filter_mutex;
+	bool _track_set_filter_enabled OV_GUARDED_BY(_track_set_filter_mutex) = false;
+	std::set<uint32_t> _allowed_track_ids OV_GUARDED_BY(_track_set_filter_mutex);
 	// Per fragment-group filter state. A "group" is the run of OvtPackets that
 	// together carry one serialized MediaPacket; only the first packet of a group
 	// contains the 4-byte track id at the start of its payload, so we cache the
 	// accept/drop decision until the group's marker packet is seen.
-	GroupDecision _current_group_decision = GroupDecision::Pending;
+	GroupDecision _current_group_decision OV_GUARDED_BY(_track_set_filter_mutex) = GroupDecision::Pending;
 	// One-shot guard to avoid log spam when the first fragment is malformed.
-	bool _warned_malformed_first_fragment = false;
+	bool _warned_malformed_first_fragment OV_GUARDED_BY(_track_set_filter_mutex) = false;
 };

--- a/src/projects/publishers/srt/srt_stream.cpp
+++ b/src/projects/publishers/srt/srt_stream.cpp
@@ -151,7 +151,7 @@ namespace pub
 
 	std::shared_ptr<SrtPlaylist> SrtStream::GetSrtPlaylist(const ov::String &file_name)
 	{
-		std::shared_lock lock(_srt_playlist_map_mutex);
+		ov::SharedLockGuard lock(_srt_playlist_map_mutex);
 
 		return GetSrtPlaylistInternal(file_name);
 	}
@@ -220,7 +220,7 @@ namespace pub
 
 	bool SrtStream::Start()
 	{
-		std::unique_lock lock(_srt_playlist_map_mutex);
+		ov::LockGuard lock(_srt_playlist_map_mutex);
 
 		if (GetState() != Stream::State::CREATED)
 		{
@@ -369,7 +369,7 @@ namespace pub
 
 	bool SrtStream::Stop()
 	{
-		std::unique_lock lock(_srt_playlist_map_mutex);
+		ov::LockGuard lock(_srt_playlist_map_mutex);
 
 		if (GetState() != Stream::State::STARTED)
 		{
@@ -400,7 +400,7 @@ namespace pub
 
 	void SrtStream::EnqueuePacket(const std::shared_ptr<MediaPacket> &media_packet)
 	{
-		std::shared_lock lock(_srt_playlist_map_mutex);
+		ov::SharedLockGuard lock(_srt_playlist_map_mutex);
 
 		if (GetState() != Stream::State::STARTED)
 		{

--- a/src/projects/publishers/srt/srt_stream.h
+++ b/src/projects/publishers/srt/srt_stream.h
@@ -57,7 +57,7 @@ namespace pub
 
 		bool IsSupportedTrack(const std::shared_ptr<MediaTrack> &track) const;
 
-		std::shared_ptr<SrtPlaylist> GetSrtPlaylistInternal(const ov::String &file_name);
+		std::shared_ptr<SrtPlaylist> GetSrtPlaylistInternal(const ov::String &file_name) OV_REQUIRES_SHARED(_srt_playlist_map_mutex);
 
 		std::map<int32_t, std::shared_ptr<MediaTrack>> GetSupportedTracks(const std::map<int32_t, std::shared_ptr<MediaTrack>> &track_map) const;
 		std::vector<std::shared_ptr<MediaTrack>> GetSupportedTracks(const std::vector<std::shared_ptr<MediaTrack>> &tracks) const;
@@ -80,10 +80,10 @@ namespace pub
 	private:
 		uint32_t _worker_count = 0;
 
-		std::shared_mutex _srt_playlist_map_mutex;
+		ov::SharedMutex _srt_playlist_map_mutex;
 		// key: track id, value: list of playlist that uses the track
-		std::map<int32_t, std::vector<std::shared_ptr<SrtPlaylist>>> _srt_playlist_map_by_track_id;
+		std::map<int32_t, std::vector<std::shared_ptr<SrtPlaylist>>> _srt_playlist_map_by_track_id OV_GUARDED_BY(_srt_playlist_map_mutex);
 		// key: playlist file name, value: playlist
-		std::map<ov::String, std::shared_ptr<SrtPlaylist>> _srt_playlist_map_by_file_name;
+		std::map<ov::String, std::shared_ptr<SrtPlaylist>> _srt_playlist_map_by_file_name OV_GUARDED_BY(_srt_playlist_map_mutex);
 	};
 }  // namespace pub

--- a/src/projects/transcoder/filter/filter_rescaler.cpp
+++ b/src/projects/transcoder/filter/filter_rescaler.cpp
@@ -751,7 +751,7 @@ void FilterRescaler::WorkerThread()
 		{
 			if (start_frame_syncronization)
 			{
-				std::lock_guard<std::mutex> lock(TranscodeGPU::GetInstance()->GetDeviceMutex());
+				ov::LockGuard<ov::Mutex> lock(TranscodeGPU::GetInstance()->GetDeviceMutex());
 
 				DO_FILTER_ONCE(frame);
 

--- a/src/projects/transcoder/transcoder_fault_injector.h
+++ b/src/projects/transcoder/transcoder_fault_injector.h
@@ -115,7 +115,7 @@ public:
 			return false;
 		}
 
-		std::shared_lock lock(_mutex);
+		ov::SharedLockGuard lock(_mutex);
 
 		auto component_it = _fault_triggers.find(std::make_pair(component_type, issue_type));
 		if (component_it == _fault_triggers.end())
@@ -154,7 +154,7 @@ public:
 
 	void SetFaultRate(ComponentType component_type, IssueType issue_type, cmn::MediaCodecModuleId module_id, cmn::DeviceId device_id, double fault_rate)
 	{
-		std::unique_lock lock(_mutex);
+		ov::LockGuard lock(_mutex);
 
 		logti("Setting fault injection. ComponentType(%s), IssueType(%s), ModuleId(%s), DeviceId(%d), Rate(%.2f%%)",
 			  GetComponentTypeString(component_type), GetIssueTypeString(issue_type), cmn::GetCodecModuleIdString(module_id), device_id, fault_rate);
@@ -165,14 +165,14 @@ public:
 
 	void Clear()
 	{
-		std::unique_lock lock(_mutex);
+		ov::LockGuard lock(_mutex);
 		_fault_triggers.clear();
 		_enabled = false;
 	}
 
 private:
-	bool _enabled = false;
+	bool _enabled OV_GUARDED_BY(_mutex) = false;
 
-	std::shared_mutex _mutex;
-	std::map<std::pair<ComponentType, IssueType>, std::map<std::pair<cmn::MediaCodecModuleId, cmn::DeviceId>, double>> _fault_triggers;
+	ov::SharedMutex _mutex;
+	std::map<std::pair<ComponentType, IssueType>, std::map<std::pair<cmn::MediaCodecModuleId, cmn::DeviceId>, double>> _fault_triggers OV_GUARDED_BY(_mutex);
 };

--- a/src/projects/transcoder/transcoder_gpu.h
+++ b/src/projects/transcoder/transcoder_gpu.h
@@ -94,10 +94,10 @@ protected:
 	std::thread _thread;
 
 public:
-	std::mutex& GetDeviceMutex() {
+	ov::Mutex& GetDeviceMutex() {
 		return _device_mutex;
 	}
 protected:
 	// Global synchronization for specific hardware (Xilinx U30)
-	std::mutex _device_mutex;
+	ov::Mutex _device_mutex;
 };

--- a/src/projects/transcoder/transcoder_whisper_model_registry.cpp
+++ b/src/projects/transcoder/transcoder_whisper_model_registry.cpp
@@ -18,7 +18,7 @@
 
 bool WhisperModelRegistry::Preload(const std::vector<std::pair<ov::String, std::vector<int32_t>>> &models)
 {
-	std::lock_guard<std::mutex> lock(_mutex);
+	ov::LockGuard<ov::Mutex> lock(_mutex);
 
 #ifdef HWACCELS_NVIDIA_ENABLED
 	int device_count = 0;
@@ -191,7 +191,7 @@ void WhisperModelRegistry::LoadModel(const ov::String &path, int32_t cuda_device
 
 void WhisperModelRegistry::Uninitialize()
 {
-	std::lock_guard<std::mutex> lock(_mutex);
+	ov::LockGuard<ov::Mutex> lock(_mutex);
 	_models.clear();
 	_state_memory_bytes.clear();
 	logti("Whisper model registry cleared.");
@@ -199,7 +199,7 @@ void WhisperModelRegistry::Uninitialize()
 
 std::shared_ptr<whisper_context> WhisperModelRegistry::GetModelContext(const ov::String &model_path, int32_t cuda_device_id)
 {
-	std::lock_guard<std::mutex> lock(_mutex);
+	ov::LockGuard<ov::Mutex> lock(_mutex);
 
 	const std::string key = ov::String::FormatString("%s@%d", model_path.CStr(), cuda_device_id).CStr();
 
@@ -225,7 +225,7 @@ std::shared_ptr<whisper_context> WhisperModelRegistry::GetModelContext(const ov:
 
 whisper_state *WhisperModelRegistry::NewState(const ov::String &model_path, int32_t cuda_device_id)
 {
-	std::lock_guard<std::mutex> lock(_mutex);
+	ov::LockGuard<ov::Mutex> lock(_mutex);
 
 	const std::string key = ov::String::FormatString("%s@%d", model_path.CStr(), cuda_device_id).CStr();
 
@@ -269,7 +269,7 @@ void WhisperModelRegistry::DeleteState(whisper_state *state)
 {
 	// Serialized with NewState so whisper_free_state and whisper_init_state
 	// never run concurrently on the shared whisper context.
-	std::lock_guard<std::mutex> lock(_mutex);
+	ov::LockGuard<ov::Mutex> lock(_mutex);
 
 	if (state != nullptr)
 	{

--- a/src/projects/transcoder/transcoder_whisper_model_registry.h
+++ b/src/projects/transcoder/transcoder_whisper_model_registry.h
@@ -11,7 +11,6 @@
 #include <whisper.h>
 
 #include <memory>
-#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -44,11 +43,11 @@ public:
 
 private:
         // Load a single model on the specified CUDA device and cache it. Caller must hold _mutex.
-        void LoadModel(const ov::String &model_path, int32_t cuda_device_id = 0);
+        void LoadModel(const ov::String &model_path, int32_t cuda_device_id = 0) OV_REQUIRES(_mutex);
 
-	std::mutex _mutex;
-	std::unordered_map<std::string, std::shared_ptr<whisper_context>> _models;
+	ov::Mutex _mutex;
+	std::unordered_map<std::string, std::shared_ptr<whisper_context>> _models OV_GUARDED_BY(_mutex);
 	// GPU memory (bytes) consumed by one whisper_state for each model.
 	// Populated during GPU warmup; 0 means CPU model (no pre-check needed).
-	std::unordered_map<std::string, size_t> _state_memory_bytes;
+	std::unordered_map<std::string, size_t> _state_memory_bytes OV_GUARDED_BY(_mutex);
 };


### PR DESCRIPTION
## Summary

Adopt Clang Thread Safety Analysis (TSA) annotations across the codebase, building on the `ov::Mutex`/`ov::SharedMutex`/`ov::RecursiveMutex` wrappers and `OV_GUARDED_BY`/`OV_REQUIRES` macros introduced in #2183.

This PR is a **mechanical conversion**:

- `std::mutex` -> `ov::Mutex`, `std::shared_mutex` -> `ov::SharedMutex`, `std::recursive_mutex` -> `ov::RecursiveMutex`
- `std::lock_guard` -> `ov::LockGuard`, `std::shared_lock` -> `ov::SharedLockGuard`, `std::scoped_lock` -> `ov::ScopedLock`
- `std::condition_variable` -> `ov::ConditionVariable` with `Wait`/`NotifyOne`/`NotifyAll`
- `OV_GUARDED_BY(mutex)` on data members protected by a mutex
- `OV_REQUIRES(mutex)`/`OV_REQUIRES_SHARED(mutex)` on private/internal methods where the caller is expected to hold the lock
- `OV_NO_THREAD_SAFETY_ANALYSIS` on methods where correctness is established but the pattern is not expressible in TSA (e.g. OpenSSL BIO callbacks invoked while the caller holds a lock that TSA cannot see through)

A small number of straightforward issues found during review were fixed inline (e.g. missing annotations on guarded members, dead-code removal, access specifier restoration).

## Intentional TSA warnings in this version

More complex concurrency issues - such as members accessed under inconsistent locks (cross-lock), lockless reads of guarded data on hot paths, and members where no single mutex consistently guards all accesses - are **not addressed in this PR**. These require runtime behavior changes (adding locks, switching to atomics, redesigning lock hierarchies) that go beyond a mechanical annotation pass.

As a result, `-Wthread-safety` warnings are expected and intentional in this version. They make previously invisible data races visible at compile time, which is the goal of this step. Fixing the underlying races will follow in subsequent PRs.

Files where `std::mutex` is intentionally retained (due to manual `lock()`/`unlock()` patterns incompatible with RAII guards) are left as-is.

## What changed

- **No runtime behavior changes.** Locking order, granularity, and scope are identical to `master`. The only functional change is the type of mutex/lock objects, which are thin wrappers around the standard types.
- **No new locks or atomics.** This PR only annotates existing synchronization; it does not introduce new synchronization primitives.

## Exceptions to mechanical conversion

Two changes in this PR go beyond a strict type-swap and are intentional:

- **`Url::_query_parsed` (`bool` -> `std::atomic<bool>`)**: The original DCL pattern over a plain `bool` was a data race (UB). Replacing the mutex with `ov::Mutex` alone would have preserved the UB, so `_query_parsed` was converted to `std::atomic<bool>` with acquire/release ordering to make the existing DCL correct.

- **`Tls::PrepareBioMethod()` (DCL+mutex -> function-local static)**: The original DCL guarded a one-time singleton init - a textbook case for a C++11 function-local static, which the standard guarantees to be thread-safe. The trade-off is that a failed init (`nullptr`) is cached permanently instead of being retried, but the two failure modes (OOM in `BIO_meth_new` and OpenSSL state corruption in `BIO_meth_set_*`) are not recoverable by retry, so the behavioral difference is negligible in practice.
