### PR TITLE
test: verify CLA check blocks merge when unsigned

### DIFF
--- a/CLA_VERIFY_BLOCK_DELETE_ME.md
+++ b/CLA_VERIFY_BLOCK_DELETE_ME.md
@@ -1,0 +1,4 @@
+# CLA merge-block verification
+
+Temporary PR to verify the CLA Assistant required check blocks merge for an unsigned contributor.
+Will be closed without merging.


### PR DESCRIPTION
Temporary PR to verify the now-required CLA Assistant check blocks merge for an unsigned contributor (choigilhoon removed from signatures for this test). **Will be closed without merging.**