### PR TITLE
fix(ci): grant actions:write so CLA check updates after signing

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,6 +7,9 @@ on:
     types: [opened, synchronize]
 
 permissions:
+  # actions: write is required so the action can re-run the PR workflow
+  # after a contributor signs, flipping the CLA Assistant check to passing.
+  actions: write
   contents: read
   issues: write
   pull-requests: write


### PR DESCRIPTION
## Problem

After a contributor signs the CLA by commenting on a PR, the `CLA Assistant` status check stayed **failing** even though the signature was recorded in `cla-signatures`.

Root cause: the `CLA Assistant` check is the workflow job's own check-run. When someone signs via comment, the action records the signature and then **re-runs the `pull_request_target` workflow** so the job re-evaluates and the check turns green. That re-run API call requires the **`actions: write`** permission, which was dropped from the `permissions` block during review of #2188. Without it the action logs:

```
All contributors have signed the CLA ✅
##[error]Error occurred when re-running the workflow: HttpError: Resource not accessible by integration
```

So the signature is saved but the red check never clears.

## Fix

Add `actions: write` back to the workflow `permissions` block (it is part of the action's official example for exactly this reason). `contents` stays `read` because signatures are stored in the remote `cla-signatures` repo via the PAT, not in this repo.

## Test plan

After merge: with a contributor removed from the signatures file, open a PR → check fails & merge is blocked → comment the sign phrase → confirm the check flips to passing and the PR becomes mergeable.