### PR TITLE
feat(webrtc): support AV1 ingest over WHIP

### DIFF
--- a/src/projects/base/mediarouter/media_type.h
+++ b/src/projects/base/mediarouter/media_type.h
@@ -63,7 +63,8 @@ namespace cmn
 		MP2,
 
 		// Backward compatibility: Logically part of Video Track. Do not change the order.
-		AV1_OBU
+		AV1_OBU,
+		AV1_RTP_AOM	 // AV1 over RTP (https://aomediacodec.github.io/av1-rtp-spec/); track origin, depacketized to AV1_OBU
 	};
 
 	enum class PacketType : int8_t
@@ -413,6 +414,7 @@ namespace cmn
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, SEI);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, SCTE35);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, WebVTT);
+			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, AV1_RTP_AOM);
 		}
 
 		return "Unknown";

--- a/src/projects/modules/bitstream/av1/av1_parser.cpp
+++ b/src/projects/modules/bitstream/av1/av1_parser.cpp
@@ -51,6 +51,25 @@ std::optional<DecodedLeb128> Av1Parser::DecodeLeb128(const uint8_t *data, size_t
 	return std::nullopt;
 }
 
+size_t Av1Parser::EncodeLeb128(uint64_t value, uint8_t *buffer)
+{
+	// AV1 spec 4.10.5: low 7 bits per byte, MSB (`0x80`) set on every byte but the last. Capped at
+	// the 8-byte limit; the values written here (OBU payload sizes) stay far below that ceiling.
+	size_t i = 0;
+	do
+	{
+		uint8_t byte = value & 0x7F;
+		value >>= 7;
+		if (value != 0 && i < LEB128_MAX_SIZE - 1)
+		{
+			byte |= 0x80;
+		}
+		buffer[i++] = byte;
+	} while (value != 0 && i < LEB128_MAX_SIZE);
+
+	return i;
+}
+
 std::optional<Av1ObuHeader> Av1Parser::ParseObuHeader(BitReader &reader)
 {
 	if (reader.BytesRemained() < 1)

--- a/src/projects/modules/bitstream/av1/av1_parser.cpp
+++ b/src/projects/modules/bitstream/av1/av1_parser.cpp
@@ -53,19 +53,29 @@ std::optional<DecodedLeb128> Av1Parser::DecodeLeb128(const uint8_t *data, size_t
 
 size_t Av1Parser::EncodeLeb128(uint64_t value, uint8_t *buffer)
 {
-	// AV1 spec 4.10.5: low 7 bits per byte, MSB (`0x80`) set on every byte but the last. Capped at
-	// the 8-byte limit; the values written here (OBU payload sizes) stay far below that ceiling.
+	if (buffer == nullptr)
+	{
+		return 0;
+	}
+
+	// AV1 spec 4.10.5: low 7 bits per byte, MSB (`0x80`) set on every byte but the last. AV1 caps
+	// leb128 at 8 bytes; a value that still has bits left after 8 bytes is not representable.
 	size_t i = 0;
 	do
 	{
 		uint8_t byte = value & 0x7F;
 		value >>= 7;
-		if (value != 0 && i < LEB128_MAX_SIZE - 1)
+		if (value != 0)
 		{
 			byte |= 0x80;
 		}
 		buffer[i++] = byte;
 	} while (value != 0 && i < LEB128_MAX_SIZE);
+
+	if (value != 0)
+	{
+		return 0;
+	}
 
 	return i;
 }

--- a/src/projects/modules/bitstream/av1/av1_parser.h
+++ b/src/projects/modules/bitstream/av1/av1_parser.h
@@ -16,6 +16,9 @@
 class Av1Parser
 {
 public:
+	// AV1 spec 4.10.5: a `leb128()` value occupies at most 8 bytes.
+	static constexpr size_t LEB128_MAX_SIZE = 8;
+
 	/// Decode a `LEB128`-encoded unsigned integer per AV1 spec section 4.10.5.
 	///
 	/// Reads up to 8 bytes from `data`. The terminating byte is the first one whose continuation bit
@@ -27,6 +30,18 @@ public:
 	///
 	/// @return `DecodedLeb128` on success, `std::nullopt` if the buffer was exhausted before a terminator.
 	static std::optional<DecodedLeb128> DecodeLeb128(const uint8_t *data, size_t size);
+
+	/// Encode an unsigned integer as `LEB128` per AV1 spec section 4.10.5.
+	///
+	/// Writes 7 bits per byte, little-endian, setting the continuation bit (`0x80`) on every byte
+	/// but the last. At most 8 bytes (the AV1 limit).
+	///
+	/// @param value Value to encode.
+	///
+	/// @param buffer Output buffer; must hold at least `LEB128_MAX_SIZE` (8) bytes.
+	///
+	/// @return Number of bytes written (1..8).
+	static size_t EncodeLeb128(uint64_t value, uint8_t *buffer);
 
 	/// Parse `obu_header()` (and `obu_extension_header()` when `extension_flag` is set) per AV1 spec
 	/// sections 5.3.2 / 5.3.3.

--- a/src/projects/modules/bitstream/av1/av1_parser.h
+++ b/src/projects/modules/bitstream/av1/av1_parser.h
@@ -40,7 +40,8 @@ public:
 	///
 	/// @param buffer Output buffer; must hold at least `LEB128_MAX_SIZE` (8) bytes.
 	///
-	/// @return Number of bytes written (1..8).
+	/// @return Number of bytes written (1..8), or 0 if `buffer` is null or `value` does not fit in
+	/// AV1's 8-byte leb128 range.
 	static size_t EncodeLeb128(uint64_t value, uint8_t *buffer);
 
 	/// Parse `obu_header()` (and `obu_extension_header()` when `extension_flag` is set) per AV1 spec

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizer_av1.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizer_av1.cpp
@@ -1,0 +1,203 @@
+#include "rtp_depacketizer_av1.h"
+
+#include <modules/bitstream/av1/av1_parser.h>
+
+#define OV_LOG_TAG "RtpDepacketizerAV1"
+
+// Aggregation header bit masks (AV1 RTP Specification).
+#define AV1_AGG_Z 0x80
+#define AV1_AGG_Y 0x40
+#define AV1_AGG_W 0x30
+#define AV1_AGG_W_SHIFT 4
+
+// obu_header: obu_has_size_field is bit 1 (forbidden|type(4)|extension_flag|has_size_field|reserved).
+#define AV1_OBU_HAS_SIZE_FIELD 0x02
+
+std::shared_ptr<ov::Data> RtpDepacketizerAV1::ParseAndAssembleFrame(std::vector<std::shared_ptr<ov::Data>> payload_list)
+{
+	if (payload_list.empty())
+	{
+		return nullptr;
+	}
+
+	// Step 1: reassemble OBU elements across packets. Z continues the previous packet's last
+	// element; Y holds the current element open for the next packet. Elements are stored without
+	// a size field, exactly as carried over RTP.
+	std::vector<std::shared_ptr<ov::Data>> obu_elements;
+	std::shared_ptr<ov::Data> current = nullptr;
+	size_t reserve_size = 0;
+
+	for (const auto &payload : payload_list)
+	{
+		const uint8_t *data = payload->GetDataAs<uint8_t>();
+		const size_t size = payload->GetLength();
+		reserve_size += size + 8;	// + LEB128/size-field overhead headroom
+
+		if (size < 1)
+		{
+			logte("Empty AV1 RTP payload");
+			return nullptr;
+		}
+
+		const uint8_t agg = data[0];
+		const bool z = (agg & AV1_AGG_Z) != 0;
+		const bool y = (agg & AV1_AGG_Y) != 0;
+		const uint8_t w = (agg & AV1_AGG_W) >> AV1_AGG_W_SHIFT;
+
+		size_t offset = 1;
+		size_t index = 0;
+		while (offset < size)
+		{
+			size_t elem_len;
+			if (w == 0 || index + 1 < w)
+			{
+				// Length-prefixed OBU element.
+				auto leb = Av1Parser::DecodeLeb128(data + offset, size - offset);
+				if (leb.has_value() == false)
+				{
+					logte("Malformed AV1 OBU element length");
+					return nullptr;
+				}
+
+				offset += leb->bytes_consumed;
+				if (leb->value > size - offset)
+				{
+					logte("AV1 OBU element length exceeds packet");
+					return nullptr;
+				}
+
+				elem_len = static_cast<size_t>(leb->value);
+			}
+			else
+			{
+				// W>0: the last (W-th) element runs to the end of the packet.
+				elem_len = size - offset;
+			}
+
+			const uint8_t *elem_ptr = data + offset;
+			offset += elem_len;
+
+			const bool first_in_packet = (index == 0);
+			const bool last_in_packet = (w == 0) ? (offset == size) : (index + 1 == w);
+
+			if (first_in_packet && z)
+			{
+				// Continuation of the previous packet's last element.
+				if (current == nullptr)
+				{
+					logte("AV1 Z bit set but no fragment in progress");
+					return nullptr;
+				}
+				current->Append(elem_ptr, elem_len);
+			}
+			else
+			{
+				// A fresh element starts. Finalize a stale fragment, if any (defensive: a
+				// previous Y that the next packet did not actually continue).
+				if (current != nullptr)
+				{
+					obu_elements.push_back(current);
+				}
+				current = std::make_shared<ov::Data>(elem_ptr, elem_len);
+			}
+
+			if (last_in_packet && y)
+			{
+				// Continues into the next packet; keep accumulating into `current`.
+			}
+			else
+			{
+				obu_elements.push_back(current);
+				current = nullptr;
+			}
+
+			index++;
+			if (w != 0 && index == w)
+			{
+				break;
+			}
+		}
+	}
+
+	// A trailing Y with no continuation packet: finalize what we have.
+	if (current != nullptr)
+	{
+		obu_elements.push_back(current);
+		current = nullptr;
+	}
+
+	if (obu_elements.empty())
+	{
+		return nullptr;
+	}
+
+	// Step 2: rewrite each OBU into the low-overhead bitstream format (obu_has_size_field == 1).
+	auto bitstream = std::make_shared<ov::Data>(reserve_size);
+	ov::ByteStream stream(bitstream);
+
+	for (const auto &element : obu_elements)
+	{
+		if (WriteObuWithSizeField(stream, element->GetDataAs<uint8_t>(), element->GetLength()) == false)
+		{
+			logte("Failed to rewrite AV1 OBU");
+			return nullptr;
+		}
+	}
+
+	return bitstream;
+}
+
+bool RtpDepacketizerAV1::WriteObuWithSizeField(ov::ByteStream &stream, const uint8_t *obu, size_t obu_size)
+{
+	if (obu_size < 1)
+	{
+		return false;
+	}
+
+	auto parsed = Av1Parser::ParseObuHeader(obu, obu_size);
+	if (parsed.has_value() == false)
+	{
+		return false;
+	}
+
+	const size_t header_size = parsed->bytes_consumed;	// 1 byte, or 2 with the extension header
+
+	// Already low-overhead (size field present): copy verbatim.
+	if (parsed->header.has_size_field)
+	{
+		return stream.Write(obu, obu_size);
+	}
+
+	const size_t payload_size = obu_size - header_size;
+
+	// Set obu_has_size_field on the first header byte; the extension byte (if any) is unchanged.
+	const uint8_t header0 = static_cast<uint8_t>(obu[0] | AV1_OBU_HAS_SIZE_FIELD);
+	if (stream.WriteBE(header0) == false)
+	{
+		return false;
+	}
+	if (header_size == 2)
+	{
+		if (stream.WriteBE(obu[1]) == false)
+		{
+			return false;
+		}
+	}
+
+	uint8_t leb[Av1Parser::LEB128_MAX_SIZE];
+	const size_t leb_len = Av1Parser::EncodeLeb128(payload_size, leb);
+	if (stream.Write(leb, leb_len) == false)
+	{
+		return false;
+	}
+
+	if (payload_size > 0)
+	{
+		if (stream.Write(obu + header_size, payload_size) == false)
+		{
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizer_av1.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizer_av1.cpp
@@ -117,6 +117,13 @@ std::shared_ptr<ov::Data> RtpDepacketizerAV1::ParseAndAssembleFrame(std::vector<
 				break;
 			}
 		}
+
+		// W (when non-zero) is the exact OBU element count; a short packet that yields fewer is malformed.
+		if (w != 0 && index != w)
+		{
+			logte("AV1 aggregation header declares W=%u but %zu OBU element(s) present", w, index);
+			return nullptr;
+		}
 	}
 
 	// A trailing Y with no continuation packet: finalize what we have.
@@ -137,11 +144,23 @@ std::shared_ptr<ov::Data> RtpDepacketizerAV1::ParseAndAssembleFrame(std::vector<
 
 	for (const auto &element : obu_elements)
 	{
+		// A zero-length OBU element is non-conformant; skip just that element so one stray
+		// entry does not discard the whole temporal unit.
+		if (element->GetLength() == 0)
+		{
+			continue;
+		}
+
 		if (WriteObuWithSizeField(stream, element->GetDataAs<uint8_t>(), element->GetLength()) == false)
 		{
 			logte("Failed to rewrite AV1 OBU");
 			return nullptr;
 		}
+	}
+
+	if (bitstream->GetLength() == 0)
+	{
+		return nullptr;
 	}
 
 	return bitstream;
@@ -186,6 +205,10 @@ bool RtpDepacketizerAV1::WriteObuWithSizeField(ov::ByteStream &stream, const uin
 
 	uint8_t leb[Av1Parser::LEB128_MAX_SIZE];
 	const size_t leb_len = Av1Parser::EncodeLeb128(payload_size, leb);
+	if (leb_len == 0)
+	{
+		return false;
+	}
 	if (stream.Write(leb, leb_len) == false)
 	{
 		return false;

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizer_av1.h
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizer_av1.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <base/ovlibrary/byte_stream.h>
+
+#include "rtp_depacketizing_manager.h"
+#include "rtp_rtcp_defines.h"
+
+/*
+	AV1 RTP Specification (https://aomediacodec.github.io/av1-rtp-spec/)
+
+	[Aggregation header] (first byte of the payload)
+
+	 0 1 2 3 4 5 6 7
+	+-+-+-+-+-+-+-+-+
+	|Z|Y| W |N|-|-|-|
+	+-+-+-+-+-+-+-+-+
+
+	* Z : first OBU element is a continuation of the previous packet's last OBU element
+	* Y : last OBU element will continue in the next packet
+	* W : number of OBU elements in the packet (0 = each element has a length field)
+	* N : first packet of a new coded video sequence
+
+	When W == 0 every OBU element is preceded by a LEB128 length field. When W is 1..3 the
+	first W-1 elements are length-prefixed and the last element runs to the end of the packet.
+
+	OBU elements carry the OBU with obu_has_size_field == 0 (the size is conveyed by the RTP
+	framing). To produce a decodable low-overhead bitstream we reassemble fragmented elements
+	(Z/Y) and rewrite each OBU with obu_has_size_field == 1 plus a LEB128 obu_size.
+*/
+
+class RtpDepacketizerAV1 : public RtpDepacketizingManager
+{
+public:
+	std::shared_ptr<ov::Data> ParseAndAssembleFrame(std::vector<std::shared_ptr<ov::Data>> payload_list) override;
+
+private:
+	// Rewrite one reassembled OBU element (obu_has_size_field == 0) into the low-overhead format
+	// (obu_has_size_field == 1 + LEB128 size) and append it to the output stream.
+	bool WriteObuWithSizeField(ov::ByteStream &stream, const uint8_t *obu, size_t obu_size);
+};

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizer_av1_test.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizer_av1_test.cpp
@@ -1,0 +1,131 @@
+//==============================================================================
+//
+//  OvenMediaEngine - Unit Tests
+//
+//  Covers: RtpDepacketizerAV1 (AV1 RTP Specification)
+//          - aggregation header W field (0 / 1 / >1)
+//          - LEB128 length-prefixed elements
+//          - Z/Y fragment reassembly across packets
+//          - obu_has_size_field rewrite + extension header
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include "rtp_depacketizer_av1.h"
+
+namespace
+{
+	std::shared_ptr<ov::Data> Packet(const std::vector<uint8_t> &bytes)
+	{
+		return std::make_shared<ov::Data>(bytes.data(), bytes.size());
+	}
+
+	std::vector<uint8_t> ToVector(const std::shared_ptr<ov::Data> &data)
+	{
+		const auto *p = data->GetDataAs<uint8_t>();
+		return std::vector<uint8_t>(p, p + data->GetLength());
+	}
+
+	// OBU header bytes used below (forbidden=0, extension=0, has_size=0, reserved=0):
+	//   TemporalDelimiter (type 2) = 0x10, SequenceHeader (type 1) = 0x08, Frame (type 6) = 0x30
+	// After rewrite the parser sets obu_has_size_field (0x02): 0x12 / 0x0A / 0x32.
+}  // namespace
+
+// W=1: a single OBU element that runs to the end of the packet (no length prefix).
+TEST(RtpDepacketizerAV1, SingleObuW1)
+{
+	RtpDepacketizerAV1 depacketizer;
+
+	// agg=0x10 (W=1), Frame OBU header 0x30 + payload {0xAA,0xBB}
+	auto out = depacketizer.ParseAndAssembleFrame({Packet({0x10, 0x30, 0xAA, 0xBB})});
+	ASSERT_NE(out, nullptr);
+	EXPECT_EQ(ToVector(out), (std::vector<uint8_t>{0x32, 0x02, 0xAA, 0xBB}));
+}
+
+// W=0: every element is preceded by a LEB128 length field.
+TEST(RtpDepacketizerAV1, TwoObusW0LengthPrefixed)
+{
+	RtpDepacketizerAV1 depacketizer;
+
+	// agg=0x00 (W=0)
+	//  len=1 -> TD {0x10}
+	//  len=2 -> Frame {0x30,0xAA}
+	auto out = depacketizer.ParseAndAssembleFrame({Packet({0x00, 0x01, 0x10, 0x02, 0x30, 0xAA})});
+	ASSERT_NE(out, nullptr);
+	EXPECT_EQ(ToVector(out), (std::vector<uint8_t>{0x12, 0x00, 0x32, 0x01, 0xAA}));
+}
+
+// W>1: first W-1 elements length-prefixed, last element runs to end of packet.
+TEST(RtpDepacketizerAV1, ThreeObusW3)
+{
+	RtpDepacketizerAV1 depacketizer;
+
+	// agg=0x30 (W=3)
+	//  len=1 -> TD {0x10}
+	//  len=2 -> SeqHeader {0x08,0xAA}
+	//  (last) -> Frame {0x30,0xBB,0xCC}
+	auto out = depacketizer.ParseAndAssembleFrame(
+		{Packet({0x30, 0x01, 0x10, 0x02, 0x08, 0xAA, 0x30, 0xBB, 0xCC})});
+	ASSERT_NE(out, nullptr);
+	EXPECT_EQ(ToVector(out),
+			  (std::vector<uint8_t>{0x12, 0x00, 0x0A, 0x01, 0xAA, 0x32, 0x02, 0xBB, 0xCC}));
+}
+
+// One OBU fragmented across two packets: packet1 Y=1 (continues), packet2 Z=1 (continuation).
+TEST(RtpDepacketizerAV1, FragmentedObuReassembled)
+{
+	RtpDepacketizerAV1 depacketizer;
+
+	// packet1: agg=0x50 (W=1, Y=1), Frame header 0x30 + first payload byte 0xAA
+	// packet2: agg=0x90 (W=1, Z=1), continuation bytes {0xBB,0xCC}
+	auto out = depacketizer.ParseAndAssembleFrame(
+		{Packet({0x50, 0x30, 0xAA}), Packet({0x90, 0xBB, 0xCC})});
+	ASSERT_NE(out, nullptr);
+	// Reassembled OBU: header 0x30 + payload {0xAA,0xBB,0xCC}
+	EXPECT_EQ(ToVector(out), (std::vector<uint8_t>{0x32, 0x03, 0xAA, 0xBB, 0xCC}));
+}
+
+// OBU with an extension header byte: the extension byte is preserved, size field inserted after it.
+TEST(RtpDepacketizerAV1, ObuWithExtensionHeader)
+{
+	RtpDepacketizerAV1 depacketizer;
+
+	// agg=0x10 (W=1), header 0x34 (Frame, extension_flag=1), ext byte 0x00, payload {0xAA}
+	auto out = depacketizer.ParseAndAssembleFrame({Packet({0x10, 0x34, 0x00, 0xAA})});
+	ASSERT_NE(out, nullptr);
+	EXPECT_EQ(ToVector(out), (std::vector<uint8_t>{0x36, 0x00, 0x01, 0xAA}));
+}
+
+// An element that already carries obu_has_size_field == 1 is passed through verbatim.
+TEST(RtpDepacketizerAV1, AlreadyHasSizeFieldPassthrough)
+{
+	RtpDepacketizerAV1 depacketizer;
+
+	// agg=0x10 (W=1), header 0x32 (has_size_field=1), size 0x01, payload {0xAA}
+	auto out = depacketizer.ParseAndAssembleFrame({Packet({0x10, 0x32, 0x01, 0xAA})});
+	ASSERT_NE(out, nullptr);
+	EXPECT_EQ(ToVector(out), (std::vector<uint8_t>{0x32, 0x01, 0xAA}));
+}
+
+// Empty payload list -> null.
+TEST(RtpDepacketizerAV1, EmptyPayloadListReturnsNull)
+{
+	RtpDepacketizerAV1 depacketizer;
+	EXPECT_EQ(depacketizer.ParseAndAssembleFrame({}), nullptr);
+}
+
+// A zero-length payload (valid empty Data, no aggregation header byte) -> null.
+TEST(RtpDepacketizerAV1, EmptyPacketReturnsNull)
+{
+	RtpDepacketizerAV1 depacketizer;
+	EXPECT_EQ(depacketizer.ParseAndAssembleFrame({std::make_shared<ov::Data>()}), nullptr);
+}
+
+// A LEB128 element length that overruns the packet -> null.
+TEST(RtpDepacketizerAV1, ElementLengthExceedsPacketReturnsNull)
+{
+	RtpDepacketizerAV1 depacketizer;
+
+	// agg=0x00 (W=0), len=5 but only 1 byte follows
+	EXPECT_EQ(depacketizer.ParseAndAssembleFrame({Packet({0x00, 0x05, 0x30})}), nullptr);
+}

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizer_av1_test.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizer_av1_test.cpp
@@ -129,3 +129,32 @@ TEST(RtpDepacketizerAV1, ElementLengthExceedsPacketReturnsNull)
 	// agg=0x00 (W=0), len=5 but only 1 byte follows
 	EXPECT_EQ(depacketizer.ParseAndAssembleFrame({Packet({0x00, 0x05, 0x30})}), nullptr);
 }
+
+// A stray zero-length element is skipped; the rest of the temporal unit survives.
+TEST(RtpDepacketizerAV1, ZeroLengthElementSkippedNotDropped)
+{
+	RtpDepacketizerAV1 depacketizer;
+
+	// agg=0x00 (W=0); len=0 -> empty element; len=2 -> Frame {0x30,0xAA}
+	auto out = depacketizer.ParseAndAssembleFrame({Packet({0x00, 0x00, 0x02, 0x30, 0xAA})});
+	ASSERT_NE(out, nullptr);
+	EXPECT_EQ(ToVector(out), (std::vector<uint8_t>{0x32, 0x01, 0xAA}));
+}
+
+// A temporal unit consisting solely of zero-length elements yields no OBU -> null.
+TEST(RtpDepacketizerAV1, OnlyZeroLengthElementsReturnsNull)
+{
+	RtpDepacketizerAV1 depacketizer;
+
+	// agg=0x00 (W=0); single len=0 element
+	EXPECT_EQ(depacketizer.ParseAndAssembleFrame({Packet({0x00, 0x00})}), nullptr);
+}
+
+// W declares more elements than the packet actually contains -> null.
+TEST(RtpDepacketizerAV1, WCountMismatchReturnsNull)
+{
+	RtpDepacketizerAV1 depacketizer;
+
+	// agg=0x30 (W=3) but only one element (len=1 -> {0x10}) is present
+	EXPECT_EQ(depacketizer.ParseAndAssembleFrame({Packet({0x30, 0x01, 0x10})}), nullptr);
+}

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizing_manager.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizing_manager.cpp
@@ -5,6 +5,7 @@
 #include "rtp_depacketizer_h264.h"
 #include "rtp_depacketizer_h265.h"
 #include "rtp_depacketizer_vp8.h"
+#include "rtp_depacketizer_av1.h"
 
 std::shared_ptr<RtpDepacketizingManager> RtpDepacketizingManager::Create(SupportedDepacketizerType type)
 {
@@ -16,6 +17,8 @@ std::shared_ptr<RtpDepacketizingManager> RtpDepacketizingManager::Create(Support
 			return std::make_shared<RtpDepacketizerH265>();			
 		case RtpDepacketizingManager::SupportedDepacketizerType::VP8:
 			return std::make_shared<RtpDepacketizerVP8>();
+		case RtpDepacketizingManager::SupportedDepacketizerType::AV1:
+			return std::make_shared<RtpDepacketizerAV1>();
 		case RtpDepacketizingManager::SupportedDepacketizerType::MPEG4_GENERIC_AUDIO:
 			return std::make_shared<RtpDepacketizerMpeg4GenericAudio>();
 		case RtpDepacketizingManager::SupportedDepacketizerType::OPUS:

--- a/src/projects/modules/rtp_rtcp/rtp_depacketizing_manager.h
+++ b/src/projects/modules/rtp_rtcp/rtp_depacketizing_manager.h
@@ -14,6 +14,7 @@ public:
 		H264,
 		H265,
 		VP8,
+		AV1,
 		OPUS,
 		MPEG4_GENERIC_AUDIO
 	};

--- a/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_rtcp.cpp
@@ -71,6 +71,7 @@ bool RtpRtcp::AddRtpReceiver(const std::shared_ptr<MediaTrack> &track, const Rtp
 			case cmn::BitstreamFormat::H264_RTP_RFC_6184:
 			case cmn::BitstreamFormat::H265_RTP_RFC_7798:
 			case cmn::BitstreamFormat::VP8_RTP_RFC_7741:
+			case cmn::BitstreamFormat::AV1_RTP_AOM:
 			{
 				auto buf = std::make_shared<RtpFrameJitterBuffer>();
 				buf->SetClockRate(track->GetTimeBase().GetDen());
@@ -902,6 +903,7 @@ bool RtpRtcp::OnRtpReceived(NodeType from_node, const std::shared_ptr<const ov::
 		case cmn::BitstreamFormat::H264_RTP_RFC_6184:
 		case cmn::BitstreamFormat::H265_RTP_RFC_7798:
 		case cmn::BitstreamFormat::VP8_RTP_RFC_7741:
+		case cmn::BitstreamFormat::AV1_RTP_AOM:
 			jitter_buffer_kind = JitterBufferKind::Frame;
 			break;
 		case cmn::BitstreamFormat::OPUS_RTP_RFC_7587:

--- a/src/projects/modules/sdp/payload_attr.cpp
+++ b/src/projects/modules/sdp/payload_attr.cpp
@@ -58,6 +58,10 @@ void PayloadAttr::SetRtpmap(const uint8_t payload_type, const ov::String &codec,
 	{
 		_codec = SupportCodec::VP9;
 	}
+	else if(codec.LowerCaseString() == "av1")
+	{
+		_codec = SupportCodec::AV1;
+	}
 	else if(codec.LowerCaseString() == "opus")
 	{
 		_codec = SupportCodec::OPUS;

--- a/src/projects/modules/sdp/payload_attr.h
+++ b/src/projects/modules/sdp/payload_attr.h
@@ -24,6 +24,7 @@ public:
 		VP9,
 		H264,
 		H265,
+		AV1,
 		MPEG4_GENERIC,
 		OPUS,
 		RED,

--- a/src/projects/providers/webrtc/webrtc_application.cpp
+++ b/src/projects/providers/webrtc/webrtc_application.cpp
@@ -348,6 +348,7 @@ namespace pvd
 				if (codec == PayloadAttr::SupportCodec::H264 ||
 					codec == PayloadAttr::SupportCodec::H265 ||
 					codec == PayloadAttr::SupportCodec::VP8 ||
+					codec == PayloadAttr::SupportCodec::AV1 ||
 					codec == PayloadAttr::SupportCodec::OPUS)
 				{
 					accepted_primary_pts.insert(offer_payload->GetId());
@@ -360,6 +361,7 @@ namespace pvd
 				if (offer_payload->GetCodec() != PayloadAttr::SupportCodec::H264 &&
 					offer_payload->GetCodec() != PayloadAttr::SupportCodec::H265 &&
 					offer_payload->GetCodec() != PayloadAttr::SupportCodec::VP8 &&
+					offer_payload->GetCodec() != PayloadAttr::SupportCodec::AV1 &&
 					offer_payload->GetCodec() != PayloadAttr::SupportCodec::OPUS &&
 					offer_payload->GetCodec() != PayloadAttr::SupportCodec::RTX)
 				{

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -10,13 +10,17 @@
 #include "webrtc_stream.h"
 
 #include "base/ovlibrary/converter.h"
-#include "base/ovlibrary/dump_utilities.h"
 #include "base/ovlibrary/random.h"
 #include "modules/rtp_rtcp/rtcp_info/sender_report.h"
 #include "modules/rtp_rtcp/rtp_header_extension/rtp_header_extension.h"
 #include "webrtc_application.h"
 #include "webrtc_private.h"
 #include "webrtc_provider.h"
+
+#if DEBUG
+#	include "base/ovlibrary/dump_utilities.h"
+#	include "base/ovlibrary/path_manager.h"
+#endif	// DEBUG
 
 namespace pvd
 {
@@ -904,20 +908,23 @@ namespace pvd
 				return;
 		}
 
-		// Debug tool (disabled): dump assembled AV1 OBU temporal units to
-		// av1_dump_<stream>_track<id>.obu in the working directory. Each temporal unit is prefixed
-		// with a Temporal Delimiter OBU so the file is a standard low-overhead .obu stream that
-		// ffmpeg/dav1d can decode directly. Flip to #if 1 to enable.
-#if 0
-		if (bitstream_format == cmn::BitstreamFormat::AV1_OBU)
+#if DEBUG
+		// When OME_DUMP_WHIP is set, dump assembled AV1 OBU temporal units to
+		// <app>/dump/whip/<stream>_track<id>.obu. Each temporal unit is prefixed with a Temporal
+		// Delimiter OBU so the file is a standard low-overhead .obu stream that ffmpeg/dav1d can
+		// decode directly.
+		static const bool dump_whip = ov::Converter::ToBool(std::getenv("OME_DUMP_WHIP"));
+		if (dump_whip && bitstream_format == cmn::BitstreamFormat::AV1_OBU)
 		{
 			auto safe_name = GetName().Replace("/", "_").Replace("#", "_");
-			auto dump_path = ov::String::FormatString("av1_dump_%s_track%u.obu", safe_name.CStr(), track->GetId());
+			auto dump_path = ov::PathManager::Combine(
+				ov::PathManager::GetAppPath("dump/whip"),
+				ov::String::FormatString("%s_track%u.obu", safe_name.CStr(), track->GetId()));
 			static const uint8_t td_obu[2] = {0x12, 0x00};	// Temporal Delimiter OBU (type 2, size 0)
 			ov::DumpToFile(dump_path.CStr(), td_obu, sizeof(td_obu), 0, true);
 			ov::DumpToFile(dump_path.CStr(), bitstream, 0, true);
 		}
-#endif
+#endif	// DEBUG
 
 		int64_t adjusted_timestamp;
 		if (AdjustRtpTimestamp(track_id, first_rtp_packet->Timestamp(), std::numeric_limits<uint32_t>::max(), adjusted_timestamp) == false)

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -10,6 +10,7 @@
 #include "webrtc_stream.h"
 
 #include "base/ovlibrary/converter.h"
+#include "base/ovlibrary/dump_utilities.h"
 #include "base/ovlibrary/random.h"
 #include "modules/rtp_rtcp/rtcp_info/sender_report.h"
 #include "modules/rtp_rtcp/rtp_header_extension/rtp_header_extension.h"
@@ -440,6 +441,13 @@ namespace pvd
 			track->SetOriginBitstream(cmn::BitstreamFormat::VP8_RTP_RFC_7741);
 			track->SetVideoTimestampScale(1.0);
 		}
+		else if (codec == PayloadAttr::SupportCodec::AV1)
+		{
+			track->SetMediaType(cmn::MediaType::Video);
+			track->SetCodecId(cmn::MediaCodecId::Av1);
+			track->SetOriginBitstream(cmn::BitstreamFormat::AV1_RTP_AOM);
+			track->SetVideoTimestampScale(1.0);
+		}
 		else
 		{
 			logte("%s - Unsupported codec : codec(%d)", GetName().CStr(), static_cast<uint8_t>(codec));
@@ -684,6 +692,10 @@ namespace pvd
 				depacketizer_codec_id = RtpDepacketizingManager::SupportedDepacketizerType::VP8;
 				break;
 
+			case cmn::MediaCodecId::Av1:
+				depacketizer_codec_id = RtpDepacketizingManager::SupportedDepacketizerType::AV1;
+				break;
+
 			case cmn::MediaCodecId::Aac:
 				depacketizer_codec_id = RtpDepacketizingManager::SupportedDepacketizerType::MPEG4_GENERIC_AUDIO;
 				break;
@@ -881,10 +893,31 @@ namespace pvd
 				packet_type = cmn::PacketType::RAW;
 				break;
 
+			case cmn::MediaCodecId::Av1:
+				// Depacketizer emits a low-overhead OBU temporal unit
+				bitstream_format = cmn::BitstreamFormat::AV1_OBU;
+				packet_type = cmn::PacketType::RAW;
+				break;
+
 			// It can't be reached here because it has already failed in GetDepacketizer.
 			default:
 				return;
 		}
+
+		// Debug tool (disabled): dump assembled AV1 OBU temporal units to
+		// av1_dump_<stream>_track<id>.obu in the working directory. Each temporal unit is prefixed
+		// with a Temporal Delimiter OBU so the file is a standard low-overhead .obu stream that
+		// ffmpeg/dav1d can decode directly. Flip to #if 1 to enable.
+#if 0
+		if (bitstream_format == cmn::BitstreamFormat::AV1_OBU)
+		{
+			auto safe_name = GetName().Replace("/", "_").Replace("#", "_");
+			auto dump_path = ov::String::FormatString("av1_dump_%s_track%u.obu", safe_name.CStr(), track->GetId());
+			static const uint8_t td_obu[2] = {0x12, 0x00};	// Temporal Delimiter OBU (type 2, size 0)
+			ov::DumpToFile(dump_path.CStr(), td_obu, sizeof(td_obu), 0, true);
+			ov::DumpToFile(dump_path.CStr(), bitstream, 0, true);
+		}
+#endif
 
 		int64_t adjusted_timestamp;
 		if (AdjustRtpTimestamp(track_id, first_rtp_packet->Timestamp(), std::numeric_limits<uint32_t>::max(), adjusted_timestamp) == false)


### PR DESCRIPTION
WHIP ingest negotiates only H264/H265/VP8, so AV1 senders such as OBS and Chrome cannot publish.

Add AV1 to the WebRTC SDP codec negotiation and a new AV1 RTP depacketizer that reassembles OBU temporal units into the low-overhead AV1_OBU stream the MediaRouter normalizer already consumes.