### PR TITLE
feat: warn when an unready track blocks stream preparation

### DIFF
--- a/src/projects/mediarouter/mediarouter_application.cpp
+++ b/src/projects/mediarouter/mediarouter_application.cpp
@@ -937,9 +937,17 @@ void MediaRouteApplication::InboundWorkerThread(uint32_t worker_id)
 
 		// When the inbound stream is finished parsing track information,
 		// Notify the Observer that the stream is parsed
-		if (stream->IsStreamPrepared() == false && stream->IsStreamReady() == true)
+		if (stream->IsStreamPrepared() == false)
 		{
-			NotifyStreamPrepared(stream);
+			if (stream->IsStreamReady() == true)
+			{
+				NotifyStreamPrepared(stream);
+			}
+			else
+			{
+				// Warn if a track has not become valid in time, blocking the stream from being prepared
+				stream->CheckUnpreparedTrackTimeout();
+			}
 		}
 
 		std::shared_lock<std::shared_mutex> lock(_observers_lock);

--- a/src/projects/mediarouter/mediarouter_stream.cpp
+++ b/src/projects/mediarouter/mediarouter_stream.cpp
@@ -135,6 +135,47 @@ bool MediaRouteStream::IsStreamReady()
 	return true;
 }
 
+// While any track is invalid, IsStreamReady() stays false and the stream is never prepared. If one of the
+// negotiated tracks (e.g. a simulcast layer or audio) never arrives, the stream hangs. Warn so it is visible.
+void MediaRouteStream::CheckUnpreparedTrackTimeout()
+{
+	auto now = std::chrono::steady_clock::now();
+
+	// Anchor at the first media packet so connection/handshake delay is excluded; full silence is the provider's job.
+	if (_first_media_recv_time_set == false)
+	{
+		_first_media_recv_time = now;
+		_last_unprepared_warn_time = now;
+		_first_media_recv_time_set = true;
+		return;
+	}
+
+	// Warn periodically (not once) while tracks remain invalid
+	if (std::chrono::duration_cast<std::chrono::milliseconds>(now - _last_unprepared_warn_time).count() < MEDIA_ROUTE_STREAM_TRACK_PREPARE_TIMEOUT_MS)
+	{
+		return;
+	}
+	_last_unprepared_warn_time = now;
+
+	auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - _first_media_recv_time).count();
+
+	auto tracks = _stream->GetTracks();
+	for (const auto &track_it : tracks)
+	{
+		auto track_id = track_it.first;
+		auto track = track_it.second;
+
+		if (track->IsValid() == true)
+		{
+			continue;
+		}
+
+		logtw("[%s/%s] Track #%u (%s) has not received valid media for %" PRId64 " ms; the stream cannot be prepared until this track is ready",
+			  _stream->GetApplicationName(), _stream->GetName().CStr(),
+			  track_id, GetMediaTypeString(track->GetMediaType()), elapsed_ms);
+	}
+}
+
 // @deprecated
 void MediaRouteStream::DropNonDecodingPackets()
 {

--- a/src/projects/mediarouter/mediarouter_stream.cpp
+++ b/src/projects/mediarouter/mediarouter_stream.cpp
@@ -159,20 +159,20 @@ void MediaRouteStream::CheckUnpreparedTrackTimeout()
 
 	auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - _first_media_recv_time).count();
 
-	auto tracks = _stream->GetTracks();
+	const auto &tracks = _stream->GetTracks();
 	for (const auto &track_it : tracks)
 	{
-		auto track_id = track_it.first;
 		auto track = track_it.second;
 
-		if (track->IsValid() == true)
+		// Mirror IsStreamReady(): a track blocks prepare until it is both valid and quality-measured
+		if (track->IsValid() == true && track->HasQualityMeasured() == true)
 		{
 			continue;
 		}
 
-		logtw("[%s/%s] Track #%u (%s) has not received valid media for %" PRId64 " ms; the stream cannot be prepared until this track is ready",
+		logtw("[%s/%s] Track #%u (%s) is not ready %" PRId64 " ms after media started; the stream cannot be prepared until this track is ready",
 			  _stream->GetApplicationName(), _stream->GetName().CStr(),
-			  track_id, GetMediaTypeString(track->GetMediaType()), elapsed_ms);
+			  track->GetId(), GetMediaTypeString(track->GetMediaType()), static_cast<int64_t>(elapsed_ms));
 	}
 }
 

--- a/src/projects/mediarouter/mediarouter_stream.h
+++ b/src/projects/mediarouter/mediarouter_stream.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 
+#include <chrono>
 #include <memory>
 #include <queue>
 #include <vector>
@@ -24,6 +25,9 @@
 #include "modules/managed_queue/managed_queue.h"
 
 static constexpr int64_t MEDIA_ROUTE_STREAM_MAX_MIRROR_BUFFER_SIZE_MS = 2000; // Maximum size of mirror buffer
+
+// Warn if a track stays invalid (no decodable media) this long after the first packet, which blocks stream prepare
+static constexpr int64_t MEDIA_ROUTE_STREAM_TRACK_PREPARE_TIMEOUT_MS = 3000;
 
 class MediaRouteStream : public MediaRouterNormalize, public MediaRouterStats, public MediaRouterEventGenerator, public MediaRouterAlert
 {
@@ -71,6 +75,9 @@ public:
 	bool IsStreamPrepared();
 	bool IsStreamReady();
 
+	// Periodically warn about tracks that stay invalid too long, which blocks the stream from being prepared
+	void CheckUnpreparedTrackTimeout();
+
 	void Flush();
 	
 private:
@@ -78,6 +85,11 @@ private:
 
 	bool _is_stream_prepared = false;
 	bool _is_all_tracks_parsed = false;
+
+	// Deadline tracking for periodically warning about tracks that never become valid (anchored at the first media packet)
+	std::chrono::steady_clock::time_point _first_media_recv_time;
+	std::chrono::steady_clock::time_point _last_unprepared_warn_time;
+	bool _first_media_recv_time_set = false;
 
 	// Incoming/Outgoing Stream
 	cmn::MediaRouterStreamType _type;


### PR DESCRIPTION
A stream is marked prepared only after every track has valid media. If one negotiated track never receives decodable media, such as a WebRTC simulcast layer or an audio track that never arrives, the stream stays unprepared indefinitely with no log indicating which track is responsible.

MediaRouter now monitors inbound streams that have started receiving media but are not yet prepared, and periodically logs a warning for each track that has stayed invalid beyond a timeout, identifying the track so the cause is visible.

example:

```
[06-15 15:23:48.625] W [InboundWorker:1106411] MediaRouter | mediarouter_stream.cpp:175  | [#default#app/stream] Track #3 (Video) has not received valid media for 3003 ms; the stream cannot be prepared until this track is ready
[06-15 15:23:51.626] W [InboundWorker:1106411] MediaRouter | mediarouter_stream.cpp:175  | [#default#app/stream] Track #3 (Video) has not received valid media for 6004 ms; the stream cannot be prepared until this track is ready
[06-15 15:23:54.627] W [InboundWorker:1106411] MediaRouter | mediarouter_stream.cpp:175  | [#default#app/stream] Track #3 (Video) has not received valid media for 9005 ms; the stream cannot be prepared until this track is ready
[06-15 15:23:57.642] W [InboundWorker:1106411] MediaRouter | mediarouter_stream.cpp:175  | [#default#app/stream] Track #3 (Video) has not received valid media for 12020 ms; the stream cannot be prepared until this track is ready
[06-15 15:24:00.656] W [InboundWorker:1106411] MediaRouter | mediarouter_stream.cpp:175  | [#default#app/stream] Track #3 (Video) has not received valid media for 15034 ms; the stream cannot be prepared until this track is ready
[06-15 15:24:03.660] W [InboundWorker:1106411] MediaRouter | mediarouter_stream.cpp:175  | [#default#app/stream] Track #3 (Video) has not received valid media for 18038 ms; the stream cannot be prepared until this track is ready
```