### PR TITLE
refactor(ovsocket): return `tl::expected` from `Socket::Recv`

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -148,5 +148,6 @@ set(OME_GLOBAL_INCLUDE_DIRS
     "${CMAKE_SOURCE_DIR}/src/projects"
     "${CMAKE_SOURCE_DIR}/src/projects/third_party"
     "${CMAKE_SOURCE_DIR}/src/projects/third_party/spdlog-1.15.1/include"
+    "${CMAKE_SOURCE_DIR}/src/projects/third_party/expected-1.3.1/include"
     "${OME_DEP_PREFIX}/include"
 )

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -1622,8 +1622,16 @@ namespace ov
 				else if (read_bytes < 0L)
 				{
 					auto error = Error::CreateErrorFromErrno();
+					auto code  = error->GetCode();
 
-					if (error->GetCode() == EAGAIN)
+					// Some platforms report the would-block condition as `EWOULDBLOCK`;
+					// normalize it to `EAGAIN` (mirrors `Accept()`).
+					if (code == EWOULDBLOCK)
+					{
+						code = EAGAIN;
+					}
+
+					if (code == EAGAIN)
 					{
 						if ((_blocking_mode == BlockingMode::NonBlocking) || non_block)
 						{
@@ -1646,7 +1654,7 @@ namespace ov
 						else
 						{
 							// Blocking read timed out (`SO_RCVTIMEO`)
-							socket_error = SocketError::CreateError(error->GetCode(), "Receive timed out: %s", error->GetMessage().CStr());
+							socket_error = SocketError::CreateError(code, "Receive timed out: %s", error->GetMessage().CStr());
 						}
 					}
 					else

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -1772,7 +1772,13 @@ namespace ov
 		{
 			logap("%zd bytes read", read_bytes);
 			received_length = static_cast<size_t>(read_bytes);
-			UpdateLastRecvTime();
+
+			// Only refresh the last-recv time when data actually arrived;
+			// a 0-byte success (retry-later / would-block) must not mask idle timeouts.
+			if (read_bytes > 0L)
+			{
+				UpdateLastRecvTime();
+			}
 		}
 
 		if (socket_error != nullptr)

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -1563,69 +1563,87 @@ namespace ov
 		OV_ASSERT2(data != nullptr);
 		OV_ASSERT(data->GetCapacity() > 0, "Must specify a data size in advance using Reserve().");
 
-		size_t read_bytes;
 		size_t capacity = data->GetCapacity();
 
 		// Set the length of the data to the capacity to avoid memory reallocation
 		data->SetLength(capacity);
 
-		auto error = Recv(data->GetWritableData(), capacity, &read_bytes, non_block);
+		auto result = Recv(data->GetWritableData(), capacity, non_block);
 
-		if (error != nullptr)
+		if (result.has_value() == false)
 		{
-			return error;
+			return result.error();
 		}
 
-		data->SetLength(read_bytes);
+		data->SetLength(result.value());
 
 		return nullptr;
 	}
 
-	std::shared_ptr<const SocketError> Socket::Recv(void *data, size_t length, size_t *received_length, const bool non_block)
+	tl::expected<size_t, std::shared_ptr<const SocketError>> Socket::Recv(void *data, size_t length, const bool non_block)
 	{
 		if (GetState() == SocketState::Closed)
 		{
-			return SocketError::CreateError("Socket is closed");
+			return tl::make_unexpected(SocketError::CreateError("Socket is closed"));
 		}
 
 		OV_ASSERT2(data != nullptr);
-		OV_ASSERT2(received_length != nullptr);
 
 		logap("Trying to read from the socket...");
 
 		ssize_t read_bytes = -1;
 		std::shared_ptr<SocketError> socket_error;
+		size_t received_length = 0;
 
 		switch (GetType())
 		{
+			case SocketType::Unknown:
+				// Must have a concrete type before `Recv()`; reaching here is a bug.
+				OV_ASSERT2(false);
+				return tl::make_unexpected(SocketError::CreateError("Cannot receive data from a socket of unknown type"));
+
 			case SocketType::Udp:
 			case SocketType::Tcp:
 				read_bytes = ::recv(GetNativeHandle(), data, length,
 									((_blocking_mode == BlockingMode::NonBlocking) || non_block) ? MSG_DONTWAIT : 0);
 
-				if (read_bytes <= 0L)
+				if (read_bytes == 0L)
+				{
+					if (GetType() == SocketType::Tcp)
+					{
+						// `0` means orderly shutdown (EOF). `errno` is not set, so classify by the return value.
+						socket_error = SocketError::CreateError("Remote is disconnected");
+					}
+					else
+					{
+						// `0` is a valid empty datagram (no EOF), so treat it as a successful 0-byte read.
+					}
+				}
+				else if (read_bytes < 0L)
 				{
 					auto error = Error::CreateErrorFromErrno();
 
 					if (error->GetCode() == EAGAIN)
 					{
-						if (_blocking_mode == BlockingMode::NonBlocking)
+						if ((_blocking_mode == BlockingMode::NonBlocking) || non_block)
 						{
-							if (IsEndOfStream() == false)
-							{
-								// Timed out
-								read_bytes	 = 0L;
-								// Actually, it is not an error
-								socket_error = nullptr;
-							}
-							else
+							// Non-blocking read: `EAGAIN` means no data right now -> retry later (0 bytes), not an error.
+							// Only a non-blocking socket at end-of-stream is actually closed.
+							if ((_blocking_mode == BlockingMode::NonBlocking) && IsEndOfStream())
 							{
 								// Socket is closed
 								socket_error = SocketError::CreateError(error);
 							}
+							else
+							{
+								// No data available now - retry later
+								read_bytes	 = 0L;
+								socket_error = nullptr;
+							}
 						}
 						else
 						{
+							// Blocking read timed out (`SO_RCVTIMEO`)
 							socket_error = SocketError::CreateError(error->GetCode(), "Receive timed out: %s", error->GetMessage().CStr());
 						}
 					}
@@ -1641,7 +1659,15 @@ namespace ov
 				SRT_MSGCTRL msg_ctrl{};
 				read_bytes = ::srt_recvmsg2(GetNativeHandle(), reinterpret_cast<char *>(data), static_cast<int>(length), &msg_ctrl);
 
-				if (read_bytes <= 0L)
+				if (read_bytes == 0L)
+				{
+					// `srt_recvmsg2()` returns `0` only on EOF (buffer/stream mode);
+					// no-data is `EASYNCRCV` and a broken link is `ECONNLOST`, both negative.
+					// The `0` return does not set the SRT last error, so classify by the return value -
+					// `srt_getlasterror()` may be stale here.
+					socket_error = SocketError::CreateError("Remote is disconnected");
+				}
+				else if (read_bytes < 0L)
 				{
 					auto error = SrtError::CreateErrorFromSrt();
 
@@ -1660,21 +1686,17 @@ namespace ov
 
 				break;
 			}
-
-			default:
-				break;
 		}
 
 		if (socket_error != nullptr)
 		{
 			if (
-				((_socket.GetType() != SocketType::Srt) && (read_bytes == 0L)) ||
+				(read_bytes == 0L) ||
 				((_socket.GetType() == SocketType::Srt) && (socket_error->GetCode() == SRT_ECONNLOST)))
 			{
 				logtt("Remote is disconnected with error: %s", socket_error->What());
 
-				socket_error	 = SocketError::CreateError("Remote is disconnected");
-				*received_length = 0UL;
+				socket_error = SocketError::CreateError("Remote is disconnected");
 
 				// NOTE: `SRT_ECONNLOST` is ambiguous - close as plain Disconnected.
 				//
@@ -1687,7 +1709,7 @@ namespace ov
 				// so downstream does not treat this as an unambiguous transport failure.
 				CloseWithState(SocketState::Disconnected);
 
-				return socket_error;
+				return tl::make_unexpected(socket_error);
 			}
 			else if (read_bytes < 0L)
 			{
@@ -1749,11 +1771,16 @@ namespace ov
 		else
 		{
 			logap("%zd bytes read", read_bytes);
-			*received_length = static_cast<size_t>(read_bytes);
+			received_length = static_cast<size_t>(read_bytes);
 			UpdateLastRecvTime();
 		}
 
-		return socket_error;
+		if (socket_error != nullptr)
+		{
+			return tl::make_unexpected(socket_error);
+		}
+
+		return received_length;
 	}
 
 	template <typename Tpktinfo>

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -1776,7 +1776,7 @@ namespace ov
 			received_length = static_cast<size_t>(read_bytes);
 
 			// Only refresh the last-recv time when data actually arrived;
-			// a 0-byte success (retry-later / would-block) must not mask idle timeouts.
+			// a `0`-byte success (retry-later / would-block) must not mask idle timeouts.
 			if (read_bytes > 0L)
 			{
 				UpdateLastRecvTime();

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -1631,8 +1631,10 @@ namespace ov
 							// Only a non-blocking socket at end-of-stream is actually closed.
 							if ((_blocking_mode == BlockingMode::NonBlocking) && IsEndOfStream())
 							{
-								// Socket is closed
-								socket_error = SocketError::CreateError(error);
+								// End of stream - route through the disconnect handling below
+								// (`read_bytes` == 0), not the `EAGAIN`/timeout path.
+								read_bytes	 = 0L;
+								socket_error = SocketError::CreateError("Remote is disconnected");
 							}
 							else
 							{

--- a/src/projects/base/ovsocket/socket.h
+++ b/src/projects/base/ovsocket/socket.h
@@ -28,6 +28,8 @@
 #include <memory>
 #include <utility>
 
+#include <tl/expected.hpp>
+
 // Failure to send data for the specified time period will be considered an error.
 // For example, it can occur when EAGAIN continues to occur for a period of time, or when the peer's TCP window is full and no longer receives data.
 #define OV_SOCKET_EXPIRE_TIMEOUT (10 * 1000)
@@ -201,7 +203,19 @@ namespace ov
 		//
 		// If MakeNonBlocking() is called, non_block is ignored
 		std::shared_ptr<const SocketError> Recv(std::shared_ptr<Data> &data, const bool non_block = false);
-		std::shared_ptr<const SocketError> Recv(void *data, size_t length, size_t *received_length, const bool non_block = false);
+
+		// On success, holds the number of bytes received; on failure, holds a `SocketError`.
+		// A received length of `0` means either "retry later" (`EAGAIN`/non-blocking with no data)
+		// or, for UDP, a valid 0-length datagram - both are reported as success, not a disconnect:
+		//
+		// ```
+		//   auto result = socket->Recv(buffer, length);
+		//   if (result.has_value()) { auto received_length = result.value(); }
+		//   else { auto error = result.error(); }
+		// ```
+		//
+		// If `MakeNonBlocking()` is called, `non_block` is ignored
+		tl::expected<size_t, std::shared_ptr<const SocketError>> Recv(void *data, size_t length, const bool non_block = false);
 
 		// If MakeNonBlocking() is called, non_block is ignored
 		std::shared_ptr<const SocketError> RecvFrom(std::shared_ptr<Data> &data, SocketAddressPair *address_pair, const bool non_block = false);
@@ -454,8 +468,6 @@ namespace ov
 		ssize_t SendInternal(const std::shared_ptr<const Data> &data);
 		ssize_t SendToInternal(const SocketAddress &address, const std::shared_ptr<const Data> &data);
 		ssize_t SendFromToInternal(const SocketAddressPair &address_pair, const std::shared_ptr<const Data> &data);
-
-		std::shared_ptr<SocketError> RecvInternal(void *data, size_t length, size_t *received_length);
 
 		virtual String ToString(const char *class_name) const;
 

--- a/src/projects/base/ovsocket/socket.h
+++ b/src/projects/base/ovsocket/socket.h
@@ -193,13 +193,13 @@ namespace ov
 		bool SendFromTo(const SocketAddressPair &address_pair, const std::shared_ptr<const Data> &data);
 		bool SendFromTo(const SocketAddressPair &address_pair, const void *data, size_t length);
 
-		// On success, writes the received byte count into `data->Length()` and returns `nullptr`.
+		// On success, sets `data->GetLength()` to the received byte count and returns `nullptr`.
 		// A length of `0` means either "retry later" (`EAGAIN`/non-blocking with no data)
 		// or, for UDP, a valid 0-length datagram - both are reported as success, not a disconnect.
 		// A TCP/SRT EOF (orderly peer shutdown) is reported as a non-null `SocketError`,
 		// never as a `0`-length success.
 		//
-		// In non-blocking mode, if `data->Length() > 0`, more data may still remain in the socket
+		// In non-blocking mode, if `data->GetLength() > 0`, more data may still remain in the socket
 		// buffer, so callers should continue reading until it returns `0` (retry later) or an error.
 		//
 		// If `MakeNonBlocking()` is called, `non_block` is ignored.

--- a/src/projects/base/ovsocket/socket.h
+++ b/src/projects/base/ovsocket/socket.h
@@ -193,15 +193,16 @@ namespace ov
 		bool SendFromTo(const SocketAddressPair &address_pair, const std::shared_ptr<const Data> &data);
 		bool SendFromTo(const SocketAddressPair &address_pair, const void *data, size_t length);
 
-		// When Recv is called in non-blocking mode,
+		// On success, writes the received byte count into `data->Length()` and returns `nullptr`.
+		// A length of `0` means either "retry later" (`EAGAIN`/non-blocking with no data)
+		// or, for UDP, a valid 0-length datagram - both are reported as success, not a disconnect.
+		// A TCP/SRT EOF (orderly peer shutdown) is reported as a non-null `SocketError`,
+		// never as a `0`-length success.
 		//
-		// 1. return != nullptr: An error occurred (Include disconnecting the client)
-		// 2. return == nullptr:
-		// 2-1. data->Length() == 0: Retry later (EAGAIN)
-		// 2-2. data->Length() > 0: Data is remained, so must call Recv() again to empty socket buffer
-		//                          (If not, epoll event will not occur later)
+		// In non-blocking mode, if `data->Length() > 0`, more data may still remain in the socket
+		// buffer, so callers should continue reading until it returns `0` (retry later) or an error.
 		//
-		// If MakeNonBlocking() is called, non_block is ignored
+		// If `MakeNonBlocking()` is called, `non_block` is ignored.
 		std::shared_ptr<const SocketError> Recv(std::shared_ptr<Data> &data, const bool non_block = false);
 
 		// On success, holds the number of bytes received; on failure, holds a `SocketError`.

--- a/src/projects/base/ovsocket/socket.h
+++ b/src/projects/base/ovsocket/socket.h
@@ -193,7 +193,7 @@ namespace ov
 		bool SendFromTo(const SocketAddressPair &address_pair, const std::shared_ptr<const Data> &data);
 		bool SendFromTo(const SocketAddressPair &address_pair, const void *data, size_t length);
 
-		// On success, sets `data->GetLength()` to the received byte count and returns `nullptr`.
+		// On success, `data->GetLength()` equals the received byte count and this returns `nullptr`.
 		// A length of `0` means either "retry later" (`EAGAIN`/non-blocking with no data)
 		// or, for UDP, a valid 0-length datagram - both are reported as success, not a disconnect.
 		// A TCP/SRT EOF (orderly peer shutdown) is reported as a non-null `SocketError`,

--- a/src/projects/base/ovsocket/socket.h
+++ b/src/projects/base/ovsocket/socket.h
@@ -206,7 +206,9 @@ namespace ov
 
 		// On success, holds the number of bytes received; on failure, holds a `SocketError`.
 		// A received length of `0` means either "retry later" (`EAGAIN`/non-blocking with no data)
-		// or, for UDP, a valid 0-length datagram - both are reported as success, not a disconnect:
+		// or, for UDP, a valid 0-length datagram - both are reported as success, not a disconnect.
+		// A TCP/SRT EOF (orderly peer shutdown) is reported as a failure (`has_value() == false`),
+		// never as a `0`-length success:
 		//
 		// ```
 		//   auto result = socket->Recv(buffer, length);

--- a/src/projects/base/ovsocket/socket_test.cpp
+++ b/src/projects/base/ovsocket/socket_test.cpp
@@ -1,0 +1,906 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <arpa/inet.h>
+#include <base/ovlibrary/ovlibrary.h>
+#include <base/ovsocket/ovsocket.h>
+#include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <srt/srt.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+	constexpr int kLoopbackTimeoutMsec = 3000;
+
+	ov::SocketAddress LoopbackAddress(uint16_t port)
+	{
+		return ov::SocketAddress::CreateAndGetFirst("127.0.0.1", port);
+	}
+
+	// Reads the local port bound to a socket directly from its `fd`. Unlike
+	// `Socket::GetLocalAddress()` (only populated by `Bind()`), this also works for
+	// a UDP socket whose local port was assigned implicitly by `Connect()`.
+	uint16_t LocalPortOf(const std::shared_ptr<ov::Socket> &socket)
+	{
+		sockaddr_in sa{};
+		socklen_t len = sizeof(sa);
+		if (::getsockname(socket->GetSocket().GetNativeHandle(), reinterpret_cast<sockaddr *>(&sa), &len) != 0)
+		{
+			return 0;
+		}
+		return ntohs(sa.sin_port);
+	}
+
+	// A minimal POSIX TCP server that accepts a single connection. It lets the
+	// test act as the remote peer of the `ov::Socket` under test.
+	class PosixTcpPeer
+	{
+	public:
+		~PosixTcpPeer()
+		{
+			CloseConnection();
+			if (_listen_fd >= 0)
+			{
+				::close(_listen_fd);
+			}
+		}
+
+		bool Listen()
+		{
+			_listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+			if (_listen_fd < 0)
+			{
+				return false;
+			}
+
+			int yes = 1;
+			::setsockopt(_listen_fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+
+			sockaddr_in sa{};
+			sa.sin_family	   = AF_INET;
+			sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+			sa.sin_port		   = 0;	 // ephemeral
+
+			if (::bind(_listen_fd, reinterpret_cast<sockaddr *>(&sa), sizeof(sa)) != 0)
+			{
+				return false;
+			}
+			if (::listen(_listen_fd, 1) != 0)
+			{
+				return false;
+			}
+
+			socklen_t len = sizeof(sa);
+			if (::getsockname(_listen_fd, reinterpret_cast<sockaddr *>(&sa), &len) != 0)
+			{
+				return false;
+			}
+			_port = ntohs(sa.sin_port);
+			return true;
+		}
+
+		// Accepts in a background thread so the `ov::Socket` blocking `Connect()`
+		// and this `accept()` can proceed concurrently.
+		void AcceptAsync()
+		{
+			_accept_thread = std::thread([this]() {
+				_conn_fd = ::accept(_listen_fd, nullptr, nullptr);
+			});
+		}
+
+		void WaitAccepted()
+		{
+			if (_accept_thread.joinable())
+			{
+				_accept_thread.join();
+			}
+		}
+
+		uint16_t Port() const
+		{
+			return _port;
+		}
+		bool IsConnected() const
+		{
+			return _conn_fd >= 0;
+		}
+
+		ssize_t Send(const void *data, size_t length)
+		{
+			return ::send(_conn_fd, data, length, MSG_NOSIGNAL);
+		}
+
+		void CloseConnection()
+		{
+			if (_accept_thread.joinable())
+			{
+				_accept_thread.join();
+			}
+			if (_conn_fd >= 0)
+			{
+				::close(_conn_fd);
+				_conn_fd = -1;
+			}
+		}
+
+	private:
+		int _listen_fd = -1;
+		std::atomic<int> _conn_fd{-1};
+		uint16_t _port = 0;
+		std::thread _accept_thread;
+	};
+
+	// A plain POSIX UDP socket that the test uses to send datagrams to the
+	// `ov::Socket` under test.
+	class PosixUdpPeer
+	{
+	public:
+		~PosixUdpPeer()
+		{
+			if (_fd >= 0)
+			{
+				::close(_fd);
+			}
+		}
+
+		bool Open()
+		{
+			_fd = ::socket(AF_INET, SOCK_DGRAM, 0);
+			if (_fd < 0)
+			{
+				return false;
+			}
+
+			sockaddr_in sa{};
+			sa.sin_family	   = AF_INET;
+			sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+			sa.sin_port		   = 0;	 // ephemeral
+
+			if (::bind(_fd, reinterpret_cast<sockaddr *>(&sa), sizeof(sa)) != 0)
+			{
+				return false;
+			}
+
+			socklen_t len = sizeof(sa);
+			if (::getsockname(_fd, reinterpret_cast<sockaddr *>(&sa), &len) != 0)
+			{
+				return false;
+			}
+			_port = ntohs(sa.sin_port);
+			return true;
+		}
+
+		uint16_t Port() const
+		{
+			return _port;
+		}
+
+		ssize_t SendTo(uint16_t dst_port, const void *data, size_t length)
+		{
+			sockaddr_in da{};
+			da.sin_family	   = AF_INET;
+			da.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+			da.sin_port		   = htons(dst_port);
+			return ::sendto(_fd, data, length, 0, reinterpret_cast<sockaddr *>(&da), sizeof(da));
+		}
+
+	private:
+		int _fd		   = -1;
+		uint16_t _port = 0;
+	};
+
+	// A libsrt peer (listener) that the OME SRT socket under test connects to, so
+	// the test can drive SRT message delivery and peer shutdown directly.
+	class SrtPeer
+	{
+	public:
+		~SrtPeer()
+		{
+			CloseConnection();
+			if (_listener != SRT_INVALID_SOCK)
+			{
+				::srt_close(_listener);
+			}
+		}
+
+		bool Listen()
+		{
+			_listener = ::srt_create_socket();
+			if (_listener == SRT_INVALID_SOCK)
+			{
+				return false;
+			}
+			Configure(_listener);
+
+			sockaddr_in sa{};
+			sa.sin_family	   = AF_INET;
+			sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+			sa.sin_port		   = 0;	 // ephemeral
+
+			if (::srt_bind(_listener, reinterpret_cast<sockaddr *>(&sa), sizeof(sa)) == SRT_ERROR)
+			{
+				return false;
+			}
+			if (::srt_listen(_listener, 1) == SRT_ERROR)
+			{
+				return false;
+			}
+
+			int len = sizeof(sa);
+			if (::srt_getsockname(_listener, reinterpret_cast<sockaddr *>(&sa), &len) == SRT_ERROR)
+			{
+				return false;
+			}
+			_port = ntohs(sa.sin_port);
+			return true;
+		}
+
+		// Accepts in a background thread so the OME blocking `Connect()` and this
+		// accept can proceed concurrently.
+		void AcceptAsync()
+		{
+			_accept_thread = std::thread([this]() {
+				_accepted = ::srt_accept(_listener, nullptr, nullptr);
+			});
+		}
+
+		void WaitAccepted()
+		{
+			if (_accept_thread.joinable())
+			{
+				_accept_thread.join();
+			}
+		}
+
+		uint16_t Port() const
+		{
+			return _port;
+		}
+		bool IsConnected() const
+		{
+			return _accepted != SRT_INVALID_SOCK;
+		}
+
+		int Send(const void *data, size_t length)
+		{
+			return ::srt_sendmsg2(_accepted, reinterpret_cast<const char *>(data), static_cast<int>(length), nullptr);
+		}
+
+		void CloseConnection()
+		{
+			if (_accept_thread.joinable())
+			{
+				_accept_thread.join();
+			}
+			if (_accepted != SRT_INVALID_SOCK)
+			{
+				::srt_close(_accepted);
+				_accepted = SRT_INVALID_SOCK;
+			}
+		}
+
+	private:
+		// Match OME's SRT configuration (live transtype + message API) so the
+		// handshake succeeds; the peer uses sync (blocking) accept/send.
+		static void Configure(SRTSOCKET s)
+		{
+			int live = SRTT_LIVE;
+			::srt_setsockopt(s, 0, SRTO_TRANSTYPE, &live, sizeof(live));
+			int yes = 1;
+			::srt_setsockopt(s, 0, SRTO_MESSAGEAPI, &yes, sizeof(yes));
+			int sync = 1;
+			::srt_setsockopt(s, 0, SRTO_RCVSYN, &sync, sizeof(sync));
+			::srt_setsockopt(s, 0, SRTO_SNDSYN, &sync, sizeof(sync));
+		}
+
+		SRTSOCKET _listener = SRT_INVALID_SOCK;
+		std::atomic<SRTSOCKET> _accepted{SRT_INVALID_SOCK};
+		uint16_t _port = 0;
+		std::thread _accept_thread;
+	};
+
+	// Aborts the process if not disarmed within the deadline. A deadlock in the
+	// code under test would otherwise hang the whole binary forever; this turns
+	// it into a visible crash with a message instead. The deadline is generous,
+	// so a healthy run (which finishes in well under a second) never trips it.
+	class Watchdog
+	{
+	public:
+		Watchdog(std::chrono::milliseconds deadline, std::string label)
+			: _label(std::move(label))
+		{
+			_thread = std::thread([this, deadline]() {
+				std::unique_lock<std::mutex> lock(_mutex);
+				if (_cv.wait_for(lock, deadline, [this]() { return _done; }) == false)
+				{
+					::fprintf(stderr, "[Watchdog] '%s' exceeded its deadline - aborting (possible deadlock)\n", _label.c_str());
+					::fflush(stderr);
+					::abort();
+				}
+			});
+		}
+
+		~Watchdog()
+		{
+			{
+				std::lock_guard<std::mutex> lock(_mutex);
+				_done = true;
+			}
+			_cv.notify_all();
+			if (_thread.joinable())
+			{
+				_thread.join();
+			}
+		}
+
+	private:
+		std::mutex _mutex;
+		std::condition_variable _cv;
+		bool _done = false;
+		std::string _label;
+		std::thread _thread;
+	};
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Base fixture: owns a one-worker socket pool and closes the socket under test
+// on teardown (so an early `ASSERT` failure does not trip the `~Socket` "not
+// closed" assertion).
+// ---------------------------------------------------------------------------
+class SocketTestBase : public ::testing::Test
+{
+protected:
+	void InitPool(const char *name, ov::SocketType type)
+	{
+		_pool = ov::SocketPool::Create(name, type, false);
+		ASSERT_NE(_pool, nullptr);
+		ASSERT_TRUE(_pool->Initialize(1));
+	}
+
+	void TearDown() override
+	{
+		if (_client != nullptr && _client->GetState() == ov::SocketState::Connected)
+		{
+			_client->Close();
+		}
+		if (_pool != nullptr)
+		{
+			_pool->Uninitialize();
+		}
+	}
+
+	std::shared_ptr<ov::SocketPool> _pool;
+	std::shared_ptr<ov::Socket> _client;
+};
+
+class SocketRecvTcpTest : public SocketTestBase
+{
+protected:
+	void SetUp() override
+	{
+		InitPool("test-recv-tcp", ov::SocketType::Tcp);
+	}
+
+	// Returns a blocking `ov::Socket` TCP client connected to `peer`.
+	std::shared_ptr<ov::Socket> ConnectClient(PosixTcpPeer &peer)
+	{
+		auto client = _pool->AllocSocket(ov::SocketFamily::Inet);
+		if (client == nullptr)
+		{
+			return nullptr;
+		}
+
+		client->MakeBlocking();
+		timeval tv = {kLoopbackTimeoutMsec / 1000, (kLoopbackTimeoutMsec % 1000) * 1000};
+		client->SetRecvTimeout(tv);
+
+		peer.AcceptAsync();
+		auto error = client->Connect(LoopbackAddress(peer.Port()), kLoopbackTimeoutMsec);
+		peer.WaitAccepted();
+
+		if (error != nullptr || peer.IsConnected() == false)
+		{
+			return nullptr;
+		}
+
+		_client = client;
+		return client;
+	}
+};
+
+class SocketRecvUdpTest : public SocketTestBase
+{
+protected:
+	void SetUp() override
+	{
+		InitPool("test-recv-udp", ov::SocketType::Udp);
+	}
+
+	// Returns a blocking `ov::Socket` UDP client connected to the loopback port.
+	std::shared_ptr<ov::Socket> ConnectClient(uint16_t peer_port)
+	{
+		auto client = _pool->AllocSocket(ov::SocketFamily::Inet);
+		if (client == nullptr)
+		{
+			return nullptr;
+		}
+
+		client->MakeBlocking();
+		timeval tv = {kLoopbackTimeoutMsec / 1000, (kLoopbackTimeoutMsec % 1000) * 1000};
+		client->SetRecvTimeout(tv);
+
+		if (client->Connect(LoopbackAddress(peer_port), kLoopbackTimeoutMsec) != nullptr)
+		{
+			return nullptr;
+		}
+
+		_client = client;
+		return client;
+	}
+};
+
+// ===========================================================================
+// TCP
+// ===========================================================================
+
+// Successful read: `value()` holds the byte count and the payload is intact.
+TEST_F(SocketRecvTcpTest, RawBufferReceivesData)
+{
+	PosixTcpPeer peer;
+	ASSERT_TRUE(peer.Listen());
+	auto client = ConnectClient(peer);
+	ASSERT_NE(client, nullptr);
+
+	const char payload[] = "OvenMediaEngine";
+	ASSERT_EQ(peer.Send(payload, sizeof(payload)), static_cast<ssize_t>(sizeof(payload)));
+
+	char buffer[64] = {0};
+	auto result		= client->Recv(buffer, sizeof(buffer));
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result.value(), sizeof(payload));
+	EXPECT_STREQ(buffer, payload);
+	EXPECT_EQ(client->GetState(), ov::SocketState::Connected);
+}
+
+// A buffer larger than the data still reports the actual number of bytes read.
+TEST_F(SocketRecvTcpTest, RawBufferReportsActualLengthForPartialFill)
+{
+	PosixTcpPeer peer;
+	ASSERT_TRUE(peer.Listen());
+	auto client = ConnectClient(peer);
+	ASSERT_NE(client, nullptr);
+
+	const char payload[] = {'a', 'b', 'c'};
+	ASSERT_EQ(peer.Send(payload, sizeof(payload)), 3);
+
+	char buffer[4096];
+	auto result = client->Recv(buffer, sizeof(buffer));
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result.value(), 3u);
+}
+
+// The `Data` overload sets the data length to the number of bytes received.
+TEST_F(SocketRecvTcpTest, DataOverloadSetsLength)
+{
+	PosixTcpPeer peer;
+	ASSERT_TRUE(peer.Listen());
+	auto client = ConnectClient(peer);
+	ASSERT_NE(client, nullptr);
+
+	const char payload[] = "hello-data";
+	ASSERT_EQ(peer.Send(payload, sizeof(payload)), static_cast<ssize_t>(sizeof(payload)));
+
+	auto data = std::make_shared<ov::Data>();
+	ASSERT_TRUE(data->Reserve(2048));
+
+	auto error = client->Recv(data);
+
+	ASSERT_EQ(error, nullptr);
+	EXPECT_EQ(data->GetLength(), sizeof(payload));
+	EXPECT_EQ(::memcmp(data->GetData(), payload, sizeof(payload)), 0);
+}
+
+// An orderly peer shutdown (`recv() == 0`) must be classified as a disconnect,
+// NOT as a retriable `0`-byte read. This is the core of the EOF handling change.
+TEST_F(SocketRecvTcpTest, PeerShutdownReportsDisconnect)
+{
+	PosixTcpPeer peer;
+	ASSERT_TRUE(peer.Listen());
+	auto client = ConnectClient(peer);
+	ASSERT_NE(client, nullptr);
+
+	peer.CloseConnection();
+
+	char buffer[64];
+	auto result = client->Recv(buffer, sizeof(buffer));
+
+	ASSERT_FALSE(result.has_value());
+	ASSERT_NE(result.error(), nullptr);
+	EXPECT_EQ(client->GetState(), ov::SocketState::Disconnected);
+}
+
+// The `Data` overload surfaces the same disconnect as a non-null error.
+TEST_F(SocketRecvTcpTest, DataOverloadReportsDisconnectOnPeerShutdown)
+{
+	PosixTcpPeer peer;
+	ASSERT_TRUE(peer.Listen());
+	auto client = ConnectClient(peer);
+	ASSERT_NE(client, nullptr);
+
+	peer.CloseConnection();
+
+	auto data = std::make_shared<ov::Data>();
+	ASSERT_TRUE(data->Reserve(64));
+
+	auto error = client->Recv(data);
+
+	ASSERT_NE(error, nullptr);
+	EXPECT_EQ(client->GetState(), ov::SocketState::Disconnected);
+}
+
+// `Recv()` on a socket we closed ourselves fails instead of touching the `fd`.
+TEST_F(SocketRecvTcpTest, RecvOnClosedSocketFails)
+{
+	PosixTcpPeer peer;
+	ASSERT_TRUE(peer.Listen());
+	auto client = ConnectClient(peer);
+	ASSERT_NE(client, nullptr);
+
+	client->Close();
+
+	char buffer[64];
+	auto result = client->Recv(buffer, sizeof(buffer));
+
+	ASSERT_FALSE(result.has_value());
+	ASSERT_NE(result.error(), nullptr);
+}
+
+// A non-blocking read (`non_block=true`) on a blocking socket with no data pending
+// means "no data right now" -> a successful `0`-byte read (retry later), NOT an
+// error and NOT a disconnect. This is the contract OVT/RTSPC rely on when they
+// call `ReceivePacket(true)` on a blocking socket, and it matches the SRT path.
+TEST_F(SocketRecvTcpTest, NonBlockParamOnBlockingSocketWithoutDataReportsRetry)
+{
+	PosixTcpPeer peer;
+	ASSERT_TRUE(peer.Listen());
+	auto client = ConnectClient(peer);
+	ASSERT_NE(client, nullptr);
+
+	char buffer[64];
+	auto result = client->Recv(buffer, sizeof(buffer), /*non_block=*/true);
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result.value(), 0u);
+	EXPECT_EQ(client->GetState(), ov::SocketState::Connected);
+}
+
+// ===========================================================================
+// UDP
+// ===========================================================================
+
+// A normal datagram is delivered with its exact length and payload.
+TEST_F(SocketRecvUdpTest, ReceivesDatagram)
+{
+	PosixUdpPeer peer;
+	ASSERT_TRUE(peer.Open());
+
+	auto client = ConnectClient(peer.Port());
+	ASSERT_NE(client, nullptr);
+
+	uint16_t local_port = LocalPortOf(client);
+	ASSERT_NE(local_port, 0u);
+
+	const char payload[] = "udp-payload";
+	ASSERT_EQ(peer.SendTo(local_port, payload, sizeof(payload)), static_cast<ssize_t>(sizeof(payload)));
+
+	char buffer[64] = {0};
+	auto result		= client->Recv(buffer, sizeof(buffer));
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result.value(), sizeof(payload));
+	EXPECT_STREQ(buffer, payload);
+}
+
+// A `0`-length UDP datagram is a valid read (datagram sockets have no EOF), so it
+// must be reported as success with `0` bytes and must NOT close the socket.
+TEST_F(SocketRecvUdpTest, ZeroLengthDatagramIsSuccessNotDisconnect)
+{
+	PosixUdpPeer peer;
+	ASSERT_TRUE(peer.Open());
+
+	auto client = ConnectClient(peer.Port());
+	ASSERT_NE(client, nullptr);
+
+	uint16_t local_port = LocalPortOf(client);
+	ASSERT_NE(local_port, 0u);
+
+	// Send an empty datagram.
+	ASSERT_EQ(peer.SendTo(local_port, "", 0), 0);
+
+	char buffer[64];
+	auto result = client->Recv(buffer, sizeof(buffer));
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result.value(), 0u);
+	EXPECT_NE(client->GetState(), ov::SocketState::Disconnected);
+	EXPECT_NE(client->GetState(), ov::SocketState::Error);
+}
+
+// After an empty datagram the socket stays usable: a subsequent normal datagram
+// is still received. Proves the `0`-length read did not tear the socket down.
+TEST_F(SocketRecvUdpTest, StaysUsableAfterZeroLengthDatagram)
+{
+	PosixUdpPeer peer;
+	ASSERT_TRUE(peer.Open());
+
+	auto client = ConnectClient(peer.Port());
+	ASSERT_NE(client, nullptr);
+
+	uint16_t local_port = LocalPortOf(client);
+	ASSERT_NE(local_port, 0u);
+
+	char buffer[64] = {0};
+
+	ASSERT_EQ(peer.SendTo(local_port, "", 0), 0);
+	auto empty_result = client->Recv(buffer, sizeof(buffer));
+	ASSERT_TRUE(empty_result.has_value());
+	EXPECT_EQ(empty_result.value(), 0u);
+
+	const char payload[] = "after-empty";
+	ASSERT_EQ(peer.SendTo(local_port, payload, sizeof(payload)), static_cast<ssize_t>(sizeof(payload)));
+	auto data_result = client->Recv(buffer, sizeof(buffer));
+	ASSERT_TRUE(data_result.has_value());
+	EXPECT_EQ(data_result.value(), sizeof(payload));
+	EXPECT_STREQ(buffer, payload);
+}
+
+// ===========================================================================
+// SRT
+//
+// Pins the `SRT_EASYNCRCV` -> retry (`0`) contract. `srt_recvmsg2()` ignores a
+// per-call `non_block` flag, so async recv (`SRTO_RCVSYN=false`) is what surfaces
+// `SRT_EASYNCRCV`; the client connects in blocking mode first (deterministic
+// handshake) and is then switched to async.
+// ===========================================================================
+class SocketRecvSrtTest : public SocketTestBase
+{
+protected:
+	void SetUp() override
+	{
+		ASSERT_NE(::srt_startup(), -1);
+		InitPool("test-recv-srt", ov::SocketType::Srt);
+	}
+
+	void TearDown() override
+	{
+		SocketTestBase::TearDown();
+		::srt_cleanup();
+	}
+
+	// Returns an OME SRT client connected (blocking handshake) to `peer`, then
+	// switched to async recv so a no-data read yields `SRT_EASYNCRCV`.
+	std::shared_ptr<ov::Socket> ConnectClient(SrtPeer &peer)
+	{
+		auto client = _pool->AllocSocket(ov::SocketFamily::Inet);
+		if (client == nullptr)
+		{
+			return nullptr;
+		}
+
+		client->MakeBlocking();
+
+		peer.AcceptAsync();
+		auto error = client->Connect(LoopbackAddress(peer.Port()), kLoopbackTimeoutMsec);
+		peer.WaitAccepted();
+
+		if (error != nullptr || peer.IsConnected() == false)
+		{
+			return nullptr;
+		}
+
+		// Switch to async recv: no data -> `SRT_EASYNCRCV`, broken link -> `SRT_ECONNLOST`.
+		client->SetSockOpt<bool>(SRTO_RCVSYN, false);
+
+		_client = client;
+		return client;
+	}
+};
+
+// On an async SRT socket with no data, `SRT_EASYNCRCV` is a retry-later success
+// (`0` bytes), not an error and not a disconnect.
+TEST_F(SocketRecvSrtTest, NoDataReportsRetry)
+{
+	SrtPeer peer;
+	ASSERT_TRUE(peer.Listen());
+	auto client = ConnectClient(peer);
+	ASSERT_NE(client, nullptr);
+
+	char buffer[1500];
+	auto result = client->Recv(buffer, sizeof(buffer));
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result.value(), 0u);
+	EXPECT_EQ(client->GetState(), ov::SocketState::Connected);
+}
+
+// ===========================================================================
+// Concurrency / stress
+//
+// These exercise `Recv()` under heavy multithreading to surface data races,
+// deadlocks, and use-after-free. Run them under ThreadSanitizer for race
+// detection (configure with `OME_SANITIZE_THREAD=ON`); even without TSan they
+// catch crashes, deadlocks (via `Watchdog`), and incorrect classification.
+// ===========================================================================
+class SocketConcurrencyTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+		_pool = ov::SocketPool::Create("test-recv-conc", ov::SocketType::Tcp, false);
+		ASSERT_NE(_pool, nullptr);
+		ASSERT_TRUE(_pool->Initialize(4));
+	}
+
+	void TearDown() override
+	{
+		if (_pool != nullptr)
+		{
+			_pool->Uninitialize();
+		}
+	}
+
+	// A blocking `ov::Socket` TCP client connected to `peer`, with a short recv
+	// timeout so a stuck read fails fast instead of hanging the stress loop.
+	std::shared_ptr<ov::Socket> Connect(PosixTcpPeer &peer)
+	{
+		auto client = _pool->AllocSocket(ov::SocketFamily::Inet);
+		if (client == nullptr)
+		{
+			return nullptr;
+		}
+
+		client->MakeBlocking();
+		timeval tv = {0, 200 * 1000};  // 200 ms
+		client->SetRecvTimeout(tv);
+
+		peer.AcceptAsync();
+		auto error = client->Connect(LoopbackAddress(peer.Port()), kLoopbackTimeoutMsec);
+		peer.WaitAccepted();
+
+		if (error != nullptr || peer.IsConnected() == false)
+		{
+			return nullptr;
+		}
+		return client;
+	}
+
+	std::shared_ptr<ov::SocketPool> _pool;
+};
+
+// Many independent sockets each receive on their own thread at the same time.
+// Stresses the pool/worker machinery and per-socket `Recv`; every read must
+// deliver its exact payload with no crash.
+TEST_F(SocketConcurrencyTest, ManyIndependentSocketsReceiveConcurrently)
+{
+	Watchdog watchdog(std::chrono::seconds(30), "ManyIndependentSocketsReceiveConcurrently");
+
+	constexpr int kSocketCount = 48;
+	const char payload[]	   = "concurrent-payload";
+
+	std::vector<std::unique_ptr<PosixTcpPeer>> peers;
+	std::vector<std::shared_ptr<ov::Socket>> clients;
+	for (int i = 0; i < kSocketCount; i++)
+	{
+		auto peer = std::make_unique<PosixTcpPeer>();
+		ASSERT_TRUE(peer->Listen());
+		auto client = Connect(*peer);
+		ASSERT_NE(client, nullptr);
+		peers.push_back(std::move(peer));
+		clients.push_back(client);
+	}
+
+	std::atomic<int> success{0};
+	std::vector<std::thread> threads;
+	threads.reserve(kSocketCount);
+	for (int i = 0; i < kSocketCount; i++)
+	{
+		threads.emplace_back([&, i]() {
+			peers[i]->Send(payload, sizeof(payload));
+
+			char buffer[64] = {0};
+			auto result		= clients[i]->Recv(buffer, sizeof(buffer));
+			if (result.has_value() && result.value() == sizeof(payload) &&
+				::memcmp(buffer, payload, sizeof(payload)) == 0)
+			{
+				success.fetch_add(1);
+			}
+		});
+	}
+	for (auto &thread : threads)
+	{
+		thread.join();
+	}
+
+	EXPECT_EQ(success.load(), kSocketCount);
+
+	for (auto &client : clients)
+	{
+		client->Close();
+	}
+}
+
+// Each socket's peer disconnects concurrently with an in-flight `Recv()`. Every
+// `Recv()` must report failure (EOF disconnect or, if it wins the race, a timeout)
+// and never a spurious success; no crash under the storm of simultaneous closes.
+TEST_F(SocketConcurrencyTest, RecvRacesPeerDisconnectStorm)
+{
+	Watchdog watchdog(std::chrono::seconds(30), "RecvRacesPeerDisconnectStorm");
+
+	constexpr int kSocketCount = 48;
+
+	std::vector<std::unique_ptr<PosixTcpPeer>> peers;
+	std::vector<std::shared_ptr<ov::Socket>> clients;
+	for (int i = 0; i < kSocketCount; i++)
+	{
+		auto peer = std::make_unique<PosixTcpPeer>();
+		ASSERT_TRUE(peer->Listen());
+		auto client = Connect(*peer);
+		ASSERT_NE(client, nullptr);
+		peers.push_back(std::move(peer));
+		clients.push_back(client);
+	}
+
+	std::atomic<int> failed_as_expected{0};
+	std::vector<std::thread> threads;
+	threads.reserve(kSocketCount);
+	for (int i = 0; i < kSocketCount; i++)
+	{
+		threads.emplace_back([&, i]() {
+			std::thread peer_closer([&, i]() { peers[i]->CloseConnection(); });
+
+			char buffer[64];
+			auto result = clients[i]->Recv(buffer, sizeof(buffer));
+
+			peer_closer.join();
+
+			if (result.has_value() == false)
+			{
+				failed_as_expected.fetch_add(1);
+			}
+		});
+	}
+	for (auto &thread : threads)
+	{
+		thread.join();
+	}
+
+	EXPECT_EQ(failed_as_expected.load(), kSocketCount);
+
+	for (auto &client : clients)
+	{
+		if (client->GetState() == ov::SocketState::Connected)
+		{
+			client->Close();
+		}
+	}
+}

--- a/src/projects/base/ovsocket/socket_test.cpp
+++ b/src/projects/base/ovsocket/socket_test.cpp
@@ -26,14 +26,14 @@
 #include <thread>
 #include <vector>
 
-// macOS lacks MSG_NOSIGNAL; fall back to no flag so the peer helpers stay portable.
+// macOS lacks `MSG_NOSIGNAL`; fall back to no flag so the peer helpers stay portable.
 #ifndef MSG_NOSIGNAL
 #	define MSG_NOSIGNAL 0
 #endif
 
 namespace
 {
-	constexpr int kLoopbackTimeoutMsec = 3000;
+	constexpr int LOOPBACK_TIMEOUT_MSEC = 3000;
 
 	ov::SocketAddress LoopbackAddress(uint16_t port)
 	{
@@ -55,7 +55,7 @@ namespace
 	}
 
 	// Reads exactly `want` bytes into `out`. A TCP stream may legally arrive across
-	// several reads (even on loopback), so this loops; returns false on
+	// several reads (even on loopback), so this loops; returns `false` on
 	// error/disconnect/timeout.
 	bool RecvExactly(const std::shared_ptr<ov::Socket> &socket, void *out, size_t want)
 	{
@@ -98,6 +98,10 @@ namespace
 			int yes = 1;
 			::setsockopt(_listen_fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
 
+			// Bound `accept()` so a failed client connect cannot hang `WaitAccepted()`.
+			timeval tv = {LOOPBACK_TIMEOUT_MSEC / 1000, (LOOPBACK_TIMEOUT_MSEC % 1000) * 1000};
+			::setsockopt(_listen_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
 			sockaddr_in sa{};
 			sa.sin_family	   = AF_INET;
 			sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
@@ -121,8 +125,9 @@ namespace
 			return true;
 		}
 
-		// Accepts in a background thread so the `ov::Socket` blocking `Connect()`
-		// and this `accept()` can proceed concurrently.
+		// Accepts in a background thread so the `ov::Socket` blocking `Connect()` and
+		// this `accept()` can proceed concurrently. `accept()` is bounded by the
+		// listener's `SO_RCVTIMEO`, so a failed client connect cannot hang `WaitAccepted()`.
 		void AcceptAsync()
 		{
 			_accept_thread = std::thread([this]() {
@@ -291,11 +296,22 @@ namespace
 		}
 
 		// Accepts in a background thread so the OME blocking `Connect()` and this
-		// accept can proceed concurrently.
+		// accept can proceed concurrently. The listener is non-blocking and the
+		// accept is polled up to a timeout, so a failed client connect cannot hang
+		// `WaitAccepted()`.
 		void AcceptAsync()
 		{
 			_accept_thread = std::thread([this]() {
-				_accepted = ::srt_accept(_listener, nullptr, nullptr);
+				for (int waited = 0; waited < LOOPBACK_TIMEOUT_MSEC; waited += 5)
+				{
+					SRTSOCKET accepted = ::srt_accept(_listener, nullptr, nullptr);
+					if (accepted != SRT_INVALID_SOCK)
+					{
+						_accepted = accepted;
+						return;
+					}
+					std::this_thread::sleep_for(std::chrono::milliseconds(5));
+				}
 			});
 		}
 
@@ -336,15 +352,17 @@ namespace
 
 	private:
 		// Match OME's SRT configuration (live transtype + message API) so the
-		// handshake succeeds; the peer uses sync (blocking) accept/send.
+		// handshake succeeds. The listener uses non-blocking accept (so a failed
+		// connect cannot hang the accept thread) and blocking send.
 		static void Configure(SRTSOCKET s)
 		{
 			int live = SRTT_LIVE;
 			::srt_setsockopt(s, 0, SRTO_TRANSTYPE, &live, sizeof(live));
 			int yes = 1;
 			::srt_setsockopt(s, 0, SRTO_MESSAGEAPI, &yes, sizeof(yes));
+			int async = 0;
+			::srt_setsockopt(s, 0, SRTO_RCVSYN, &async, sizeof(async));
 			int sync = 1;
-			::srt_setsockopt(s, 0, SRTO_RCVSYN, &sync, sizeof(sync));
 			::srt_setsockopt(s, 0, SRTO_SNDSYN, &sync, sizeof(sync));
 		}
 
@@ -446,11 +464,11 @@ protected:
 		}
 
 		client->MakeBlocking();
-		timeval tv = {kLoopbackTimeoutMsec / 1000, (kLoopbackTimeoutMsec % 1000) * 1000};
+		timeval tv = {LOOPBACK_TIMEOUT_MSEC / 1000, (LOOPBACK_TIMEOUT_MSEC % 1000) * 1000};
 		client->SetRecvTimeout(tv);
 
 		peer.AcceptAsync();
-		auto error = client->Connect(LoopbackAddress(peer.Port()), kLoopbackTimeoutMsec);
+		auto error = client->Connect(LoopbackAddress(peer.Port()), LOOPBACK_TIMEOUT_MSEC);
 		peer.WaitAccepted();
 
 		if (error != nullptr || peer.IsConnected() == false)
@@ -481,10 +499,10 @@ protected:
 		}
 
 		client->MakeBlocking();
-		timeval tv = {kLoopbackTimeoutMsec / 1000, (kLoopbackTimeoutMsec % 1000) * 1000};
+		timeval tv = {LOOPBACK_TIMEOUT_MSEC / 1000, (LOOPBACK_TIMEOUT_MSEC % 1000) * 1000};
 		client->SetRecvTimeout(tv);
 
-		if (client->Connect(LoopbackAddress(peer_port), kLoopbackTimeoutMsec) != nullptr)
+		if (client->Connect(LoopbackAddress(peer_port), LOOPBACK_TIMEOUT_MSEC) != nullptr)
 		{
 			return nullptr;
 		}
@@ -753,7 +771,7 @@ protected:
 		client->MakeBlocking();
 
 		peer.AcceptAsync();
-		auto error = client->Connect(LoopbackAddress(peer.Port()), kLoopbackTimeoutMsec);
+		auto error = client->Connect(LoopbackAddress(peer.Port()), LOOPBACK_TIMEOUT_MSEC);
 		peer.WaitAccepted();
 
 		if (error != nullptr || peer.IsConnected() == false)
@@ -827,7 +845,7 @@ protected:
 		client->SetRecvTimeout(tv);
 
 		peer.AcceptAsync();
-		auto error = client->Connect(LoopbackAddress(peer.Port()), kLoopbackTimeoutMsec);
+		auto error = client->Connect(LoopbackAddress(peer.Port()), LOOPBACK_TIMEOUT_MSEC);
 		peer.WaitAccepted();
 
 		if (error != nullptr || peer.IsConnected() == false)
@@ -847,12 +865,12 @@ TEST_F(SocketConcurrencyTest, ManyIndependentSocketsReceiveConcurrently)
 {
 	Watchdog watchdog(std::chrono::seconds(30), "ManyIndependentSocketsReceiveConcurrently");
 
-	constexpr int kSocketCount = 48;
+	constexpr int SOCKET_COUNT = 48;
 	const char payload[]	   = "concurrent-payload";
 
 	std::vector<std::unique_ptr<PosixTcpPeer>> peers;
 	std::vector<std::shared_ptr<ov::Socket>> clients;
-	for (int i = 0; i < kSocketCount; i++)
+	for (int i = 0; i < SOCKET_COUNT; i++)
 	{
 		auto peer = std::make_unique<PosixTcpPeer>();
 		ASSERT_TRUE(peer->Listen());
@@ -864,8 +882,8 @@ TEST_F(SocketConcurrencyTest, ManyIndependentSocketsReceiveConcurrently)
 
 	std::atomic<int> success{0};
 	std::vector<std::thread> threads;
-	threads.reserve(kSocketCount);
-	for (int i = 0; i < kSocketCount; i++)
+	threads.reserve(SOCKET_COUNT);
+	for (int i = 0; i < SOCKET_COUNT; i++)
 	{
 		threads.emplace_back([&, i]() {
 			peers[i]->Send(payload, sizeof(payload));
@@ -883,7 +901,7 @@ TEST_F(SocketConcurrencyTest, ManyIndependentSocketsReceiveConcurrently)
 		thread.join();
 	}
 
-	EXPECT_EQ(success.load(), kSocketCount);
+	EXPECT_EQ(success.load(), SOCKET_COUNT);
 
 	for (auto &client : clients)
 	{
@@ -898,11 +916,11 @@ TEST_F(SocketConcurrencyTest, RecvRacesPeerDisconnectStorm)
 {
 	Watchdog watchdog(std::chrono::seconds(30), "RecvRacesPeerDisconnectStorm");
 
-	constexpr int kSocketCount = 48;
+	constexpr int SOCKET_COUNT = 48;
 
 	std::vector<std::unique_ptr<PosixTcpPeer>> peers;
 	std::vector<std::shared_ptr<ov::Socket>> clients;
-	for (int i = 0; i < kSocketCount; i++)
+	for (int i = 0; i < SOCKET_COUNT; i++)
 	{
 		auto peer = std::make_unique<PosixTcpPeer>();
 		ASSERT_TRUE(peer->Listen());
@@ -914,8 +932,8 @@ TEST_F(SocketConcurrencyTest, RecvRacesPeerDisconnectStorm)
 
 	std::atomic<int> failed_as_expected{0};
 	std::vector<std::thread> threads;
-	threads.reserve(kSocketCount);
-	for (int i = 0; i < kSocketCount; i++)
+	threads.reserve(SOCKET_COUNT);
+	for (int i = 0; i < SOCKET_COUNT; i++)
 	{
 		threads.emplace_back([&, i]() {
 			std::thread peer_closer([&, i]() { peers[i]->CloseConnection(); });
@@ -936,7 +954,7 @@ TEST_F(SocketConcurrencyTest, RecvRacesPeerDisconnectStorm)
 		thread.join();
 	}
 
-	EXPECT_EQ(failed_as_expected.load(), kSocketCount);
+	EXPECT_EQ(failed_as_expected.load(), SOCKET_COUNT);
 
 	for (auto &client : clients)
 	{

--- a/src/projects/base/ovsocket/socket_test.cpp
+++ b/src/projects/base/ovsocket/socket_test.cpp
@@ -26,6 +26,11 @@
 #include <thread>
 #include <vector>
 
+// macOS lacks MSG_NOSIGNAL; fall back to no flag so the peer helpers stay portable.
+#ifndef MSG_NOSIGNAL
+#	define MSG_NOSIGNAL 0
+#endif
+
 namespace
 {
 	constexpr int kLoopbackTimeoutMsec = 3000;
@@ -47,6 +52,25 @@ namespace
 			return 0;
 		}
 		return ntohs(sa.sin_port);
+	}
+
+	// Reads exactly `want` bytes into `out`. A TCP stream may legally arrive across
+	// several reads (even on loopback), so this loops; returns false on
+	// error/disconnect/timeout.
+	bool RecvExactly(const std::shared_ptr<ov::Socket> &socket, void *out, size_t want)
+	{
+		auto *cursor	= static_cast<uint8_t *>(out);
+		size_t received = 0;
+		while (received < want)
+		{
+			auto result = socket->Recv(cursor + received, want - received);
+			if (result.has_value() == false)
+			{
+				return false;
+			}
+			received += result.value();
+		}
+		return true;
 	}
 
 	// A minimal POSIX TCP server that accepts a single connection. It lets the
@@ -461,7 +485,8 @@ protected:
 // TCP
 // ===========================================================================
 
-// Successful read: `value()` holds the byte count and the payload is intact.
+// A successful read returns the data intact. TCP is a stream, so the payload may
+// span several reads; accumulate via `RecvExactly` rather than assuming one call.
 TEST_F(SocketRecvTcpTest, RawBufferReceivesData)
 {
 	PosixTcpPeer peer;
@@ -473,16 +498,13 @@ TEST_F(SocketRecvTcpTest, RawBufferReceivesData)
 	ASSERT_EQ(peer.Send(payload, sizeof(payload)), static_cast<ssize_t>(sizeof(payload)));
 
 	char buffer[64] = {0};
-	auto result		= client->Recv(buffer, sizeof(buffer));
-
-	ASSERT_TRUE(result.has_value());
-	EXPECT_EQ(result.value(), sizeof(payload));
-	EXPECT_STREQ(buffer, payload);
+	ASSERT_TRUE(RecvExactly(client, buffer, sizeof(payload)));
+	EXPECT_EQ(::memcmp(buffer, payload, sizeof(payload)), 0);
 	EXPECT_EQ(client->GetState(), ov::SocketState::Connected);
 }
 
-// A buffer larger than the data still reports the actual number of bytes read.
-TEST_F(SocketRecvTcpTest, RawBufferReportsActualLengthForPartialFill)
+// A single read reports the bytes actually available, never the buffer capacity.
+TEST_F(SocketRecvTcpTest, RawBufferReportsActualLengthNotCapacity)
 {
 	PosixTcpPeer peer;
 	ASSERT_TRUE(peer.Listen());
@@ -496,10 +518,13 @@ TEST_F(SocketRecvTcpTest, RawBufferReportsActualLengthForPartialFill)
 	auto result = client->Recv(buffer, sizeof(buffer));
 
 	ASSERT_TRUE(result.has_value());
-	EXPECT_EQ(result.value(), 3u);
+	// May be a short read (1..3) on a stream, but never the 4096 buffer capacity.
+	EXPECT_GT(result.value(), 0u);
+	EXPECT_LE(result.value(), 3u);
 }
 
-// The `Data` overload sets the data length to the number of bytes received.
+// The `Data` overload sets the data length to the number of bytes received. TCP
+// may split the payload across reads, so accumulate until the whole thing arrives.
 TEST_F(SocketRecvTcpTest, DataOverloadSetsLength)
 {
 	PosixTcpPeer peer;
@@ -510,14 +535,19 @@ TEST_F(SocketRecvTcpTest, DataOverloadSetsLength)
 	const char payload[] = "hello-data";
 	ASSERT_EQ(peer.Send(payload, sizeof(payload)), static_cast<ssize_t>(sizeof(payload)));
 
-	auto data = std::make_shared<ov::Data>();
-	ASSERT_TRUE(data->Reserve(2048));
+	std::string received;
+	while (received.size() < sizeof(payload))
+	{
+		auto data = std::make_shared<ov::Data>();
+		ASSERT_TRUE(data->Reserve(2048));
 
-	auto error = client->Recv(data);
+		auto error = client->Recv(data);
+		ASSERT_EQ(error, nullptr);
+		received.append(static_cast<const char *>(data->GetData()), data->GetLength());
+	}
 
-	ASSERT_EQ(error, nullptr);
-	EXPECT_EQ(data->GetLength(), sizeof(payload));
-	EXPECT_EQ(::memcmp(data->GetData(), payload, sizeof(payload)), 0);
+	EXPECT_EQ(received.size(), sizeof(payload));
+	EXPECT_EQ(::memcmp(received.data(), payload, sizeof(payload)), 0);
 }
 
 // An orderly peer shutdown (`recv() == 0`) must be classified as a disconnect,

--- a/src/projects/base/ovsocket/socket_test.cpp
+++ b/src/projects/base/ovsocket/socket_test.cpp
@@ -147,9 +147,22 @@ namespace
 			return _conn_fd >= 0;
 		}
 
+		// Sends the whole buffer; a TCP stream may accept a short write, so loop until
+		// everything is queued. Returns total bytes sent, or the failing return value.
 		ssize_t Send(const void *data, size_t length)
 		{
-			return ::send(_conn_fd, data, length, MSG_NOSIGNAL);
+			auto *cursor = static_cast<const uint8_t *>(data);
+			size_t sent	 = 0;
+			while (sent < length)
+			{
+				ssize_t written = ::send(_conn_fd, cursor + sent, length - sent, MSG_NOSIGNAL);
+				if (written <= 0)
+				{
+					return written;
+				}
+				sent += static_cast<size_t>(written);
+			}
+			return static_cast<ssize_t>(sent);
 		}
 
 		void CloseConnection()
@@ -858,8 +871,7 @@ TEST_F(SocketConcurrencyTest, ManyIndependentSocketsReceiveConcurrently)
 			peers[i]->Send(payload, sizeof(payload));
 
 			char buffer[64] = {0};
-			auto result		= clients[i]->Recv(buffer, sizeof(buffer));
-			if (result.has_value() && result.value() == sizeof(payload) &&
+			if (RecvExactly(clients[i], buffer, sizeof(payload)) &&
 				::memcmp(buffer, payload, sizeof(payload)) == 0)
 			{
 				success.fetch_add(1);

--- a/src/projects/modules/http/client/http_client.cpp
+++ b/src/projects/modules/http/client/http_client.cpp
@@ -164,12 +164,11 @@ namespace http
 
 			if (socket != nullptr)
 			{
-				size_t received_length;
-				auto error = socket->Recv(data, length, &received_length);
+				auto result = socket->Recv(data, length);
 
-				if (error == nullptr)
+				if (result.has_value())
 				{
-					return received_length;
+					return result.value();
 				}
 			}
 

--- a/src/projects/modules/http/client/http_client_v2.cpp
+++ b/src/projects/modules/http/client/http_client_v2.cpp
@@ -205,12 +205,11 @@ namespace http
 
 			if (socket != nullptr)
 			{
-				size_t received_length;
-				auto error = socket->Recv(data, length, &received_length);
+				auto result = socket->Recv(data, length);
 
-				if (error == nullptr)
+				if (result.has_value())
 				{
-					return received_length;
+					return result.value();
 				}
 			}
 

--- a/src/projects/providers/ovt/ovt_stream.cpp
+++ b/src/projects/providers/ovt/ovt_stream.cpp
@@ -631,7 +631,6 @@ namespace pvd
 	bool OvtStream::ReceivePacket(bool non_block)
 	{
 		uint8_t buffer[65535];
-		size_t read_bytes = 0ULL;
 
 		auto client_socket = _client_socket;
 		if (client_socket == nullptr)
@@ -640,27 +639,26 @@ namespace pvd
 			return false;
 		}
 
-		auto error = client_socket->Recv(buffer, 65535, &read_bytes, non_block);
+		auto result = client_socket->Recv(buffer, 65535, non_block);
+		if (result.has_value() == false)
+		{
+			logte("[%s/%s] An error occurred while receiving packet: %s", GetApplicationName(), GetName().CStr(), result.error()->What());
+			client_socket->Close();
+			return false;
+		}
+
+		auto read_bytes = result.value();
 		if (read_bytes == 0)
 		{
-			if (error != nullptr)
+			if (non_block == true)
 			{
-				logte("[%s/%s] An error occurred while receiving packet: %s", GetApplicationName(), GetName().CStr(), error->What());
-				client_socket->Close();
-				return false;
+				// retry later
+				return true;
 			}
 			else
 			{
-				if (non_block == true)
-				{
-					// retry later
-					return true;
-				}
-				else
-				{
-					// timeout
-					return false;
-				}
+				// timeout
+				return false;
 			}
 		}
 

--- a/src/projects/providers/ovt/ovt_stream.cpp
+++ b/src/projects/providers/ovt/ovt_stream.cpp
@@ -651,7 +651,7 @@ namespace pvd
 		if (read_bytes == 0)
 		{
 			// No data available right now - retry later. A real error/disconnect arrives
-			// as a failed result and is handled above, so 0 is never fatal here.
+			// as a failed result and is handled above, so `0` is never fatal here.
 			return true;
 		}
 

--- a/src/projects/providers/ovt/ovt_stream.cpp
+++ b/src/projects/providers/ovt/ovt_stream.cpp
@@ -650,16 +650,9 @@ namespace pvd
 		auto read_bytes = result.value();
 		if (read_bytes == 0)
 		{
-			if (non_block == true)
-			{
-				// retry later
-				return true;
-			}
-			else
-			{
-				// timeout
-				return false;
-			}
+			// No data available right now - retry later. A real error/disconnect arrives
+			// as a failed result and is handled above, so 0 is never fatal here.
+			return true;
 		}
 
 		if (_depacketizer.AppendPacket(buffer, read_bytes) == false)

--- a/src/projects/providers/rtspc/rtspc_stream.cpp
+++ b/src/projects/providers/rtspc/rtspc_stream.cpp
@@ -905,16 +905,9 @@ namespace pvd
 		auto read_bytes = result.value();
 		if (read_bytes == 0)
 		{
-			if (non_block == true)
-			{
-				// retry later
-				return true;
-			}
-			else
-			{
-				// timeout
-				return false;
-			}
+			// No data available right now - retry later. A real error/timeout arrives as
+			// a failed result and is handled above, so 0 is never fatal here.
+			return true;
 		}
 
 		// Since the response to the Play request and part of the interleaved data can be received at once,

--- a/src/projects/providers/rtspc/rtspc_stream.cpp
+++ b/src/projects/providers/rtspc/rtspc_stream.cpp
@@ -887,7 +887,6 @@ namespace pvd
 	bool RtspcStream::ReceivePacket(bool non_block, int64_t timeout_msec)
 	{
 		uint8_t buffer[65535];
-		size_t read_bytes = 0ULL;
 
 		if (non_block == false && timeout_msec != 0)
 		{
@@ -895,27 +894,26 @@ namespace pvd
 			_signalling_socket->SetRecvTimeout(tv);
 		}
 
-		auto error = _signalling_socket->Recv(buffer, 65535, &read_bytes, non_block);
+		auto result = _signalling_socket->Recv(buffer, 65535, non_block);
+		if (result.has_value() == false)
+		{
+			logte("[%s/%s] An error occurred while receiving packet: %s", GetApplicationName(), GetName().CStr(), result.error()->What());
+			SetState(State::ERROR);
+			return false;
+		}
+
+		auto read_bytes = result.value();
 		if (read_bytes == 0)
 		{
-			if (error != nullptr)
+			if (non_block == true)
 			{
-				logte("[%s/%s] An error occurred while receiving packet: %s", GetApplicationName(), GetName().CStr(), error->What());
-				SetState(State::ERROR);
-				return false;
+				// retry later
+				return true;
 			}
 			else
 			{
-				if (non_block == true)
-				{
-					// retry later
-					return true;
-				}
-				else
-				{
-					// timeout
-					return false;
-				}
+				// timeout
+				return false;
 			}
 		}
 

--- a/src/projects/providers/rtspc/rtspc_stream.cpp
+++ b/src/projects/providers/rtspc/rtspc_stream.cpp
@@ -906,7 +906,7 @@ namespace pvd
 		if (read_bytes == 0)
 		{
 			// No data available right now - retry later. A real error/timeout arrives as
-			// a failed result and is handled above, so 0 is never fatal here.
+			// a failed result and is handled above, so `0` is never fatal here.
 			return true;
 		}
 


### PR DESCRIPTION
## Summary

The raw-buffer `Socket::Recv()` previously returned an error pointer and wrote the byte count through an out-parameter.
The real risk in this path is not the byte count but how a read result is *classified* (would-block vs EOF vs empty datagram vs disconnect), and the old code blurred those cases.
This reworks the API to `tl::expected`, fixes the classification, and adds tests that behaviorally pin that contract.

## Changes

- Replace `Recv(void*, size_t, size_t*, bool)` with `Recv(void*, size_t, bool) -> tl::expected<size_t, std::shared_ptr<const SocketError>>`. The byte count and error are one value, so callers can no longer read an uninitialized length on the error path.
- Split `read_bytes <= 0` into `== 0` and `< 0`. A `recv()`/`srt_recvmsg2()` return of `0` does not set `errno`/the SRT last error, so the old code could read a stale `EAGAIN`/`EASYNCRCV` and misreport an EOF as a retriable timeout. Now `0` is classified by the return value alone: TCP `0` -> disconnect, UDP `0` -> valid empty datagram (`0`-byte success), SRT `0` -> EOF (buffer/stream mode; defensive).
- Honor `non_block=true` on a blocking socket: `EAGAIN` with no data is now a retry-later (`0`-byte) success instead of a "receive timed out" error that closed the socket. This matches the SRT path and the OVT/RTSPC callers (`ReceivePacket(true)` treating `0` as "retry later").
- A non-blocking end-of-stream is routed through the disconnect path instead of building an `EAGAIN` error that tripped the `OV_ASSERT2(_blocking_mode == Blocking)` assertion.
- Normalize `EWOULDBLOCK` to `EAGAIN` in `Recv()` (mirroring `Accept()`) so the would-block/timeout condition is handled consistently across platforms.
- Treat `SocketType::Unknown` as an explicit error instead of falling through.
- Update the `Recv()` contract comment and the callers (`http_client`, `http_client_v2`, `ovt_stream`, `rtspc_stream`), and add the `third_party/expected-1.3.1` include path.

## Tests (scope)

`socket_test.cpp` behaviorally pins the recv state-interpretation contract with real sockets, asserting both the returned value and the resulting socket state:

- normal read -> `has_value()`, `value() == bytes`, payload intact, state stays `Connected`.
- would-block (`EAGAIN` / `SRT_EASYNCRCV`, via `non_block`/async) -> `has_value()`, `value() == 0`, state stays `Connected`.
- empty UDP datagram -> `has_value()`, `value() == 0`, state NOT `Disconnected`/`Error`, and the socket stays usable.
- EOF / orderly peer shutdown -> `!has_value()`, state `Disconnected`.
- self-closed and unknown-type socket -> `!has_value()`.

Multithreaded stress tests (many independent sockets, peer-disconnect storm) also run clean, including under ThreadSanitizer.

## Known issues / follow-up (out of scope)

- ThreadSanitizer surfaced two **pre-existing** data races: `Recv()`'s `::recv()` vs `Close()`'s `::close()` on the same fd, and `HalfClose()` reading a flag outside the dispatch lock during concurrent `Close()`. Both are in the close path; left for a separate change.
- The SRT contract is pinned in-repo only for `SRT_EASYNCRCV` -> retry. Pinning SRT message delivery and `SRT_ECONNLOST` -> disconnect faithfully needs the SRT server (accept) path.
