### PR TITLE
feat(webrtc): support AV1 over WebRTC playback

### DIFF
--- a/src/projects/modules/rtp_rtcp/rtp_packetizer.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer.cpp
@@ -37,6 +37,9 @@ bool RtpPacketizer::SetCodec(cmn::MediaCodecId codec_type)
 		case cmn::MediaCodecId::H265:
 			SetVideoCodec(cmn::MediaCodecId::H265);
 			break;
+		case cmn::MediaCodecId::Av1:
+			SetVideoCodec(cmn::MediaCodecId::Av1);
+			break;
 		case cmn::MediaCodecId::Opus:
 			SetAudioCodec(cmn::MediaCodecId::Opus);
 			break;

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_av1.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_av1.cpp
@@ -69,6 +69,15 @@ bool RtpPacketizerAV1::BuildObuList(const uint8_t *data, size_t size)
 			continue;
 		}
 
+		// A low-overhead OBU stream is size-delimited. Without a size field, ReadObu consumes the rest
+		// of the buffer as this OBU's payload and any following OBUs are lost; fail loud instead.
+		if (span.header.has_size_field == false)
+		{
+			logte("AV1 OBU (type %s) without size field in a low-overhead stream; dropping temporal unit",
+				  EnumToString(span.header.type));
+			return false;
+		}
+
 		if (span.header.type == Av1ObuType::SequenceHeader)
 		{
 			_new_coded_video_sequence = true;

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_av1.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_av1.cpp
@@ -1,0 +1,262 @@
+#include "rtp_packetizer_av1.h"
+
+#include <algorithm>
+#include <cstring>
+
+#include <modules/bitstream/av1/av1_parser.h>
+
+#define OV_LOG_TAG "RtpPacketizerAV1"
+
+// Aggregation header bit masks (AV1 RTP Specification).
+#define AV1_AGG_Z 0x80
+#define AV1_AGG_Y 0x40
+#define AV1_AGG_W_SHIFT 4
+#define AV1_AGG_W_MASK 0x30
+#define AV1_AGG_N 0x08
+
+// obu_header: obu_has_size_field is bit 1 (forbidden|type(4)|extension_flag|has_size_field|reserved).
+#define AV1_OBU_HAS_SIZE_FIELD 0x02
+
+// One OBU element per AV1 RTP payload plus its possible length prefix; W is 2 bits, and the last element
+// of a packet omits its length, so at most 3 elements fit one packet.
+static constexpr size_t kAggregationHeaderSize = 1;
+static constexpr size_t kMaxObuElementsPerPacket = 3;
+
+size_t RtpPacketizerAV1::SetPayloadData(size_t max_payload_len, size_t last_packet_reduction_len, const RTPVideoTypeHeader * /* rtp_type_header */, FrameType /* frame_type */,
+										const uint8_t *payload_data, size_t payload_size, const FragmentationHeader * /* fragmentation */)
+{
+	_max_payload_len		   = max_payload_len;
+	_last_packet_reduction_len = last_packet_reduction_len;
+	_obus.clear();
+	_packets.clear();
+	_next_packet			   = 0;
+	_new_coded_video_sequence  = false;
+
+	if (payload_data == nullptr || payload_size == 0)
+	{
+		return 0;
+	}
+
+	if (BuildObuList(payload_data, payload_size) == false)
+	{
+		return 0;
+	}
+
+	if (GeneratePackets() == false)
+	{
+		return 0;
+	}
+
+	return _packets.size();
+}
+
+bool RtpPacketizerAV1::BuildObuList(const uint8_t *data, size_t size)
+{
+	size_t offset = 0;
+	while (offset < size)
+	{
+		Av1ObuSpan span;
+		if (Av1Parser::ReadObu(data, size, offset, span) == false)
+		{
+			logte("Malformed AV1 OBU stream while packetizing");
+			return false;
+		}
+
+		if (span.header.type == Av1ObuType::TemporalDelimiter)
+		{
+			// Dropped: the RTP framing conveys temporal-unit boundaries (AV1 RTP spec).
+			offset = span.next_offset;
+			continue;
+		}
+
+		if (span.header.type == Av1ObuType::SequenceHeader)
+		{
+			_new_coded_video_sequence = true;
+		}
+
+		Obu obu;
+		obu.header_size = span.header.extension_flag ? 2 : 1;
+		// Carry the OBU without its size field; the depacketizer restores obu_has_size_field.
+		obu.header[0] = static_cast<uint8_t>(data[span.obu_offset] & ~AV1_OBU_HAS_SIZE_FIELD);
+		if (obu.header_size == 2)
+		{
+			obu.header[1] = data[span.obu_offset + 1];
+		}
+		obu.payload		 = (span.payload_size > 0) ? (data + span.payload_offset) : nullptr;
+		obu.payload_size = span.payload_size;
+
+		_obus.push_back(obu);
+
+		offset = span.next_offset;
+	}
+
+	return _obus.empty() == false;
+}
+
+bool RtpPacketizerAV1::GeneratePackets()
+{
+	if (_obus.empty())
+	{
+		return false;
+	}
+
+	if (_max_payload_len <= kAggregationHeaderSize + _last_packet_reduction_len)
+	{
+		logte("AV1 max payload length(%zu) is too small to packetize", _max_payload_len);
+		return false;
+	}
+
+	// OBU element bytes available per packet (the last-packet reduction is applied to every packet so
+	// the final packet is always within budget; it is normally zero here).
+	const size_t budget = _max_payload_len - kAggregationHeaderSize - _last_packet_reduction_len;
+
+	Packet cur;
+	size_t used = 0;	// OBU element bytes used in `cur` (excludes the aggregation header)
+
+	auto flush = [&]() {
+		if (cur.fragments.empty() == false)
+		{
+			_packets.push_back(std::move(cur));
+			cur = Packet();
+			used = 0;
+		}
+	};
+
+	size_t obu_index  = 0;
+	size_t obu_offset = 0;	// bytes of _obus[obu_index] already emitted in earlier packets
+
+	while (obu_index < _obus.size())
+	{
+		const size_t obu_total = _obus[obu_index].Size();
+		const size_t remaining = obu_total - obu_offset;
+		const bool	 fresh	   = (obu_offset == 0);
+
+		// A 4th OBU element does not fit the 2-bit W field; start a new packet.
+		if (cur.fragments.size() >= kMaxObuElementsPerPacket)
+		{
+			flush();
+		}
+
+		// Appending an element forces a length prefix onto the previous (currently last, length-omitted)
+		// element of the packet.
+		size_t promote_cost = cur.fragments.empty() ? 0 : Leb128Size(cur.fragments.back().length);
+
+		if (used + promote_cost >= budget)
+		{
+			// No room to promote the previous element and still carry a byte of this one.
+			flush();
+			promote_cost = 0;
+		}
+
+		const size_t space = budget - used - promote_cost;	// data bytes for this (length-omitted last) element
+
+		if (remaining <= space)
+		{
+			cur.fragments.push_back({obu_index, obu_offset, remaining, fresh == false, false});
+			used += promote_cost + remaining;
+			obu_index++;
+			obu_offset = 0;
+		}
+		else
+		{
+			// Fill the packet; this element continues into the next packet.
+			cur.fragments.push_back({obu_index, obu_offset, space, fresh == false, true});
+			obu_offset += space;
+			flush();
+		}
+	}
+
+	flush();
+
+	return _packets.empty() == false;
+}
+
+bool RtpPacketizerAV1::NextPacket(RtpPacket *packet)
+{
+	if (_next_packet >= _packets.size())
+	{
+		return false;
+	}
+
+	const Packet &plan = _packets[_next_packet];
+	const size_t  w	   = plan.fragments.size();	// 1..3
+
+	// Allocate the per-packet maximum and shrink to the bytes actually written below; GeneratePackets
+	// already kept each packet within budget.
+	uint8_t *buffer = packet->AllocatePayload(_max_payload_len);
+	if (buffer == nullptr)
+	{
+		return false;
+	}
+
+	// Aggregation header.
+	uint8_t agg = 0;
+	if (plan.fragments.front().continuation)
+	{
+		agg |= AV1_AGG_Z;
+	}
+	if (plan.fragments.back().continues)
+	{
+		agg |= AV1_AGG_Y;
+	}
+	agg |= static_cast<uint8_t>(w << AV1_AGG_W_SHIFT) & AV1_AGG_W_MASK;
+	if (_next_packet == 0 && _new_coded_video_sequence)
+	{
+		agg |= AV1_AGG_N;
+	}
+	buffer[0] = agg;
+
+	size_t pos = kAggregationHeaderSize;
+	for (size_t i = 0; i < w; i++)
+	{
+		const Fragment &frag = plan.fragments[i];
+
+		if (i + 1 != w)
+		{
+			uint8_t		 leb[Av1Parser::LEB128_MAX_SIZE];
+			const size_t leb_len = Av1Parser::EncodeLeb128(frag.length, leb);
+			if (leb_len == 0)
+			{
+				return false;
+			}
+			::memcpy(buffer + pos, leb, leb_len);
+			pos += leb_len;
+		}
+
+		CopyObuRange(_obus[frag.obu_index], frag.offset, frag.length, buffer + pos);
+		pos += frag.length;
+	}
+
+	packet->SetPayloadSize(pos);
+	packet->SetMarker(_next_packet + 1 == _packets.size());
+	_next_packet++;
+
+	return true;
+}
+
+void RtpPacketizerAV1::CopyObuRange(const Obu &obu, size_t offset, size_t length, uint8_t *dst) const
+{
+	const size_t end = offset + length;
+	size_t		 pos = offset;
+
+	// Header bytes (obu_header [+ obu_extension_header]).
+	if (pos < obu.header_size)
+	{
+		const size_t h_end = std::min(end, obu.header_size);
+		::memcpy(dst, obu.header + pos, h_end - pos);
+		dst += h_end - pos;
+		pos = h_end;
+	}
+
+	// Payload bytes.
+	if (pos < end)
+	{
+		::memcpy(dst, obu.payload + (pos - obu.header_size), end - pos);
+	}
+}
+
+size_t RtpPacketizerAV1::Leb128Size(uint64_t value)
+{
+	uint8_t scratch[Av1Parser::LEB128_MAX_SIZE];
+	return Av1Parser::EncodeLeb128(value, scratch);
+}

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_av1.h
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_av1.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <vector>
+
+#include "rtp_packetizing_manager.h"
+#include "rtp_rtcp_defines.h"
+
+/*
+	AV1 RTP Specification (https://aomediacodec.github.io/av1-rtp-spec/)
+
+	The inverse of RtpDepacketizerAV1: take a low-overhead AV1 temporal unit (each OBU has
+	obu_has_size_field == 1) and emit AV1 RTP payloads.
+
+	[Aggregation header] (first byte of every payload)
+
+	 0 1 2 3 4 5 6 7
+	+-+-+-+-+-+-+-+-+
+	|Z|Y| W |N|-|-|-|
+	+-+-+-+-+-+-+-+-+
+
+	* Z : first OBU element is a continuation of the previous packet's last OBU element
+	* Y : last OBU element continues in the next packet
+	* W : number of OBU elements in the packet (1..3 here; the last one omits its length field)
+	* N : first packet of a new coded video sequence (set when the temporal unit has a sequence header)
+
+	The Temporal Delimiter OBU is dropped (the RTP framing conveys temporal-unit boundaries). Each OBU
+	element is carried with obu_has_size_field == 0 and no obu_size field; the depacketizer restores the
+	size field. Elements larger than the MTU are fragmented across packets via the Z/Y bits.
+
+	Dependency Descriptor / scalability are out of scope; the aggregation header alone is a valid payload.
+*/
+
+class RtpPacketizerAV1 : public RtpPacketizingManager
+{
+public:
+	size_t SetPayloadData(size_t max_payload_len, size_t last_packet_reduction_len, const RTPVideoTypeHeader *rtp_type_header, FrameType frame_type,
+						  const uint8_t *payload_data, size_t payload_size, const FragmentationHeader *fragmentation) override;
+
+	bool NextPacket(RtpPacket *packet) override;
+
+private:
+	// One OBU element to transmit: the header (obu_has_size_field cleared) plus a pointer into the
+	// source temporal unit for the payload. The obu_size field of the source OBU is not carried.
+	struct Obu
+	{
+		uint8_t header[2] = {0, 0};	  // obu_header (+ obu_extension_header), obu_has_size_field cleared
+		size_t header_size = 0;		  // 1 or 2
+		const uint8_t *payload = nullptr;
+		size_t payload_size = 0;
+
+		size_t Size() const { return header_size + payload_size; }
+	};
+
+	// One contiguous slice of an OBU element placed in a packet.
+	struct Fragment
+	{
+		size_t obu_index = 0;
+		size_t offset = 0;	  // offset within the OBU element
+		size_t length = 0;	  // bytes of the OBU element in this fragment
+		bool continuation = false;	  // continues the previous packet's last element (Z when first in packet)
+		bool continues = false;		  // continues into the next packet (Y when last in packet)
+	};
+
+	struct Packet
+	{
+		std::vector<Fragment> fragments;
+	};
+
+	// Split the temporal unit into OBU elements, dropping Temporal Delimiters; sets `_new_coded_video_sequence`.
+	bool BuildObuList(const uint8_t *data, size_t size);
+
+	// Lay the OBU elements out into packets that respect `max_payload_len` and the last-packet reduction.
+	bool GeneratePackets();
+
+	// Copy [offset, offset + length) of an OBU element (header bytes then payload) into `dst`.
+	void CopyObuRange(const Obu &obu, size_t offset, size_t length, uint8_t *dst) const;
+
+	// LEB128 byte count for `value` (reuses the shared encoder).
+	static size_t Leb128Size(uint64_t value);
+
+	std::vector<Obu> _obus;
+	std::vector<Packet> _packets;
+	size_t _next_packet = 0;
+
+	size_t _max_payload_len = 0;
+	size_t _last_packet_reduction_len = 0;
+	bool _new_coded_video_sequence = false;
+};

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_av1_test.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_av1_test.cpp
@@ -1,0 +1,147 @@
+//==============================================================================
+//
+//  OvenMediaEngine - Unit Tests
+//
+//  Covers: RtpPacketizerAV1 (AV1 RTP Specification)
+//          - aggregation header Z/Y/W/N
+//          - LEB128 length-prefixed elements + last-element length omission
+//          - Temporal Delimiter removal
+//          - MTU fragmentation across packets
+//          - round-trip against RtpDepacketizerAV1
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include "rtp_depacketizer_av1.h"
+#include "rtp_packetizer_av1.h"
+#include "rtp_packet.h"
+
+namespace
+{
+	// A generous MTU that keeps any small temporal unit in a single packet.
+	constexpr size_t kLargeMtu = 1200;
+
+	std::vector<std::vector<uint8_t>> Packetize(const std::vector<uint8_t> &temporal_unit, size_t max_payload_len)
+	{
+		RtpPacketizerAV1 packetizer;
+		const size_t	 num_packets = packetizer.SetPayloadData(max_payload_len, 0, nullptr, FrameType::VideoFrameDelta,
+																 temporal_unit.data(), temporal_unit.size(), nullptr);
+
+		std::vector<std::vector<uint8_t>> payloads;
+		for (size_t i = 0; i < num_packets; i++)
+		{
+			RtpPacket packet;
+			EXPECT_TRUE(packetizer.NextPacket(&packet));
+			const uint8_t *p = packet.Payload();
+			payloads.emplace_back(p, p + packet.PayloadSize());
+		}
+
+		// The packetizer is drained.
+		RtpPacket extra;
+		EXPECT_FALSE(packetizer.NextPacket(&extra));
+
+		return payloads;
+	}
+
+	std::vector<uint8_t> RoundTrip(const std::vector<uint8_t> &temporal_unit, size_t max_payload_len)
+	{
+		auto payloads = Packetize(temporal_unit, max_payload_len);
+
+		std::vector<std::shared_ptr<ov::Data>> rtp_payloads;
+		for (const auto &payload : payloads)
+		{
+			rtp_payloads.push_back(std::make_shared<ov::Data>(payload.data(), payload.size()));
+		}
+
+		RtpDepacketizerAV1 depacketizer;
+		auto			   out = depacketizer.ParseAndAssembleFrame(rtp_payloads);
+		if (out == nullptr)
+		{
+			return {};
+		}
+
+		const auto *p = out->GetDataAs<uint8_t>();
+		return std::vector<uint8_t>(p, p + out->GetLength());
+	}
+
+	// Low-overhead OBUs (obu_has_size_field == 1) used as packetizer input:
+	//   SequenceHeader (type 1) header = 0x0A, Frame (type 6) header = 0x32, TemporalDelimiter (type 2) header = 0x12.
+}  // namespace
+
+// One small Frame temporal unit fits a single packet; round-trip reproduces the input verbatim.
+TEST(RtpPacketizerAV1, RoundTripSingleFrame)
+{
+	const std::vector<uint8_t> tu = {0x32, 0x02, 0xAA, 0xBB};	// Frame OBU, size 2
+
+	auto payloads = Packetize(tu, kLargeMtu);
+	ASSERT_EQ(payloads.size(), 1u);
+	// agg=0x10 (Z=0,Y=0,W=1,N=0), element {0x30,0xAA,0xBB} (size field stripped).
+	EXPECT_EQ(payloads[0], (std::vector<uint8_t>{0x10, 0x30, 0xAA, 0xBB}));
+
+	EXPECT_EQ(RoundTrip(tu, kLargeMtu), tu);
+}
+
+// A sequence-header + frame temporal unit packs into one packet, sets the N bit, and length-prefixes
+// every element but the last.
+TEST(RtpPacketizerAV1, RoundTripSequenceHeaderAndFrameSetsNBit)
+{
+	const std::vector<uint8_t> tu = {0x0A, 0x01, 0xAA, 0x32, 0x02, 0xBB, 0xCC};
+
+	auto payloads = Packetize(tu, kLargeMtu);
+	ASSERT_EQ(payloads.size(), 1u);
+	// agg: W=2 (0x20) | N=1 (0x08) = 0x28; then leb(2)+{0x08,0xAA}; last element {0x30,0xBB,0xCC}.
+	EXPECT_EQ(payloads[0], (std::vector<uint8_t>{0x28, 0x02, 0x08, 0xAA, 0x30, 0xBB, 0xCC}));
+
+	EXPECT_EQ(RoundTrip(tu, kLargeMtu), tu);
+}
+
+// The Temporal Delimiter OBU is removed; the round-trip yields the temporal unit without it.
+TEST(RtpPacketizerAV1, TemporalDelimiterDropped)
+{
+	const std::vector<uint8_t> tu_with_td = {0x12, 0x00, 0x32, 0x02, 0xAA, 0xBB};	// TD + Frame
+	const std::vector<uint8_t> frame_only = {0x32, 0x02, 0xAA, 0xBB};
+
+	auto payloads = Packetize(tu_with_td, kLargeMtu);
+	ASSERT_EQ(payloads.size(), 1u);
+	EXPECT_EQ(payloads[0], (std::vector<uint8_t>{0x10, 0x30, 0xAA, 0xBB}));
+
+	EXPECT_EQ(RoundTrip(tu_with_td, kLargeMtu), frame_only);
+}
+
+// A frame larger than the MTU is fragmented across packets with correct Z/Y bits; reassembly restores it.
+TEST(RtpPacketizerAV1, FragmentedAcrossPackets)
+{
+	// Frame OBU with a 10-byte payload (element bytes = 1 header + 10 payload = 11).
+	std::vector<uint8_t> tu = {0x32, 0x0A};
+	for (uint8_t i = 0; i < 10; i++)
+	{
+		tu.push_back(static_cast<uint8_t>(0xA0 + i));
+	}
+
+	// budget = max_payload_len - 1 (agg header) = 4 bytes of element data per packet -> 11 bytes => 3 packets.
+	auto payloads = Packetize(tu, 5);
+	ASSERT_EQ(payloads.size(), 3u);
+
+	// Every packet carries a single OBU element (W=1).
+	EXPECT_EQ(payloads[0][0], 0x10 | 0x40);			   // W=1, Y=1
+	EXPECT_EQ(payloads[1][0], 0x10 | 0x80 | 0x40);	   // W=1, Z=1, Y=1
+	EXPECT_EQ(payloads[2][0], 0x10 | 0x80);			   // W=1, Z=1, Y=0
+
+	EXPECT_EQ(RoundTrip(tu, 5), tu);
+}
+
+// Two OBUs that do not fit one packet split across packets and still reassemble exactly.
+TEST(RtpPacketizerAV1, TwoObusSmallMtuRoundTrip)
+{
+	std::vector<uint8_t> tu = {0x0A, 0x03, 0x11, 0x22, 0x33};	// SequenceHeader, payload 3 bytes
+	tu.insert(tu.end(), {0x32, 0x06, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46});	// Frame, payload 6 bytes
+
+	EXPECT_EQ(RoundTrip(tu, 7), tu);
+}
+
+// Empty input and a temporal unit consisting solely of a Temporal Delimiter produce no packets.
+TEST(RtpPacketizerAV1, EmptyAndTemporalDelimiterOnlyProduceNoPackets)
+{
+	EXPECT_TRUE(Packetize({}, kLargeMtu).empty());
+	EXPECT_TRUE(Packetize({0x12, 0x00}, kLargeMtu).empty());	// TD only
+}

--- a/src/projects/modules/rtp_rtcp/rtp_packetizing_manager.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizing_manager.cpp
@@ -2,6 +2,7 @@
 #include "rtp_packetizer_vp8.h"
 #include "rtp_packetizer_h264.h"
 #include "rtp_packetizer_h265.h"
+#include "rtp_packetizer_av1.h"
 
 #include <base/ovlibrary/converter.h>
 
@@ -17,6 +18,9 @@ std::shared_ptr<RtpPacketizingManager> RtpPacketizingManager::Create(cmn::MediaC
 
 		case cmn::MediaCodecId::H265:
 			return std::make_shared<RtpPacketizerH265>();
+
+		case cmn::MediaCodecId::Av1:
+			return std::make_shared<RtpPacketizerAV1>();
 
 		default:
 			// Not supported

--- a/src/projects/publishers/webrtc/rtc_common_types.h
+++ b/src/projects/publishers/webrtc/rtc_common_types.h
@@ -23,6 +23,8 @@ enum class FixedRtcPayloadType : uint8_t
 	H264_RTX_PAYLOAD_TYPE = 99,
 	H265_PAYLOAD_TYPE	  = 100,
 	H265_RTX_PAYLOAD_TYPE = 101,
+	AV1_PAYLOAD_TYPE	  = 102,
+	AV1_RTX_PAYLOAD_TYPE  = 103,
 	OPUS_PAYLOAD_TYPE	  = 110,
 	RED_PAYLOAD_TYPE	  = 120,
 	RED_RTX_PAYLOAD_TYPE  = 121,
@@ -45,6 +47,10 @@ static cmn::MediaCodecId CodecIdFromPayloadType(FixedRtcPayloadType payload_type
 			return cmn::MediaCodecId::H265;
 		case FixedRtcPayloadType::H265_RTX_PAYLOAD_TYPE:
 			return cmn::MediaCodecId::H265;
+		case FixedRtcPayloadType::AV1_PAYLOAD_TYPE:
+			return cmn::MediaCodecId::Av1;
+		case FixedRtcPayloadType::AV1_RTX_PAYLOAD_TYPE:
+			return cmn::MediaCodecId::Av1;
 		case FixedRtcPayloadType::OPUS_PAYLOAD_TYPE:
 			return cmn::MediaCodecId::Opus;
 		default:
@@ -74,6 +80,9 @@ static uint8_t PayloadTypeFromCodecId(cmn::MediaCodecId codec_id)
 		case cmn::MediaCodecId::H265:
 			payload_type = static_cast<uint8_t>(FixedRtcPayloadType::H265_PAYLOAD_TYPE);
 			break;
+		case cmn::MediaCodecId::Av1:
+			payload_type = static_cast<uint8_t>(FixedRtcPayloadType::AV1_PAYLOAD_TYPE);
+			break;
 		case cmn::MediaCodecId::Opus:
 			payload_type = static_cast<uint8_t>(FixedRtcPayloadType::OPUS_PAYLOAD_TYPE);
 			break;
@@ -99,6 +108,9 @@ static uint8_t RtxPayloadTypeFromCodecId(cmn::MediaCodecId codec_id)
 			break;
 		case cmn::MediaCodecId::H265:
 			payload_type = static_cast<uint8_t>(FixedRtcPayloadType::H265_RTX_PAYLOAD_TYPE);
+			break;
+		case cmn::MediaCodecId::Av1:
+			payload_type = static_cast<uint8_t>(FixedRtcPayloadType::AV1_RTX_PAYLOAD_TYPE);
 			break;
 		default:
 			// No support codecs

--- a/src/projects/publishers/webrtc/rtc_stream.cpp
+++ b/src/projects/publishers/webrtc/rtc_stream.cpp
@@ -330,6 +330,7 @@ bool RtcStream::IsSupportedCodec(cmn::MediaCodecId codec_id)
 		case cmn::MediaCodecId::H264:
 		case cmn::MediaCodecId::H265:
 		case cmn::MediaCodecId::Vp8:
+		case cmn::MediaCodecId::Av1:
 		case cmn::MediaCodecId::Opus:
 			return true;
 		default:
@@ -641,6 +642,9 @@ std::shared_ptr<PayloadAttr> RtcStream::MakePayloadAttr(const std::shared_ptr<co
 	{
 		case MediaCodecId::Vp8:
 			payload->SetRtpmap(PayloadTypeFromCodecId(track->GetCodecId()), "VP8", 90000);
+			break;
+		case MediaCodecId::Av1:
+			payload->SetRtpmap(PayloadTypeFromCodecId(track->GetCodecId()), "AV1", 90000);
 			break;
 		case MediaCodecId::H265:
 			payload->SetRtpmap(PayloadTypeFromCodecId(track->GetCodecId()), "H265", 90000);
@@ -972,6 +976,12 @@ void RtcStream::MakeRtpVideoHeader(uint32_t track_id, const CodecSpecificInfo *i
 			rtp_video_header->codec								   = cmn::MediaCodecId::H265;
 			rtp_video_header->codec_header.h26X.packetization_mode = info->codec_specific.h26X.packetization_mode;
 			rtp_video_header->simulcast_idx						   = info->codec_specific.h26X.simulcast_idx;
+			return;
+
+		case cmn::MediaCodecId::Av1:
+			// AV1 carries no per-codec RTP header here; the aggregation header is built from the OBU
+			// stream by RtpPacketizerAV1.
+			rtp_video_header->codec = cmn::MediaCodecId::Av1;
 			return;
 		default:
 			break;


### PR DESCRIPTION
Support sending AV1 to WebRTC subscribers. The publisher packetizes AV1 into RTP and advertises AV1 in the SDP offer.