### PR TITLE
fix(provider): stop OVT pull re-DESCRIBE storm from a reachable-but-silent origin

### DIFF
--- a/src/base/provider/pull_provider/application.cpp
+++ b/src/base/provider/pull_provider/application.cpp
@@ -13,7 +13,9 @@
 #include "stream_props.h"
 #include "provider_private.h"
 
+#include <chrono>
 #include <cinttypes>
+#include <map>
 
 namespace pvd
 {
@@ -59,20 +61,49 @@ namespace pvd
 
 		auto global_no_input_timeout_ms = GetHostInfo().GetOrigins().GetProperties().GetNoInputFailoverTimeout(); 
 		auto global_unused_stream_timeout_ms = GetHostInfo().GetOrigins().GetProperties().GetUnusedStreamDeletionTimeout();
-		auto global_failback_timeout_ms = GetHostInfo().GetOrigins().GetProperties().GetStreamFailbackTimeout();	
-		
-		constexpr int64_t idle_wait_time_ms = 100; 
+		auto global_failback_timeout_ms = GetHostInfo().GetOrigins().GetProperties().GetStreamFailbackTimeout();
+
+		// The no-input timer below is measured from
+		// max(last_recv, last_reconnect) so a reachable-but-silent origin (the reconnect succeeds but no
+		// media follows) is not stopped and re-DESCRIBEd on every tick, which would flood the origin's
+		// OVT publisher. Touched only by this collector thread, so it needs no lock.
+		std::map<info::stream_id_t, std::chrono::steady_clock::time_point> last_reconnect_time;
+
+		constexpr int64_t idle_wait_time_ms = 100;
 		while (!_stop_collector_thread_flag.load())
 		{
 			auto streams = GetStreams();
+
+			// Drop reconnect timestamps for streams that no longer exist.
+			for (auto it = last_reconnect_time.begin(); it != last_reconnect_time.end();)
+			{
+				if (streams.find(it->first) == streams.end())
+				{
+					it = last_reconnect_time.erase(it);
+				}
+				else
+				{
+					++it;
+				}
+			}
+
 			for (auto const &x : streams)
 			{
 				auto stream = std::dynamic_pointer_cast<PullStream>(x.second);
 
+				auto current = std::chrono::steady_clock::now();
+
 				if (stream->GetState() == Stream::State::STOPPED || stream->GetState() == Stream::State::ERROR)
 				{
-					// Retry
-					ResumeStream(stream);
+					// Retry. On a successful reconnect, remember when: the no-input timer restarts from
+					// this reconnect, so a reachable-but-silent origin (the reconnect succeeds but
+					// delivers no media, leaving last_recv old) is not stopped and re-DESCRIBEd again on
+					// the very next tick.
+					if (ResumeStream(stream))
+					{
+						last_reconnect_time[stream->GetId()] = current;
+						logtd("Re-pulled %s/%s(%u): reconnected to the origin", stream->GetApplicationInfo().GetVHostAppName().CStr(), stream->GetName().CStr(), stream->GetId());
+					}
 				}
 				else if (stream->GetState() == Stream::State::TERMINATED)
 				{
@@ -81,8 +112,6 @@ namespace pvd
 				}
 				else
 				{
-					auto current = std::chrono::steady_clock::now();
-
 					// Default Properties of PullStream
 					auto is_persistent = false;
 					auto is_failback = false;
@@ -144,7 +173,13 @@ namespace pvd
 										// `Start()`/`Stop()`/`Resume()` safe to compose from outside.
 										stream->Stop();
 										stream->ResetUrlIndex();
-										ResumeStream(stream);
+										// Same as the retry path: on a successful reconnect, restart the no-input
+										// timer from here so the just-switched primary is not stopped before it
+										// can deliver media.
+										if (ResumeStream(stream))
+										{
+											last_reconnect_time[stream->GetId()] = current;
+										}
 									}
 									
 								}
@@ -165,14 +200,39 @@ namespace pvd
 						int64_t elapsed_time_from_last_sent = std::chrono::duration_cast<std::chrono::milliseconds>(current - stream_metrics->GetLastSentTimeSteady()).count();
 						int64_t elapsed_time_from_last_recv = std::chrono::duration_cast<std::chrono::milliseconds>(current - stream_metrics->GetLastRecvTimeSteady()).count();
 
+						// Measure no-input from whichever is more recent - the last media packet or the last
+						// reconnect - so a successful-but-silent reconnect is not immediately re-stopped. The
+						// monitoring last_recv is left untouched (only real media advances it), so the reported
+						// stats stay honest.
+						auto last_input_time = stream_metrics->GetLastRecvTimeSteady();
+						auto reconnect_it = last_reconnect_time.find(stream->GetId());
+						if (reconnect_it != last_reconnect_time.end())
+						{
+							if (last_input_time > reconnect_it->second)
+							{
+								// Media arrived after the reconnect -> the stream has recovered. Log it once and
+								// drop the marker; from here the timer runs off last_recv again.
+								logti("Media resumed on %s/%s(%u) after re-pulling a silent origin", stream->GetApplicationInfo().GetVHostAppName().CStr(), stream->GetName().CStr(), stream->GetId());
+								last_reconnect_time.erase(reconnect_it);
+							}
+							else
+							{
+								// Still no media since the reconnect -> measure no-input from the reconnect.
+								last_input_time = reconnect_it->second;
+							}
+						}
+						int64_t elapsed_time_from_last_input = std::chrono::duration_cast<std::chrono::milliseconds>(current - last_input_time).count();
+
 						if((elapsed_time_from_last_sent > unused_stream_timeout_ms) && (!is_persistent))
 						{
 							logtw("%s/%s(%u) stream will be deleted because it hasn't been used for %" PRId64 " milliseconds", stream->GetApplicationInfo().GetVHostAppName().CStr(), stream->GetName().CStr(), stream->GetId(), elapsed_time_from_last_sent);
 							DeleteStream(stream);
 						}
 						// The stream type is pull stream, if packets do NOT arrive for more than 3 seconds, it is a seriously warning situation
-						else if(elapsed_time_from_last_recv > no_input_timeout_ms && (!is_persistent))
+						else if(elapsed_time_from_last_input > no_input_timeout_ms && (!is_persistent))
 						{
+							// The decision uses last_input (which counts from the reconnect); the log reports the
+							// true time since the last media packet, so it can read higher than the timeout.
 							logtw("Stop stream %s/%s(%u) : there are no incoming packets. %" PRId64 " milliseconds have elapsed since the last packet was received.",
 								  stream->GetApplicationInfo().GetVHostAppName().CStr(), stream->GetName().CStr(), stream->GetId(), elapsed_time_from_last_recv);
 


### PR DESCRIPTION
The below is Claude-written (as is the change), from analysing crash dumps we've been seeing in prod, plus a back-and-forth with @getroot on the approach. The crash itself (the `OvtStream::_description` race) is already fixed on master by #2165; this fixes the OVT connection storm that was driving it.

Reworked to @getroot's suggested approach: instead of a re-pull backoff with new `PullStream` state, reset the no-input clock on a successful reconnect.

### Problem

When an edge relays a stream from an origin and the source stops sending media **while its TCP connection stays up** (a stalled encoder whose host keeps answering at the socket level), the origin keeps the stream alive. The edge's `WhiteElephantStreamCollector` then enters a tight re-pull loop:

- It runs every 100 ms. A pull stream with no incoming packets for `NoInputFailoverTimeout` is `Stop()`-ed; on the next tick it is `STOPPED`, so the collector re-pulls it — reconnecting and re-`DESCRIBE`ing the origin, with no delay.
- The reconnect *succeeds* (the stream still exists at the origin) but delivers no media, so `last_recv` stays old and the stream is stopped and re-pulled again on the very next tick.

Three edges relaying one silent stream produce a continuous **DESCRIBE storm** (~25/s per stream) at the origin's OVT publisher.

(The collector re-pull loop — and thus this storm — only engages when `RetryCount > 0`; with the default `RetryCount = 0`, `ResumeInternal` terminates a silent pull stream on its first re-pull instead of reconnecting. The reproduction and our deployment use `RetryCount = 2`.)

### Reproduction

Minimal Docker reproduction (origin + 3 edges + a publisher frozen with `docker pause` to model a silent-but-connected source): https://github.com/naanlizard/ome-ovt-flap-repro

### Fix

Measure the no-input timeout from `max(last_recv, last_reconnect)` instead of `last_recv` alone:

- The collector keeps a thread-local map of the last time it resumed each pull stream, stamped only on a *successful* reconnect.
- A successful reconnect to a reachable-but-silent origin delivers no media, so `last_recv` stays old; measuring from `max(last_recv, last_reconnect)` means the stream is not stopped again until a full `NoInputFailoverTimeout` has elapsed *since the reconnect*. The re-pull (re-DESCRIBE) cadence therefore settles at `NoInputFailoverTimeout` (default 3 s) instead of once per 100 ms tick.
- No new `PullStream` members and no lock — the map is touched only by the collector thread and pruned each tick for streams that no longer exist. The monitoring `last_recv` is never written, so reported stats stay honest. Both collector resume sites (the no-input retry and the failback URL switch) reset the clock.

### Logging

The silent-origin lifecycle is now visible in the edge log:

- **reconnect** — `debug`: each time the collector re-pulls and reconnects to the origin. Off at the default level; raise the edge to `debug` to watch the cadence.
- **no input → stop** — `warning` (unchanged): prints the true time since the last *media* packet, which keeps growing while the origin stays silent.
- **media resumed** — `info`: once, when media starts flowing again after a re-pull.

### Behaviour (from the reproduction, 3 edges, one silent stream, 20 s window)

| | before | after |
|---|---|---|
| origin OVT re-pulls | 506 (~25/s) | 36 (≈ one per `NoInputFailoverTimeout` per edge) |
| edge `no incoming packets` stops | 255 | 18 |
| failover to a healthy backup URL | immediate | immediate |
| recovery when the source returns | immediate (via viewer pull) | immediate (via viewer pull) |

`NoInputFailoverTimeout` / `RetryCount` / `UnusedStreamDeletionTimeout` semantics are unchanged.

### Behaviours to be aware of

- **While retries are enabled, a reachable-but-silent origin is re-DESCRIBEd once per `NoInputFailoverTimeout` indefinitely; it does not reach `TERMINATED`.** A successful reconnect resets `_restart_count`, so the relay is never abandoned while the origin is reachable — by design. This change caps the DESCRIBE rate at the timeout cadence; it does not end the relay. Tearing such a stream down is what `PacketSilenceTimeoutMs` on the origin is for — the origin-side fix is the root cause; this patches the storm in the window before the origin removes the silent stream.
- **The stop log reports true media-silence, not the value that triggered the stop.** The decision uses `max(last_recv, last_reconnect)`, but the log prints the real time since the last media packet (so it can exceed `NoInputFailoverTimeout` after a silent reconnect). This keeps the logged number honest.
- **The clock resets on real media, not on signaling.** `last_recv` advances only on media packets, not on the OVT DESCRIBE/PLAY exchange, so a silent reconnect never resets it.
