### PR TITLE
feat: log track info on stream creation

### DIFF
--- a/src/projects/base/info/media_track.cpp
+++ b/src/projects/base/info/media_track.cpp
@@ -494,6 +494,104 @@ ov::String MediaTrack::GetInfoString()
 	return out_str;
 }
 
+ov::String MediaTrack::GetInfoStringForCreated()
+{
+	ov::String out_str;
+
+	const char *codec_status_str = cmn::GetCodecStatusString(GetCodecStatus());
+
+	switch (GetMediaType())
+	{
+		case MediaType::Video:
+		{
+			out_str.AppendFormat(
+				"Video Track #%u: Public Name(%s) Variant Name(%s) Codec(%s%s%s) BSF(%s) ",
+				GetId(), GetPublicName().CStr(), GetVariantName().CStr(),
+				cmn::GetCodecIdString(GetCodecId()),
+				codec_status_str ? "," : "", codec_status_str ? codec_status_str : "",
+				GetBitstreamFormatString(GetOriginBitstream()));
+
+			// Measured/negotiated values are shown only once known, so the log carries no zeros at creation
+			auto bitrate = GetBitrate();
+			if (bitrate > 0)
+				out_str.AppendFormat("Bitrate(%s) ", ov::Converter::BitToString(bitrate).CStr());
+
+			auto resolution = GetResolution();
+			if (resolution.width > 0 && resolution.height > 0)
+				out_str.AppendFormat("Resolution(%s) ", resolution.ToString().CStr());
+
+			auto max_resolution = GetMaxResolution();
+			if (max_resolution.width > 0 && max_resolution.height > 0)
+				out_str.AppendFormat("MaxResolution(%s) ", max_resolution.ToString().CStr());
+
+			auto framerate = GetFrameRate();
+			if (framerate > 0)
+				out_str.AppendFormat("Framerate(%.2f) ", framerate);
+
+			auto max_framerate = GetMaxFrameRate();
+			if (max_framerate > 0)
+				out_str.AppendFormat("MaxFramerate(%.2f) ", max_framerate);
+			break;
+		}
+
+		case MediaType::Audio:
+		{
+			out_str.AppendFormat(
+				"Audio Track #%u: Public Name(%s) Variant Name(%s) Codec(%s%s%s) BSF(%s) ",
+				GetId(), GetPublicName().CStr(), GetVariantName().CStr(),
+				cmn::GetCodecIdString(GetCodecId()),
+				codec_status_str ? "," : "", codec_status_str ? codec_status_str : "",
+				GetBitstreamFormatString(GetOriginBitstream()));
+
+			auto bitrate = GetBitrate();
+			if (bitrate > 0)
+				out_str.AppendFormat("Bitrate(%s) ", ov::Converter::BitToString(bitrate).CStr());
+
+			auto samplerate = GetSampleRate();
+			if (samplerate > 0)
+				out_str.AppendFormat("Samplerate(%s) ", ov::Converter::ToSiString(samplerate, 1).CStr());
+
+			auto sample = GetSample();
+			if (sample.GetFormat() != cmn::AudioSample::Format::None)
+				out_str.AppendFormat("Format(%s) ", sample.GetName());
+
+			if (IsValidChannel())
+				out_str.AppendFormat("Channel(%s) ", GetChannel().GetName());
+			break;
+		}
+
+		case MediaType::Data:
+			out_str.AppendFormat(
+				"Data  Track #%u: Public Name(%s) Variant Name(%s) Codec(%s%s%s) BSF(%s) ",
+				GetId(), GetPublicName().CStr(), GetVariantName().CStr(),
+				cmn::GetCodecIdString(GetCodecId()),
+				codec_status_str ? "," : "", codec_status_str ? codec_status_str : "",
+				GetBitstreamFormatString(GetOriginBitstream()));
+			break;
+
+		case MediaType::Subtitle:
+		{
+			out_str.AppendFormat(
+				"Subtitle Track #%u: Public Name(%s) Variant Name(%s) Codec(%s%s%s) ",
+				GetId(), GetPublicName().CStr(), GetVariantName().CStr(),
+				cmn::GetCodecIdString(GetCodecId()),
+				codec_status_str ? "," : "", codec_status_str ? codec_status_str : "");
+
+			auto extra_info = GetExtraInfo();
+			if (extra_info.IsEmpty() == false)
+				out_str.AppendFormat("%s ", extra_info.CStr());
+			break;
+		}
+
+		default:
+			break;
+	}
+
+	out_str.AppendFormat("timebase(%s)", GetTimeBase().ToString().CStr());
+
+	return out_str;
+}
+
 bool MediaTrack::IsValid()
 {
 	if (_is_valid == true)

--- a/src/projects/base/info/media_track.cpp
+++ b/src/projects/base/info/media_track.cpp
@@ -504,17 +504,18 @@ ov::String MediaTrack::GetInfoStringForCreated()
 	{
 		case MediaType::Video:
 		{
-			out_str.AppendFormat(
-				"Video Track #%u: Public Name(%s) Variant Name(%s) Codec(%s%s%s) BSF(%s) ",
-				GetId(), GetPublicName().CStr(), GetVariantName().CStr(),
-				cmn::GetCodecIdString(GetCodecId()),
-				codec_status_str ? "," : "", codec_status_str ? codec_status_str : "",
-				GetBitstreamFormatString(GetOriginBitstream()));
+			out_str.AppendFormat("Video Track #%u: Public Name(%s) Variant Name(%s) ",
+				GetId(), GetPublicName().CStr(), GetVariantName().CStr());
 
-			// Measured/negotiated values are shown only once known, so the log carries no zeros at creation
+			// Field order matches GetInfoString(); measured values are shown only once known, so no zeros at creation
 			auto bitrate = GetBitrate();
 			if (bitrate > 0)
 				out_str.AppendFormat("Bitrate(%s) ", ov::Converter::BitToString(bitrate).CStr());
+
+			out_str.AppendFormat("Codec(%s%s%s) BSF(%s) ",
+				cmn::GetCodecIdString(GetCodecId()),
+				codec_status_str ? "," : "", codec_status_str ? codec_status_str : "",
+				GetBitstreamFormatString(GetOriginBitstream()));
 
 			auto resolution = GetResolution();
 			if (resolution.width > 0 && resolution.height > 0)
@@ -536,16 +537,17 @@ ov::String MediaTrack::GetInfoStringForCreated()
 
 		case MediaType::Audio:
 		{
-			out_str.AppendFormat(
-				"Audio Track #%u: Public Name(%s) Variant Name(%s) Codec(%s%s%s) BSF(%s) ",
-				GetId(), GetPublicName().CStr(), GetVariantName().CStr(),
-				cmn::GetCodecIdString(GetCodecId()),
-				codec_status_str ? "," : "", codec_status_str ? codec_status_str : "",
-				GetBitstreamFormatString(GetOriginBitstream()));
+			out_str.AppendFormat("Audio Track #%u: Public Name(%s) Variant Name(%s) ",
+				GetId(), GetPublicName().CStr(), GetVariantName().CStr());
 
 			auto bitrate = GetBitrate();
 			if (bitrate > 0)
 				out_str.AppendFormat("Bitrate(%s) ", ov::Converter::BitToString(bitrate).CStr());
+
+			out_str.AppendFormat("Codec(%s%s%s) BSF(%s) ",
+				cmn::GetCodecIdString(GetCodecId()),
+				codec_status_str ? "," : "", codec_status_str ? codec_status_str : "",
+				GetBitstreamFormatString(GetOriginBitstream()));
 
 			auto samplerate = GetSampleRate();
 			if (samplerate > 0)

--- a/src/projects/base/info/media_track.h
+++ b/src/projects/base/info/media_track.h
@@ -142,6 +142,9 @@ public:
 
 	ov::String GetInfoString();
 
+	// Track info known at stream-creation time; omits not-yet-measured fields (resolution, framerate, bitrate, ...)
+	ov::String GetInfoStringForCreated();
+
 	// Codec status: set by encoder/decoder after initialization
 	using CodecStatus = cmn::CodecStatus;
 	void SetCodecStatus(cmn::CodecStatus status);

--- a/src/projects/base/info/media_track.h
+++ b/src/projects/base/info/media_track.h
@@ -142,7 +142,7 @@ public:
 
 	ov::String GetInfoString();
 
-	// Track info known at stream-creation time; omits not-yet-measured fields (resolution, framerate, bitrate, ...)
+	// Track info for the stream-created log; measured fields (resolution, framerate, bitrate, ...) are shown only once known
 	ov::String GetInfoStringForCreated();
 
 	// Codec status: set by encoder/decoder after initialization

--- a/src/projects/base/info/stream.cpp
+++ b/src/projects/base/info/stream.cpp
@@ -584,7 +584,7 @@ namespace info
 		return (_app_info == nullptr) ? "Unknown" : _app_info->GetVHostAppName().CStr();
 	}
 
-	ov::String Stream::GetInfoString()
+	ov::String Stream::GetInfoString(bool created)
 	{
 		ov::String out_str = ov::String::FormatString("\n[Stream Info]\nid(%u), msid(%u), output(%s), SourceType(%s), RepresentationType(%s), Created Time (%s) UUID(%s)\n",
 													  GetId(), GetMsid(), GetName().CStr(), ::StringFromStreamSourceType(_source_type).CStr(), ::StringFromStreamRepresentationType(_representation_type).CStr(),
@@ -605,7 +605,7 @@ namespace info
 		{
 			auto track = it->second;
 
-			out_str.AppendFormat("\n\t%s", track->GetInfoString().CStr());
+			out_str.AppendFormat("\n\t%s", created ? track->GetInfoStringForCreated().CStr() : track->GetInfoString().CStr());
 		}
 
 		return out_str;

--- a/src/projects/base/info/stream.h
+++ b/src/projects/base/info/stream.h
@@ -110,7 +110,7 @@ namespace info
 		std::shared_ptr<const TrackSet> GetTrackSet(const ov::String &name) const;
 		const std::map<ov::String, std::shared_ptr<const TrackSet>> &GetTrackSets() const;
 
-		ov::String GetInfoString();
+		ov::String GetInfoString(bool created = false);
 		void ShowInfo();
 
 		void SetApplicationInfo(const std::shared_ptr<Application> &app_info);

--- a/src/projects/mediarouter/mediarouter_application.cpp
+++ b/src/projects/mediarouter/mediarouter_application.cpp
@@ -462,7 +462,7 @@ bool MediaRouteApplication::NotifyStreamCreate(const std::shared_ptr<info::Strea
 	auto observers = _observers; // Avoid deadlock
 	lock.unlock();
 
-	logti("[%s/%s(%u)] %sStream has been created", _application_info.GetVHostAppName().CStr(), stream_info->GetName().CStr(), stream_info->GetId(), stream_info->IsInternal() ? "[Internal] " : "");
+	logti("[%s/%s(%u)] %sStream has been created %s", _application_info.GetVHostAppName().CStr(), stream_info->GetName().CStr(), stream_info->GetId(), stream_info->IsInternal() ? "[Internal] " : "", stream_info->GetInfoString(true).CStr());
 
 	if (stream_info->IsInternal())
 	{


### PR DESCRIPTION
The stream-created log printed only the stream name and id, so when a stream failed to reach the prepared state there was no record of its negotiated tracks to match against the per-track logs.

The stream-created log now lists each track with the values already known at creation, such as codec, variant name, bitstream format, audio sample rate and channel, and any negotiated resolution or framerate, omitting fields that are only available after media is measured.

Example:

```
[#default#app/stream(101)] Stream has been created
[Stream Info]
id(101), msid(0), output(stream), SourceType(WebRTC), RepresentationType(Source), Created Time (Mon Jun 15 16:11:08 2026) UUID(cee02946-9f70-4469-a068-cce2ca5428c2/#default#app/stream/i)

	Audio Track #6: Public Name(Audio_6) Variant Name(Audio) Codec(OPUS) BSF(OPUS_RTP_RFC_7587) Samplerate(48.0K) Channel(mono) timebase(1/48000)
	Video Track #7: Public Name(Video_7) Variant Name(Video) Codec(H264) BSF(H264_RTP_RFC_6184) timebase(1/90000)
	Video Track #8: Public Name(Video_8) Variant Name(Video) Codec(H264) BSF(H264_RTP_RFC_6184) timebase(1/90000)
	Data  Track #9: Public Name(Data_9) Variant Name(Data) Codec(None) BSF(Unknown) timebase(1/1000)
	Subtitle Track #10: Public Name(stt) Variant Name(subtitle) Codec(WebVTT) timebase(1/1000)
```
