### PR TITLE
ci: add CLA Assistant GitHub Action workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,9 +29,9 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-path-to-document: 'https://raw.githubusercontent.com/${{ github.repository }}/${{ github.event.repository.default_branch }}/CLA.md'
+          path-to-document: 'https://raw.githubusercontent.com/${{ github.repository }}/${{ github.event.repository.default_branch }}/CLA.md'
           branch: 'main'
           # Bots are exempt. Add core maintainers (corporate CLA holders) here, comma-separated, no spaces.
-allowlist: 'dependabot[bot],*[bot]'
+          allowlist: 'dependabot[bot],*[bot]'
           remote-organization-name: OvenMediaLabs
           remote-repository-name: cla-signatures

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,37 @@
+name: "CLA Assistant"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    name: CLA Assistant
+    runs-on: ubuntu-latest
+    steps:
+      # contributor-assistant/github-action pinned to the forked v2.6.1 commit
+      # (upstream is archived; the fork lives at OvenMediaLabs/cla-github-action).
+      # Signatures are stored in the private OvenMediaLabs/cla-signatures repo.
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: OvenMediaLabs/cla-github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT with write access to OvenMediaLabs/cla-signatures (repo secret)
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CLA.md'
+          branch: 'main'
+          # Bots are exempt. Add core maintainers (corporate CLA holders) here, comma-separated, no spaces.
+          allowlist: dependabot[bot],*[bot]
+          remote-organization-name: OvenMediaLabs
+          remote-repository-name: cla-signatures

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,7 +21,7 @@ jobs:
       # (upstream is archived; the fork lives at OvenMediaLabs/cla-github-action).
       # Signatures are stored in the private OvenMediaLabs/cla-signatures repo.
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: (github.event_name == 'issue_comment' && github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
         uses: OvenMediaLabs/cla-github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,7 +29,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CLA.md'
+path-to-document: 'https://raw.githubusercontent.com/${{ github.repository }}/${{ github.event.repository.default_branch }}/CLA.md'
           branch: 'main'
           # Bots are exempt. Add core maintainers (corporate CLA holders) here, comma-separated, no spaces.
 allowlist: 'dependabot[bot],*[bot]'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,7 +4,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    types: [opened, synchronize]
 
 permissions:
   contents: read

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -32,6 +32,6 @@ jobs:
           path-to-document: 'https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CLA.md'
           branch: 'main'
           # Bots are exempt. Add core maintainers (corporate CLA holders) here, comma-separated, no spaces.
-          allowlist: dependabot[bot],*[bot]
+allowlist: 'dependabot[bot],*[bot]'
           remote-organization-name: OvenMediaLabs
           remote-repository-name: cla-signatures

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,8 +7,8 @@ on:
     types: [opened, closed, synchronize]
 
 permissions:
-  actions: write
-  contents: write
+  contents: read
+  issues: write
   pull-requests: write
   statuses: write
 


### PR DESCRIPTION
## Summary

Replaces the externally hosted **cla-assistant.io** GitHub App with an **in-repo GitHub Action** for collecting Contributor License Agreement signatures. Contributors will be able to sign the CLA directly in the pull request by posting a comment, with no round-trip to an external service — this addresses the latency of the current SaaS-based flow.

### What changes
- Adds `.github/workflows/cla.yml` using [`contributor-assistant/github-action`](https://github.com/contributor-assistant/github-action), pinned to the **v2.6.1 commit** (`ca4a40a`) of our fork at **`OvenMediaLabs/cla-github-action`**. Upstream was archived in 2026-03, so we run from a fork pinned by commit SHA to avoid supply-chain/archive risk.
- Signature records are stored in the private **`OvenMediaLabs/cla-signatures`** repo. The `master` branch here is protected and cannot receive signature commits, so a dedicated remote repo is used.
- Reuses the existing `CLA.md` as the signed document.

### How signing works
1. A contributor opens a PR → the bot comments asking unsigned contributors to sign, and sets a failing status check.
2. The contributor comments: `I have read the CLA Document and I hereby sign the CLA`.
3. The signature is recorded in `cla-signatures` and the status check turns green. `recheck` re-runs the check.

Only bots (`*[bot]`) are exempt via the allowlist; maintainers sign like any other contributor.

## Prerequisites before merge
- [x] `CLA_SIGNATURES_TOKEN` repo secret set (PAT with write access to `cla-signatures`).
- [x] Existing signers migrated from cla-assistant.io into `signatures/version1/cla.json` (17 signers across both CLA document versions; the only diff between versions was the company rename AirenSoft → OvenMedia Labs).
- [x] Allowlist policy decided: bots only.

## Rollout
This runs **in parallel** with the existing cla-assistant.io app. After verifying the full flow on a test PR (and that migrated signers are not re-prompted), the cla-assistant.io app and its required status check will be removed.

## Test plan
- Open a test PR from a non-allowlisted account → confirm the bot requests a signature.
- Comment the sign phrase → confirm the check passes and an entry appears in `cla-signatures`.
- Confirm a migrated signer is not asked to re-sign.