### PR TITLE
fix(tsa): resolve data races surfaced by thread-safety annotations across modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ logs
 build
 run
 
+# Ignore local temporary build trees (e.g. compile_commands / test builds)
+__temp_build/
+__test_build/
+
 # Ignore pugixml's build directory
 src/projects/third_party/pugixml-1.9/scripts/gmake
 

--- a/src/projects/base/info/CMakeLists.txt
+++ b/src/projects/base/info/CMakeLists.txt
@@ -6,3 +6,10 @@ ome_add_static_library(base_info
         ovcrypto
         ovlibrary
 )
+
+if(OME_BUILD_TESTS)
+    file(GLOB _srcs "${CMAKE_CURRENT_SOURCE_DIR}/*_test.cpp")
+    ome_add_tests(ome_test_base
+        SRCS ${_srcs}
+    )
+endif()

--- a/src/projects/base/info/managed_queue.h
+++ b/src/projects/base/info/managed_queue.h
@@ -57,9 +57,9 @@ namespace info
 			TimeBased  = 1
 		};
 
-		const char *GetThresholdModeString() const
+		static const char *GetThresholdModeString(ThresholdMode threshold_mode)
 		{
-			switch (_threshold_mode)
+			switch (threshold_mode)
 			{
 			case ThresholdMode::CountBased:
 				return "CountBased";
@@ -175,6 +175,7 @@ namespace info
 
 		ov::String GetTypeName() const
 		{
+			ov::SharedLockGuard lock_guard(_name_mutex);
 			return _type_name;
 		}
 
@@ -203,6 +204,7 @@ namespace info
 
 		ThresholdMode GetThresholdMode() const
 		{
+			ov::SharedLockGuard lock_guard(_name_mutex);
 			return _threshold_mode;
 		}
 
@@ -211,11 +213,13 @@ namespace info
 		//   TimeBased  mode → milliseconds
 		size_t GetThresholdValue() const
 		{
+			ov::SharedLockGuard lock_guard(_name_mutex);
 			return _threshold_value;
 		}
 
 		size_t GetThreshold() const
 		{
+			ov::SharedLockGuard lock_guard(_name_mutex);
 			return _threshold;
 		}
 
@@ -264,11 +268,13 @@ namespace info
 
 		std::shared_ptr<URN> GetUrn() const
 		{
+			ov::SharedLockGuard lock_guard(_name_mutex);
 			return _urn;
 		}
 
 		ov::String ToString() const
 		{
+			ov::SharedLockGuard lock_guard(_name_mutex);
 			if(_urn == nullptr)
 			{
 				return "No Urn";
@@ -289,7 +295,7 @@ namespace info
 		managed_queue_id_t _id = 0;
 
 		// Name of the queue
-		ov::SharedMutex _name_mutex;
+		mutable ov::SharedMutex _name_mutex;
 		std::shared_ptr<URN> _urn OV_GUARDED_BY(_name_mutex);
 
 		// Type of template

--- a/src/projects/base/info/managed_queue.h
+++ b/src/projects/base/info/managed_queue.h
@@ -291,8 +291,8 @@ namespace info
 		}
 
 	protected:
-		// ID of the queue
-		managed_queue_id_t _id = 0;
+		// ID of the queue (set once at registration)
+		std::atomic<managed_queue_id_t> _id{0};
 
 		// Name of the queue
 		mutable ov::SharedMutex _name_mutex;
@@ -301,11 +301,18 @@ namespace info
 		// Type of template
 		ov::String _type_name OV_GUARDED_BY(_name_mutex);
 
+		// The ATOMIC metric members below are written only under the derived queue's
+		// `_mutex` (kept consistent with the queue contents there);
+		// they are atomic so that lock-free diagnostic/monitoring reads
+		// (`GetSize()`/`GetInfoString()`/...) are well-defined.
+		// TSA cannot model atomics, hence no `OV_GUARDED_BY`.
+		// (`_threshold*` members are a separate group, guarded by `_name_mutex`.)
+
 		// Peak size of the queue
-		size_t _peak = 0;
+		std::atomic<size_t> _peak{0};
 
 		// Current size of the queue
-		size_t _size = 0;
+		std::atomic<size_t> _size{0};
 
 		// Threshold value computed according to the Threshold Mode.
 		// 0 : No threshold
@@ -321,26 +328,26 @@ namespace info
 		std::atomic<int64_t> _threshold_exceeded_time_ms{0};
 
 		// Buffering delay (milliseconds).
-		int _buffering_delay = 0;
+		std::atomic<int> _buffering_delay{0};
 
 		// Input Message Count
-		int64_t _input_message_count = 0;
-		int64_t _last_input_message_count = 0;
+		std::atomic<int64_t> _input_message_count{0};
+		std::atomic<int64_t> _last_input_message_count{0};
 		// Output Message Count
-		int64_t _output_message_count = 0;
-		int64_t _last_output_message_count = 0;
+		std::atomic<int64_t> _output_message_count{0};
+		std::atomic<int64_t> _last_output_message_count{0};
 
 		// Input Message Per Second
-		size_t _input_message_per_second = 0;
+		std::atomic<size_t> _input_message_per_second{0};
 
 		// Output Message Per Second
-		size_t _output_message_per_second = 0;
+		std::atomic<size_t> _output_message_per_second{0};
 
 		// Average Waiting Time(microseconds)
-		int64_t _waiting_time_in_us = 0;
+		std::atomic<int64_t> _waiting_time_in_us{0};
 
 		// Drop Count
-		uint64_t _drop_message_count = 0;
+		std::atomic<uint64_t> _drop_message_count{0};
 	};
 
 }  // namespace info

--- a/src/projects/base/info/media_track.cpp
+++ b/src/projects/base/info/media_track.cpp
@@ -674,7 +674,7 @@ void MediaTrack::OnFrameAdded(const std::shared_ptr<MediaPacket> &media_packet)
 	}
 	else
 	{
-		auto duration = (media_packet->GetDts() - _last_received_timestamp) * _time_base.GetExpr();
+		auto duration = (media_packet->GetDts() - _last_received_timestamp) * GetTimeBase().GetExpr();
 		if (duration >= 1.0)
 		{
 			SetBitrateByMeasured(static_cast<int32_t>(_last_frame_bytes / duration * 8));

--- a/src/projects/base/info/stream.cpp
+++ b/src/projects/base/info/stream.cpp
@@ -48,7 +48,7 @@ namespace info
 		_id = stream._id;
 		_name = stream._name;
 		_source_type = stream._source_type;
-		_source_url = stream._source_url;
+		_source_url = stream.GetMediaSource();
 		_output_profile_name = stream._output_profile_name;
 		_created_time = stream._created_time;
 		_published_time = stream._published_time;
@@ -168,10 +168,12 @@ namespace info
 
 	ov::String Stream::GetMediaSource() const
 	{
+		ov::LockGuard lock(_source_url_mutex);
 		return _source_url;
 	}
 	void Stream::SetMediaSource(ov::String url)
 	{
+		ov::LockGuard lock(_source_url_mutex);
 		_source_url = url;
 	}
 

--- a/src/projects/base/info/stream.h
+++ b/src/projects/base/info/stream.h
@@ -172,7 +172,9 @@ namespace info
 		info::stream_id_t _id = 0;
 		uint32_t _msid = 0;
 		ov::String _name;
-		ov::String _source_url;
+		// Rewritten on every pull-stream failover, read from monitoring/serdes/publisher threads
+		mutable ov::Mutex _source_url_mutex;
+		ov::String _source_url OV_GUARDED_BY(_source_url_mutex);
 		ov::String _output_profile_name;
 		
 		// Key : MediaTrack ID

--- a/src/projects/base/info/stream_test.cpp
+++ b/src/projects/base/info/stream_test.cpp
@@ -1,0 +1,124 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <base/info/stream.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+// Tests for `info::Stream` thread-safety fixes on this branch:
+// `_source_url` is rewritten on every pull-stream failover (`SetMediaSource()`)
+// while monitoring/serdes/publisher threads read it concurrently;
+// both accessors now synchronize on `_source_url_mutex`.
+// These tests pin the value-integrity contract
+// (a reader/copier can only ever observe a fully written value, never a torn one)
+// and are intended to run under TSan as well,
+// where the pre-fix code would report a data race.
+
+namespace
+{
+	const ov::String kUrlA = "ovt://primary.example.com:9000/app/stream";
+	const ov::String kUrlB = "ovt://backup.example.com:9000/app/stream-with-a-long-tail-to-force-heap-allocation";
+
+	bool IsExpectedValue(const ov::String &value)
+	{
+		// Empty is allowed only before the writer has stored anything
+		return value.IsEmpty() || (value == kUrlA) || (value == kUrlB);
+	}
+}  // namespace
+
+TEST(InfoStreamSourceUrl, ConcurrentSetAndGetObservesOnlyWholeValues)
+{
+	info::Stream stream(StreamSourceType::Ovt);
+
+	std::atomic<bool> stop{false};
+	std::atomic<uint64_t> read_count{0};
+	std::atomic<bool> all_reads_valid{true};
+
+	std::thread writer([&] {
+		bool flip = false;
+		while (stop.load() == false)
+		{
+			stream.SetMediaSource(flip ? kUrlA : kUrlB);
+			flip = !flip;
+		}
+	});
+
+	std::vector<std::thread> readers;
+	for (int i = 0; i < 4; i++)
+	{
+		readers.emplace_back([&] {
+			while (stop.load() == false)
+			{
+				auto value = stream.GetMediaSource();
+				if (IsExpectedValue(value) == false)
+				{
+					all_reads_valid = false;
+				}
+				read_count++;
+			}
+		});
+	}
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(200));
+	stop = true;
+
+	writer.join();
+	for (auto &reader : readers)
+	{
+		reader.join();
+	}
+
+	EXPECT_TRUE(all_reads_valid.load());
+	EXPECT_GT(read_count.load(), 0u);
+}
+
+TEST(InfoStreamSourceUrl, CopyConstructorRacingWriterObservesOnlyWholeValues)
+{
+	// The copy path reads the source's `_source_url` via `GetMediaSource()` (locked);
+	// copying while a failover-style writer is running must never yield a torn string.
+	info::Stream stream(StreamSourceType::Ovt);
+	stream.SetMediaSource(kUrlA);
+
+	std::atomic<bool> stop{false};
+	std::atomic<uint64_t> copy_count{0};
+	std::atomic<bool> all_copies_valid{true};
+
+	std::thread writer([&] {
+		bool flip = false;
+		while (stop.load() == false)
+		{
+			stream.SetMediaSource(flip ? kUrlA : kUrlB);
+			flip = !flip;
+		}
+	});
+
+	std::thread copier([&] {
+		while (stop.load() == false)
+		{
+			info::Stream copy(stream);
+			if (IsExpectedValue(copy.GetMediaSource()) == false)
+			{
+				all_copies_valid = false;
+			}
+			copy_count++;
+		}
+	});
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(200));
+	stop = true;
+
+	writer.join();
+	copier.join();
+
+	EXPECT_TRUE(all_copies_valid.load());
+	EXPECT_GT(copy_count.load(), 0u);
+}

--- a/src/projects/base/ovcrypto/certificate.cpp
+++ b/src/projects/base/ovcrypto/certificate.cpp
@@ -385,19 +385,24 @@ STACK_OF(X509) * Certificate::GetChainCertification() const
 
 ov::String Certificate::GetFingerprint(const ov::String &algorithm)
 {
+	ov::Data digest_copy;
+
 	{
 		ov::LockGuard lock(_digest_mutex);
-	// Create digest if not created yet
-	if (_digest.GetLength() <= 0)
-	{
-		if (!ComputeDigest(algorithm))
+
+		// Create digest if not created yet
+		if (_digest.GetLength() <= 0)
 		{
-			return "";
+			if (!ComputeDigest(algorithm))
+			{
+				return "";
+			}
 		}
-	}
+
+		digest_copy = _digest;
 	}
 
-	ov::String fingerprint = ov::ToHexStringWithDelimiter(&_digest, ':');
+	ov::String fingerprint = ov::ToHexStringWithDelimiter(&digest_copy, ':');
 	fingerprint.MakeUpper();
 	return fingerprint;
 }

--- a/src/projects/base/ovlibrary/bps_calculator.cpp
+++ b/src/projects/base/ovlibrary/bps_calculator.cpp
@@ -55,6 +55,8 @@ namespace ov
 
 	int64_t BpsCalculator::GetBps() const
 	{
+		SharedLockGuard lock_guard(_mutex);
+
 		if (_bits_count == 0)
 		{
 			return _acc_bits;

--- a/src/projects/base/ovlibrary/bps_calculator.h
+++ b/src/projects/base/ovlibrary/bps_calculator.h
@@ -32,7 +32,7 @@ namespace ov
 		DelayQueue _timer{"BpsCalc"};
 		StopWatch _stop_watch;
 
-		SharedMutex _mutex;
+		mutable SharedMutex _mutex;
 		int64_t _bits[10] OV_GUARDED_BY(_mutex){0};
 		int _bits_count OV_GUARDED_BY(_mutex) = 0;
 

--- a/src/projects/base/ovlibrary/bps_calculator.h
+++ b/src/projects/base/ovlibrary/bps_calculator.h
@@ -20,6 +20,11 @@ namespace ov
 	{
 	public:
 		BpsCalculator();
+		~BpsCalculator()
+		{
+			// Join the timer thread while every member it touches is still alive
+			_timer.Stop();
+		}
 
 		void AddBits(int64_t bits);
 

--- a/src/projects/base/ovlibrary/bps_calculator_test.cpp
+++ b/src/projects/base/ovlibrary/bps_calculator_test.cpp
@@ -1,0 +1,89 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <base/ovlibrary/bps_calculator.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+// Tests around the `BpsCalculator` destruction-order fix on this branch:
+// `_timer` (`DelayQueue`) used to be destroyed AFTER the members
+// its tick lambda touches (`_mutex`/`_bits`/`_acc_bits`);
+// the explicit destructor now joins the timer thread first.
+// Honest scope note: the tick interval is a hardcoded 1000ms,
+// so the pre-fix UAF window (a tick in flight exactly at destruction)
+// is practically impossible to hit deterministically from a unit test -
+// `DestructionJoinsTimerThread` is a construct/destroy smoke, and
+// `ConcurrentAddAndReadKeepsTotals` runs PAST the first tick so the timer lambda's
+// exclusive section genuinely overlaps the readers/writers
+// (TSan-meaningful for the `GetBps()` shared-lock fix).
+
+TEST(BpsCalculator, DestructionJoinsTimerThread)
+{
+	// Each iteration starts a `DelayQueue` thread with a 1s tick and destroys
+	// the calculator immediately; the destructor must join the thread
+	// while every member it touches is still alive.
+	// 200 iterations keeps the test fast while giving the old UAF window
+	// plenty of chances to fire.
+	for (int i = 0; i < 200; i++)
+	{
+		ov::BpsCalculator bps;
+		bps.AddBits(1024);
+	}
+	SUCCEED();
+}
+
+TEST(BpsCalculator, ConcurrentAddAndReadKeepsTotals)
+{
+	ov::BpsCalculator bps;
+
+	constexpr int kThreads = 4;
+	constexpr int64_t kBitsPerAdd = 8;
+	// Must outlive the 1000ms tick so the timer lambda's exclusive-lock section
+	// actually runs concurrently with the readers/writers below
+	constexpr auto kRunTime = std::chrono::milliseconds(1300);
+
+	std::atomic<bool> stop{false};
+	std::atomic<int64_t> added_total{0};
+
+	std::thread reader([&] {
+		while (stop.load() == false)
+		{
+			// Lock-grade fix under test: `GetBps()` takes the shared lock
+			// that the timer lambda's exclusive section pairs with
+			(void)bps.GetBps();
+			(void)bps.GetTotalBits();
+		}
+	});
+
+	std::vector<std::thread> writers;
+	for (int t = 0; t < kThreads; t++)
+	{
+		writers.emplace_back([&] {
+			while (stop.load() == false)
+			{
+				bps.AddBits(kBitsPerAdd);
+				added_total += kBitsPerAdd;
+			}
+		});
+	}
+
+	std::this_thread::sleep_for(kRunTime);
+	stop = true;
+
+	for (auto &writer : writers)
+	{
+		writer.join();
+	}
+	reader.join();
+
+	EXPECT_EQ(bps.GetTotalBits(), added_total.load());
+}

--- a/src/projects/base/ovlibrary/log.cpp
+++ b/src/projects/base/ovlibrary/log.cpp
@@ -65,7 +65,12 @@ void ov_log_set_path(const char *log_path)
 
 const char *ov_log_get_path()
 {
-	return g_log_internal.GetLogPath();
+	// extern "C" API cannot return `ov::String` directly;
+	// keep a thread-local copy so the returned pointer stays valid
+	// (per thread) until the next call.
+	static thread_local ov::String log_path;
+	log_path = g_log_internal.GetLogPath();
+	return log_path.CStr();
 }
 
 void ov_log_set_file_enabled(bool enabled)

--- a/src/projects/base/ovlibrary/log_internal.cpp
+++ b/src/projects/base/ovlibrary/log_internal.cpp
@@ -54,7 +54,7 @@
 
 namespace ov
 {
-	LogInternal::LogInternal(std::string log_file_name) noexcept
+	LogInternal::LogInternal(String log_file_name) noexcept
 		: _level(OVLogLevelTrace),
 		  _log_file(log_file_name)
 	{
@@ -364,7 +364,7 @@ namespace ov
 		_log_file.SetLogPath(log_path);
 	}
 
-	const char *LogInternal::GetLogPath() const
+	String LogInternal::GetLogPath() const
 	{
 		if (_released)
 		{

--- a/src/projects/base/ovlibrary/log_internal.h
+++ b/src/projects/base/ovlibrary/log_internal.h
@@ -76,7 +76,7 @@ namespace ov
 		// This situation occurs when the LogInternal instance declared static is disabled just before the OME is terminated and then logs are written by another module.
 		std::atomic<bool> _released = false;
 
-		std::atomic<OVLogLevel> _level;
+		std::atomic<OVLogLevel> _level{OVLogLevelTrace};
 
 		Mutex _mutex;
 

--- a/src/projects/base/ovlibrary/log_internal.h
+++ b/src/projects/base/ovlibrary/log_internal.h
@@ -38,7 +38,7 @@ namespace ov
 	class LogInternal
 	{
 	public:
-		LogInternal(std::string log_file_name) noexcept;
+		LogInternal(String log_file_name) noexcept;
 		~LogInternal();
 
 		/// First filtering rule applied to all logs
@@ -67,7 +67,7 @@ namespace ov
 		void Log(bool show_format, OVLogLevel level, const char *tag, const char *file, int line, const char *method, const char *format, va_list &arg_list);
 
 		void SetLogPath(const char *log_path);
-		const char *GetLogPath() const;
+		String GetLogPath() const;
 
 		void SetFileEnabled(bool enabled);
 
@@ -87,7 +87,7 @@ namespace ov
 			std::shared_ptr<std::regex> regex;
 			OVLogLevel level;
 			bool is_enabled;
-			ov::String regex_string;
+			String regex_string;
 		};
 
 		std::vector<EnableItem> _enable_list OV_GUARDED_BY(_mutex);
@@ -95,6 +95,6 @@ namespace ov
 		// This map used for cache (It reduces regex matching cost)
 		// key: tag
 		// value: is_enabled
-		std::unordered_map<ov::String, EnableItem> _enable_map OV_GUARDED_BY(_mutex);
+		std::unordered_map<String, EnableItem> _enable_map OV_GUARDED_BY(_mutex);
 	};
 }  // namespace ov

--- a/src/projects/base/ovlibrary/log_internal.h
+++ b/src/projects/base/ovlibrary/log_internal.h
@@ -76,7 +76,7 @@ namespace ov
 		// This situation occurs when the LogInternal instance declared static is disabled just before the OME is terminated and then logs are written by another module.
 		std::atomic<bool> _released = false;
 
-		OVLogLevel _level;
+		std::atomic<OVLogLevel> _level;
 
 		Mutex _mutex;
 

--- a/src/projects/base/ovlibrary/log_write.cpp
+++ b/src/projects/base/ovlibrary/log_write.cpp
@@ -18,13 +18,11 @@
 
 namespace ov
 {
-	bool LogWrite::_start_service = false;
-
-	LogWrite::LogWrite(std::string log_file_name, bool include_date_in_filename)
+	LogWrite::LogWrite(String log_file_name, bool include_date_in_filename)
 		: _last_day(0),
 		  _log_path(OV_LOG_DIR)
 	{
-		if (log_file_name.empty())
+		if (log_file_name.IsEmpty())
 		{
 			_log_file_name = OV_DEFAULT_LOG_FILE;
 		}
@@ -33,37 +31,43 @@ namespace ov
 			_log_file_name = log_file_name;
 		}
 
-		_log_file = _log_path + std::string("/") + log_file_name;
+		_log_file.Format("%s/%s", _log_path.CStr(), _log_file_name.CStr());
 		_include_date_in_filename = include_date_in_filename;
 	}
 
 	void LogWrite::SetLogPath(const char *log_path)
 	{
-		_log_path = log_path;
-		_log_file = log_path + std::string("/") + _log_file_name;
+		LockGuard lock_guard(_log_stream_mutex);
+		SetLogPathInternal(log_path);
 	}
 
-	const char *LogWrite::GetLogPath() const
+	void LogWrite::SetLogPathInternal(const char *log_path)
 	{
-		return _log_path.c_str();
+		_log_path = log_path;
+		_log_file.Format("%s/%s", _log_path.CStr(), _log_file_name.CStr());
+	}
+
+	String LogWrite::GetLogPath() const
+	{
+		LockGuard lock_guard(_log_stream_mutex);
+		return _log_path;
 	}
 
 	void LogWrite::OpenNewFile(std::time_t time)
 	{
 		if (_start_service)
 		{
-			SetLogPath(OV_LOG_DIR_SVC);
+			SetLogPathInternal(OV_LOG_DIR_SVC);
 
 			// Change default log path to /var once for running service
 			_start_service = false;
 		}
 
-		if ((::mkdir(_log_path.c_str(), 0755) == -1) && errno != EEXIST)
+		if ((::mkdir(_log_path.CStr(), 0755) == -1) && errno != EEXIST)
 		{
 			return;
 		}
 
-		LockGuard<Mutex> lock_guard(_log_stream_mutex);
 		_log_stream.close();
 		_log_stream.clear();
 
@@ -77,7 +81,7 @@ namespace ov
 		}
 		else
 		{
-			_log_stream.open(_log_file, std::ofstream::out | std::ofstream::app);
+			_log_stream.open(_log_file.CStr(), std::ofstream::out | std::ofstream::app);
 		}
 	}
 
@@ -105,6 +109,10 @@ namespace ov
 		std::tm local_time{};
 		::localtime_r(&time, &local_time);
 
+		// One lock for the whole stream section (open/rotate/write); OpenNewFile()
+		// requires it to be held by the caller.
+		LockGuard lock_guard(_log_stream_mutex);
+
 		if (!_log_stream.is_open() || _log_stream.fail())
 		{
 			OpenNewFile(time);
@@ -121,7 +129,7 @@ namespace ov
 					// Backup file to (filename.log.yymmdd)
 					std::ostringstream logfile;
 					logfile << _log_file << "." << std::put_time(&local_time, "%Y%m%d");
-					::rename(_log_file.c_str(), logfile.str().c_str());
+					::rename(_log_file.CStr(), logfile.str().c_str());
 				}
 
 				// Open new file (filename.log.yymmdd)
@@ -130,7 +138,6 @@ namespace ov
 			_last_day = local_time.tm_mday;
 		}
 
-		LockGuard<Mutex> lock_guard(_log_stream_mutex);
 		_log_stream << log << std::endl;
 		_log_stream.flush();
 	}

--- a/src/projects/base/ovlibrary/log_write.h
+++ b/src/projects/base/ovlibrary/log_write.h
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <fstream>
 #include "./tsa/mutex.h"
+#include "./string.h"
 
 #define OV_LOG_DIR "logs"
 #define OV_LOG_DIR_SVC "/var/log/ovenmediaengine"
@@ -21,26 +22,27 @@ namespace ov
 	class LogWrite
 	{
 	public:
-		LogWrite(std::string log_file_name, bool include_date_in_filename = false);
+		LogWrite(String log_file_name, bool include_date_in_filename = false);
 		virtual ~LogWrite() = default;
 		void Write(const char *log, std::time_t time = 0);
 		void SetLogPath(const char *log_path);
-		const char *GetLogPath() const;
+		String GetLogPath() const;
 		void SetEnabled(bool enabled);
 
 		static void SetAsService(bool start_service);
 
 	private:
-		void OpenNewFile(std::time_t time = 0);
+		void OpenNewFile(std::time_t time = 0) OV_REQUIRES(_log_stream_mutex);
+		void SetLogPathInternal(const char *log_path) OV_REQUIRES(_log_stream_mutex);
 
-		Mutex _log_stream_mutex;
+		mutable Mutex _log_stream_mutex;
 		std::ofstream _log_stream OV_GUARDED_BY(_log_stream_mutex);
-		int _last_day;
-		std::string _log_path;
-		std::string _log_file_name;
-		std::string _log_file;
+		int _last_day OV_GUARDED_BY(_log_stream_mutex);
+		String _log_path OV_GUARDED_BY(_log_stream_mutex);
+		String _log_file_name OV_GUARDED_BY(_log_stream_mutex);
+		String _log_file OV_GUARDED_BY(_log_stream_mutex);
 		bool _include_date_in_filename = false;
 		std::atomic<bool> _enabled{true};
-		static bool _start_service;
+		static inline std::atomic<bool> _start_service{false};
 	};
 }  // namespace ov

--- a/src/projects/base/ovlibrary/queue.h
+++ b/src/projects/base/ovlibrary/queue.h
@@ -72,8 +72,7 @@ namespace ov
 
 		void SetThreshold(size_t threshold)
 		{
-			LockGuard lock_guard(_name_mutex);
-
+			// `_threshold` is atomic (release/acquire pair with CheckThreshold); no lock needed
 			_threshold.store(threshold, std::memory_order_release);
 			logt("ov.Queue", "[%p] The threshold is changed to %zu", this, threshold);
 		}

--- a/src/projects/base/ovlibrary/queue.h
+++ b/src/projects/base/ovlibrary/queue.h
@@ -8,6 +8,7 @@
 //==============================================================================
 #pragma once
 
+#include <atomic>
 #include <optional>
 #include <queue>
 
@@ -73,8 +74,8 @@ namespace ov
 		{
 			LockGuard lock_guard(_name_mutex);
 
-			_threshold = threshold;
-			logt("ov.Queue", "[%p] The threshold is changed to %d", this, _threshold);
+			_threshold.store(threshold, std::memory_order_release);
+			logt("ov.Queue", "[%p] The threshold is changed to %d", this, threshold);
 		}
 
 		void Enqueue(const T &item)
@@ -263,21 +264,21 @@ namespace ov
 
 		bool IsStopped() const
 		{
-			return _stop;
+			return _stop.load(std::memory_order_acquire);
 		}
 
 		void Start()
 		{
 			LockGuard lock_guard(_mutex);
 
-			_stop = false;
+			_stop.store(false, std::memory_order_release);
 		}
 
 		void Stop()
 		{
 			LockGuard lock_guard(_mutex);
 
-			_stop = true;
+			_stop.store(true, std::memory_order_release);
 			_condition.NotifyAll();
 		}
 
@@ -289,30 +290,31 @@ namespace ov
 				_peak = _queue.size();
 			}
 
-			if ((_threshold > 0) && (_queue.size() >= _threshold))
+			auto threshold = _threshold.load(std::memory_order_acquire);
+			if ((threshold > 0) && (_queue.size() >= threshold))
 			{
 				if (_last_log_time.IsElapsed(_log_interval) && _last_log_time.Update())
 				{
 					SharedLockGuard shared_lock(_name_mutex);
-					logw("ov.Queue", "[%p] %s size has exceeded the threshold: queue: %zu, threshold: %zu, peak: %zu", this, _queue_name.CStr(), _queue.size(), _threshold, _peak);
+					logw("ov.Queue", "[%p] %s size has exceeded the threshold: queue: %zu, threshold: %zu, peak: %zu", this, _queue_name.CStr(), _queue.size(), threshold, _peak);
 				}
 			}
 		}
 
 	private:
-		StopWatch _last_log_time;
+		StopWatch _last_log_time OV_GUARDED_BY(_mutex);
 
 		SharedMutex _name_mutex;
 		String _queue_name OV_GUARDED_BY(_name_mutex);
 
-		size_t _threshold = 0;
+		std::atomic<size_t> _threshold{0};
 		size_t _peak OV_GUARDED_BY(_mutex) = 0;
 		int _log_interval = 0;
 
 		std::queue<T> _queue OV_GUARDED_BY(_mutex);
 		mutable Mutex _mutex;
 		ConditionVariable _condition;
-		bool _stop OV_GUARDED_BY(_mutex) = false;
+		std::atomic<bool> _stop{false};
 	};
 
 }  // namespace ov

--- a/src/projects/base/ovlibrary/queue.h
+++ b/src/projects/base/ovlibrary/queue.h
@@ -75,7 +75,7 @@ namespace ov
 			LockGuard lock_guard(_name_mutex);
 
 			_threshold.store(threshold, std::memory_order_release);
-			logt("ov.Queue", "[%p] The threshold is changed to %d", this, threshold);
+			logt("ov.Queue", "[%p] The threshold is changed to %zu", this, threshold);
 		}
 
 		void Enqueue(const T &item)
@@ -304,7 +304,7 @@ namespace ov
 	private:
 		StopWatch _last_log_time OV_GUARDED_BY(_mutex);
 
-		SharedMutex _name_mutex;
+		mutable SharedMutex _name_mutex;
 		String _queue_name OV_GUARDED_BY(_name_mutex);
 
 		std::atomic<size_t> _threshold{0};

--- a/src/projects/base/ovlibrary/queue_test.cpp
+++ b/src/projects/base/ovlibrary/queue_test.cpp
@@ -1,0 +1,114 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <base/ovlibrary/queue.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <thread>
+
+// Tests around the `ov::Queue` thread-safety changes on this branch.
+// Honest scope note: `StopWakesBlockedDequeue` guards the CV wakeup contract
+// (a store-outside-mutex regression would make it flaky/failing);
+// the other two are behavior pins/TSan smoke - the `_threshold` atomic conversion
+// and the dead-lock removal in `SetThreshold()` have no deterministic failure mode
+// in a  plain build (the pre-fix defect was a data race only TSan can observe).
+
+TEST(OvQueue, StopWakesBlockedDequeue)
+{
+	ov::Queue<int> queue("OvQueueTest", 0);
+
+	std::promise<bool> dequeue_returned;
+	std::thread consumer([&] {
+		// Bounded timeout: if `Stop()` fails to wake this thread (the regression
+		// under guard), the consumer self-unblocks so the test can FAIL instead
+		// of `std::terminate`-ing the whole binary on a joinable-thread dtor
+		auto item = queue.Dequeue(10000);
+		dequeue_returned.set_value(item.has_value() == false);
+	});
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	queue.Stop();
+
+	auto future				= dequeue_returned.get_future();
+	const bool woke_in_time = (future.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+	consumer.join();
+
+	EXPECT_TRUE(woke_in_time) << "Stop() did not wake the blocked Dequeue() (lost wakeup)";
+	EXPECT_TRUE(queue.IsStopped());
+}
+
+TEST(OvQueue, ThresholdExceedanceOnlyLogsAndKeepsItems)
+{
+	ov::Queue<int> queue("OvQueueTest", 3 /* threshold */);
+
+	for (int i = 0; i < 5; i++)
+	{
+		queue.Enqueue(i);
+	}
+
+	// `CheckThreshold()` must not clear the queue - it only tracks the peak and logs
+	EXPECT_EQ(queue.Size(), 5u);
+
+	for (int i = 0; i < 5; i++)
+	{
+		auto item = queue.Dequeue(0);
+		ASSERT_TRUE(item.has_value());
+		EXPECT_EQ(*item, i);
+	}
+}
+
+TEST(OvQueue, ConcurrentSetThresholdWithTraffic)
+{
+	// `SetThreshold()` is now a bare atomic store racing `CheckThreshold()`'s
+	// acquire load inside `Enqueue()`; this must be free of crashes/deadlocks
+	// and must not disturb the item flow.
+	ov::Queue<int> queue("OvQueueTest", 1);
+
+	std::atomic<bool> stop{false};
+	std::atomic<uint64_t> dequeued{0};
+
+	std::thread threshold_toggler([&] {
+		size_t threshold = 0;
+		while (stop.load() == false)
+		{
+			queue.SetThreshold(threshold);
+			threshold = (threshold + 7) % 32;
+		}
+	});
+
+	std::thread producer([&] {
+		int value = 0;
+		while (stop.load() == false)
+		{
+			queue.Enqueue(value++);
+		}
+	});
+
+	std::thread consumer([&] {
+		while (stop.load() == false)
+		{
+			if (queue.Dequeue(1).has_value())
+			{
+				dequeued++;
+			}
+		}
+	});
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(200));
+	stop = true;
+
+	threshold_toggler.join();
+	producer.join();
+	queue.Stop();
+	consumer.join();
+
+	EXPECT_GT(dequeued.load(), 0u);
+}

--- a/src/projects/base/ovlibrary/thread_checker.h
+++ b/src/projects/base/ovlibrary/thread_checker.h
@@ -14,6 +14,7 @@
 
 #include "./assert.h"
 #include "./log.h"
+#include "./platform.h"
 #include "./tsa/mutex.h"
 
 namespace ov

--- a/src/projects/base/ovlibrary/thread_checker.h
+++ b/src/projects/base/ovlibrary/thread_checker.h
@@ -113,7 +113,7 @@ namespace ov
 		// Binds to the current thread on construction.
 		ThreadChecker(ThreadLocation loc = {})
 			: _bound_thread(::pthread_self()),
-			  _bind_location{loc, ov::StackTrace::GetStackTrace()}
+			  _bind_location{loc, StackTrace::GetStackTrace()}
 		{
 		}
 
@@ -139,7 +139,7 @@ namespace ov
 				// No explicit call site available, so location is left empty.
 				_bound_thread  = ::pthread_self();
 				_attached	   = true;
-				_bind_location = {{}, ov::StackTrace::GetStackTrace()};
+				_bind_location = {{}, StackTrace::GetStackTrace()};
 				return true;
 			}
 
@@ -154,7 +154,7 @@ namespace ov
 			ScopedLock lock(_mutex);
 			_bound_thread  = ::pthread_self();
 			_attached	   = true;
-			_bind_location = {loc, ov::StackTrace::GetStackTrace()};
+			_bind_location = {loc, StackTrace::GetStackTrace()};
 		}
 
 		// Detaches the checker from its current thread.
@@ -176,25 +176,34 @@ namespace ov
 				return;
 			}
 
-			auto expected					= _bound_thread;
 			auto self						= ::pthread_self();
 
-			ov::String expected_thread_name = ov::Platform::GetThreadName(expected);
-			ov::String thread_name			= ov::Platform::GetThreadName(self);
-
-			ov::String bind_location_str;
-			if (_bind_location.loc.file != nullptr)
+			// Snapshot the bound-thread state under the lock before building the
+			// diagnostic, so the cold failure path does not read it unsynchronized.
+			pthread_t expected;
+			BindLocation bind_location;
 			{
-				bind_location_str = ov::String::FormatString(
+				ScopedLock lock(_mutex);
+				expected	  = _bound_thread;
+				bind_location = _bind_location;
+			}
+
+			String expected_thread_name = Platform::GetThreadName(expected);
+			String thread_name			= Platform::GetThreadName(self);
+
+			String bind_location_str;
+			if (bind_location.loc.file != nullptr)
+			{
+				bind_location_str = String::FormatString(
 					"%s:%d in %s()\n\tBind stack trace:\n%s",
-					_bind_location.loc.file, _bind_location.loc.line, _bind_location.loc.func,
-					_bind_location.stack_trace.CStr());
+					bind_location.loc.file, bind_location.loc.line, bind_location.loc.func,
+					bind_location.stack_trace.CStr());
 			}
 			else
 			{
-				bind_location_str = ov::String::FormatString(
+				bind_location_str = String::FormatString(
 					"(implicit bind)\n\tBind stack trace:\n%s",
-					_bind_location.stack_trace.CStr());
+					bind_location.stack_trace.CStr());
 			}
 
 			OV_ASSERT(false,
@@ -207,14 +216,14 @@ namespace ov
 					  expected_thread_name.CStr(), static_cast<unsigned long>(expected),
 					  bind_location_str.CStr(),
 					  thread_name.CStr(), static_cast<unsigned long>(self),
-					  ov::StackTrace::GetStackTrace().CStr());
+					  StackTrace::GetStackTrace().CStr());
 		}
 
 	private:
 		struct BindLocation
 		{
 			ThreadLocation loc;
-			ov::String stack_trace;
+			String stack_trace;
 		};
 
 		mutable Mutex _mutex;

--- a/src/projects/base/ovlibrary/url.cpp
+++ b/src/projects/base/ovlibrary/url.cpp
@@ -125,59 +125,132 @@ namespace ov
 		return absolute_url_regex.Matches(url).IsMatched();
 	}
 
+	ov::String Url::Source() const
+	{
+		SharedLockGuard lock(_mutex);
+		return _source;
+	}
+
 	bool Url::SetSource(const ov::String &value)
 	{
+		LockGuard lock(_mutex);
 		_source = value;
 		return ParseFromSource();
 	}
+
+	ov::String Url::Scheme() const
+	{
+		SharedLockGuard lock(_mutex);
+		return _scheme;
+	}
+
 	bool Url::SetScheme(const ov::String &value)
 	{
+		LockGuard lock(_mutex);
 		_scheme = value;
 		return UpdateSource();
 	}
+
+	ov::String Url::Host() const
+	{
+		SharedLockGuard lock(_mutex);
+		return _host;
+	}
+
 	bool Url::SetHost(const ov::String &value)
 	{
+		LockGuard lock(_mutex);
 		_host = value;
 		return UpdateSource();
 	}
+
+	uint32_t Url::Port() const
+	{
+		SharedLockGuard lock(_mutex);
+		return _port;
+	}
+
 	bool Url::SetPort(uint32_t port)
 	{
+		LockGuard lock(_mutex);
 		_port = port;
 		return UpdateSource();
 	}
 
+	ov::String Url::Path() const
+	{
+		SharedLockGuard lock(_mutex);
+		return _path;
+	}
+
 	bool Url::SetPath(const ov::String &path)
 	{
+		LockGuard lock(_mutex);
 		_path = path;
 		return UpdatePathComponentsFromPath() && UpdateSource();
 	}
 
+	ov::String Url::App() const
+	{
+		SharedLockGuard lock(_mutex);
+		return _app;
+	}
+
 	bool Url::SetApp(const ov::String &value)
 	{
+		LockGuard lock(_mutex);
 		_app = SetPathComponent(1, value);
 		return UpdatePathFromComponents() && UpdateSource();
 	}
 
+	ov::String Url::Stream() const
+	{
+		SharedLockGuard lock(_mutex);
+		return _stream;
+	}
+
 	bool Url::SetStream(const ov::String &value)
 	{
+		LockGuard lock(_mutex);
 		_stream = SetPathComponent(2, value);
 		return UpdatePathFromComponents() && UpdateSource();
 	}
 
+	ov::String Url::File() const
+	{
+		SharedLockGuard lock(_mutex);
+		return _file;
+	}
+
 	bool Url::SetFile(const ov::String &value)
 	{
+		LockGuard lock(_mutex);
 		_file = SetPathComponent(3, value);
 		return UpdatePathFromComponents() && UpdateSource();
 	}
 
+	ov::String Url::Id() const
+	{
+		SharedLockGuard lock(_mutex);
+		return _id;
+	}
+
 	bool Url::SetId(const ov::String &value)
 	{
+		LockGuard lock(_mutex);
 		_id = value;
 		return UpdateSource();
 	}
 
+	ov::String Url::Password() const
+	{
+		SharedLockGuard lock(_mutex);
+		return _password;
+	}
+
 	bool Url::SetPassword(const ov::String &value)
 	{
+		LockGuard lock(_mutex);
 		_password = value;
 		return UpdateSource();
 	}
@@ -198,11 +271,11 @@ namespace ov
 			_path_components.clear();
 			_query_string	  = "";
 			_has_query_string = false;
-			_query_parsed.store(false, std::memory_order_release);
+			InvalidateQueryMap();
 
-			_app			  = "";
-			_stream			  = "";
-			_file			  = "";
+			_app	= "";
+			_stream = "";
+			_file	= "";
 
 			return false;
 		}
@@ -222,7 +295,7 @@ namespace ov
 		}
 		_query_string	  = group_list["qs"].GetValue();
 		_has_query_string = (_query_string.IsEmpty() == false);
-		_query_parsed.store(false, std::memory_order_release);
+		InvalidateQueryMap();
 
 		return true;
 	}
@@ -241,6 +314,8 @@ namespace ov
 
 	bool Url::PushBackQueryKey(const ov::String &key)
 	{
+		LockGuard lock(_mutex);
+
 		if (_has_query_string)
 		{
 			_query_string.Append("&");
@@ -248,13 +323,15 @@ namespace ov
 
 		_query_string.Append(key);
 		_has_query_string = true;
-		_query_parsed.store(false, std::memory_order_release);
+		InvalidateQueryMap();
 
 		return true;
 	}
 
 	bool Url::PushBackQueryKey(const ov::String &key, const ov::String &value)
 	{
+		LockGuard lock(_mutex);
+
 		if (_has_query_string)
 		{
 			_query_string.Append("&");
@@ -262,13 +339,15 @@ namespace ov
 
 		_query_string.AppendFormat("%s=%s", key.CStr(), Encode(value).CStr());
 		_has_query_string = true;
-		_query_parsed.store(false, std::memory_order_release);
+		InvalidateQueryMap();
 
 		return true;
 	}
 
 	bool Url::AppendQueryString(const ov::String &query_string)
 	{
+		LockGuard lock(_mutex);
+
 		if (_has_query_string)
 		{
 			_query_string.Append("&");
@@ -284,7 +363,7 @@ namespace ov
 		}
 
 		_has_query_string = true;
-		_query_parsed.store(false, std::memory_order_release);
+		InvalidateQueryMap();
 
 		return true;
 	}
@@ -292,6 +371,8 @@ namespace ov
 	// Keep the order of queries.
 	bool Url::RemoveQueryKey(const ov::String &remove_key)
 	{
+		LockGuard lock(_mutex);
+
 		if (_has_query_string == false)
 		{
 			return false;
@@ -332,8 +413,9 @@ namespace ov
 			}
 		}
 
-		_query_string = new_query_string;
-		_query_parsed.store(false, std::memory_order_release);
+		_query_string	  = new_query_string;
+		_has_query_string = (_query_string.IsEmpty() == false);
+		InvalidateQueryMap();
 
 		return true;
 	}
@@ -352,7 +434,7 @@ namespace ov
 
 	bool Url::UpdateSource()
 	{
-		_source = ToUrlString();
+		_source = ToUrlStringInternal(true);
 		return true;
 	}
 
@@ -392,86 +474,91 @@ namespace ov
 		return true;
 	}
 
-	void Url::ParseQueryIfNeeded() const
+	void Url::InvalidateQueryMap() const
 	{
-		if ((_has_query_string == false) || _query_parsed.load(std::memory_order_acquire))
+		LockGuard map_lock(_query_map_mutex);
+		_query_parsed = false;
+	}
+
+	void Url::EnsureQueryParsed() const
+	{
+		if (_query_parsed)
 		{
 			return;
 		}
 
-		LockGuard lock_guard(_query_map_mutex);
+		_query_map.clear();
+		_query_parsed = true;
 
-		// DCL
-		if (_query_parsed.load(std::memory_order_relaxed))
+		if ((_has_query_string == false) || _query_string.IsEmpty())
 		{
 			return;
 		}
 
 		// Split the query string into the map
-		if (_query_string.IsEmpty() == false)
+		const auto &query_list = _query_string.Split("&");
+
+		for (auto &query : query_list)
 		{
-			const auto &query_list = _query_string.Split("&");
+			auto tokens = query.Split("=", 2);
 
-			for (auto &query : query_list)
+			if (tokens.size() == 2)
 			{
-				auto tokens = query.Split("=", 2);
-
-				if (tokens.size() == 2)
-				{
-					_query_map[tokens[0]] = Decode(tokens[1]);
-				}
-				else
-				{
-					_query_map[query] = "";
-				}
+				_query_map[tokens[0]] = Decode(tokens[1]);
+			}
+			else
+			{
+				_query_map[query] = "";
 			}
 		}
-
-		// Publish AFTER population so the lock-free fast path that observes `true` via
-		// acquire is guaranteed to see the fully built _query_map.
-		_query_parsed.store(true, std::memory_order_release);
 	}
 
 	bool Url::HasQueryString() const
 	{
+		SharedLockGuard lock(_mutex);
 		return _has_query_string;
 	}
 
-	const ov::String &Url::Query() const
+	ov::String Url::Query() const
 	{
-		ParseQueryIfNeeded();
+		SharedLockGuard lock(_mutex);
 		return _query_string;
 	}
 
-	const bool Url::HasQueryKey(ov::String key) const
+	bool Url::HasQueryKey(ov::String key) const
 	{
-		ParseQueryIfNeeded();
-		if (_query_map.find(key) == _query_map.end())
-		{
-			return false;
-		}
-
-		return true;
+		SharedLockGuard lock(_mutex);
+		LockGuard map_lock(_query_map_mutex);
+		EnsureQueryParsed();
+		return _query_map.find(key) != _query_map.end();
 	}
 
-	const ov::String Url::GetQueryValue(ov::String key) const
+	ov::String Url::GetQueryValue(ov::String key) const
 	{
-		if (HasQueryKey(key) == false)
+		SharedLockGuard lock(_mutex);
+		LockGuard map_lock(_query_map_mutex);
+		EnsureQueryParsed();
+
+		auto item = _query_map.find(key);
+		if (item == _query_map.end())
 		{
 			return "";
 		}
 
-		return Decode(_query_map[key]);
+		return Decode(item->second);
 	}
 
-	const std::map<ov::String, ov::String> &Url::QueryMap() const
+	Url &Url::operator=(const Url &other)
 	{
-		ParseQueryIfNeeded();
-		return _query_map;
-	}
+		if (this == &other)
+		{
+			return *this;
+		}
 
-	Url &Url::operator=(const Url &other) noexcept
-	{
+		// ScopedLock uses std::lock internally for deadlock-free acquisition.
+		// Both exclusive is acceptable since operator= is rare.
+		ScopedLock lock(_mutex, other._mutex);
+
 		_source			  = other._source;
 		_scheme			  = other._scheme;
 		_id				  = other._id;
@@ -480,20 +567,38 @@ namespace ov
 		_port			  = other._port;
 		_path			  = other._path;
 		_path_components  = other._path_components;
-		_has_query_string = other._has_query_string;
 		_query_string	  = other._query_string;
-		_query_parsed.store(other._query_parsed.load(std::memory_order_acquire), std::memory_order_release);
-		_query_map		  = other._query_map;
+		_has_query_string = other._has_query_string;
 		_app			  = other._app;
 		_stream			  = other._stream;
 		_file			  = other._file;
+
+		{
+			LockGuard map_lock(_query_map_mutex);
+			_query_parsed = false;
+		}
 
 		return *this;
 	}
 
 	Url::Url(const Url &other)
 	{
-		operator=(other);
+		// this is under construction - no locking needed on this side
+		SharedLockGuard lock(other._mutex);
+
+		_source			  = other._source;
+		_scheme			  = other._scheme;
+		_id				  = other._id;
+		_password		  = other._password;
+		_host			  = other._host;
+		_port			  = other._port;
+		_path			  = other._path;
+		_path_components  = other._path_components;
+		_query_string	  = other._query_string;
+		_has_query_string = other._has_query_string;
+		_app			  = other._app;
+		_stream			  = other._stream;
+		_file			  = other._file;
 	}
 
 	std::shared_ptr<Url> Url::Clone() const
@@ -503,12 +608,20 @@ namespace ov
 
 	void Url::Print() const
 	{
+		SharedLockGuard lock(_mutex);
+
 		logi("URL Parser", "%s %s %d %s %s %s %s",
 			 _scheme.CStr(), _host.CStr(), _port,
 			 _app.CStr(), _stream.CStr(), _file.CStr(), _query_string.CStr());
 	}
 
 	ov::String Url::ToUrlString(bool include_query_string) const
+	{
+		SharedLockGuard lock(_mutex);
+		return ToUrlStringInternal(include_query_string);
+	}
+
+	ov::String Url::ToUrlStringInternal(bool include_query_string) const
 	{
 		ov::String url;
 
@@ -548,7 +661,9 @@ namespace ov
 
 	ov::String Url::ToString() const
 	{
-		auto url = ToUrlString();
+		SharedLockGuard lock(_mutex);
+
+		auto url = ToUrlStringInternal(true);
 
 		url.AppendFormat(" (app: %s, stream: %s, file: %s)", _app.CStr(), _stream.CStr(), _file.CStr());
 

--- a/src/projects/base/ovlibrary/url.cpp
+++ b/src/projects/base/ovlibrary/url.cpp
@@ -540,7 +540,9 @@ namespace ov
 			return "";
 		}
 
-		return Decode(item->second);
+		// Values are already percent-decoded when stored in EnsureQueryParsed(),
+		// so return the cached value directly to avoid double-decoding.
+		return item->second;
 	}
 
 	Url &Url::operator=(const Url &other)

--- a/src/projects/base/ovlibrary/url.cpp
+++ b/src/projects/base/ovlibrary/url.cpp
@@ -85,7 +85,7 @@ namespace ov
 
 		for (size_t index = 0; index < length;)
 		{
-			char character = val[index];
+			const char character = val[index];
 			if (character == '%')
 			{
 				// Change '%??' to ascii character
@@ -104,13 +104,8 @@ namespace ov
 					}
 				}
 			}
-			else if (character == '+')
-			{
-				// Change '+' to ' '
-				character = ' ';
-			}
 
-			result[result_index] = val[index];
+			result[result_index] = character;
 			index++;
 			result_index++;
 		}

--- a/src/projects/base/ovlibrary/url.h
+++ b/src/projects/base/ovlibrary/url.h
@@ -8,15 +8,24 @@
 //==============================================================================
 #pragma once
 
-#include <atomic>
-
 #include "./ovlibrary.h"
 #include "./string.h"
 #include "./tsa/mutex.h"
 
+// TODO(dimiden): Since `ov::Url` is mostly parsed once at initialization and then values are only read, protecting every field with a mutex may be an unnecessary overhead.
+// Therefore, it would be better to make `ov::Url` immutable and return a new instance with `WithX()` methods when modification is needed.
 namespace ov
 {
-	// Url is immutable class
+	// Url is fully synchronized: a `SharedMutex` (`_mutex`) guards every field.
+	// Read accessors take a shared lock and return BY VALUE (a snapshot);
+	// mutators take an exclusive lock.
+	// Concurrent reads and writes on a shared Url are therefore safe,
+	// at the cost of a lock (and a copy of the returned value) per access.
+	//
+	// The parsed query map is cached lazily behind its own `_query_map_mutex`
+	// (rebuilt from `_query_string` on first query read), so read accessors that
+	// hold `_mutex` only in shared mode can still populate it without racing.
+	// Lock order is always `_mutex` (outer) -> `_query_map_mutex` (inner).
 	class Url
 	{
 	public:
@@ -35,42 +44,41 @@ namespace ov
 		// Example of relative URL: /path/to/resource or path/to/resource
 		static bool IsAbsolute(const char *url);
 
-		// Getters and Setters (Setters are NOT THREAD-SAFE)
-		OV_DEFINE_CONST_GETTER(Source, _source)
+		// Getters return a snapshot taken under a shared lock; Setters mutate under an exclusive lock.
+		ov::String Source() const;
 		bool SetSource(const ov::String &value);
 
-		OV_DEFINE_CONST_GETTER(Scheme, _scheme)
+		ov::String Scheme() const;
 		bool SetScheme(const ov::String &value);
 
-		OV_DEFINE_CONST_GETTER(Host, _host)
+		ov::String Host() const;
 		bool SetHost(const ov::String &value);
 
-		OV_DEFINE_CONST_GETTER(Port, _port)
+		uint32_t Port() const;
 		bool SetPort(uint32_t port);
 
-		OV_DEFINE_CONST_GETTER(Path, _path)
+		ov::String Path() const;
 		bool SetPath(const ov::String &value);
 
-		OV_DEFINE_CONST_GETTER(App, _app)
+		ov::String App() const;
 		bool SetApp(const ov::String &value);
 
-		OV_DEFINE_CONST_GETTER(Stream, _stream)
+		ov::String Stream() const;
 		bool SetStream(const ov::String &value);
 
-		OV_DEFINE_CONST_GETTER(File, _file)
+		ov::String File() const;
 		bool SetFile(const ov::String &value);
 
-		OV_DEFINE_CONST_GETTER(Id, _id)
+		ov::String Id() const;
 		bool SetId(const ov::String &value);
 
-		OV_DEFINE_CONST_GETTER(Password, _password)
+		ov::String Password() const;
 		bool SetPassword(const ov::String &value);
 
 		bool HasQueryString() const;
-		const ov::String &Query() const;
-		const bool HasQueryKey(ov::String key) const;
-		const ov::String GetQueryValue(ov::String key) const;
-		const std::map<ov::String, ov::String> &QueryMap() const;
+		ov::String Query() const;
+		bool HasQueryKey(ov::String key) const;
+		ov::String GetQueryValue(ov::String key) const;
 		bool PushBackQueryKey(const ov::String &key, const ov::String &value);
 		bool PushBackQueryKey(const ov::String &key);
 		bool AppendQueryString(const ov::String &query_string);
@@ -80,49 +88,60 @@ namespace ov
 		ov::String ToUrlString(bool include_query_string = true) const;
 		ov::String ToString() const;
 
-		Url &operator=(const Url &other) noexcept;
+		Url &operator=(const Url &other);
 
 		Url() = default;
 		Url(const Url &other);
 
 		std::shared_ptr<Url> Clone() const;
 
-	protected:
-		bool ParseFromSource();
+	private:
+		// Mutating helpers require the caller's exclusive lock; read-only helpers require at least shared.
+		bool ParseFromSource() OV_REQUIRES(_mutex);
 		// Since _path is in the form of /app/stream/file, the index of `app` should be 1
-		const ov::String &SetPathComponent(size_t index, const ov::String &value);
-		bool UpdateSource();
+		const ov::String &SetPathComponent(size_t index, const ov::String &value) OV_REQUIRES(_mutex);
+		bool UpdateSource() OV_REQUIRES(_mutex);
 		// Update _path from _path_components
-		bool UpdatePathFromComponents();
+		bool UpdatePathFromComponents() OV_REQUIRES(_mutex);
 		// Update _path_components/_app/_stream/_file from _path
-		bool UpdatePathComponentsFromPath();
+		bool UpdatePathComponentsFromPath() OV_REQUIRES(_mutex);
+		// Lock-free body of ToUrlString(); the public method takes the shared lock.
+		ov::String ToUrlStringInternal(bool include_query_string) const OV_REQUIRES_SHARED(_mutex);
+
+		// Query-map cache helpers (lock order: `_mutex` -> `_query_map_mutex`).
+		// Marks the cached query map stale; called by mutators that change `_query_string`.
+		void InvalidateQueryMap() const OV_REQUIRES(_mutex);
+		// Rebuilds the cached query map from `_query_string` if stale (lazy parse).
+		void EnsureQueryParsed() const OV_REQUIRES_SHARED(_mutex) OV_REQUIRES(_query_map_mutex);
 
 	private:
-		void ParseQueryIfNeeded() const;
+		mutable SharedMutex _mutex;
 
-	private:
 		// Full URL
-		ov::String _source;
+		ov::String _source OV_GUARDED_BY(_mutex);
 
-		ov::String _scheme;
-		ov::String _id;
-		ov::String _password;
-		ov::String _host;
-		uint32_t _port = 0;
-		ov::String _path;
+		ov::String _scheme OV_GUARDED_BY(_mutex);
+		ov::String _id OV_GUARDED_BY(_mutex);
+		ov::String _password OV_GUARDED_BY(_mutex);
+		ov::String _host OV_GUARDED_BY(_mutex);
+		uint32_t _port OV_GUARDED_BY(_mutex) = 0;
+		ov::String _path OV_GUARDED_BY(_mutex);
 		// Path tokens (separated by '/')
-		std::vector<ov::String> _path_components;
-		ov::String _query_string;
-		bool _has_query_string = false;
-		// To reduce the cost of parsing the query map, parsing the query only when Query() or QueryMap() is called.
-		// Atomic acquire/release publishes _query_map so the lock-free fast path in ParseQueryIfNeeded is race-free.
-		mutable std::atomic<bool> _query_parsed{false};
+		std::vector<ov::String> _path_components OV_GUARDED_BY(_mutex);
+		ov::String _query_string OV_GUARDED_BY(_mutex);
+		bool _has_query_string OV_GUARDED_BY(_mutex) = false;
+
+		// `_query_map` is parsed lazily from `_query_string` on first query read and cached.
+		// It has its OWN mutex so read accessors (which hold `_mutex` only in shared mode)
+		// can populate the cache without racing each other.
+		// Lock order is always `_mutex` (outer) -> `_query_map_mutex` (inner).
 		mutable Mutex _query_map_mutex;
+		mutable bool _query_parsed OV_GUARDED_BY(_query_map_mutex) = false;
 		mutable std::map<ov::String, ov::String> _query_map OV_GUARDED_BY(_query_map_mutex);
 
 		// Valid for URLs of the form: <scheme>://<domain>[:<port>]/<app>/<stream>[<file>[/<remaining>]][?<query string>]
-		ov::String _app;
-		ov::String _stream;
-		ov::String _file;
+		ov::String _app OV_GUARDED_BY(_mutex);
+		ov::String _stream OV_GUARDED_BY(_mutex);
+		ov::String _file OV_GUARDED_BY(_mutex);
 	};
 }  // namespace ov

--- a/src/projects/base/ovlibrary/url_test.cpp
+++ b/src/projects/base/ovlibrary/url_test.cpp
@@ -6,9 +6,8 @@
 //  Covers: ov::Url
 //
 //==============================================================================
-#include <gtest/gtest.h>
-
 #include <base/ovlibrary/url.h>
+#include <gtest/gtest.h>
 
 // ---------------------------------------------------------------------------
 // Parse - basic components
@@ -216,8 +215,165 @@ TEST(OvUrl, Clone)
 TEST(OvUrl, ToUrlStringRoundTrip)
 {
 	const char *original = "rtmp://live.example.com:1935/app/stream";
-	auto url = ov::Url::Parse(original);
+	auto url			 = ov::Url::Parse(original);
 	ASSERT_NE(url, nullptr);
 	auto reconstructed = url->ToUrlString(false);
 	EXPECT_STREQ(reconstructed.CStr(), original);
+}
+
+// ---------------------------------------------------------------------------
+// operator= and copy constructor
+// ---------------------------------------------------------------------------
+
+TEST(OvUrl, CopyConstructor)
+{
+	auto url = ov::Url::Parse("rtmp://host.com:1935/app/stream?token=abc");
+	ASSERT_NE(url, nullptr);
+	ov::Url copy(*url);
+	EXPECT_EQ(copy.Scheme(), url->Scheme());
+	EXPECT_EQ(copy.Host(), url->Host());
+	EXPECT_EQ(copy.Port(), url->Port());
+	EXPECT_EQ(copy.App(), url->App());
+	EXPECT_EQ(copy.Stream(), url->Stream());
+	EXPECT_STREQ(copy.GetQueryValue("token").CStr(), "abc");
+}
+
+TEST(OvUrl, AssignmentOperator)
+{
+	auto a = ov::Url::Parse("rtmp://a.com:1935/app1/stream1");
+	auto b = ov::Url::Parse("https://b.com:443/app2/stream2?key=val");
+	ASSERT_NE(a, nullptr);
+	ASSERT_NE(b, nullptr);
+	*a = *b;
+	EXPECT_STREQ(a->Scheme().CStr(), "https");
+	EXPECT_STREQ(a->Host().CStr(), "b.com");
+	EXPECT_EQ(a->Port(), 443u);
+	EXPECT_STREQ(a->App().CStr(), "app2");
+	EXPECT_STREQ(a->Stream().CStr(), "stream2");
+	EXPECT_STREQ(a->GetQueryValue("key").CStr(), "val");
+}
+
+TEST(OvUrl, SelfAssignment)
+{
+	auto url = ov::Url::Parse("rtmp://host.com:1935/app/stream");
+	ASSERT_NE(url, nullptr);
+	auto &ref = *url;
+	ref		  = ref;
+	EXPECT_STREQ(url->Host().CStr(), "host.com");
+}
+
+// ---------------------------------------------------------------------------
+// Thread safety: concurrent reads
+// ---------------------------------------------------------------------------
+
+#include <thread>
+#include <vector>
+
+TEST(OvUrl, ConcurrentReads)
+{
+	auto url = ov::Url::Parse("rtmp://host.com:1935/app/stream?token=abc");
+	ASSERT_NE(url, nullptr);
+
+	constexpr int kThreads	  = 8;
+	constexpr int kIterations = 10000;
+	std::vector<std::thread> threads;
+
+	for (int i = 0; i < kThreads; i++)
+	{
+		threads.emplace_back([&url]() {
+			for (int j = 0; j < kIterations; j++)
+			{
+				EXPECT_STREQ(url->Host().CStr(), "host.com");
+				EXPECT_EQ(url->Port(), 1935u);
+				EXPECT_STREQ(url->App().CStr(), "app");
+				EXPECT_STREQ(url->Stream().CStr(), "stream");
+				EXPECT_STREQ(url->GetQueryValue("token").CStr(), "abc");
+			}
+		});
+	}
+
+	for (auto &t : threads)
+	{
+		t.join();
+	}
+}
+
+TEST(OvUrl, ConcurrentReadWrite)
+{
+	auto url = ov::Url::Parse("rtmp://host.com:1935/app/stream");
+	ASSERT_NE(url, nullptr);
+
+	constexpr int kIterations = 5000;
+	std::atomic<bool> stop{false};
+
+	// Writer: toggles between two hostnames
+	std::thread writer([&]() {
+		for (int i = 0; i < kIterations; i++)
+		{
+			if (i % 2 == 0)
+				url->SetHost("alpha.com");
+			else
+				url->SetHost("beta.com");
+		}
+		stop.store(true, std::memory_order_release);
+	});
+
+	// Readers: continuously read host, must see one of the two valid values
+	std::vector<std::thread> readers;
+	for (int i = 0; i < 4; i++)
+	{
+		readers.emplace_back([&]() {
+			while (!stop.load(std::memory_order_acquire))
+			{
+				auto host  = url->Host();
+				bool valid = (host == "host.com" || host == "alpha.com" || host == "beta.com");
+				EXPECT_TRUE(valid) << "unexpected host: " << host.CStr();
+			}
+		});
+	}
+
+	writer.join();
+	for (auto &t : readers)
+	{
+		t.join();
+	}
+}
+
+TEST(OvUrl, ConcurrentCopy)
+{
+	auto url = ov::Url::Parse("rtmp://host.com:1935/app/stream?token=abc");
+	ASSERT_NE(url, nullptr);
+
+	constexpr int kIterations = 5000;
+	std::atomic<bool> stop{false};
+
+	// Writer
+	std::thread writer([&]() {
+		for (int i = 0; i < kIterations; i++)
+		{
+			url->SetPort(static_cast<uint32_t>(1935 + (i % 100)));
+		}
+		stop.store(true, std::memory_order_release);
+	});
+
+	// Copiers: clone via copy constructor while writer is active
+	std::vector<std::thread> copiers;
+	for (int i = 0; i < 4; i++)
+	{
+		copiers.emplace_back([&]() {
+			while (!stop.load(std::memory_order_acquire))
+			{
+				auto clone = url->Clone();
+				EXPECT_NE(clone, nullptr);
+				EXPECT_STREQ(clone->Scheme().CStr(), "rtmp");
+				EXPECT_STREQ(clone->Host().CStr(), "host.com");
+			}
+		});
+	}
+
+	writer.join();
+	for (auto &t : copiers)
+	{
+		t.join();
+	}
 }

--- a/src/projects/base/ovsocket/datagram_socket.cpp
+++ b/src/projects/base/ovsocket/datagram_socket.cpp
@@ -77,7 +77,7 @@ namespace ov
 
 	bool DatagramSocket::CloseInternal(SocketState close_reason)
 	{
-		_callback = nullptr;
+		std::atomic_store(&_callback, {});
 
 		if (Socket::CloseInternal(close_reason))
 		{

--- a/src/projects/base/ovsocket/server_socket.cpp
+++ b/src/projects/base/ovsocket/server_socket.cpp
@@ -255,7 +255,7 @@ namespace ov
 			client.second->Close();
 		}
 
-		_callback = nullptr;
+		std::atomic_store(&_callback, {});
 
 		if (Socket::CloseInternal(close_reason))
 		{

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -2188,8 +2188,11 @@ namespace ov
 	{
 		CHECK_STATE(!= SocketState::Closed, false);
 
+		// Written BEFORE the `_post_callback` store so the first close's reason is
+		// published with the handoff; atomic because a second `CloseInternal()` can
+		// rewrite it while the callback thread still reads the first value
+		_close_reason = close_reason;
 		std::atomic_store(&_post_callback, std::atomic_exchange(&_callback, {}));
-		_close_reason  = close_reason;
 
 		if (_socket.IsValid())
 		{

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -1955,7 +1955,7 @@ namespace ov
 		CHECK_STATE(== SocketState::Connected, false);
 
 		// Dispatch ALL commands
-		while (_dispatch_queue.size() > 0)
+		while (HasCommand())
 		{
 			if (DispatchEvents() == DispatchResult::Error)
 			{
@@ -2188,7 +2188,7 @@ namespace ov
 	{
 		CHECK_STATE(!= SocketState::Closed, false);
 
-		_post_callback = std::atomic_exchange(&_callback, {});
+		std::atomic_store(&_post_callback, std::atomic_exchange(&_callback, {}));
 		_close_reason  = close_reason;
 
 		if (_socket.IsValid())

--- a/src/projects/base/ovsocket/socket.h
+++ b/src/projects/base/ovsocket/socket.h
@@ -549,7 +549,9 @@ namespace ov
 
 		// A temporary variable used to send callback without mutex lock
 		std::shared_ptr<SocketAsyncInterface> _post_callback;
-		SocketState _close_reason = SocketState::Closed;
+		// Atomic: a second `CloseInternal()` can rewrite this while the close callback
+		// thread is still reading the first close's value (no common lock on that pair)
+		std::atomic<SocketState> _close_reason{SocketState::Closed};
 
 		std::atomic<bool> _force_stop = false;
 

--- a/src/projects/base/ovsocket/socket.h
+++ b/src/projects/base/ovsocket/socket.h
@@ -176,7 +176,7 @@ namespace ov
 		SocketType GetType() const;
 		std::shared_ptr<SocketAsyncInterface> GetAsyncInterface()
 		{
-			return _callback;
+			return std::atomic_load(&_callback);
 		}
 
 		// only available for SRT socket
@@ -223,6 +223,7 @@ namespace ov
 
 		bool HasCommand() const
 		{
+			LockGuard lock_guard(_dispatch_queue_lock);
 			return _dispatch_queue.size() > 0;
 		}
 
@@ -230,7 +231,7 @@ namespace ov
 		{
 			LockGuard lock_guard(_dispatch_queue_lock);
 
-			if (HasCommand())
+			if (_dispatch_queue.size() > 0)
 			{
 				return _dispatch_queue.front().IsExpired(OV_SOCKET_EXPIRE_TIMEOUT);
 			}

--- a/src/projects/base/provider/CMakeLists.txt
+++ b/src/projects/base/provider/CMakeLists.txt
@@ -14,3 +14,14 @@ ome_add_static_library(base_provider
         ovlibrary
         ovcrypto
 )
+
+if(OME_BUILD_TESTS)
+    file(GLOB _srcs
+        "${CMAKE_CURRENT_SOURCE_DIR}/*_test.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/pull_provider/*_test.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/push_provider/*_test.cpp"
+    )
+    ome_add_tests(ome_test_base
+        SRCS ${_srcs}
+    )
+endif()

--- a/src/projects/base/provider/pull_provider/application.cpp
+++ b/src/projects/base/provider/pull_provider/application.cpp
@@ -133,6 +133,14 @@ namespace pvd
 									if((state == pvd::Stream::State::PLAYING) || (state == pvd::Stream::State::DESCRIBED))
 									{
 										// Stop the current stream and switch to the Primary URL.
+
+										// FIXME: this stop -> reset -> resume sequence is not atomic.
+										// Each call locks internally, but another thread's `Start()`/`Stop()`
+										// can interleave between the steps (e.g. `GetNextURL()` advancing the index
+										// after the reset, so the resume lands on a non-primary URL,
+										// or a concurrent delete reviving the stream).
+										// Needs an API-level solution that keeps `Start()`/`Stop()`/`Resume()`
+										// safe to compose from outside.
 										stream->Stop();
 										stream->ResetUrlIndex();
 										ResumeStream(stream);

--- a/src/projects/base/provider/pull_provider/application.cpp
+++ b/src/projects/base/provider/pull_provider/application.cpp
@@ -135,12 +135,13 @@ namespace pvd
 										// Stop the current stream and switch to the Primary URL.
 
 										// FIXME: this stop -> reset -> resume sequence is not atomic.
-										// Each call locks internally, but another thread's `Start()`/`Stop()`
-										// can interleave between the steps (e.g. `GetNextURL()` advancing the index
-										// after the reset, so the resume lands on a non-primary URL,
-										// or a concurrent delete reviving the stream).
-										// Needs an API-level solution that keeps `Start()`/`Stop()`/`Resume()`
-										// safe to compose from outside.
+										// Each call locks internally, but other threads can interleave between
+										// the steps - the live hazard today is a concurrent `DeleteStream()`
+										// landing between them, after which the resume revives a stream already
+										// erased from the app map (ghost stream re-attached to a motor).
+										// (The URL-index hazard stays dormant only while this collector thread
+										// is the sole `Resume()` caller.) Needs an API-level solution that keeps
+										// `Start()`/`Stop()`/`Resume()` safe to compose from outside.
 										stream->Stop();
 										stream->ResetUrlIndex();
 										ResumeStream(stream);

--- a/src/projects/base/provider/pull_provider/stream.cpp
+++ b/src/projects/base/provider/pull_provider/stream.cpp
@@ -42,7 +42,7 @@ namespace pvd
 
 	bool PullStream::Start()
 	{
-		ov::LockGuard<ov::Mutex> lock(_start_stop_stream_lock);
+		ov::LockGuard lock(_start_stop_stream_lock);
 		_restart_count = 0;
 		while (true)
 		{
@@ -68,7 +68,7 @@ namespace pvd
 
 	bool PullStream::Stop()
 	{
-		ov::LockGuard<ov::Mutex> lock(_start_stop_stream_lock);
+		ov::LockGuard lock(_start_stop_stream_lock);
 		StopStream();
 		return Stream::Stop();
 	}

--- a/src/projects/base/provider/pull_provider/stream.cpp
+++ b/src/projects/base/provider/pull_provider/stream.cpp
@@ -46,7 +46,17 @@ namespace pvd
 		_restart_count = 0;
 		while (true)
 		{
-			if (StartStream(GetNextURL()) == false)
+			auto url = GetNextURL();
+			if (url == nullptr)
+			{
+				// Empty URL list (e.g. every configured URL failed to parse).
+				// Must be filtered HERE: provider `StartStream()` implementations
+				// dereference the URL unconditionally, so a `nullptr` would crash.
+				SetState(Stream::State::TERMINATED);
+				return false;
+			}
+
+			if (StartStream(url) == false)
 			{
 				_restart_count++;
 				if (_restart_count > (_url_list.size() * _properties->GetRetryCount()))
@@ -102,7 +112,16 @@ namespace pvd
 			return false;
 		}
 
-		if (RestartStream(GetNextURL()) == false)
+		auto url = GetNextURL();
+		if (url == nullptr)
+		{
+			// Empty URL list - nothing to reconnect to. Same as Start(): a nullptr
+			// must not reach RestartStream(), which dereferences it unconditionally.
+			SetState(Stream::State::TERMINATED);
+			return false;
+		}
+
+		if (RestartStream(url) == false)
 		{
 			StopInternal();
 			_restart_count++;

--- a/src/projects/base/provider/pull_provider/stream.cpp
+++ b/src/projects/base/provider/pull_provider/stream.cpp
@@ -69,21 +69,42 @@ namespace pvd
 	bool PullStream::Stop()
 	{
 		ov::LockGuard lock(_start_stop_stream_lock);
+		return StopInternal();
+	}
+
+	bool PullStream::StopInternal()
+	{
 		StopStream();
 		return Stream::Stop();
 	}
 
 	bool PullStream::Resume()
 	{
+		{
+			ov::LockGuard lock(_start_stop_stream_lock);
+
+			if (ResumeInternal() == false)
+			{
+				return false;
+			}
+		}
+
+		UpdateStream();
+
+		return Stream::Start();
+	}
+
+	bool PullStream::ResumeInternal()
+	{
 		if (_properties->GetRetryCount() <= 0)
 		{
 			SetState(Stream::State::TERMINATED);
 			return false;
 		}
-		
+
 		if (RestartStream(GetNextURL()) == false)
 		{
-			Stop();
+			StopInternal();
 			_restart_count++;
 			if (_restart_count > _url_list.size() * _properties->GetRetryCount())
 			{
@@ -94,10 +115,8 @@ namespace pvd
 			return false;
 		}
 
-		UpdateStream();
-
 		_restart_count = 0;
-		return Stream::Start();
+		return true;
 	}
 
 	const std::shared_ptr<const ov::Url> PullStream::GetNextURL()
@@ -122,6 +141,8 @@ namespace pvd
 
 	const std::shared_ptr<const ov::Url> PullStream::GetPrimaryURL()
 	{
+		ov::LockGuard lock(_start_stop_stream_lock);
+
 		if (_url_list.size() == 0)
 		{
 			return nullptr;
@@ -134,6 +155,14 @@ namespace pvd
 
 	bool PullStream::IsCurrPrimaryURL()
 	{
+		ov::LockGuard lock(_start_stop_stream_lock);
+
+		// No URL to fail back to - treat as primary so the failback path stays idle
+		if (_url_list.empty())
+		{
+			return true;
+		}
+
 		// If the currently playing URL and the 0th URL are the same, it is the primary URL.
 		if (GetMediaSource() == _url_list[0]->ToUrlString(true))
 			return true;
@@ -143,6 +172,8 @@ namespace pvd
 
 	void PullStream::ResetUrlIndex()
 	{
+		ov::LockGuard lock(_start_stop_stream_lock);
+
 		_curr_url_index = 0;
 	}
 

--- a/src/projects/base/provider/pull_provider/stream.h
+++ b/src/projects/base/provider/pull_provider/stream.h
@@ -65,8 +65,10 @@ namespace pvd
 		}
 
 	private:
+		// FIXME: `Resume()`/`GetNextURL()`/`ResetUrlIndex()`/`IsCurrPrimaryURL()` access these without lock (data race).
+		// Split `Stop()` into `Stop()`+`StopLocked()` so `Resume()` can hold the lock without deadlocking.
 		uint32_t	_restart_count OV_GUARDED_BY(_start_stop_stream_lock) = 0;
-		std::vector<std::shared_ptr<const ov::Url>> _url_list;
+		std::vector<std::shared_ptr<const ov::Url>> _url_list OV_GUARDED_BY(_start_stop_stream_lock);
 		int _curr_url_index OV_GUARDED_BY(_start_stop_stream_lock) = 0;
 
 		std::shared_ptr<pvd::PullStreamProperties> _properties;

--- a/src/projects/base/provider/pull_provider/stream.h
+++ b/src/projects/base/provider/pull_provider/stream.h
@@ -65,8 +65,15 @@ namespace pvd
 		}
 
 	private:
-		// FIXME: `Resume()`/`GetNextURL()`/`ResetUrlIndex()`/`IsCurrPrimaryURL()` access these without lock (data race).
-		// Split `Stop()` into `Stop()`+`StopLocked()` so `Resume()` can hold the lock without deadlocking.
+		bool StopInternal() OV_REQUIRES(_start_stop_stream_lock);
+
+		// Locked body of `Resume()`: retry-count check + one `RestartStream()` attempt.
+		// `UpdateStream()`/`Stream::Start()` are deliberately called by the wrapper AFTER
+		// the lock is released so this lock stays a leaf
+		// (never held while entering `Application`/`MediaRouter`).
+		bool ResumeInternal() OV_REQUIRES(_start_stop_stream_lock);
+		const std::shared_ptr<const ov::Url> GetNextURL() OV_REQUIRES(_start_stop_stream_lock);
+
 		uint32_t	_restart_count OV_GUARDED_BY(_start_stop_stream_lock) = 0;
 		std::vector<std::shared_ptr<const ov::Url>> _url_list OV_GUARDED_BY(_start_stop_stream_lock);
 		int _curr_url_index OV_GUARDED_BY(_start_stop_stream_lock) = 0;
@@ -77,7 +84,6 @@ namespace pvd
 		ov::Mutex _start_stop_stream_lock;
 
 	public:
-		const std::shared_ptr<const ov::Url> GetNextURL();
 		const std::shared_ptr<const ov::Url> GetPrimaryURL();
 		void ResetUrlIndex();
 		bool IsCurrPrimaryURL();

--- a/src/projects/base/provider/pull_provider/stream.h
+++ b/src/projects/base/provider/pull_provider/stream.h
@@ -69,8 +69,8 @@ namespace pvd
 
 		// Locked body of `Resume()`: retry-count check + one `RestartStream()` attempt.
 		// `UpdateStream()`/`Stream::Start()` are deliberately called by the wrapper AFTER
-		// the lock is released so this lock stays a leaf
-		// (never held while entering `Application`/`MediaRouter`).
+		// the lock is released, so this lock is never held while entering
+		// `Application`/`MediaRouter`.
 		bool ResumeInternal() OV_REQUIRES(_start_stop_stream_lock);
 		const std::shared_ptr<const ov::Url> GetNextURL() OV_REQUIRES(_start_stop_stream_lock);
 

--- a/src/projects/base/provider/pull_provider/stream_test.cpp
+++ b/src/projects/base/provider/pull_provider/stream_test.cpp
@@ -1,0 +1,117 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <base/provider/pull_provider/stream.h>
+#include <base/provider/pull_provider/stream_props.h>
+#include <gtest/gtest.h>
+
+// Tests for the `PullStream` empty-URL guard on this branch:
+// when every configured URL fails to parse (reachable through the `OriginMap` pull path,
+// which performs no URL validation), `GetNextURL()` returns `nullptr`
+// and `Start()`/`Resume()` must terminate the stream cleanly
+// instead of feeding the `nullptr` into provider `StartStream()`/`RestartStream()`
+// implementations that dereference it unconditionally
+// (RTSPC crashed on this before the fix).
+//
+// Note: the failure paths under test never touch the (`nullptr`) application pointer -
+// only the success path logs through it,
+// which is why these tests stick to the empty/unparsable cases.
+
+namespace
+{
+	std::shared_ptr<pvd::PullStreamProperties> RetryingProperties()
+	{
+		// The default retry count (-1) makes `ResumeInternal()` bail out
+		// at the retry-count gate BEFORE reaching the null-URL guard under test
+		auto properties = std::make_shared<pvd::PullStreamProperties>();
+		properties->SetRetryCount(1);
+		return properties;
+	}
+
+	class TestPullStream : public pvd::PullStream
+	{
+	public:
+		explicit TestPullStream(const std::vector<ov::String> &url_list)
+			: pvd::PullStream(std::shared_ptr<pvd::Application>(), info::Stream(StreamSourceType::Ovt), url_list, RetryingProperties())
+		{
+		}
+
+		int start_stream_calls = 0;
+		int restart_stream_calls = 0;
+
+		ProcessMediaEventTrigger GetProcessMediaEventTriggerMode() override
+		{
+			return ProcessMediaEventTrigger::TRIGGER_EPOLL;
+		}
+
+		int GetFileDescriptorForDetectingEvent() override
+		{
+			return -1;
+		}
+
+		ProcessMediaResult ProcessMediaPacket() override
+		{
+			return ProcessMediaResult::PROCESS_MEDIA_FINISH;
+		}
+
+	protected:
+		bool StartStream(const std::shared_ptr<const ov::Url> &url) override
+		{
+			start_stream_calls++;
+			// The guard under test must prevent a `nullptr` from ever arriving here
+			EXPECT_NE(url, nullptr);
+			return false;
+		}
+
+		bool RestartStream(const std::shared_ptr<const ov::Url> &url) override
+		{
+			restart_stream_calls++;
+			EXPECT_NE(url, nullptr);
+			return false;
+		}
+
+		bool StopStream() override
+		{
+			return true;
+		}
+	};
+}  // namespace
+
+TEST(PullStreamEmptyUrl, StartTerminatesWithoutCallingProvider)
+{
+	TestPullStream stream({});
+
+	EXPECT_FALSE(stream.Start());
+	EXPECT_EQ(stream.GetState(), pvd::Stream::State::TERMINATED);
+	EXPECT_EQ(stream.start_stream_calls, 0);
+}
+
+TEST(PullStreamEmptyUrl, UnparsableUrlsTerminateWithoutCallingProvider)
+{
+	// Every entry fails `ov::Url::Parse()`, so the constructor leaves the internal
+	// URL list empty - exactly what an invalid Origins entry produces.
+	// Pin the precondition: if either string ever starts parsing,
+	// this test would silently stop covering the empty-list path.
+	ASSERT_EQ(ov::Url::Parse("definitely not a url"), nullptr);
+	ASSERT_EQ(ov::Url::Parse("also::not::valid"), nullptr);
+
+	TestPullStream stream({"definitely not a url", "also::not::valid"});
+
+	EXPECT_FALSE(stream.Start());
+	EXPECT_EQ(stream.GetState(), pvd::Stream::State::TERMINATED);
+	EXPECT_EQ(stream.start_stream_calls, 0);
+}
+
+TEST(PullStreamEmptyUrl, ResumeTerminatesWithoutCallingProvider)
+{
+	TestPullStream stream({});
+
+	EXPECT_FALSE(stream.Resume());
+	EXPECT_EQ(stream.GetState(), pvd::Stream::State::TERMINATED);
+	EXPECT_EQ(stream.restart_stream_calls, 0);
+}

--- a/src/projects/base/provider/stream.cpp
+++ b/src/projects/base/provider/stream.cpp
@@ -119,7 +119,7 @@ namespace pvd
 
 	int64_t Stream::GetCurrentTimestampMs()
 	{
-		ov::LockGuard<ov::Mutex> lock(_timestamp_mutex);
+		ov::LockGuard lock(_timestamp_mutex);
 
 		// Not yet started
 		if (_last_media_timestamp_ms == -1)
@@ -165,9 +165,14 @@ namespace pvd
 				return false;
 			}
 
-			logtt("SendDataFrame - %s/%s(%u) - last_media_timestamp_ms: %" PRId64 ", elapsed_from_last_media_timestamp: %" PRId64 ", timestamp: %" PRId64 " ms",
-				  GetApplicationName(), GetName().CStr(), GetId(),
-				  _last_media_timestamp_ms, _elapsed_from_last_media_timestamp.Elapsed(), timestamp_in_ms);
+#if DEBUG
+			{
+				ov::LockGuard lock(_timestamp_mutex);
+				logtt("SendDataFrame - %s/%s(%u) - last_media_timestamp_ms: %" PRId64 ", elapsed_from_last_media_timestamp: %" PRId64 ", timestamp: %" PRId64 " ms",
+					  GetApplicationName(), GetName().CStr(), GetId(),
+					  _last_media_timestamp_ms, _elapsed_from_last_media_timestamp.Elapsed(), timestamp_in_ms);
+			}
+#endif	// DEBUG
 		}
 
 		auto timestamp_in_tb = static_cast<int64_t>(timestamp_in_ms * data_track->GetTimeBase().GetTimescale() / 1000.0);
@@ -368,7 +373,7 @@ namespace pvd
 
 		if (master_clock_track != nullptr && packet->GetTrackId() == master_clock_track->GetId())
 		{
-			ov::LockGuard<ov::Mutex> lock(_timestamp_mutex);
+			ov::LockGuard lock(_timestamp_mutex);
 			_last_media_timestamp_ms = packet->GetPts() / GetTrack(packet->GetTrackId())->GetTimeBase().GetTimescale() * 1000.0;
 			_elapsed_from_last_media_timestamp.Restart();
 		}

--- a/src/projects/modules/dtls_srtp/dtls_transport.cpp
+++ b/src/projects/modules/dtls_srtp/dtls_transport.cpp
@@ -28,6 +28,8 @@ bool DtlsTransport::Stop()
 // Set Local Certificate
 void DtlsTransport::SetLocalCertificate(const std::shared_ptr<::Certificate> &certificate)
 {
+	ov::LockGuard<ov::Mutex> lock(_tls_lock);
+
 	_local_certificate = certificate;
 
 	ov::TlsContextCallback tls_context_callback = {
@@ -67,6 +69,8 @@ void DtlsTransport::SetLocalCertificate(const std::shared_ptr<::Certificate> &ce
 // Set Peer Fingerprint for verification
 void DtlsTransport::SetPeerFingerprint(ov::String algorithm, ov::String fingerprint)
 {
+	ov::LockGuard<ov::Mutex> lock(_tls_lock);
+
 	_peer_fingerprint_algorithm = algorithm;
 	_peer_fingerprint_value = fingerprint;
 }
@@ -237,7 +241,13 @@ bool DtlsTransport::OnDataReceivedFromPrevNode(NodeType from_node, const std::sh
 		return false;
 	}
 
-	switch (_state)
+	SSLState state;
+	{
+		ov::LockGuard lock(_tls_lock);
+		state = _state;
+	}
+
+	switch (state)
 	{
 		case SSL_NONE:
 		case SSL_WAIT:
@@ -251,7 +261,7 @@ bool DtlsTransport::OnDataReceivedFromPrevNode(NodeType from_node, const std::sh
 			}
 			else
 			{
-				ov::LockGuard<ov::Mutex> lock(_tls_lock);
+				ov::LockGuard lock(_tls_lock);
 				// If it is not SRTP, it must be encrypted in DTLS.
 				// TODO: Currently, SCTP is not supported, so there is no need to encrypt,
 				// and it will be developed if it supports data channels in the future.
@@ -286,7 +296,13 @@ bool DtlsTransport::OnDataReceivedFromNextNode(NodeType from_node, const std::sh
 
 	logtt("OnDataReceived (%zu) bytes", data->GetLength());
 
-	switch (_state)
+	SSLState state;
+	{
+		ov::LockGuard lock(_tls_lock);
+		state = _state;
+	}
+
+	switch (state)
 	{
 		case SSL_NONE:
 		case SSL_WAIT:

--- a/src/projects/modules/dtls_srtp/dtls_transport.h
+++ b/src/projects/modules/dtls_srtp/dtls_transport.h
@@ -81,11 +81,11 @@ private:
 	std::shared_ptr<info::Session> _session_info;
 	std::shared_ptr<IcePort> _ice_port;
 	std::shared_ptr<SrtpTransport> _srtp_transport;
-	std::shared_ptr<::Certificate> _local_certificate;
-	std::shared_ptr<ov::TlsContext> _tls_context;
+	std::shared_ptr<::Certificate> _local_certificate OV_GUARDED_BY(_tls_lock);
+	std::shared_ptr<ov::TlsContext> _tls_context OV_GUARDED_BY(_tls_lock);
 	std::shared_ptr<::Certificate> _peer_certificate OV_GUARDED_BY(_tls_lock);
-	ov::String _peer_fingerprint_algorithm;
-	ov::String _peer_fingerprint_value;
+	ov::String _peer_fingerprint_algorithm OV_GUARDED_BY(_tls_lock);
+	ov::String _peer_fingerprint_value OV_GUARDED_BY(_tls_lock);
 
 	// SSL이 가져갈 패킷을 임시로 보관하는 버퍼, 동시에 1개만 저장한다.
 	std::deque<std::shared_ptr<const ov::Data>> _packet_buffer OV_GUARDED_BY(_tls_lock);

--- a/src/projects/modules/dtls_srtp/dtls_transport.h
+++ b/src/projects/modules/dtls_srtp/dtls_transport.h
@@ -45,14 +45,16 @@ public:
 	// 그 외에는 모르는 패킷이므로 처리하지 않는다.
 	bool RecvPacket(const std::shared_ptr<ov::Data> &data);
 
-protected:
-	// SSL에서 암호화 할 패킷을 읽어갈 때 호출한다. _packet_buffer에 쌓인 패킷을 준다.
-	ssize_t Read(ov::Tls *tls, void *buffer, size_t length) OV_NO_THREAD_SAFETY_ANALYSIS;
+private:
+	// BIO read callback: hands the packets buffered in `_packet_buffer` to the TLS layer.
+	// Invoked only through the in-class BIO binding, and every entry path runs `_tls`
+	// operations under `_tls_lock` - hence `OV_REQUIRES` on a private method is satisfiable.
+	ssize_t Read(ov::Tls *tls, void *buffer, size_t length) OV_REQUIRES(_tls_lock);
 
-	// SSL에서 복호화한 패킷의 전송을 요청할 때 호출한다. ice로 최종 전송한다.
+	// BIO write callback: requested when the TLS layer emits a packet; finally sent via ICE
 	ssize_t Write(ov::Tls *tls, const void *data, size_t length);
 
-	bool VerifyPeerCertificate() OV_NO_THREAD_SAFETY_ANALYSIS;
+	bool VerifyPeerCertificate() OV_REQUIRES(_tls_lock);
 
 private:
 	bool ContinueSSL() OV_REQUIRES(_tls_lock);

--- a/src/projects/modules/dtls_srtp/srtp_adapter.cpp
+++ b/src/projects/modules/dtls_srtp/srtp_adapter.cpp
@@ -87,6 +87,8 @@ bool SrtpAdapter::SetKey(srtp_ssrc_type_t type, uint64_t crypto_suite, std::shar
 
 bool SrtpAdapter::ProtectRtp(std::shared_ptr<ov::Data> data)
 {
+	ov::LockGuard lock(_session_lock);
+
 	if(!_session)
 	{
 		return false;
@@ -110,7 +112,6 @@ bool SrtpAdapter::ProtectRtp(std::shared_ptr<ov::Data> data)
 	uint8_t red_payload_type = byte_buffer[12];
 	uint16_t seq = ByteReader<uint16_t>::ReadBigEndian(&byte_buffer[2]);
 
-	ov::LockGuard<ov::Mutex> lock(_session_lock);
 	int err = srtp_protect(_session, buffer, &out_len);
 	if(err != srtp_err_status_ok)
 	{
@@ -123,6 +124,8 @@ bool SrtpAdapter::ProtectRtp(std::shared_ptr<ov::Data> data)
 
 bool SrtpAdapter::ProtectRtcp(std::shared_ptr<ov::Data> data)
 {
+	ov::LockGuard lock(_session_lock);
+
     if(!_session)
     {
         return false;
@@ -141,7 +144,6 @@ bool SrtpAdapter::ProtectRtcp(std::shared_ptr<ov::Data> data)
     int out_len = static_cast<int>(data->GetLength());
     data->SetLength(need_len);
 
-	ov::LockGuard<ov::Mutex> lock(_session_lock);
     int err = srtp_protect_rtcp(_session, buffer, &out_len);
     if(err != srtp_err_status_ok)
     {
@@ -154,6 +156,8 @@ bool SrtpAdapter::ProtectRtcp(std::shared_ptr<ov::Data> data)
 
 bool SrtpAdapter::UnprotectRtp(const std::shared_ptr<ov::Data> &data)
 {
+	ov::LockGuard lock(_session_lock);
+
 	if (!_session)
     {
         return false;
@@ -162,7 +166,6 @@ bool SrtpAdapter::UnprotectRtp(const std::shared_ptr<ov::Data> &data)
     auto buffer = data->GetWritableData();
     int out_len = static_cast<int>(data->GetLength());
 
-	ov::LockGuard<ov::Mutex> lock(_session_lock);
     int err = srtp_unprotect(_session, buffer, &out_len);
     if (err != srtp_err_status_ok)
     {
@@ -177,6 +180,8 @@ bool SrtpAdapter::UnprotectRtp(const std::shared_ptr<ov::Data> &data)
 
 bool SrtpAdapter::UnprotectRtcp(const std::shared_ptr<ov::Data> &data)
 {
+	ov::LockGuard lock(_session_lock);
+
     if (!_session)
     {
         return false;
@@ -185,7 +190,6 @@ bool SrtpAdapter::UnprotectRtcp(const std::shared_ptr<ov::Data> &data)
     auto buffer = data->GetWritableData();
     int out_len = static_cast<int>(data->GetLength());
 
-	ov::LockGuard<ov::Mutex> lock(_session_lock);
     int err = srtp_unprotect_rtcp(_session, buffer, &out_len);
     if (err != srtp_err_status_ok)
     {

--- a/src/projects/modules/dtls_srtp/srtp_adapter.cpp
+++ b/src/projects/modules/dtls_srtp/srtp_adapter.cpp
@@ -31,6 +31,7 @@ bool SrtpAdapter::Release()
 	if(_session != nullptr)
 	{
 		srtp_dealloc(_session);
+		_session = nullptr;
 	}
 	return true;
 }

--- a/src/projects/modules/http/cors/cors_manager.cpp
+++ b/src/projects/modules/http/cors/cors_manager.cpp
@@ -173,14 +173,14 @@ namespace http
 		ov::String origin_header = request->GetHeader("ORIGIN");
 		ov::String cors_header = "";
 		bool found_origin = false;
-		std::unordered_map<info::VHostAppName, cfg::cmn::CrossDomains>::const_iterator cors_cfg_iterator;
+		cfg::cmn::CrossDomains cors_cfg;
 
 		{
 			ov::LockGuard lock_guard(_cors_mutex);
 
 			auto cors_policy_iterator = _cors_policy_map.find(vhost_app_name);
 			auto cors_regex_list_iterator = _cors_item_list_map.find(vhost_app_name);
-			cors_cfg_iterator = _cors_cfg_map.find(vhost_app_name);
+			auto cors_cfg_iterator = _cors_cfg_map.find(vhost_app_name);
 			
 			if (
 				(cors_policy_iterator == _cors_policy_map.end()) ||
@@ -234,9 +234,9 @@ namespace http
 					cors_header = origin_header;
 				}
 			}
-		}
 
-		const auto &cors_cfg = cors_cfg_iterator->second;
+			cors_cfg = cors_cfg_iterator->second;
+		}
 		if (found_origin == false)
 		{
 			response->UnsetHeader("Access-Control-Allow-Origin");

--- a/src/projects/modules/http/cors/cors_manager.h
+++ b/src/projects/modules/http/cors/cors_manager.h
@@ -28,7 +28,7 @@ namespace http
 		//
 		// Empty url_list means 'Do not set any CORS header'
 		//
-		// NOTE - SetCrossDomains() isn't thread-safe.
+		// NOTE - All methods are protected by _cors_mutex.
 		void SetCrossDomains(const info::VHostAppName &vhost_app_name, const cfg::cmn::CrossDomains &cross_domain_cfg);
 		void SetDefaultCrossDomains(const cfg::cmn::CrossDomains &cross_domain_cfg);
 		bool SetupRtmpCorsXml(const std::shared_ptr<http::svr::HttpResponse> &response) const;

--- a/src/projects/modules/http/server/http1/http1_response.cpp
+++ b/src/projects/modules/http/server/http1/http1_response.cpp
@@ -60,9 +60,12 @@ namespace http
 				std::shared_ptr<ov::Data> response = std::make_shared<ov::Data>(65535);
 				ov::ByteStream stream(response.get());
 
-				if (_chunked_transfer == false && 
-						GetStatusCode() != StatusCode::NoContent && 
-						GetStatusCode() != StatusCode::NotModified)
+				// Load once so the status line cannot mix two different status codes
+				const auto status_code = GetStatusCode();
+
+				if (_chunked_transfer == false &&
+						status_code != StatusCode::NoContent &&
+						status_code != StatusCode::NotModified)
 				{
 					// Calculate the content length
 					SetHeader("Content-Length", ov::Converter::ToString(GetResponseDataSize()));
@@ -71,7 +74,7 @@ namespace http
 				// RFC7230 - 3.1.2.  Status Line
 				// status-line = HTTP-version SP status-code SP reason-phrase CRLF
 				// TODO(dimiden): Replace this HTTP version with the version that received from the request
-				stream.Append(ov::String::FormatString("HTTP/1.1 %d %s\r\n", ov::ToUnderlyingType(GetStatusCode()), GetReason().CStr()).ToData(false));
+				stream.Append(ov::String::FormatString("HTTP/1.1 %d %s\r\n", ov::ToUnderlyingType(status_code), StringFromStatusCode(status_code)).ToData(false));
 
 				// RFC7230 - 3.2.  Header Fields
 				for (const auto &pair : GetResponseHeaderList())

--- a/src/projects/modules/http/server/http2/http2_response.cpp
+++ b/src/projects/modules/http/server/http2/http2_response.cpp
@@ -142,8 +142,10 @@ namespace http
 
 				uint32_t sent_bytes = 0;
 
-				for (const auto &data : GetResponseDataList())
+				auto response_data_list = GetResponseDataList();
+				for (size_t i = 0; i < response_data_list.size(); ++i)
 				{
+					const auto &data = response_data_list[i];
 					size_t offset = 0;
 					auto data_fragment = data;
 					while (offset + MAX_HTTP2_DATA_SIZE < data->GetLength())
@@ -169,7 +171,7 @@ namespace http
 					payload_frame->SetData(data_fragment);
 
 					// End Stream
-					if (_keep_stream == false && (&data == &GetResponseDataList().back()))
+					if (_keep_stream == false && (i == response_data_list.size() - 1))
 					{
 						payload_frame->SetEndStream();
 					}

--- a/src/projects/modules/http/server/http2/http2_response.h
+++ b/src/projects/modules/http/server/http2/http2_response.h
@@ -42,7 +42,7 @@ namespace http
 				int32_t SendPayload() override;
 
 				uint32_t _stream_id = 0;
-				bool _keep_stream = false;
+				std::atomic<bool> _keep_stream{false};
 				std::shared_ptr<hpack::Encoder> _hpack_encoder;
 			};
 		}

--- a/src/projects/modules/http/server/http_response.cpp
+++ b/src/projects/modules/http/server/http_response.cpp
@@ -36,6 +36,8 @@ namespace http
 		{
 			OV_ASSERT2(http_response != nullptr);
 
+			ov::LockGuard lock(http_response->_response_mutex);
+
 			_client_socket = http_response->_client_socket;
 			_tls_data = http_response->_tls_data;
 			_status_code = http_response->_status_code;
@@ -206,7 +208,7 @@ namespace http
 				return false;
 			}
 
-			ov::LockGuard<decltype(_response_mutex)> lock(_response_mutex);
+			ov::LockGuard lock(_response_mutex);
 
 			auto cloned_data = data->Clone();
 
@@ -256,18 +258,21 @@ namespace http
 
 		bool HttpResponse::IsHeaderSent() const
 		{
+			ov::LockGuard lock(_response_mutex);
 			return _is_header_sent;
 		}
 
 		// Get Response Data Size
 		size_t HttpResponse::GetResponseDataSize() const
 		{
+			ov::LockGuard lock(_response_mutex);
 			return _response_data_size;
 		}
 
 		// Get Response Data List
-		const std::vector<std::shared_ptr<const ov::Data>> &HttpResponse::GetResponseDataList() const
+		std::vector<std::shared_ptr<const ov::Data>> HttpResponse::GetResponseDataList() const
 		{
+			ov::LockGuard lock(_response_mutex);
 			return _response_data_list;
 		}
 
@@ -279,6 +284,7 @@ namespace http
 
 		void HttpResponse::ResetResponseData()
 		{
+			ov::LockGuard lock(_response_mutex);
 			_response_data_list.clear();
 			_response_data_size = 0ULL;
 		}
@@ -292,18 +298,20 @@ namespace http
 		// Get Resopnsed Time
 		std::chrono::system_clock::time_point HttpResponse::GetResponseTime() const
 		{
+			ov::LockGuard lock(_response_mutex);
 			return _response_time;
 		}
-		
+
 		// Get Sent size
 		uint32_t HttpResponse::GetSentSize() const
 		{
+			ov::LockGuard lock(_response_mutex);
 			return _sent_size;
 		}
 
 		int32_t HttpResponse::Response()
 		{
-			ov::LockGuard<decltype(_response_mutex)> lock(_response_mutex);
+			ov::LockGuard lock(_response_mutex);
 			_response_time = std::chrono::system_clock::now();
 
 			uint32_t sent_size = 0;
@@ -440,6 +448,7 @@ namespace http
 		{
 			ov::String output;
 
+			ov::LockGuard lock(_response_mutex);
 			output.AppendFormat("<HttpResponse> Status(%d) Reason(%s) Header(%zu) Data(%zu)\n",
 								static_cast<int>(GetStatusCode()),
 								GetReason().CStr(),

--- a/src/projects/modules/http/server/http_response.cpp
+++ b/src/projects/modules/http/server/http_response.cpp
@@ -36,23 +36,22 @@ namespace http
 		{
 			OV_ASSERT2(http_response != nullptr);
 
+			_tls_data = std::atomic_load(&http_response->_tls_data);
+
 			ov::LockGuard lock(http_response->_response_mutex);
 
 			_client_socket = http_response->_client_socket;
-			_tls_data = http_response->_tls_data;
-			_status_code = http_response->_status_code;
-			_reason = http_response->_reason;
+			_status_code = http_response->_status_code.load();
 			_is_header_sent = http_response->_is_header_sent;
 			_response_header = http_response->_response_header;
 			_response_data_list = http_response->_response_data_list;
-			_response_data_size = http_response->_response_data_size;
-			_default_value = http_response->_default_value;
+			_response_data_size = http_response->_response_data_size.load();
 			_created_time = http_response->_created_time;
 		}
 
 		void HttpResponse::SetTlsData(const std::shared_ptr<ov::TlsServerData> &tls_data)
 		{
-			_tls_data = tls_data;
+			std::atomic_store(&_tls_data, tls_data);
 		}
 
 		std::shared_ptr<ov::ClientSocket> HttpResponse::GetRemote()
@@ -67,7 +66,7 @@ namespace http
 
 		std::shared_ptr<ov::TlsServerData> HttpResponse::GetTlsData()
 		{
-			return _tls_data;
+			return std::atomic_load(&_tls_data);
 		}
 
 		void HttpResponse::SetMethod(Method method)
@@ -82,12 +81,13 @@ namespace http
 
 		void HttpResponse::SetIfNoneMatch(const ov::String &etag)
 		{
-			_if_none_match = etag;
+			std::atomic_store(&_if_none_match, std::make_shared<const ov::String>(etag));
 		}
 
-		const ov::String &HttpResponse::GetIfNoneMatch() const
+		ov::String HttpResponse::GetIfNoneMatch() const
 		{
-			return _if_none_match;
+			auto if_none_match = std::atomic_load(&_if_none_match);
+			return (if_none_match != nullptr) ? *if_none_match : "";
 		}
 
 		StatusCode HttpResponse::GetStatusCode() const
@@ -98,30 +98,25 @@ namespace http
 		// Get Reason
 		ov::String HttpResponse::GetReason() const
 		{
-			return _reason;
+			return StringFromStatusCode(_status_code);
 		}
 
 		// reason = default
 		void HttpResponse::SetStatusCode(StatusCode status_code)
 		{
-			SetStatusCode(status_code, StringFromStatusCode(status_code));
-		}
-
-		// custom reason
-		void HttpResponse::SetStatusCode(StatusCode status_code, const ov::String &reason)
-		{
 			_status_code = status_code;
-			_reason = reason;
 		}
 
 		bool HttpResponse::AddHeader(const ov::String &key, const ov::String &value)
 		{
+			ov::LockGuard lock(_response_mutex);
+
 			if (IsHeaderSent())
 			{
 				logtw("Cannot add header: Header is sent: %s", _client_socket->ToString().CStr());
 				return false;
 			}
-			
+
 			_response_header[key].push_back(value);
 
 			return true;
@@ -129,12 +124,14 @@ namespace http
 
 		bool HttpResponse::SetHeader(const ov::String &key, const ov::String &value)
 		{
+			ov::LockGuard lock(_response_mutex);
+
 			if (IsHeaderSent())
 			{
 				logtw("Cannot set header: Header is sent: %s", _client_socket->ToString().CStr());
 				return false;
 			}
-			
+
 			_response_header[key] = {value};
 
 			return true;
@@ -142,6 +139,8 @@ namespace http
 
 		bool HttpResponse::UnsetHeader(const ov::String &key)
 		{
+			ov::LockGuard lock(_response_mutex);
+
 			if (IsHeaderSent())
 			{
 				logtw("Cannot unset header: Header is sent: %s", _client_socket->ToString().CStr());
@@ -159,13 +158,15 @@ namespace http
 			return true;
 		}
 
-		const std::vector<ov::String> &HttpResponse::GetHeader(const ov::String &key) const
+		std::vector<ov::String> HttpResponse::GetHeader(const ov::String &key) const
 		{
+			ov::LockGuard lock(_response_mutex);
+
 			auto item = _response_header.find(key);
 
 			if (item == _response_header.end())
 			{
-				return _default_value;
+				return {};
 			}
 
 			return item->second;
@@ -173,6 +174,8 @@ namespace http
 
 		bool HttpResponse::RemoveHeader(const ov::String &key)
 		{
+			ov::LockGuard lock(_response_mutex);
+
 			if (IsHeaderSent())
 			{
 				logtw("Cannot remove header: Header is sent: %s", _client_socket->ToString().CStr());
@@ -198,7 +201,7 @@ namespace http
 				return "";
 			}
 
-			return ov::String::FormatString("%s-%zu", _response_hash->ToHexString().CStr(), _response_data_size);
+			return ov::String::FormatString("%s-%zu", _response_hash->ToHexString().CStr(), _response_data_size.load());
 		}
 
 		bool HttpResponse::AppendData(const std::shared_ptr<const ov::Data> &data)
@@ -265,7 +268,6 @@ namespace http
 		// Get Response Data Size
 		size_t HttpResponse::GetResponseDataSize() const
 		{
-			ov::LockGuard lock(_response_mutex);
 			return _response_data_size;
 		}
 
@@ -277,8 +279,9 @@ namespace http
 		}
 
 		// Get Response Header
-		const std::unordered_map<ov::String, std::vector<ov::String>, ov::CaseInsensitiveHash, ov::CaseInsensitiveEqual> &HttpResponse::GetResponseHeaderList() const
+		std::unordered_map<ov::String, std::vector<ov::String>, ov::CaseInsensitiveHash, ov::CaseInsensitiveEqual> HttpResponse::GetResponseHeaderList() const
 		{
+			ov::LockGuard lock(_response_mutex);
 			return _response_header;
 		}
 
@@ -298,14 +301,12 @@ namespace http
 		// Get Resopnsed Time
 		std::chrono::system_clock::time_point HttpResponse::GetResponseTime() const
 		{
-			ov::LockGuard lock(_response_mutex);
 			return _response_time;
 		}
 
 		// Get Sent size
 		uint32_t HttpResponse::GetSentSize() const
 		{
-			ov::LockGuard lock(_response_mutex);
 			return _sent_size;
 		}
 
@@ -320,7 +321,7 @@ namespace http
 			if (IsHeaderSent() == false)
 			{
 				// Date header
-				auto date = ov::Converter::ToRFC7231String(_response_time);
+				auto date = ov::Converter::ToRFC7231String(_response_time.load());
 				SetHeader("Date", date);
 
 				if (_etag_enabled_by_config == true)
@@ -404,15 +405,18 @@ namespace http
 
 			std::shared_ptr<const ov::Data> send_data;
 
-			if (_tls_data == nullptr)
+			// Atomic snapshot; the encrypt/send path below must not touch `_tls_data` directly
+			auto tls_data = GetTlsData();
+
+			if (tls_data == nullptr)
 			{
 				send_data = data->Clone();
 			}
 			else
 			{
-				ov::LockGuard<ov::Mutex> lock(_tls_data->GetSequentialSendMutex());
+				ov::LockGuard<ov::Mutex> lock(tls_data->GetSequentialSendMutex());
 
-				if (_tls_data->Encrypt(data, &send_data) == false)
+				if (tls_data->Encrypt(data, &send_data) == false)
 				{
 					logte("Failed to encrypt data: %s", _client_socket->ToString().CStr());
 					return false;
@@ -453,7 +457,7 @@ namespace http
 								static_cast<int>(GetStatusCode()),
 								GetReason().CStr(),
 								_response_header.size(),
-								_response_data_size);
+								_response_data_size.load());
 
 			output.AppendFormat("\n[Header]\n");
 			for (auto &[key, values] : _response_header)

--- a/src/projects/modules/http/server/http_response.h
+++ b/src/projects/modules/http/server/http_response.h
@@ -38,19 +38,17 @@ namespace http
 			Method GetMethod() const;
 
 			void SetIfNoneMatch(const ov::String &etag);
-			const ov::String &GetIfNoneMatch() const;
+			ov::String GetIfNoneMatch() const;
 
 			// reason = default
 			void SetStatusCode(StatusCode status_code);
-			// custom reason
-			void SetStatusCode(StatusCode status_code, const ov::String &reason);
 
 			// Append a new item to the existing header
 			bool AddHeader(const ov::String &key, const ov::String &value);
 			// Overwrites the existing value to <value>
 			bool SetHeader(const ov::String &key, const ov::String &value);
 			bool UnsetHeader(const ov::String &key);
-			const std::vector<ov::String> &GetHeader(const ov::String &key) const;
+			std::vector<ov::String> GetHeader(const ov::String &key) const;
 			bool RemoveHeader(const ov::String &key);
 
 			// Enqueue the data into the queue (This data will be sent when SendResponse() is called)
@@ -80,7 +78,7 @@ namespace http
 			// Get Response Data List
 			std::vector<std::shared_ptr<const ov::Data>> GetResponseDataList() const;
 			// Get Response Header
-			const std::unordered_map<ov::String, std::vector<ov::String>, ov::CaseInsensitiveHash, ov::CaseInsensitiveEqual> &GetResponseHeaderList() const;
+			std::unordered_map<ov::String, std::vector<ov::String>, ov::CaseInsensitiveHash, ov::CaseInsensitiveEqual> GetResponseHeaderList() const;
 			void ResetResponseData();
 
 			// Can be used for response without content-length
@@ -99,10 +97,10 @@ namespace http
 			ov::String GetEtag() OV_REQUIRES(_response_mutex);
 
 			std::shared_ptr<ov::ClientSocket> _client_socket;
+			// Accessed only via `std::atomic_load`/`std::atomic_store` (TSA cannot model this)
 			std::shared_ptr<ov::TlsServerData> _tls_data;
 
-			StatusCode _status_code = StatusCode::OK;
-			ov::String _reason = StringFromStatusCode(StatusCode::OK);
+			std::atomic<StatusCode> _status_code{StatusCode::OK};
 
 			bool _is_header_sent OV_GUARDED_BY(_response_mutex) = false;
 
@@ -123,20 +121,21 @@ namespace http
 			// So _response_header is a map of case insentitive header key and value
 			std::unordered_map<ov::String, std::vector<ov::String>, ov::CaseInsensitiveHash, ov::CaseInsensitiveEqual> _response_header OV_GUARDED_BY(_response_mutex);
 			std::vector<std::shared_ptr<const ov::Data>> _response_data_list OV_GUARDED_BY(_response_mutex);
-			size_t _response_data_size OV_GUARDED_BY(_response_mutex) = 0;
-
-			std::vector<ov::String> _default_value{};
+			// Written only under `_response_mutex` together with `_response_data_list`
+			// (Content-Length/etag pair consistency); atomic so standalone reads are lock-free
+			std::atomic<size_t> _response_data_size{0};
 
 			// Created time
 			std::chrono::system_clock::time_point _created_time;
 			// Responsed time
-			std::chrono::system_clock::time_point _response_time OV_GUARDED_BY(_response_mutex);
-			uint32_t _sent_size OV_GUARDED_BY(_response_mutex) = 0;
+			std::atomic<std::chrono::system_clock::time_point> _response_time{std::chrono::system_clock::time_point()};
+			std::atomic<uint32_t> _sent_size{0};
 
-			Method _method = Method::Unknown;
+			std::atomic<Method> _method{Method::Unknown};
 
 			bool _etag_enabled_by_config = false;
-			ov::String _if_none_match = "";
+			// Accessed only via `std::atomic_load`/`std::atomic_store`
+			std::shared_ptr<const ov::String> _if_none_match;
 			std::shared_ptr<ov::Data> _response_hash OV_GUARDED_BY(_response_mutex) = nullptr;
 		};
 	}  // namespace svr

--- a/src/projects/modules/http/server/http_response.h
+++ b/src/projects/modules/http/server/http_response.h
@@ -78,7 +78,7 @@ namespace http
 			bool IsHeaderSent() const;
 			
 			// Get Response Data List
-			const std::vector<std::shared_ptr<const ov::Data>> &GetResponseDataList() const;
+			std::vector<std::shared_ptr<const ov::Data>> GetResponseDataList() const;
 			// Get Response Header
 			const std::unordered_map<ov::String, std::vector<ov::String>, ov::CaseInsensitiveHash, ov::CaseInsensitiveEqual> &GetResponseHeaderList() const;
 			void ResetResponseData();
@@ -107,7 +107,7 @@ namespace http
 			bool _is_header_sent OV_GUARDED_BY(_response_mutex) = false;
 
 			// FIXME(dimiden): It is supposed to be synchronized whenever a packet is sent, but performance needs to be improved
-			ov::RecursiveMutex _response_mutex;
+			mutable ov::RecursiveMutex _response_mutex;
 
 			// https://www.rfc-editor.org/rfc/rfc7230#section-3.2
 			// Each header field consists of a case-insensitive field name followed
@@ -121,7 +121,7 @@ namespace http
 			// encoding in HTTP/2.
 
 			// So _response_header is a map of case insentitive header key and value
-			std::unordered_map<ov::String, std::vector<ov::String>, ov::CaseInsensitiveHash, ov::CaseInsensitiveEqual> _response_header;
+			std::unordered_map<ov::String, std::vector<ov::String>, ov::CaseInsensitiveHash, ov::CaseInsensitiveEqual> _response_header OV_GUARDED_BY(_response_mutex);
 			std::vector<std::shared_ptr<const ov::Data>> _response_data_list OV_GUARDED_BY(_response_mutex);
 			size_t _response_data_size OV_GUARDED_BY(_response_mutex) = 0;
 

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -392,14 +392,14 @@ namespace ov
 			ov::String threshold_info = ov::String::FormatString("%zu (%s %zu%s", _threshold, GetThresholdModeString(_threshold_mode), _threshold_value, (_threshold_mode == ThresholdMode::TimeBased) ? "ms" : "");
 			if(_buffering_delay > 0)
 			{
-				threshold_info.AppendFormat(" + delay %dms", _buffering_delay);
+				threshold_info.AppendFormat(" + delay %dms", _buffering_delay.load());
 			}
 			threshold_info.Append(")");
 
 			return ov::String::FormatString(
 				"ManagedQueue [Id: %u, Size: %zu, Threshold: %s, Peak: %zu, Imps: %zu, Omps: %zu, Wait: %s, Urn: %s]",
-				GetId(), _size, threshold_info.CStr(),
-				_peak, _input_message_per_second, _output_message_per_second, _exceed_threshold_and_wait_enabled ? "On" : "Off",
+				GetId(), _size.load(), threshold_info.CStr(),
+				_peak.load(), _input_message_per_second.load(), _output_message_per_second.load(), _exceed_threshold_and_wait_enabled ? "On" : "Off",
 				urn_str.CStr());
 		}
 
@@ -449,7 +449,7 @@ namespace ov
 				{
 					{
 						SharedLockGuard name_lock(_name_mutex);
-						logw(LOG_TAG, "[%s] Stop is requested. Failed to enqueue item.", _urn->ToString().CStr());
+						logw(LOG_TAG, "[%s] Stop is requested. Failed to enqueue item.", (_urn != nullptr) ? _urn->ToString().CStr() : "NoUrn");
 					}
 					delete node;
 					return;
@@ -459,7 +459,7 @@ namespace ov
 				{
 					{
 						SharedLockGuard name_lock(_name_mutex);
-						loge(LOG_TAG, "[%s] queue is full. q.size(%zu), q.threshold(%zu)", _urn->ToString().CStr(), _size, _threshold);
+						loge(LOG_TAG, "[%s] queue is full. q.size(%zu), q.threshold(%zu)", (_urn != nullptr) ? _urn->ToString().CStr() : "NoUrn", _size.load(), _threshold);
 					}
 					delete node;
 					return;
@@ -522,7 +522,7 @@ namespace ov
 			// Update the peak statistics
 			if (_peak < _size)
 			{
-				_peak = _size;
+				_peak = _size.load();
 			}
 
 			if (_timer.IsStart() == false)
@@ -538,8 +538,8 @@ namespace ov
 				// Update statistics of message per second
 				_input_message_per_second = (double)(_input_message_count - _last_input_message_count) * (1000.0 / (double)elapsed_time);
 				_output_message_per_second = (double)(_output_message_count - _last_output_message_count) * (1000.0 / (double)elapsed_time);
-				_last_input_message_count = _input_message_count;
-				_last_output_message_count = _output_message_count;
+				_last_input_message_count = _input_message_count.load();
+				_last_output_message_count = _output_message_count.load();
 	
 				UpdateThreshold();
 

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -11,6 +11,7 @@
 
 #include <monitoring/monitoring.h>
 
+#include <atomic>
 #include <optional>
 #include <queue>
 
@@ -53,8 +54,7 @@ namespace ov
 			  _stats_metric_interval(MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC),
 			  _log_interval(log_interval_in_msec),
 			  _front_node(nullptr),
-			  _rear_node(nullptr),
-			  _stop(false)
+			  _rear_node(nullptr)
 		{
 			info::ManagedQueue::SetUrn(urn, Demangle(typeid(T).name()).CStr());
 
@@ -295,7 +295,7 @@ namespace ov
 		// Notes: exceeded time is updated only on each stats tick (MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC)
 		bool IsThresholdExceededFor(std::chrono::milliseconds duration) const
 		{
-			return _threshold_exceeded_time_ms.load() >= static_cast<int64_t>(duration.count());
+			return _threshold_exceeded_time_ms.load(std::memory_order_acquire) >= static_cast<int64_t>(duration.count());
 		}
 
 		// Cleared all items in the queue
@@ -330,7 +330,7 @@ namespace ov
 		{
 			LockGuard lock_guard(_mutex);
 
-			_stop = true;
+			_stop.store(true, std::memory_order_release);
 
 			ClearMetrics();
 
@@ -357,23 +357,23 @@ namespace ov
 
 		bool IsStopped() const
 		{
-			return _stop;
+			return _stop.load(std::memory_order_acquire);
 		}
 
 		void SetExceedWaitEnable(bool enable)
 		{
-			_exceed_threshold_and_wait_enabled = enable;
+			_exceed_threshold_and_wait_enabled.store(enable, std::memory_order_release);
 		}
 
 		bool IsExceedWaitEnable()
 		{
-			return _exceed_threshold_and_wait_enabled;
+			return _exceed_threshold_and_wait_enabled.load(std::memory_order_acquire);
 		}
 
 		// Buffer keeps items for a certain amount of time
 		void SetBufferingDelay(int delay_ms)
 		{
-			LockGuard lock(_mutex);
+			LockGuard lock_guard(_mutex);
 			if(delay_ms < 0)
 			{
 				logw(LOG_TAG, "[%s] Invalid buffering delay value: %d. Setting to 0.", GetInfoString().CStr(), delay_ms);
@@ -389,7 +389,7 @@ namespace ov
 
 			ov::String urn_str = (_urn != nullptr) ? _urn->ToString() : ov::String("NoUrn");
 
-			ov::String threshold_info = ov::String::FormatString("%zu (%s %zu%s", _threshold, GetThresholdModeString(), _threshold_value, (_threshold_mode == ThresholdMode::TimeBased) ? "ms" : "");
+			ov::String threshold_info = ov::String::FormatString("%zu (%s %zu%s", _threshold, GetThresholdModeString(_threshold_mode), _threshold_value, (_threshold_mode == ThresholdMode::TimeBased) ? "ms" : "");
 			if(_buffering_delay > 0)
 			{
 				threshold_info.AppendFormat(" + delay %dms", _buffering_delay);
@@ -447,13 +447,20 @@ namespace ov
 				});
 				if (_stop)
 				{
-					logw(LOG_TAG, "[%s] Stop is requested. Failed to enqueue item.", GetInfoString().CStr());
+					{
+						SharedLockGuard name_lock(_name_mutex);
+						logw(LOG_TAG, "[%s] Stop is requested. Failed to enqueue item.", _urn->ToString().CStr());
+					}
 					delete node;
 					return;
 				}
-				else if (!result)
+
+				if (!result)
 				{
-					loge(LOG_TAG, "[%s] queue is full. q.size(%zu), q.threshold(%zu)", _urn->ToString().CStr(), _size, _threshold);
+					{
+						SharedLockGuard name_lock(_name_mutex);
+						loge(LOG_TAG, "[%s] queue is full. q.size(%zu), q.threshold(%zu)", _urn->ToString().CStr(), _size, _threshold);
+					}
 					delete node;
 					return;
 				}
@@ -546,7 +553,6 @@ namespace ov
 					{
 						_last_logging_time = 0;
 
-						SharedLockGuard shared_lock(_name_mutex);
 						logw(LOG_TAG, "Exceeded. %s", GetInfoString().CStr());
 
 						_last_logged_peak = _peak;
@@ -589,6 +595,7 @@ namespace ov
 		// _threshold == 0 means no threshold.
 		bool IsThresholdExceeded() const OV_REQUIRES(_mutex)
 		{
+			SharedLockGuard shared_lock(_name_mutex);
 			if (_threshold == 0) return false;
 			return _size >= _threshold;
 		}
@@ -596,6 +603,8 @@ namespace ov
 		// Compute the threshold
 		void UpdateThreshold() OV_REQUIRES(_mutex)
 		{
+			LockGuard name_lock(_name_mutex);
+
 			// Compute the delay buffer count
 			size_t delay_buffer_count = 0;
 			if (_buffering_delay > 0 && _input_message_per_second > 0)
@@ -636,12 +645,19 @@ namespace ov
 		ManagedQueueNode* _front_node OV_GUARDED_BY(_mutex);
 		ManagedQueueNode* _rear_node OV_GUARDED_BY(_mutex);
 
-		// Mutex and condition variable for the queue
+	protected:
+		// `_mutex` is `protected` so derived classes can take the lock when calling
+		// protected helpers like `UpdateMetrics()`/`ClearMetrics()` which are annotated
+		// `OV_REQUIRES(_mutex)`. Capability scope must match the methods that require it.
 		mutable Mutex _mutex;
+
+	private:
+		// `_condition` stays `private`: notify/wait are internal queue-thread coordination
+		// that derived classes should not touch directly.
 		ConditionVariable _condition;
 
 		// Stop flag
-		std::atomic<bool> _stop;
+		std::atomic<bool> _stop{false};
 
 		// Set by InjectWakeup(), consumed by Dequeue(). A pending one-shot
 		// wakeup. Unlike _stop, the queue stays usable.

--- a/src/projects/modules/managed_queue/managed_queue_concurrency_test.cpp
+++ b/src/projects/modules/managed_queue/managed_queue_concurrency_test.cpp
@@ -1,0 +1,127 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <modules/managed_queue/managed_queue.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <thread>
+
+// Tests for the `ManagedQueue` thread-safety changes on this branch:
+// - the base metric members became atomics
+//   ("writes only under the derived queue's `_mutex`" convention)
+//   so lock-free monitoring reads are well-defined while traffic is flowing
+// - the enqueue stop/full log paths null-guard `_urn`
+//   (a default-constructed queue has no URN; the old code dereferenced it unconditionally)
+
+TEST(ManagedQueueConcurrency, StopDropWithNullUrnDoesNotCrash)
+{
+	// Default-constructed queue: URN is `nullptr` (`SetUrn()` was never called).
+	// Fill to the threshold, block a producer in the exceed-wait predicate,
+	// then `Stop()` - the drop path logs with the null-guarded URN.
+	ov::ManagedQueue<int> queue;
+	queue.SetThreshold(1);
+	queue.SetExceedWaitEnable(true);
+
+	queue.Enqueue(1);  // size == threshold -> next enqueue waits
+
+	std::promise<void> producer_returned;
+	std::thread producer([&] {
+		// Bounded timeout: even if `Stop()` fails to wake this thread
+		// (the regression under guard), the producer self-unblocks and the test
+		// can FAIL instead of `std::terminate`-ing the whole binary
+		queue.Enqueue(2, false, 10000);
+		producer_returned.set_value();
+	});
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	queue.Stop();
+
+	auto future = producer_returned.get_future();
+	const bool woke_in_time = (future.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+	producer.join();
+
+	EXPECT_TRUE(woke_in_time) << "Stop() did not release the blocked producer";
+	EXPECT_TRUE(queue.IsStopped());
+}
+
+TEST(ManagedQueueConcurrency, FullDropTimeoutWithNullUrnDoesNotCrash)
+{
+	// The actually-fixed crash path: the timeout-expiry "queue is full" drop
+	// used to dereference `_urn` unconditionally (`nullptr` for a default-constructed queue).
+	// Fill to the threshold and let an exceed-wait enqueue time out.
+	ov::ManagedQueue<int> queue;
+	queue.SetThreshold(1);
+	queue.SetExceedWaitEnable(true);
+
+	queue.Enqueue(1);				// size == threshold
+	queue.Enqueue(2, false, 50);	// waits 50ms, expires -> full-drop log with null URN
+
+	EXPECT_EQ(queue.Size(), 1u);	// the timed-out item was dropped, not enqueued
+}
+
+TEST(ManagedQueueConcurrency, LockFreeMetricReadsDuringTraffic)
+{
+	ov::ManagedQueue<int> queue;
+
+	std::atomic<bool> stop{false};
+	std::atomic<bool> metrics_sane{true};
+	std::atomic<uint64_t> metric_reads{0};
+
+	std::thread producer([&] {
+		int value = 0;
+		while (stop.load() == false)
+		{
+			queue.Enqueue(value++);
+		}
+	});
+
+	std::thread consumer([&] {
+		while (stop.load() == false)
+		{
+			(void)queue.Dequeue(1);
+		}
+	});
+
+	std::thread monitor([&] {
+		while (stop.load() == false)
+		{
+			// These are the lock-free reads the atomic conversion legalized;
+			// before the conversion they were plain reads racing `_mutex`-held writers
+			// (UB - only TSan can catch the pre-fix defect on x86_64,
+			// so the bound below is a sanity pin, not the primary oracle).
+			// `GetInfoString()` additionally formats them via `.load()`.
+			auto size = queue.GetSize();
+			auto peak = queue.GetPeak();
+			(void)queue.GetInfoString();
+
+			// `_peak` is monotonic while traffic flows and is raised
+			// in the same `_mutex` section that grows `_size`;
+			// with a single producer a reader loading size-then-peak
+			// can be ahead by at most one in-flight item
+			if (peak > 0 && size > peak + 1)
+			{
+				metrics_sane = false;
+			}
+			metric_reads++;
+		}
+	});
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(200));
+	stop = true;
+
+	producer.join();
+	queue.Stop();
+	consumer.join();
+	monitor.join();
+
+	EXPECT_TRUE(metrics_sane.load());
+	EXPECT_GT(metric_reads.load(), 0u);
+}

--- a/src/projects/modules/rtc_signalling/p2p/rtc_p2p_manager.cpp
+++ b/src/projects/modules/rtc_signalling/p2p/rtc_p2p_manager.cpp
@@ -247,10 +247,12 @@ std::map<peer_id_t, std::shared_ptr<RtcPeerInfo>> RtcP2PManager::GetClientPeerLi
 
 int RtcP2PManager::GetPeerCount() const
 {
+	auto lock_guard = ov::LockGuard(_list_mutex);
 	return static_cast<int>(_peer_list.size());
 }
 
 int RtcP2PManager::GetClientPeerCount() const
 {
+	auto lock_guard = ov::LockGuard(_list_mutex);
 	return _total_client_count;
 }

--- a/src/projects/modules/rtc_signalling/p2p/rtc_p2p_manager.h
+++ b/src/projects/modules/rtc_signalling/p2p/rtc_p2p_manager.h
@@ -41,7 +41,7 @@ protected:
 
 	int _max_client_peers_per_host_peer = -1;
 
-	ov::RecursiveMutex _list_mutex;
+	mutable ov::RecursiveMutex _list_mutex;
 
 	// All peer list
 	// key: peer id, value: peer info list

--- a/src/projects/modules/rtc_signalling/rtc_signalling_server.cpp
+++ b/src/projects/modules/rtc_signalling/rtc_signalling_server.cpp
@@ -497,7 +497,11 @@ bool RtcSignallingServer::SetupWebSocketHandler(std::shared_ptr<http::svr::ws::I
 
 bool RtcSignallingServer::AddObserver(const std::shared_ptr<RtcSignallingObserver> &observer)
 {
-	for (const auto &item : _observers)
+	std::lock_guard lock_guard{_observers_mutex};
+
+	auto observers = std::atomic_load(&_observers);
+
+	for (const auto &item : *observers)
 	{
 		if (item == observer)
 		{
@@ -506,25 +510,33 @@ bool RtcSignallingServer::AddObserver(const std::shared_ptr<RtcSignallingObserve
 		}
 	}
 
-	_observers.push_back(observer);
+	auto new_observers = std::make_shared<ObserverList>(*observers);
+	new_observers->push_back(observer);
+	std::atomic_store(&_observers, std::shared_ptr<const ObserverList>(new_observers));
 
 	return true;
 }
 
 bool RtcSignallingServer::RemoveObserver(const std::shared_ptr<RtcSignallingObserver> &observer)
 {
-	auto item = std::find_if(_observers.begin(), _observers.end(), [&](std::shared_ptr<RtcSignallingObserver> const &value) -> bool {
+	std::lock_guard lock_guard{_observers_mutex};
+
+	auto observers = std::atomic_load(&_observers);
+
+	auto item	   = std::find_if(observers->begin(), observers->end(), [&](std::shared_ptr<RtcSignallingObserver> const &value) -> bool {
 		return value == observer;
 	});
 
-	if (item == _observers.end())
+	if (item == observers->end())
 	{
 		// 기존에 등록되어 있지 않음
 		logtw("%p is not registered observer", observer.get());
 		return false;
 	}
 
-	_observers.erase(item);
+	auto new_observers = std::make_shared<ObserverList>(*observers);
+	new_observers->erase(new_observers->begin() + (item - observers->begin()));
+	std::atomic_store(&_observers, std::shared_ptr<const ObserverList>(new_observers));
 
 	return true;
 }
@@ -743,7 +755,9 @@ std::shared_ptr<const ov::Error> RtcSignallingServer::DispatchRequestOffer(const
 
 		bool tcp_relay = false;
 		// None of the hosts can accept this client, so the peer will be connectioned to OME
-		std::find_if(_observers.begin(), _observers.end(), [ws_session, info, &sdp, vhost_app_name, stream_name, &tcp_relay](auto &observer) -> bool {
+		auto observers = std::atomic_load(&_observers);
+
+		std::find_if(observers->begin(), observers->end(), [ws_session, info, &sdp, vhost_app_name, stream_name, &tcp_relay](auto &observer) -> bool {
 			// Ask observer to fill local_candidates
 			sdp = observer->OnRequestOffer(ws_session, vhost_app_name, info->host_name, stream_name, &(info->local_candidates), tcp_relay);
 			return sdp != nullptr;
@@ -914,7 +928,8 @@ std::shared_ptr<const ov::Error> RtcSignallingServer::DispatchAnswer(const std::
 		{
 			info->answer_sdp = answer_sdp;
 
-			for (auto &observer : _observers)
+			auto observers	 = std::atomic_load(&_observers);
+			for (const auto &observer : *observers)
 			{
 				logtt("Trying to callback OnAddRemoteDescription to %p (%s / %s)...", observer.get(), info->vhost_app_name.CStr(), info->stream_name.CStr());
 
@@ -982,7 +997,8 @@ std::shared_ptr<const ov::Error> RtcSignallingServer::DispatchChangeRendition(co
 
 	if (info->answer_sdp != nullptr)
 	{
-		for (auto &observer : _observers)
+		auto observers = std::atomic_load(&_observers);
+		for (const auto &observer : *observers)
 		{
 			if (observer->OnChangeRendition(ws_session, has_rendition_name, rendition_name, has_auto_abr, auto_abr, info->offer_sdp, info->answer_sdp) == false)
 			{
@@ -1037,7 +1053,8 @@ std::shared_ptr<const ov::Error> RtcSignallingServer::DispatchCandidate(const st
 				return std::make_shared<http::HttpError>(http::StatusCode::BadRequest, "Invalid candidate: %s", candidate.CStr());
 			}
 
-			for (auto &observer : _observers)
+			auto observers = std::atomic_load(&_observers);
+			for (const auto &observer : *observers)
 			{
 				observer->OnIceCandidate(ws_session, info->vhost_app_name, info->host_name, info->stream_name, ice_candidate, username_fragment);
 			}
@@ -1173,7 +1190,8 @@ std::shared_ptr<const ov::Error> RtcSignallingServer::DispatchStop(const std::sh
 
 	if (info->answer_sdp != nullptr)
 	{
-		for (auto &observer : _observers)
+		auto observers = std::atomic_load(&_observers);
+		for (const auto &observer : *observers)
 		{
 			logtt("Trying to callback OnStopCommand to %p for client %d (%s / %s)...", observer.get(), info->id, info->vhost_app_name.CStr(), info->stream_name.CStr());
 

--- a/src/projects/modules/rtc_signalling/rtc_signalling_server.cpp
+++ b/src/projects/modules/rtc_signalling/rtc_signalling_server.cpp
@@ -354,8 +354,8 @@ bool RtcSignallingServer::SetupWebSocketHandler(std::shared_ptr<http::svr::ws::I
 
 			// Find the "Host" header
 			auto host_name = request->GetHeader("HOST").Split(":")[0];
-			auto &app_name = uri->App();
-			auto &stream_name = uri->Stream();
+			auto app_name = uri->App();
+			auto stream_name = uri->Stream();
 
 			info::VHostAppName vhost_app_name = ocst::Orchestrator::GetInstance()->ResolveApplicationNameFromDomain(host_name, app_name);
 

--- a/src/projects/modules/rtc_signalling/rtc_signalling_server.cpp
+++ b/src/projects/modules/rtc_signalling/rtc_signalling_server.cpp
@@ -198,13 +198,17 @@ bool RtcSignallingServer::Start(
 	bool is_tls_port_configured, uint16_t tls_port,
 	int worker_count, std::shared_ptr<http::svr::ws::Interceptor> interceptor)
 {
-	if ((_http_server_list.empty() == false) || (_https_server_list.empty() == false))
 	{
-		OV_ASSERT(false, "%s is already running (%zu, %zu)",
-				  server_name,
-				  _http_server_list.size(),
-				  _https_server_list.size());
-		return false;
+		std::lock_guard lock_guard{_http_server_list_mutex};
+
+		if ((_http_server_list.empty() == false) || (_https_server_list.empty() == false))
+		{
+			OV_ASSERT(false, "%s is already running (%zu, %zu)",
+					  server_name,
+					  _http_server_list.size(),
+					  _https_server_list.size());
+			return false;
+		}
 	}
 
 	if (SetupWebSocketHandler(interceptor) == false)
@@ -529,7 +533,17 @@ bool RtcSignallingServer::Disconnect(const info::VHostAppName &vhost_app_name, c
 {
 	size_t disconnected_count = 0;
 
-	for (auto &http_server : _http_server_list)
+	// Snapshot under the lock so a concurrent `Stop()` moving the vectors cannot
+	// invalidate this traversal; `DisconnectIf()` runs outside the lock.
+	std::vector<std::shared_ptr<http::svr::HttpServer>> http_server_list;
+	std::vector<std::shared_ptr<http::svr::HttpsServer>> https_server_list;
+	{
+		std::lock_guard lock_guard{_http_server_list_mutex};
+		http_server_list = _http_server_list;
+		https_server_list = _https_server_list;
+	}
+
+	for (auto &http_server : http_server_list)
 	{
 		disconnected_count += http_server->DisconnectIf(
 			[vhost_app_name, stream_name, peer_sdp](const std::shared_ptr<http::svr::HttpConnection> &connection) -> bool {
@@ -556,7 +570,7 @@ bool RtcSignallingServer::Disconnect(const info::VHostAppName &vhost_app_name, c
 			});
 	}
 
-	for (auto &https_server : _https_server_list)
+	for (auto &https_server : https_server_list)
 	{
 		disconnected_count += https_server->DisconnectIf(
 			[vhost_app_name, stream_name, peer_sdp](const std::shared_ptr<http::svr::HttpConnection> &connection) -> bool {

--- a/src/projects/modules/rtc_signalling/rtc_signalling_server.h
+++ b/src/projects/modules/rtc_signalling/rtc_signalling_server.h
@@ -168,11 +168,24 @@ protected:
 	// Lock order: this mutex (outer) -> `HttpsServer::_https_certificate_map_mutex` (inner).
 	std::map<ov::String, std::shared_ptr<const info::Certificate>> _certificate_map;
 
-	std::vector<std::shared_ptr<RtcSignallingObserver>> _observers;
+	// Copy-on-write observer list:
+	// writers (Add/RemoveObserver) rebuild the vector under `_observers_mutex`
+	// and publish with `std::atomic_store`; dispatch paths take an `std::atomic_load` snapshot,
+	// so no lock is ever held across the heavy observer callbacks.
+	// Note: a dispatch that snapshotted before `RemoveObserver()` returned
+	// may still deliver ONE trailing callback to the removed observer
+	// (the snapshot keeps it alive - no UAF, but removal is not a barrier)
+	using ObserverList = std::vector<std::shared_ptr<RtcSignallingObserver>>;
+	std::mutex _observers_mutex;
+	std::shared_ptr<const ObserverList> _observers = std::make_shared<ObserverList>();
 
 	std::map<peer_id_t, std::shared_ptr<RtcSignallingInfo>> _client_list;
 	std::shared_mutex _client_list_mutex;
 
+	// FIXME: written by `PrepareForTCPRelay()`/`PrepareForExternalIceServer()` in `Start()`
+	// after `CreateServers()` has live listeners, and read by the `request_offer` dispatch
+	// path on HTTP worker threads without a lock (data race).
+	// Same fix options as the WHIP config members: a dedicated guard, or finishing all writes before listeners go live.
 	Json::Value _ice_servers;
 	Json::Value _new_ice_servers;
 	bool _tcp_force = false;

--- a/src/projects/modules/rtp_rtcp/rtp_receive_statistics.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_receive_statistics.cpp
@@ -15,7 +15,7 @@ RtpReceiveStatistics::RtpReceiveStatistics(uint32_t media_ssrc, uint32_t clock_r
 
 bool RtpReceiveStatistics::AddReceivedRtpPacket(const std::shared_ptr<RtpPacket> &packet)
 {
-	ov::LockGuard<ov::Mutex> lock(_lock);
+	ov::LockGuard lock(_lock);
 	if(_first == true)
 	{
 		_first = false;
@@ -34,7 +34,7 @@ bool RtpReceiveStatistics::AddReceivedRtpPacket(const std::shared_ptr<RtpPacket>
 
 bool RtpReceiveStatistics::AddReceivedRtcpSenderReport(const std::shared_ptr<SenderReport> &report)
 {
-	ov::LockGuard<ov::Mutex> lock(_lock);
+	ov::LockGuard lock(_lock);
 	_last_sr_received_time = std::chrono::steady_clock::now();
 
 	// the middle 32 bits out of 64 in the NTP timestamp
@@ -46,25 +46,25 @@ bool RtpReceiveStatistics::AddReceivedRtcpSenderReport(const std::shared_ptr<Sen
 
 uint32_t RtpReceiveStatistics::GetMediaSSRC()
 {
-	ov::LockGuard<ov::Mutex> lock(_lock);
+	ov::LockGuard lock(_lock);
 	return _media_ssrc;
 }
 
 uint32_t RtpReceiveStatistics::GetReceiverSSRC()
 {
-	ov::LockGuard<ov::Mutex> lock(_lock);
+	ov::LockGuard lock(_lock);
 	return _receiver_ssrc;
 }
 
 uint64_t RtpReceiveStatistics::GetNumberOfFirRequests()
 {
-	ov::LockGuard<ov::Mutex> lock(_lock);
+	ov::LockGuard lock(_lock);
 	return _fir_request_count;
 }
 
 void RtpReceiveStatistics::OnFirRequested()
 {
-	ov::LockGuard<ov::Mutex> lock(_lock);
+	ov::LockGuard lock(_lock);
 	_fir_request_count ++;
 }
 
@@ -132,19 +132,19 @@ bool RtpReceiveStatistics::UpdateStat(const std::shared_ptr<RtpPacket> &packet)
 
 bool RtpReceiveStatistics::HasElapsedSinceLastReportBlock(uint32_t milliseconds)
 {
-	ov::LockGuard<ov::Mutex> lock(_lock);
+	ov::LockGuard lock(_lock);
 	return _report_block_timer.IsElapsed(milliseconds);
 }
 
 bool RtpReceiveStatistics::IsSenderReportReceived()
 {
-	ov::LockGuard<ov::Mutex> lock(_lock);
+	ov::LockGuard lock(_lock);
 	return _last_sr_timestamp != 0;
 }
 
 std::shared_ptr<ReportBlock> RtpReceiveStatistics::GenerateReportBlock()
 {
-	ov::LockGuard<ov::Mutex> lock(_lock);
+	ov::LockGuard lock(_lock);
 	int32_t extented_highest_seq = _cycles + _highest_seq;
 	int32_t expected_packet_count = extented_highest_seq - _init_seq + 1;
 

--- a/src/projects/modules/rtp_rtcp/rtp_receive_statistics.h
+++ b/src/projects/modules/rtp_rtcp/rtp_receive_statistics.h
@@ -30,11 +30,10 @@ public:
 	uint64_t GetNumberOfFirRequests();
 	void OnFirRequested();
 
-	void InitSeq(uint16_t seq);
-	bool UpdateSeq(uint16_t seq);
-	bool UpdateStat(const std::shared_ptr<RtpPacket> &packet);
-
 private:
+	void InitSeq(uint16_t seq) OV_REQUIRES(_lock);
+	bool UpdateSeq(uint16_t seq) OV_REQUIRES(_lock);
+	bool UpdateStat(const std::shared_ptr<RtpPacket> &packet) OV_REQUIRES(_lock);
 	uint32_t	_media_ssrc OV_GUARDED_BY(_lock) = 0;
 	uint32_t	_receiver_ssrc = 0;		// random generated local ssrc, for ReceiverReport, FIR ...
 	uint32_t	_clock_rate = 0;

--- a/src/projects/modules/whip/whip_server.cpp
+++ b/src/projects/modules/whip/whip_server.cpp
@@ -181,7 +181,7 @@ bool WhipServer::Start(
 		return false;
 	}
 
-	_observer = observer;
+	std::atomic_store(&_observer, observer);
 
 	auto http_server_manager = http::svr::HttpServerManager::GetInstance();
 
@@ -240,7 +240,7 @@ bool WhipServer::Start(
 
 bool WhipServer::Stop()
 {
-	_observer = nullptr;
+	std::atomic_store(&_observer, std::shared_ptr<WhipObserver>());
 
 	return true;
 }
@@ -353,7 +353,8 @@ std::shared_ptr<WhipInterceptor> WhipServer::CreateInterceptor()
 
 		logti("WHIP Requested: %s", request->ToString().CStr());
 
-		if (_observer == nullptr)
+		auto observer = std::atomic_load(&_observer);
+		if (observer == nullptr)
 		{
 			logte("Internal Server Error - Observer is not set");
 			response->SetStatusCode(http::StatusCode::InternalServerError);
@@ -393,7 +394,7 @@ std::shared_ptr<WhipInterceptor> WhipServer::CreateInterceptor()
 			return http::svr::NextHandler::DoNotCall;
 		}
 
-		auto answer = _observer->OnSdpOffer(request, offer_sdp);
+		auto answer = observer->OnSdpOffer(request, offer_sdp);
 		response->SetStatusCode(answer._status_code);
 
 		if (answer._status_code == http::StatusCode::Created)
@@ -462,7 +463,8 @@ std::shared_ptr<WhipInterceptor> WhipServer::CreateInterceptor()
 
 		logti("WHIP Requested: %s", request->ToString().CStr());
 
-		if (_observer == nullptr)
+		auto observer = std::atomic_load(&_observer);
+		if (observer == nullptr)
 		{
 			logte("Internal Server Error - Observer is not set");
 			response->SetStatusCode(http::StatusCode::InternalServerError);
@@ -485,7 +487,7 @@ std::shared_ptr<WhipInterceptor> WhipServer::CreateInterceptor()
 			return http::svr::NextHandler::DoNotCall;
 		}
 
-		auto answer = _observer->OnSessionDelete(request, session_key);
+		auto answer = observer->OnSessionDelete(request, session_key);
 		response->SetStatusCode(answer._status_code);
 
 		if (answer._status_code == http::StatusCode::OK)
@@ -513,7 +515,8 @@ std::shared_ptr<WhipInterceptor> WhipServer::CreateInterceptor()
 
 		logti("WHIP Requested: %s", request->ToString().CStr());
 
-		if (_observer == nullptr)
+		auto observer = std::atomic_load(&_observer);
+		if (observer == nullptr)
 		{
 			logte("Internal Server Error - Observer is not set");
 			response->SetStatusCode(http::StatusCode::InternalServerError);
@@ -579,7 +582,7 @@ std::shared_ptr<WhipInterceptor> WhipServer::CreateInterceptor()
 			return http::svr::NextHandler::DoNotCall;
 		}
 
-		auto answer = _observer->OnTrickleCandidate(request, session_id, if_match, patch_sdp);
+		auto answer = observer->OnTrickleCandidate(request, session_id, if_match, patch_sdp);
 		response->SetStatusCode(answer._status_code);
 		response->SetHeader("Content-Type", "application/trickle-ice-sdpfrag");
 

--- a/src/projects/modules/whip/whip_server.cpp
+++ b/src/projects/modules/whip/whip_server.cpp
@@ -161,13 +161,16 @@ bool WhipServer::Start(
 	bool is_tls_port_configured, uint16_t tls_port,
 	int worker_count)
 {
-	if ((_http_server_list.empty() == false) || (_https_server_list.empty() == false))
 	{
-		OV_ASSERT(false, "%s is already running (%zu, %zu)",
-				  server_name,
-				  _http_server_list.size(),
-				  _https_server_list.size());
-		return false;
+		ov::LockGuard lock_guard{_http_server_list_mutex};
+		if ((_http_server_list.empty() == false) || (_https_server_list.empty() == false))
+		{
+			OV_ASSERT(false, "%s is already running (%zu, %zu)",
+					  server_name,
+					  _http_server_list.size(),
+					  _https_server_list.size());
+			return false;
+		}
 	}
 
 	auto interceptor = CreateInterceptor();

--- a/src/projects/modules/whip/whip_server.h
+++ b/src/projects/modules/whip/whip_server.h
@@ -73,6 +73,8 @@ private:
 
 	const cfg::bind::cmm::Webrtc _webrtc_bind_cfg;
 
+	// Accessed only via `std::atomic_load`/`std::atomic_store`: `Stop()` writes `nullptr`
+	// while interceptor lambdas read from HTTP worker threads (TSA cannot model this)
 	std::shared_ptr<WhipObserver> _observer;
 
 	ov::RecursiveMutex _http_server_list_mutex;
@@ -88,6 +90,10 @@ private:
 	// Lock order: this mutex (outer) -> `HttpsServer::_https_certificate_map_mutex` (inner).
 	std::map<ov::String, std::shared_ptr<const info::Certificate>> _certificate_map OV_GUARDED_BY(_http_server_list_mutex);
 
+	// FIXME: these and `_tcp_relay_address` below are written by `PrepareForTCPRelay()`/
+	// `PrepareForExternalIceServer()` after `CreateServers()` has live listeners,
+	// and read by the POST handler lambda without a lock (data race).
+	// Same fix options as `_observer` above.
 	std::set<ov::String> _link_headers;
 	bool _tcp_force = false;
 	ov::String _default_transport{"UDPTCP"};

--- a/src/projects/monitoring/alert/alert_rules_updater.cpp
+++ b/src/projects/monitoring/alert/alert_rules_updater.cpp
@@ -42,14 +42,7 @@ namespace mon::alrt
 
 	std::shared_ptr<const cfg::alrt::rule::Rules> AlertRulesUpdater::GetRules() const
 	{
-		if (_is_dynamic_update)
-		{
-			ov::SharedLockGuard lock(_dynamic_rules_mutex);
-
-			return _rules;
-		}
-
-		return _rules;
+		return std::atomic_load(&_rules);
 	}
 
 	bool AlertRulesUpdater::UpdateIfNeeded()
@@ -133,10 +126,7 @@ namespace mon::alrt
 			cfg::ItemName item_name(RULES_ITEM_NAME);
 			rules->FromDataSource(item_name.GetName(data_source.GetType()), item_name, data_source);
 
-			{
-				ov::LockGuard lock_guard(_dynamic_rules_mutex);
-				_rules = rules;
-			}
+			std::atomic_store(&_rules, std::shared_ptr<const cfg::alrt::rule::Rules>(rules));
 
 			logti("The alert rules file has been updated: %s", _rules_file.CStr());
 		}

--- a/src/projects/monitoring/alert/alert_rules_updater.h
+++ b/src/projects/monitoring/alert/alert_rules_updater.h
@@ -31,7 +31,7 @@ namespace mon::alrt
 		std::atomic<uint64_t> _last_modified = 0;
 		ov::String _rules_file;
 
-		mutable ov::SharedMutex _dynamic_rules_mutex;
-		std::shared_ptr<const cfg::alrt::rule::Rules> _rules OV_GUARDED_BY(_dynamic_rules_mutex) = nullptr;
+		// Accessed only via std::atomic_load/atomic_store after construction
+		std::shared_ptr<const cfg::alrt::rule::Rules> _rules = nullptr;
 	};
 }  // namespace mon::alrt

--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -686,7 +686,7 @@ namespace ocst
 		auto app_info = info::Application::GetInvalidApplication();
 		std::vector<ov::String> url_list;
 		Origin matched_origin;
-		auto &host_name = request_from->Host();
+		auto host_name = request_from->Host();
 
 		std::vector<ov::String> url_list_in_map;
 		if (GetUrlListForLocation(vhost_app_name, host_name, stream_name, matched_origin, url_list_in_map) == false)

--- a/src/projects/transcoder/transcoder_fault_injector.h
+++ b/src/projects/transcoder/transcoder_fault_injector.h
@@ -8,6 +8,8 @@
 //==============================================================================
 #pragma once
 
+#include <atomic>
+
 #include <base/mediarouter/media_type.h>
 #include <base/ovlibrary/ovlibrary.h>
 #include "codec/codec_base.h"
@@ -105,12 +107,12 @@ public:
 public:
 	bool IsEnabled()
 	{
-		return _enabled;
+		return _enabled.load(std::memory_order_acquire);
 	}
 
 	bool IsTriggered(ComponentType component_type, IssueType issue_type, cmn::MediaCodecModuleId module_id, cmn::DeviceId device_id)
 	{
-		if (!_enabled)
+		if (!_enabled.load(std::memory_order_acquire))
 		{
 			return false;
 		}
@@ -160,18 +162,18 @@ public:
 			  GetComponentTypeString(component_type), GetIssueTypeString(issue_type), cmn::GetCodecModuleIdString(module_id), device_id, fault_rate);
 
 		_fault_triggers[std::make_pair(component_type, issue_type)][std::make_pair(module_id, device_id)] = fault_rate;
-		_enabled = true;
+		_enabled.store(true, std::memory_order_release);
 	}
 
 	void Clear()
 	{
 		ov::LockGuard lock(_mutex);
 		_fault_triggers.clear();
-		_enabled = false;
+		_enabled.store(false, std::memory_order_release);
 	}
 
 private:
-	bool _enabled OV_GUARDED_BY(_mutex) = false;
+	std::atomic<bool> _enabled{false};
 
 	ov::SharedMutex _mutex;
 	std::map<std::pair<ComponentType, IssueType>, std::map<std::pair<cmn::MediaCodecModuleId, cmn::DeviceId>, double>> _fault_triggers OV_GUARDED_BY(_mutex);


### PR DESCRIPTION
## Thread safety: fix data races and harden TSA annotations across modules

### Summary

This branch advances TSA (Thread Safety Analysis) adoption by fixing data races surfaced by annotations, removing unnecessary analysis suppressions, and converting fields to atomics where a mutex was suboptimal.

### Working criteria

- Every modified TU (Translation Unit) compiles warning-clean under `-Wthread-safety` with real build flags; template headers are verified via explicit-instantiation probes.
- Races are fixed or deferred only after identifying the writer, the reader, and the missing *synchronizes-with* edge.
- Simple fixes (a lock, an atomic, a small method split) are addressed directly in this PR, while refactoring-level work is deferred and documented.
- Suppressions are retained only for provably unmodelable patterns, and deliberate trade-offs are fully documented.

### Changes

- **`ov::Url`**: Redesigned internal locking with by-value getters, and added comprehensive concurrency tests.
- **Core library**: Synchronized the log path chain, converted log level to atomic, guarded `_source_url`, fixed `BpsCalculator` destruction order, and updated `ov::Queue` atomic flags.
- **Sockets**: Enforced consistent atomic access for callback pointers, and ensured `_close_reason` is published atomically before the close-callback handoff.
- **DTLS/SRTP**: Serialized setters under `_tls_lock`, replaced suppressions with `OV_REQUIRES`, and nulled the SRTP session pointer post-deallocation.
- **`HttpResponse`**: Fully locked composite state, decoupled simple fields via atomics, converted reference-returning getters to by-value, and removed the unused `_reason` member.
- **ManagedQueue**: Converted metrics to atomics to ensure well-defined monitoring reads without hot-path locks.
- **Pull provider**: Serialized `Stop()`/`Resume()` to prevent deadlocks, fully guarded URL state, and fixed a crash caused by feeding `nullptr` into provider implementations from an unparsable URL list.
- **Signaling/WHIP**: Guarded server-list access, updated `Disconnect()` to traverse a snapshot, moved the WHIP observer to atomic access with snapshot-based handlers, and replaced the signalling observer vector with a copy-on-write list to fix erase-while-iterate UB.

### Behavior changes

- `ov::Url` dropped the unused `QueryMap()` and its `operator=` is no longer `noexcept`.
- `HttpResponse` removed the unused 2-argument `SetStatusCode()`.
- Stopping a pull stream can now wait up to one bounded reconnect attempt when racing a failover.

### Verification

- Zero `-Wthread-safety` warnings across all modified TUs.
- All unit tests passing, including the new `ov::Url` concurrency tests.
- Verified by an independent adversarial review that re-derived the lock graphs and audited every atomic conversion.

### Follow-ups (known issues, deliberately out of scope)

The following issues were found during this analysis but need refactoring-level changes or separate behavior decisions, so they are left in place (the significant sites carry `FIXME` comments) and will be addressed in follow-up tasks:

- The failback `Stop()` -> `ResetUrlIndex()` -> `ResumeStream()` sequence is not atomic across calls, so a concurrent `DeleteStream()` can revive an already-erased stream; this needs an API-level solution for composing `Start()`/`Stop()`/`Resume()`.
- `DtlsTransport` reads a `_state` snapshot and re-locks afterwards (TOCTOU), and `Stop()` does not transition the state to `SSL_CLOSED`, so a late packet can still
reach an uninitialized TLS object.
- `RtcSignallingServer` members are guarded by a raw `std::recursive_mutex`, which TSA cannot annotate, and should migrate to the `ov::Mutex` wrappers; its ICE config members (`_ice_servers`/`_tcp_force`) and the WHIP TCP-relay config members share the same "written after listeners are live, read lock-free by handlers" race, needing either a dedicated guard or an init-order change.
- `RtcPeerInfo` accessors (`GetHostPeer()`/`IsHost()`/`ToString()`) read state that is elsewhere guarded by `RtcP2PManager::_list_mutex`, which requires a lock ownership redesign.
- `HttpResponse` still holds `_response_mutex` across TLS encrypt and socket I/O in `Response()`; shrinking the lock to state changes only is the remaining performance follow-up, and its copy constructor does not copy the ETag-related fields.
- `ManagedQueue` setters that affect the condition-variable predicate (`Clear`/`SetBufferingDelay`/`SetThreshold`/`SetThresholdByTime`) do not notify waiters, and its monitoring callback runs while holding the queue mutex, which would self-deadlock if the callback path ever re-enters the queue.
- Smaller items: the orchestrator OriginMap pull path skips the URL validation that the API path performs, `Start()` of WHIP/signalling has a benign check-then-act window between the empty-check and the list publish, `SocketPoolWorker` reads its close-callback map's `empty()` without the lock, `LogWrite::_start_service` has ambiguous consume-once semantics across instances, `Certificate::GetFingerprint` ignores the algorithm argument once cached, `ov::Url` double-decodes query values, and the queue drop-count metric has no writer and always reports zero.