### PR TITLE
test: re-verify CLA flow after actions:write fix

### DIFF
--- a/CLA_REVERIFY_DELETE_ME.md
+++ b/CLA_REVERIFY_DELETE_ME.md
@@ -1,0 +1,4 @@
+# CLA re-verification after actions:write fix
+
+Temporary PR to verify the full CLA flow: unsigned -> blocked -> sign comment -> check turns green -> mergeable.
+Will be closed without merging.


### PR DESCRIPTION
Temporary PR to verify, after the actions:write fix, that an unsigned contributor is blocked and that signing via comment now flips the check to green. **Will be closed without merging.**