### PR TITLE
feat(rtmp): support AV1 ingest over enhanced RTMP

### DIFF
--- a/docs/live-source/rtmp.md
+++ b/docs/live-source/rtmp.md
@@ -6,7 +6,7 @@ sidebar_position: 11
 
 RTMP is one of the most widely used protocols in live streaming.
 
-<table><thead><tr><th width="290">Title</th><th>Functions</th></tr></thead><tbody><tr><td>Container</td><td>FLV</td></tr><tr><td>Transport</td><td>TCP</td></tr><tr><td>Codec</td><td>H.264, AAC / H.265 (E-RTMP only)</td></tr></tbody></table>
+<table><thead><tr><th width="290">Title</th><th>Functions</th></tr></thead><tbody><tr><td>Container</td><td>FLV</td></tr><tr><td>Transport</td><td>TCP</td></tr><tr><td>Codec</td><td>H.264, AAC / H.265, AV1 (E-RTMP only)</td></tr></tbody></table>
 
 ## Configuration
 
@@ -112,14 +112,14 @@ You can set the Stream Key to any name you like at any time.
 
 ## E-RTMP
 
-Enhanced RTMP (E-RTMP) is an experimental streaming feature that extends the capabilities of the traditional RTMP protocol. One of its key advantages is support for modern video codecs such as H.265 (HEVC), which are not available in standard RTMP. This allows for better video quality and lower bitrates, making it ideal for high-efficiency streaming workflows. The list of supported codecs will continue to grow as development progresses.
+Enhanced RTMP (E-RTMP) is an experimental streaming feature that extends the capabilities of the traditional RTMP protocol. One of its key advantages is support for modern video codecs such as H.265 (HEVC) and AV1, which are not available in standard RTMP. This allows for better video quality and lower bitrates, making it ideal for high-efficiency streaming workflows. The list of supported codecs will continue to grow as development progresses.
 
-| Title               | Functions             |
-| ------------------- | --------------------- |
-| Container           | FLV                   |
-| Transport           | TCP                   |
-| Codec               | H.264, H.265, AAC     |
-| Additional Features | Simulcast, Multitrack |
+| Title               | Functions              |
+| ------------------- | ---------------------- |
+| Container           | FLV                    |
+| Transport           | TCP                    |
+| Codec               | H.264, H.265, AV1, AAC |
+| Additional Features | Simulcast, Multitrack  |
 
 Since E-RTMP is still experimental, **it is disabled by default** and must be manually enabled in the server settings.
 

--- a/src/projects/modules/containers/flv_v2/flv_common.h
+++ b/src/projects/modules/containers/flv_v2/flv_common.h
@@ -11,6 +11,8 @@
 #include <base/info/decoder_configuration_record.h>
 #include <base/ovlibrary/ovlibrary.h>
 
+#include <algorithm>
+
 #include "./flv_datastructure.h"
 
 namespace modules
@@ -62,15 +64,25 @@ namespace modules
 			// reader holding several concatenated tracks does not spill into the next track.
 			size_t GetRemainingTrackSize(bool is_multi_track, const ov::BitReader &reader, uint24_t size_of_track, size_t size_of_track_offset)
 			{
+				const auto remaining_bytes = reader.GetRemainingBytes();
+
 				if ((is_multi_track == false) || (size_of_track == 0))
 				{
-					return reader.GetRemainingBytes();
+					return remaining_bytes;
 				}
 
 				// How many bytes have been read since the sizeOfVideoTrack field
 				auto read_bytes_since_size_of_track = reader.GetByteOffset() - size_of_track_offset;
 
-				return size_of_track - read_bytes_since_size_of_track;
+				// A malformed `sizeOfVideoTrack` may be smaller than what has already been read.
+				// Treat that as an empty track rather than underflowing to a huge `size_t`.
+				if (size_of_track <= read_bytes_since_size_of_track)
+				{
+					return 0;
+				}
+
+				// Never report more than what is actually left in the buffer.
+				return std::min(static_cast<size_t>(size_of_track) - read_bytes_since_size_of_track, remaining_bytes);
 			}
 
 			std::shared_ptr<const ov::Data> GetPayload(bool is_multi_track, ov::BitReader &reader, uint24_t size_of_track, size_t size_of_track_offset)

--- a/src/projects/modules/containers/flv_v2/flv_common.h
+++ b/src/projects/modules/containers/flv_v2/flv_common.h
@@ -57,22 +57,27 @@ namespace modules
 			OV_DEFINE_CONST_GETTER(GetMultitrackType, _multitrack_type, noexcept);
 
 		protected:
+			// Returns the number of bytes that belong to the current track at the reader's
+			// position. In multitrack mode this is bounded by `sizeOfVideoTrack` so that a
+			// reader holding several concatenated tracks does not spill into the next track.
+			size_t GetRemainingTrackSize(bool is_multi_track, const ov::BitReader &reader, uint24_t size_of_track, size_t size_of_track_offset)
+			{
+				if ((is_multi_track == false) || (size_of_track == 0))
+				{
+					return reader.GetRemainingBytes();
+				}
+
+				// How many bytes have been read since the sizeOfVideoTrack field
+				auto read_bytes_since_size_of_track = reader.GetByteOffset() - size_of_track_offset;
+
+				return size_of_track - read_bytes_since_size_of_track;
+			}
+
 			std::shared_ptr<const ov::Data> GetPayload(bool is_multi_track, ov::BitReader &reader, uint24_t size_of_track, size_t size_of_track_offset)
 			{
 				static auto EMPTY_DATA = std::make_shared<ov::Data>();
 
-				size_t payload_size	   = 0;
-
-				if ((is_multi_track == false) || (size_of_track == 0))
-				{
-					payload_size = reader.GetRemainingBytes();
-				}
-				else
-				{
-					// How many bytes have been read since the sizeOfVideoTrack field
-					auto read_bytes_since_size_of_track = reader.GetByteOffset() - size_of_track_offset;
-					payload_size						= size_of_track - read_bytes_since_size_of_track;
-				}
+				size_t payload_size	   = GetRemainingTrackSize(is_multi_track, reader, size_of_track, size_of_track_offset);
 
 				return (payload_size > 0) ? reader.ReadBytes(payload_size) : EMPTY_DATA;
 			}

--- a/src/projects/modules/containers/flv_v2/flv_video_data.h
+++ b/src/projects/modules/containers/flv_v2/flv_video_data.h
@@ -8,6 +8,7 @@
 //==============================================================================
 #pragma once
 
+#include <modules/bitstream/av1/av1_decoder_configuration_record.h>
 #include <modules/bitstream/h264/h264_decoder_configuration_record.h>
 #include <modules/bitstream/h265/h265_decoder_configuration_record.h>
 #include <modules/rtmp_v2/amf0/amf_document.h>

--- a/src/projects/modules/containers/flv_v2/flv_video_parser.cpp
+++ b/src/projects/modules/containers/flv_v2/flv_video_parser.cpp
@@ -10,6 +10,8 @@
 
 #include <modules/rtmp_v2/amf0/amf_document.h>
 
+#include <algorithm>
+
 #include "./flv_private.h"
 
 #undef OV_LOG_TAG
@@ -269,21 +271,23 @@ namespace modules
 			return record;
 		}
 
-		std::shared_ptr<AV1DecoderConfigurationRecord> VideoParser::ParseAV1(ov::BitReader &reader)
+		std::shared_ptr<AV1DecoderConfigurationRecord> VideoParser::ParseAV1(ov::BitReader &reader, size_t available_bytes)
 		{
 			if ((reader.GetBitOffset() % 8) != 0)
 			{
 				OV_ASSERT2(false);
 			}
 
-			// `AV1CodecConfigurationRecord` (`av1C`) consumes all remaining bytes
-			// of the `ExVideoTagBody` `SequenceStart` payload.
-			const auto remaining_bytes = reader.GetRemainingBytes();
-			auto buffer				   = (remaining_bytes > 0)
-											 ? reader.ReadBytes(remaining_bytes)
-											 : std::make_shared<ov::Data>();
+			// `AV1CodecConfigurationRecord` (`av1C`) has no internal length field; it spans the
+			// rest of the current track's `SequenceStart` payload. In multitrack mode that span
+			// is bounded by `sizeOfVideoTrack` (`available_bytes`), so it must not be read with
+			// `GetRemainingBytes()` - that would consume bytes belonging to subsequent tracks.
+			const auto record_bytes = std::min(available_bytes, reader.GetRemainingBytes());
+			auto buffer				= (record_bytes > 0)
+										  ? reader.ReadBytes(record_bytes)
+										  : std::make_shared<ov::Data>();
 
-			auto record				   = std::make_shared<AV1DecoderConfigurationRecord>();
+			auto record				= std::make_shared<AV1DecoderConfigurationRecord>();
 
 			// ffmpeg's `libaom-av1` muxer over enhanced-RTMP emits a `SequenceStart` with an empty body -
 			// the AV1 sequence header OBU is delivered in-band in the first `CodedFrames` packet instead.
@@ -424,7 +428,16 @@ namespace modules
 						// for the description of the `AV1CodecConfigurationRecord`.
 						// av1Header = [AV1CodecConfigurationRecord]
 						logap("[SequenceStart] AV1CodecConfigurationRecord");
-						video_data->header = ParseAV1(reader);
+
+						// Bound the record to the current track so that, in multitrack mode, parsing
+						// does not read past `sizeOfVideoTrack` into the next track's bytes.
+						auto available_bytes = GetRemainingTrackSize(
+							_is_multitrack,
+							reader,
+							size_of_video_track,
+							size_of_video_track_offset);
+
+						video_data->header = ParseAV1(reader, available_bytes);
 
 						if (video_data->header != nullptr)
 						{

--- a/src/projects/modules/containers/flv_v2/flv_video_parser.cpp
+++ b/src/projects/modules/containers/flv_v2/flv_video_parser.cpp
@@ -148,6 +148,7 @@ namespace modules
 			//         colorConfig: {}  (Object)
 			//     }
 			// }
+			// ```
 			auto data = reader.GetData();
 			ov::ByteStream byte_stream(data);
 			rtmp::AmfDocument document;
@@ -239,7 +240,9 @@ namespace modules
 
 			if (record == nullptr)
 			{
-				logae("FAILED TO PARSE!");
+				// Release falls through to graceful reject of a malformed
+				// `AVCDecoderConfigurationRecord` from remote input.
+				logae("Failed to parse AVCDecoderConfigurationRecord");
 				OV_ASSERT2(false);
 			}
 
@@ -257,8 +260,59 @@ namespace modules
 
 			if (record == nullptr)
 			{
-				logae("FAILED TO PARSE!");
+				// Release falls through to graceful reject of a malformed
+				// `HEVCDecoderConfigurationRecord` from remote input.
+				logae("Failed to parse HEVCDecoderConfigurationRecord");
 				OV_ASSERT2(false);
+			}
+
+			return record;
+		}
+
+		std::shared_ptr<AV1DecoderConfigurationRecord> VideoParser::ParseAV1(ov::BitReader &reader)
+		{
+			if ((reader.GetBitOffset() % 8) != 0)
+			{
+				OV_ASSERT2(false);
+			}
+
+			// `AV1CodecConfigurationRecord` (`av1C`) consumes all remaining bytes
+			// of the `ExVideoTagBody` `SequenceStart` payload.
+			const auto remaining_bytes = reader.GetRemainingBytes();
+			auto buffer				   = (remaining_bytes > 0)
+											 ? reader.ReadBytes(remaining_bytes)
+											 : std::make_shared<ov::Data>();
+
+			auto record				   = std::make_shared<AV1DecoderConfigurationRecord>();
+
+			// ffmpeg's `libaom-av1` muxer over enhanced-RTMP emits a `SequenceStart` with an empty body -
+			// the AV1 sequence header OBU is delivered in-band in the first `CodedFrames` packet instead.
+			// Tolerate that: synthesize a minimal-default `AV1DecoderConfigurationRecord`;
+			// the actual sequence header OBU will be picked up from the bytestream by downstream consumers
+			// (transcoder / packagers parse the OBU stream directly).
+			if (buffer->GetLength() == 0)
+			{
+				logaw(
+					"Empty AV1CodecConfigurationRecord in SequenceStart - "
+					"using defaults (sequence header OBU is expected in-band in CodedFrames)");
+
+				// Minimal `av1C` blob: `marker=1`, `version=1` -> `0x81`, then three zero bytes covering
+				// `seq_profile`/`seq_level_idx_0`/... defaults. Sequence header OBU arrives in-band.
+				static constexpr uint8_t kDefaultAv1Config[] = {0x81, 0x00, 0x00, 0x00};
+
+				if (record->Parse(kDefaultAv1Config, OV_COUNTOF(kDefaultAv1Config)) == false)
+				{
+					logae("Failed to synthesize default AV1DecoderConfigurationRecord");
+					return nullptr;
+				}
+
+				return record;
+			}
+
+			if (record->Parse(buffer) == false)
+			{
+				logae("Failed to parse AV1DecoderConfigurationRecord");
+				return nullptr;
 			}
 
 			return record;
@@ -363,9 +417,22 @@ namespace modules
 					}
 					else if (video_data->video_fourcc == VideoFourCc::Av1)
 					{
-						// body contains a configuration record to start the sequence
+						auto current_data = reader.GetData();
+
+						// body contains a configuration record to start the sequence.
+						// See https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-syntax
+						// for the description of the `AV1CodecConfigurationRecord`.
 						// av1Header = [AV1CodecConfigurationRecord]
 						logap("[SequenceStart] AV1CodecConfigurationRecord");
+						video_data->header = ParseAV1(reader);
+
+						if (video_data->header != nullptr)
+						{
+							auto used_bits			= (reader.GetBitOffset() - last_bit_offset);
+							auto used_bytes			= (used_bits + 7) / 8;
+
+							video_data->header_data = current_data->Subdata(0, used_bytes);
+						}
 					}
 					else if (video_data->video_fourcc == VideoFourCc::Avc)
 					{
@@ -529,12 +596,12 @@ namespace modules
 						auto current_bit_offset = reader.GetBitOffset();
 #endif	// DEBUG
 
-						auto payload = GetPayload(
-										   _is_multitrack,
-										   reader,
-										   size_of_video_track,
-										   size_of_video_track_offset)
-										   ->Clone();
+						auto payload		= GetPayload(
+												  _is_multitrack,
+												  reader,
+												  size_of_video_track,
+												  size_of_video_track_offset)
+												  ->Clone();
 						video_data->payload = payload;
 #if DEBUG
 						[[maybe_unused]] auto used_bits = reader.GetBitOffset() - current_bit_offset;

--- a/src/projects/modules/containers/flv_v2/flv_video_parser.h
+++ b/src/projects/modules/containers/flv_v2/flv_video_parser.h
@@ -44,7 +44,7 @@ namespace modules
 			std::shared_ptr<HEVCDecoderConfigurationRecord> ParseHEVC(ov::BitReader &reader);
 
 			MAY_THROWS(BitReaderError)
-			std::shared_ptr<AV1DecoderConfigurationRecord> ParseAV1(ov::BitReader &reader);
+			std::shared_ptr<AV1DecoderConfigurationRecord> ParseAV1(ov::BitReader &reader, size_t available_bytes);
 
 			MAY_THROWS(BitReaderError)
 			std::shared_ptr<VideoData> ProcessExVideoTagBody(ov::BitReader &reader, bool process_video_body, std::shared_ptr<VideoData> video_data);

--- a/src/projects/modules/containers/flv_v2/flv_video_parser.h
+++ b/src/projects/modules/containers/flv_v2/flv_video_parser.h
@@ -44,6 +44,9 @@ namespace modules
 			std::shared_ptr<HEVCDecoderConfigurationRecord> ParseHEVC(ov::BitReader &reader);
 
 			MAY_THROWS(BitReaderError)
+			std::shared_ptr<AV1DecoderConfigurationRecord> ParseAV1(ov::BitReader &reader);
+
+			MAY_THROWS(BitReaderError)
 			std::shared_ptr<VideoData> ProcessExVideoTagBody(ov::BitReader &reader, bool process_video_body, std::shared_ptr<VideoData> video_data);
 
 			std::vector<std::shared_ptr<VideoData>> _data_list;

--- a/src/projects/modules/rtmp/chunk/rtmp_define.h
+++ b/src/projects/modules/rtmp/chunk/rtmp_define.h
@@ -275,6 +275,19 @@ enum class RtmpEncoderType : int32_t
 	Lavf,		 // Libavformat (lavf)
 };
 
+constexpr const char *ToString(RtmpEncoderType encoder_type)
+{
+	switch (encoder_type)
+	{
+		OV_CASE_RETURN(RtmpEncoderType::Custom, "General");
+		OV_CASE_RETURN(RtmpEncoderType::Xsplit, "Xsplit");
+		OV_CASE_RETURN(RtmpEncoderType::OBS, "OBS");
+		OV_CASE_RETURN(RtmpEncoderType::Lavf, "Lavf/ffmpeg");
+	}
+
+	return "Unknown";
+}
+
 enum class RtmpCodecType : int32_t
 {
 	Unknown,
@@ -284,6 +297,23 @@ enum class RtmpCodecType : int32_t
 	Speex,	//	SPEEX(11)
 	AV1,	//	AV1 (Enhanced RTMP)
 };
+
+constexpr const char *ToString(RtmpCodecType codec_type)
+{
+	switch (codec_type)
+	{
+		OV_CASE_RETURN(RtmpCodecType::H264, "h264");
+		OV_CASE_RETURN(RtmpCodecType::AAC, "aac");
+		OV_CASE_RETURN(RtmpCodecType::MP3, "mp3");
+		OV_CASE_RETURN(RtmpCodecType::Speex, "speex");
+		OV_CASE_RETURN(RtmpCodecType::AV1, "av1");
+
+		case RtmpCodecType::Unknown:
+			break;
+	}
+
+	return "unknown";
+}
 
 enum class RtmpHandshakeState
 {

--- a/src/projects/modules/rtmp/chunk/rtmp_define.h
+++ b/src/projects/modules/rtmp/chunk/rtmp_define.h
@@ -282,6 +282,7 @@ enum class RtmpCodecType : int32_t
 	AAC,	//	AAC          mp4a(10)
 	MP3,	//	MP3(2)
 	Speex,	//	SPEEX(11)
+	AV1,	//	AV1 (Enhanced RTMP)
 };
 
 enum class RtmpHandshakeState

--- a/src/projects/providers/rtmp/flv_av1_parser_test.cpp
+++ b/src/projects/providers/rtmp/flv_av1_parser_test.cpp
@@ -12,6 +12,9 @@
 #include <modules/bitstream/av1/av1_decoder_configuration_record.h>
 #include <modules/containers/flv_v2/flv_video_parser.h>
 
+#include <cstring>
+#include <vector>
+
 namespace
 {
 	constexpr uint32_t TRACK_ID		 = 100;
@@ -104,7 +107,7 @@ TEST(FlvAv1Parser, SequenceStartWithValidAv1C)
 	// header_data must contain the raw av1C bytes
 	ASSERT_NE(video_data->header_data, nullptr);
 	EXPECT_EQ(video_data->header_data->GetLength(), sizeof(MINIMAL_AV1C));
-	EXPECT_EQ(memcmp(video_data->header_data->GetData(), MINIMAL_AV1C, sizeof(MINIMAL_AV1C)), 0);
+	EXPECT_EQ(std::memcmp(video_data->header_data->GetData(), MINIMAL_AV1C, sizeof(MINIMAL_AV1C)), 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -159,7 +162,7 @@ TEST(FlvAv1Parser, CodedFramesKeyFramePayloadPassthrough)
 	// payload must contain the entire OBU body
 	ASSERT_NE(video_data->payload, nullptr);
 	EXPECT_EQ(video_data->payload->GetLength(), sizeof(DUMMY_OBU_PAYLOAD));
-	EXPECT_EQ(memcmp(video_data->payload->GetData(), DUMMY_OBU_PAYLOAD, sizeof(DUMMY_OBU_PAYLOAD)), 0);
+	EXPECT_EQ(std::memcmp(video_data->payload->GetData(), DUMMY_OBU_PAYLOAD, sizeof(DUMMY_OBU_PAYLOAD)), 0);
 
 	// No header for CodedFrames
 	EXPECT_EQ(video_data->header, nullptr);
@@ -201,7 +204,7 @@ TEST(FlvAv1Parser, CodedFramesNoCtsConsumed)
 	// All 5 bytes must appear in the payload (no 3-byte CTS consumed)
 	ASSERT_NE(video_data->payload, nullptr);
 	EXPECT_EQ(video_data->payload->GetLength(), sizeof(body));
-	EXPECT_EQ(memcmp(video_data->payload->GetData(), body, sizeof(body)), 0);
+	EXPECT_EQ(std::memcmp(video_data->payload->GetData(), body, sizeof(body)), 0);
 	EXPECT_EQ(video_data->composition_time_offset, 0);
 }
 
@@ -281,7 +284,7 @@ TEST(FlvAv1Pipeline, CodedFramesPayloadIsObuData)
 	// The payload is what becomes the NALU MediaPacket's data
 	ASSERT_NE(video_data->payload, nullptr);
 	EXPECT_EQ(video_data->payload->GetLength(), sizeof(DUMMY_OBU_PAYLOAD));
-	EXPECT_EQ(memcmp(video_data->payload->GetData(), DUMMY_OBU_PAYLOAD, sizeof(DUMMY_OBU_PAYLOAD)), 0);
+	EXPECT_EQ(std::memcmp(video_data->payload->GetData(), DUMMY_OBU_PAYLOAD, sizeof(DUMMY_OBU_PAYLOAD)), 0);
 
 	// CTS must be 0 (not consumed from wire)
 	EXPECT_EQ(video_data->composition_time_offset, 0);

--- a/src/projects/providers/rtmp/flv_av1_parser_test.cpp
+++ b/src/projects/providers/rtmp/flv_av1_parser_test.cpp
@@ -6,7 +6,7 @@
 //  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
 //
 //==============================================================================
-#include <base/ovlibrary/bit_reader.h>
+#include <base/ovlibrary/bit_reader_v2.h>
 #include <base/ovlibrary/data.h>
 #include <gtest/gtest.h>
 #include <modules/bitstream/av1/av1_decoder_configuration_record.h>

--- a/src/projects/providers/rtmp/flv_av1_parser_test.cpp
+++ b/src/projects/providers/rtmp/flv_av1_parser_test.cpp
@@ -12,6 +12,8 @@
 #include <modules/bitstream/av1/av1_decoder_configuration_record.h>
 #include <modules/containers/flv_v2/flv_video_parser.h>
 
+#include "../../providers/rtmp/tracks/rtmp_track.h"
+
 #include <cstring>
 #include <vector>
 
@@ -230,9 +232,6 @@ TEST(FlvAv1Parser, CodedFramesXReturnsNull)
 //   - ToCommonPacketType mapping
 //   - Track sequence header state
 // ===========================================================================
-
-#include "../../providers/rtmp/tracks/rtmp_av1_track.h"
-#include "../../providers/rtmp/tracks/rtmp_track.h"
 
 TEST(FlvAv1Pipeline, SequenceStartVideoPacketTypeIsCorrect)
 {

--- a/src/projects/providers/rtmp/flv_av1_parser_test.cpp
+++ b/src/projects/providers/rtmp/flv_av1_parser_test.cpp
@@ -1,0 +1,311 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <base/ovlibrary/bit_reader.h>
+#include <base/ovlibrary/data.h>
+#include <gtest/gtest.h>
+#include <modules/bitstream/av1/av1_decoder_configuration_record.h>
+#include <modules/containers/flv_v2/flv_video_parser.h>
+
+namespace
+{
+	constexpr uint32_t TRACK_ID		 = 100;
+
+	// Enhanced RTMP ExVideoTag byte layout:
+	//   bit 7     : isExVideoHeader (1 = enhanced)
+	//   bits 6-4  : VideoFrameType  (1 = Key, 2 = Inter)
+	//   bits 3-0  : VideoPacketType (0 = SequenceStart, 1 = CodedFrames)
+	//   bytes 1-4 : FourCC ("av01" for AV1)
+	//   bytes 5+  : body
+
+	// FourCC "av01" in big-endian
+	constexpr uint8_t AV1_FOURCC[]	 = {0x61, 0x76, 0x30, 0x31};
+
+	// Valid minimal av1C: marker=1 version=1, seq_profile=0, seq_level_idx_0=8,
+	// 4:2:0 subsampling, no configOBUs
+	constexpr uint8_t MINIMAL_AV1C[] = {
+		0x81,  // marker=1, version=1
+		0x08,  // seq_profile=0, seq_level_idx_0=8
+		0x0C,  // seq_tier_0=0, high_bitdepth=0, twelve_bit=0, monochrome=0, subsampling_x=1, subsampling_y=1, csp=0
+		0x00   // initial_presentation_delay_present=0, reserved=0
+	};
+
+	// Dummy OBU payload (just bytes that survive passthrough)
+	constexpr uint8_t DUMMY_OBU_PAYLOAD[] = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE};
+
+	std::vector<uint8_t> BuildExVideoTag(uint8_t frame_type, uint8_t packet_type,
+										 const uint8_t *fourcc,
+										 const uint8_t *body, size_t body_len)
+	{
+		uint8_t header_byte = (1 << 7) | ((frame_type & 0x07) << 4) | (packet_type & 0x0F);
+
+		std::vector<uint8_t> result;
+		result.push_back(header_byte);
+		result.insert(result.end(), fourcc, fourcc + 4);
+		if (body != nullptr && body_len > 0)
+		{
+			result.insert(result.end(), body, body + body_len);
+		}
+		return result;
+	}
+
+	// Parse a raw ExVideoTag and return the first VideoData
+	std::shared_ptr<modules::flv::VideoData> ParseAv1ExVideoTag(const std::vector<uint8_t> &raw)
+	{
+		auto data = std::make_shared<ov::Data>(raw.data(), raw.size());
+		ov::BitReader reader(data);
+
+		modules::flv::VideoParser parser(TRACK_ID);
+		if (parser.Parse(reader) == false)
+		{
+			return nullptr;
+		}
+
+		auto &list = parser.GetDataList();
+		if (list.empty())
+		{
+			return nullptr;
+		}
+
+		return list[0];
+	}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// SequenceStart with valid av1C
+// ---------------------------------------------------------------------------
+TEST(FlvAv1Parser, SequenceStartWithValidAv1C)
+{
+	auto raw		= BuildExVideoTag(1, 0, AV1_FOURCC, MINIMAL_AV1C, sizeof(MINIMAL_AV1C));
+
+	auto video_data = ParseAv1ExVideoTag(raw);
+	ASSERT_NE(video_data, nullptr);
+
+	EXPECT_TRUE(video_data->from_ex_header);
+	EXPECT_EQ(video_data->video_packet_type, modules::flv::VideoPacketType::SequenceStart);
+	ASSERT_TRUE(video_data->video_fourcc.has_value());
+	EXPECT_EQ(video_data->video_fourcc.value(), modules::flv::VideoFourCc::Av1);
+	EXPECT_TRUE(video_data->IsKeyFrame());
+
+	// header must be a valid AV1DecoderConfigurationRecord
+	ASSERT_NE(video_data->header, nullptr);
+	auto av1_dcr = std::dynamic_pointer_cast<AV1DecoderConfigurationRecord>(video_data->header);
+	ASSERT_NE(av1_dcr, nullptr);
+	EXPECT_EQ(av1_dcr->SeqProfile(), 0);
+	EXPECT_EQ(av1_dcr->SeqLevelIdx0(), 8);
+	EXPECT_EQ(av1_dcr->ChromaSubsamplingX(), 1);
+	EXPECT_EQ(av1_dcr->ChromaSubsamplingY(), 1);
+
+	// header_data must contain the raw av1C bytes
+	ASSERT_NE(video_data->header_data, nullptr);
+	EXPECT_EQ(video_data->header_data->GetLength(), sizeof(MINIMAL_AV1C));
+	EXPECT_EQ(memcmp(video_data->header_data->GetData(), MINIMAL_AV1C, sizeof(MINIMAL_AV1C)), 0);
+}
+
+// ---------------------------------------------------------------------------
+// SequenceStart with empty body (ffmpeg libaom-av1 behavior)
+// ---------------------------------------------------------------------------
+TEST(FlvAv1Parser, SequenceStartWithEmptyBodySynthesizesDefault)
+{
+	// SequenceStart with no av1C body
+	auto raw		= BuildExVideoTag(1, 0, AV1_FOURCC, nullptr, 0);
+
+	auto video_data = ParseAv1ExVideoTag(raw);
+	ASSERT_NE(video_data, nullptr);
+
+	EXPECT_EQ(video_data->video_packet_type, modules::flv::VideoPacketType::SequenceStart);
+	ASSERT_TRUE(video_data->video_fourcc.has_value());
+	EXPECT_EQ(video_data->video_fourcc.value(), modules::flv::VideoFourCc::Av1);
+
+	// A synthesized default AV1DecoderConfigurationRecord must be present
+	ASSERT_NE(video_data->header, nullptr);
+	auto av1_dcr = std::dynamic_pointer_cast<AV1DecoderConfigurationRecord>(video_data->header);
+	ASSERT_NE(av1_dcr, nullptr);
+
+	// Synthesized defaults: marker=1, version=1, everything else zeroed
+	EXPECT_EQ(av1_dcr->SeqProfile(), 0);
+	EXPECT_EQ(av1_dcr->SeqLevelIdx0(), 0);
+
+	// header_data is empty because 0 bytes were consumed from the reader.
+	// The SEQUENCE_HEADER MediaPacket will carry empty data - this is by design;
+	// MediaRouter relies on the in-band OBU_SEQUENCE_HEADER in the first CodedFrames.
+	ASSERT_NE(video_data->header_data, nullptr);
+	EXPECT_EQ(video_data->header_data->GetLength(), 0U);
+}
+
+// ---------------------------------------------------------------------------
+// CodedFrames (key frame) - payload passthrough, no compositionTimeOffset
+// ---------------------------------------------------------------------------
+TEST(FlvAv1Parser, CodedFramesKeyFramePayloadPassthrough)
+{
+	auto raw		= BuildExVideoTag(1, 1, AV1_FOURCC, DUMMY_OBU_PAYLOAD, sizeof(DUMMY_OBU_PAYLOAD));
+
+	auto video_data = ParseAv1ExVideoTag(raw);
+	ASSERT_NE(video_data, nullptr);
+
+	EXPECT_EQ(video_data->video_packet_type, modules::flv::VideoPacketType::CodedFrames);
+	ASSERT_TRUE(video_data->video_fourcc.has_value());
+	EXPECT_EQ(video_data->video_fourcc.value(), modules::flv::VideoFourCc::Av1);
+	EXPECT_TRUE(video_data->IsKeyFrame());
+
+	// AV1 CodedFrames must NOT consume compositionTimeOffset from the wire
+	EXPECT_EQ(video_data->composition_time_offset, 0);
+
+	// payload must contain the entire OBU body
+	ASSERT_NE(video_data->payload, nullptr);
+	EXPECT_EQ(video_data->payload->GetLength(), sizeof(DUMMY_OBU_PAYLOAD));
+	EXPECT_EQ(memcmp(video_data->payload->GetData(), DUMMY_OBU_PAYLOAD, sizeof(DUMMY_OBU_PAYLOAD)), 0);
+
+	// No header for CodedFrames
+	EXPECT_EQ(video_data->header, nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// CodedFrames (inter frame) - verify frame type propagates
+// ---------------------------------------------------------------------------
+TEST(FlvAv1Parser, CodedFramesInterFrame)
+{
+	auto raw		= BuildExVideoTag(2, 1, AV1_FOURCC, DUMMY_OBU_PAYLOAD, sizeof(DUMMY_OBU_PAYLOAD));
+
+	auto video_data = ParseAv1ExVideoTag(raw);
+	ASSERT_NE(video_data, nullptr);
+
+	EXPECT_EQ(video_data->video_packet_type, modules::flv::VideoPacketType::CodedFrames);
+	EXPECT_FALSE(video_data->IsKeyFrame());
+	EXPECT_EQ(video_data->composition_time_offset, 0);
+
+	ASSERT_NE(video_data->payload, nullptr);
+	EXPECT_EQ(video_data->payload->GetLength(), sizeof(DUMMY_OBU_PAYLOAD));
+}
+
+// ---------------------------------------------------------------------------
+// Verify AV1 CodedFrames does NOT consume compositionTimeOffset,
+// unlike AVC which would eat 3 bytes from the body as SI24 CTS.
+// ---------------------------------------------------------------------------
+TEST(FlvAv1Parser, CodedFramesNoCtsConsumed)
+{
+	// Build a payload where the first 3 bytes are non-zero.
+	// If AV1 incorrectly consumed CTS like AVC does, these 3 bytes would be
+	// eaten and the payload would be 3 bytes shorter.
+	const uint8_t body[] = {0xFF, 0x01, 0x02, 0xAA, 0xBB};
+	auto raw			 = BuildExVideoTag(1, 1, AV1_FOURCC, body, sizeof(body));
+
+	auto video_data		 = ParseAv1ExVideoTag(raw);
+	ASSERT_NE(video_data, nullptr);
+
+	// All 5 bytes must appear in the payload (no 3-byte CTS consumed)
+	ASSERT_NE(video_data->payload, nullptr);
+	EXPECT_EQ(video_data->payload->GetLength(), sizeof(body));
+	EXPECT_EQ(memcmp(video_data->payload->GetData(), body, sizeof(body)), 0);
+	EXPECT_EQ(video_data->composition_time_offset, 0);
+}
+
+// ---------------------------------------------------------------------------
+// CodedFramesX for AV1 is not handled - should return nullptr
+// ---------------------------------------------------------------------------
+TEST(FlvAv1Parser, CodedFramesXReturnsNull)
+{
+	// VideoPacketType::CodedFramesX = 3
+	auto raw		= BuildExVideoTag(1, 3, AV1_FOURCC, DUMMY_OBU_PAYLOAD, sizeof(DUMMY_OBU_PAYLOAD));
+
+	auto video_data = ParseAv1ExVideoTag(raw);
+	EXPECT_EQ(video_data, nullptr);
+}
+
+// ===========================================================================
+// Pipeline: FLV parse -> VideoData -> verify packet-type mapping and data
+// that RtmpVideoTrack::Handle() would produce.
+//
+// RtmpTrack::CreateMediaPacket() requires a non-null RtmpStreamV2 (for GetMsid()),
+// so we verify the intermediate data structures that feed into it:
+//   - VideoData fields (header, header_data, payload, composition_time_offset)
+//   - ToCommonPacketType mapping
+//   - Track sequence header state
+// ===========================================================================
+
+#include "../../providers/rtmp/tracks/rtmp_av1_track.h"
+#include "../../providers/rtmp/tracks/rtmp_track.h"
+
+TEST(FlvAv1Pipeline, SequenceStartVideoPacketTypeIsCorrect)
+{
+	auto raw		= BuildExVideoTag(1, 0, AV1_FOURCC, MINIMAL_AV1C, sizeof(MINIMAL_AV1C));
+	auto video_data = ParseAv1ExVideoTag(raw);
+	ASSERT_NE(video_data, nullptr);
+
+	// RtmpVideoTrack::ToCommonPacketType maps SequenceStart -> SEQUENCE_HEADER
+	EXPECT_EQ(video_data->video_packet_type, modules::flv::VideoPacketType::SequenceStart);
+}
+
+TEST(FlvAv1Pipeline, CodedFramesVideoPacketTypeIsCorrect)
+{
+	auto raw		= BuildExVideoTag(1, 1, AV1_FOURCC, DUMMY_OBU_PAYLOAD, sizeof(DUMMY_OBU_PAYLOAD));
+	auto video_data = ParseAv1ExVideoTag(raw);
+	ASSERT_NE(video_data, nullptr);
+
+	// RtmpVideoTrack::ToCommonPacketType maps CodedFrames -> NALU
+	EXPECT_EQ(video_data->video_packet_type, modules::flv::VideoPacketType::CodedFrames);
+}
+
+TEST(FlvAv1Pipeline, SequenceStartHeaderDataMatchesAv1C)
+{
+	auto raw		= BuildExVideoTag(1, 0, AV1_FOURCC, MINIMAL_AV1C, sizeof(MINIMAL_AV1C));
+	auto video_data = ParseAv1ExVideoTag(raw);
+	ASSERT_NE(video_data, nullptr);
+
+	// Verify the data that would become the SEQUENCE_HEADER MediaPacket's payload
+	ASSERT_NE(video_data->header_data, nullptr);
+	EXPECT_EQ(video_data->header_data->GetLength(), sizeof(MINIMAL_AV1C));
+
+	// Verify header is a valid AV1 DCR that MediaRouter can re-parse
+	auto av1_dcr = std::dynamic_pointer_cast<AV1DecoderConfigurationRecord>(video_data->header);
+	ASSERT_NE(av1_dcr, nullptr);
+
+	// header_data must be parseable as av1C by MediaRouter
+	auto reparsed = std::make_shared<AV1DecoderConfigurationRecord>();
+	EXPECT_TRUE(reparsed->Parse(video_data->header_data));
+	EXPECT_EQ(reparsed->SeqProfile(), av1_dcr->SeqProfile());
+	EXPECT_EQ(reparsed->SeqLevelIdx0(), av1_dcr->SeqLevelIdx0());
+}
+
+TEST(FlvAv1Pipeline, CodedFramesPayloadIsObuData)
+{
+	auto raw		= BuildExVideoTag(1, 1, AV1_FOURCC, DUMMY_OBU_PAYLOAD, sizeof(DUMMY_OBU_PAYLOAD));
+	auto video_data = ParseAv1ExVideoTag(raw);
+	ASSERT_NE(video_data, nullptr);
+
+	// The payload is what becomes the NALU MediaPacket's data
+	ASSERT_NE(video_data->payload, nullptr);
+	EXPECT_EQ(video_data->payload->GetLength(), sizeof(DUMMY_OBU_PAYLOAD));
+	EXPECT_EQ(memcmp(video_data->payload->GetData(), DUMMY_OBU_PAYLOAD, sizeof(DUMMY_OBU_PAYLOAD)), 0);
+
+	// CTS must be 0 (not consumed from wire)
+	EXPECT_EQ(video_data->composition_time_offset, 0);
+}
+
+TEST(FlvAv1Pipeline, EmptySequenceStartHeaderDataIsEmpty)
+{
+	auto raw		= BuildExVideoTag(1, 0, AV1_FOURCC, nullptr, 0);
+	auto video_data = ParseAv1ExVideoTag(raw);
+	ASSERT_NE(video_data, nullptr);
+
+	// Synthesized DCR exists but header_data is 0 bytes.
+	// MediaRouter receives empty SEQUENCE_HEADER packet data -> drops it ->
+	// relies on in-band OBU_SEQUENCE_HEADER in first CodedFrames.
+	ASSERT_NE(video_data->header, nullptr);
+	ASSERT_NE(video_data->header_data, nullptr);
+	EXPECT_EQ(video_data->header_data->GetLength(), 0U);
+}
+
+TEST(FlvAv1Pipeline, TrackBitstreamFormatIsAv1Obu)
+{
+	auto track = pvd::rtmp::RtmpTrack::Create(nullptr, TRACK_ID, true, cmn::MediaCodecId::Av1);
+	ASSERT_NE(track, nullptr);
+
+	// BitstreamFormat::AV1_OBU is what routes to ProcessAV1OBUStream in MediaRouter
+	EXPECT_EQ(track->GetBitstreamFormat(), cmn::BitstreamFormat::AV1_OBU);
+}

--- a/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
+++ b/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
@@ -95,12 +95,12 @@ namespace pvd::rtmp
 			OV_CASE_RETURN(cmn::MediaCodecId::H264, true);
 			OV_CASE_RETURN(cmn::MediaCodecId::H265, true);
 			OV_CASE_RETURN(cmn::MediaCodecId::Aac, true);
+			OV_CASE_RETURN(cmn::MediaCodecId::Av1, true);
 
 			// Unsupported codecs
 			OV_CASE_RETURN(cmn::MediaCodecId::None, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Vp8, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Vp9, false);
-			OV_CASE_RETURN(cmn::MediaCodecId::Av1, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Flv, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Mp2, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Mp3, false);
@@ -166,10 +166,10 @@ namespace pvd::rtmp
 		{
 			switch (four_cc.value())
 			{
-				// VP8/VP9/AV1 are not supported yet
+				// VP8/VP9 are not supported yet
 				OV_CASE_RETURN(modules::flv::VideoFourCc::Vp8, cmn::MediaCodecId::None);
 				OV_CASE_RETURN(modules::flv::VideoFourCc::Vp9, cmn::MediaCodecId::None);
-				OV_CASE_RETURN(modules::flv::VideoFourCc::Av1, cmn::MediaCodecId::None);
+				OV_CASE_RETURN(modules::flv::VideoFourCc::Av1, cmn::MediaCodecId::Av1);
 				OV_CASE_RETURN(modules::flv::VideoFourCc::Avc, cmn::MediaCodecId::H264);
 				OV_CASE_RETURN(modules::flv::VideoFourCc::Hevc, cmn::MediaCodecId::H265);
 			}
@@ -342,9 +342,13 @@ namespace pvd::rtmp
 
 	ov::String RtmpChunkHandler::Stats::GetStatsString(int64_t elapsed_ms) const
 	{
+		// last: interval between the two most recent key frames (stale when key frames stop arriving)
+		// since: elapsed time since the last key frame (grows in real time, reveals long gaps)
+		auto since_last_key_frame = last_video_timestamp - previous_key_frame_timestamp;
+
 		return ov::String::FormatString(
-			"keyint_ms(%u) ts_ms(v:%" PRId64 "/a:%" PRId64 "/v-a:%" PRId64 ") fps(v:%.2f/a:%.2f) gap_ms(v:%" PRId64 "/a:%" PRId64 ")",
-			key_frame_interval,
+			"keyint_ms(last:%u/since:%" PRId64 ") ts_ms(v:%" PRId64 "/a:%" PRId64 "/v-a:%" PRId64 ") fps(v:%.2f/a:%.2f) gap_ms(v:%" PRId64 "/a:%" PRId64 ")",
+			key_frame_interval, since_last_key_frame,
 			last_video_timestamp, last_audio_timestamp, GetVADelta(),
 			((video_frame_count * 1000) / static_cast<double>(elapsed_ms)),
 			((audio_frame_count * 1000) / static_cast<double>(elapsed_ms)),
@@ -1574,8 +1578,9 @@ namespace pvd::rtmp
 					rtmp_track->SetIgnored(true);
 					rtmp_track->ClearMediaPacketList();
 
-					// In this case, it is highly likely that the sequence header
-					// was not processed correctly in RtmpTrack.
+					// This branch usually indicates that the sequence header was not processed correctly
+					// in `RtmpTrack`. Release falls through and ignores the track;
+					// remote input (peer sends frames before/without a valid `SequenceStart`) must not abort the process.
 					OV_ASSERT2(false);
 				}
 			}
@@ -1726,8 +1731,9 @@ namespace pvd::rtmp
 					rtmp_track->SetIgnored(true);
 					rtmp_track->ClearMediaPacketList();
 
-					// In this case, it is highly likely that the sequence header
-					// was not processed correctly in RtmpTrack.
+					// This branch usually indicates that the sequence header was not processed correctly in `RtmpTrack`.
+					// Release falls through and ignores the track;
+					// remote input (peer sends frames before/without a valid `SequenceStart`) must not abort the process.
 					OV_ASSERT2(false);
 				}
 			}

--- a/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
+++ b/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
@@ -343,7 +343,9 @@ namespace pvd::rtmp
 	ov::String RtmpChunkHandler::Stats::GetStatsString(int64_t elapsed_ms) const
 	{
 		// last: interval between the two most recent key frames (stale when key frames stop arriving)
-		// since: elapsed time since the last key frame (grows in real time, reveals long gaps)
+		// since: stream-timestamp distance from the last key frame to the latest video frame;
+		//        advances as video frames arrive (not wall-clock) and reveals long gaps within a GOP.
+		//        May go negative on regressing/malformed timestamps - shown as-is to surface the anomaly.
 		auto since_last_key_frame = last_video_timestamp - previous_key_frame_timestamp;
 
 		return ov::String::FormatString(

--- a/src/projects/providers/rtmp/rtmp_av1_track_test.cpp
+++ b/src/projects/providers/rtmp/rtmp_av1_track_test.cpp
@@ -1,0 +1,38 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include "../../providers/rtmp/tracks/rtmp_av1_track.h"
+
+#include <base/ovlibrary/data.h>
+#include <gtest/gtest.h>
+
+#include "../../providers/rtmp/tracks/rtmp_track.h"
+
+TEST(RtmpAv1Track, CreateReturnsNonNullForAv1)
+{
+	auto track = pvd::rtmp::RtmpTrack::Create(nullptr, 0, true, cmn::MediaCodecId::Av1);
+
+	ASSERT_NE(track, nullptr);
+	EXPECT_EQ(track->GetCodecId(), cmn::MediaCodecId::Av1);
+	EXPECT_EQ(track->GetBitstreamFormat(), cmn::BitstreamFormat::AV1_OBU);
+	EXPECT_EQ(track->GetMediaType(), cmn::MediaType::Video);
+}
+
+TEST(RtmpAv1Track, FillMediaTrackMetadataAppliesCommonFields)
+{
+	auto track = pvd::rtmp::RtmpTrack::Create(nullptr, 7, true, cmn::MediaCodecId::Av1);
+	ASSERT_NE(track, nullptr);
+
+	auto media_track = std::make_shared<MediaTrack>();
+	track->FillMediaTrackMetadata(media_track);
+
+	EXPECT_EQ(media_track->GetId(), 7U);
+	EXPECT_EQ(media_track->GetMediaType(), cmn::MediaType::Video);
+	EXPECT_EQ(media_track->GetCodecId(), cmn::MediaCodecId::Av1);
+	EXPECT_EQ(media_track->GetOriginBitstream(), cmn::BitstreamFormat::AV1_OBU);
+}

--- a/src/projects/providers/rtmp/rtmp_av1_track_test.cpp
+++ b/src/projects/providers/rtmp/rtmp_av1_track_test.cpp
@@ -8,7 +8,7 @@
 //==============================================================================
 #include "../../providers/rtmp/tracks/rtmp_av1_track.h"
 
-#include <base/ovlibrary/data.h>
+#include <base/info/media_track.h>
 #include <gtest/gtest.h>
 
 #include "../../providers/rtmp/tracks/rtmp_track.h"

--- a/src/projects/providers/rtmp/rtmp_provider.cpp
+++ b/src/projects/providers/rtmp/rtmp_provider.cpp
@@ -34,7 +34,9 @@ namespace pvd
 
 			if (remote_address != nullptr)
 			{
-				auto file_name = remote_address->ToString().Replace(":", "_");
+				auto file_name = remote_address->ToString()
+									 .Replace(":", "_")
+									 .Replace("/", "_");
 
 				ov::DumpToFile(ov::PathManager::Combine(ov::PathManager::GetAppPath("dump/rtmp"), file_name), data, 0L, true);
 			}

--- a/src/projects/providers/rtmp/rtmp_stream.cpp
+++ b/src/projects/providers/rtmp/rtmp_stream.cpp
@@ -2342,8 +2342,11 @@ namespace pvd
 			case RtmpCodecType::Speex:
 				codec_string = "speex";
 				break;
+			case RtmpCodecType::AV1:
+				codec_string = "av1";
+				break;
+
 			case RtmpCodecType::Unknown:
-			default:
 				codec_string = "unknown";
 				break;
 		}

--- a/src/projects/providers/rtmp/rtmp_stream.cpp
+++ b/src/projects/providers/rtmp/rtmp_stream.cpp
@@ -849,8 +849,8 @@ namespace pvd
 			(audio_available && (audio_codec_type != RtmpCodecType::AAC)))
 		{
 			logaw("AmfMeta has incompatible codec information. - video(%s) audio(%s)",
-				  GetCodecString(video_codec_type).CStr(),
-				  GetCodecString(audio_codec_type).CStr());
+				  ToString(video_codec_type),
+				  ToString(audio_codec_type));
 		}
 
 		return true;
@@ -2322,62 +2322,5 @@ namespace pvd
 		}
 
 		return SendAmfCommand(message_header, document);
-	}
-
-	ov::String RtmpStream::GetCodecString(RtmpCodecType codec_type)
-	{
-		ov::String codec_string;
-
-		switch (codec_type)
-		{
-			case RtmpCodecType::H264:
-				codec_string = "h264";
-				break;
-			case RtmpCodecType::AAC:
-				codec_string = "aac";
-				break;
-			case RtmpCodecType::MP3:
-				codec_string = "mp3";
-				break;
-			case RtmpCodecType::Speex:
-				codec_string = "speex";
-				break;
-			case RtmpCodecType::AV1:
-				codec_string = "av1";
-				break;
-
-			case RtmpCodecType::Unknown:
-				codec_string = "unknown";
-				break;
-		}
-
-		return codec_string;
-	}
-
-	ov::String RtmpStream::GetEncoderTypeString(RtmpEncoderType encoder_type)
-	{
-		ov::String codec_string;
-
-		switch (encoder_type)
-		{
-			case RtmpEncoderType::Xsplit:
-				codec_string = "Xsplit";
-				break;
-			case RtmpEncoderType::OBS:
-				codec_string = "OBS";
-				break;
-			case RtmpEncoderType::Lavf:
-				codec_string = "Lavf/ffmpeg";
-				break;
-			case RtmpEncoderType::Custom:
-				codec_string = "Unknown";
-				break;
-
-			default:
-				codec_string = "Unknown";
-				break;
-		}
-
-		return codec_string;
 	}
 }  // namespace pvd

--- a/src/projects/providers/rtmp/rtmp_stream.h
+++ b/src/projects/providers/rtmp/rtmp_stream.h
@@ -111,9 +111,6 @@ namespace pvd
 		bool ReceiveAudioMessage(const std::shared_ptr<const RtmpMessage> &message);
 		bool ReceiveVideoMessage(const std::shared_ptr<const RtmpMessage> &message);
 
-		ov::String GetCodecString(RtmpCodecType codec_type);
-		ov::String GetEncoderTypeString(RtmpEncoderType encoder_type);
-
 		bool CheckReadyToPublish();
 		bool PublishStream();
 		bool SetTrackInfo(const std::shared_ptr<RtmpMediaInfo> &media_info);

--- a/src/projects/providers/rtmp/tracks/rtmp_av1_track.cpp
+++ b/src/projects/providers/rtmp/tracks/rtmp_av1_track.cpp
@@ -1,0 +1,16 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include "./rtmp_av1_track.h"
+
+namespace pvd::rtmp
+{
+	// `RtmpAv1Track` defers all width/height extraction to `MediaRouterNormalize::ProcessAV1OBUStream()`,
+	// so this translation unit is intentionally minimal - mirroring `RtmpHevcTrack`, which has no overrides.
+	// The `cmn::MediaCodecId::Av1` + `cmn::BitstreamFormat::AV1_OBU` association is set by the base constructor.
+}  // namespace pvd::rtmp

--- a/src/projects/providers/rtmp/tracks/rtmp_av1_track.h
+++ b/src/projects/providers/rtmp/tracks/rtmp_av1_track.h
@@ -1,0 +1,25 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include "./rtmp_video_track.h"
+
+namespace pvd::rtmp
+{
+	class RtmpStreamV2;
+
+	class RtmpAv1Track : public RtmpVideoTrack
+	{
+	public:
+		RtmpAv1Track(std::shared_ptr<RtmpStreamV2> stream, uint32_t track_id, bool from_ex_header)
+			: RtmpVideoTrack(std::move(stream), track_id, from_ex_header, cmn::MediaCodecId::Av1, cmn::BitstreamFormat::AV1_OBU)
+		{
+		}
+	};
+}  // namespace pvd::rtmp

--- a/src/projects/providers/rtmp/tracks/rtmp_track.cpp
+++ b/src/projects/providers/rtmp/tracks/rtmp_track.cpp
@@ -11,6 +11,7 @@
 #include "../rtmp_provider_private.h"
 #include "../rtmp_stream_v2.h"
 #include "./rtmp_aac_track.h"
+#include "./rtmp_av1_track.h"
 #include "./rtmp_avc_track.h"
 #include "./rtmp_hevc_track.h"
 
@@ -25,7 +26,7 @@ namespace pvd::rtmp
 			OV_CASE_RETURN(cmn::MediaCodecId::H265, std::make_shared<RtmpHevcTrack>(stream, track_id, from_ex_header));
 			OV_CASE_RETURN(cmn::MediaCodecId::Vp8, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::Vp9, nullptr);
-			OV_CASE_RETURN(cmn::MediaCodecId::Av1, nullptr);
+			OV_CASE_RETURN(cmn::MediaCodecId::Av1, std::make_shared<RtmpAv1Track>(stream, track_id, from_ex_header));
 			OV_CASE_RETURN(cmn::MediaCodecId::Flv, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::Aac, std::make_shared<RtmpAacTrack>(stream, track_id, from_ex_header));
 			OV_CASE_RETURN(cmn::MediaCodecId::Mp2, nullptr);

--- a/src/projects/providers/rtmp/tracks/rtmp_video_track.cpp
+++ b/src/projects/providers/rtmp/tracks/rtmp_video_track.cpp
@@ -77,7 +77,12 @@ namespace pvd::rtmp
 				if (video_data->header == nullptr)
 				{
 					logte("%s sequence header is not found", cmn::GetCodecIdString(_codec_id));
+
+					// Release falls through to graceful reject.
+					// The parser failed to extract a decoder configuration record from the `SequenceStart` payload
+					// (e.g. a malformed or unsupported av1C/avcC/hevcC blob from remote input).
 					OV_ASSERT2(false);
+
 					return false;
 				}
 
@@ -94,7 +99,10 @@ namespace pvd::rtmp
 				if (video_data->payload == nullptr)
 				{
 					logte("%s payload is not found", cmn::GetCodecIdString(_codec_id));
+
+					// Release falls through to graceful reject of a remote-input `CodedFrames` record without a payload.
 					OV_ASSERT2(false);
+
 					return false;
 				}
 


### PR DESCRIPTION
## Summary
- Add AV1 codec support to the enhanced RTMP (E-RTMP) ingest pipeline
- Parse `AV1CodecConfigurationRecord` from `ExVideoTag` `SequenceStart`, with fallback for FFmpeg's `libaom-av1` muxer which sends an empty body (sequence header OBU delivered in-band in the first `CodedFrames` packet)
- Add `RtmpAv1Track` to route AV1 OBU streams through MediaRouter
- Show elapsed time since last key frame in RTMP stats log to detect stale key frame intervals
- Add unit tests for FLV AV1 parsing and track creation
