### PR TITLE
fix(llhls): block chunklist reload when _HLS_part is omitted

### DIFF
--- a/src/projects/publishers/llhls/llhls_stream.cpp
+++ b/src/projects/publishers/llhls/llhls_stream.cpp
@@ -885,12 +885,12 @@ std::tuple<LLHlsStream::RequestResult, std::shared_ptr<const ov::Data>> LLHlsStr
 		if (msn > last_msn || (msn >= last_msn && requested_psn > last_psn))
 		{
 			// Hold the request until a Playlist contains a Segment with the requested Sequence Number
-			logtt("Accepted chunklist for track_id = %d, msn = %ld, psn = %ld (last_msn = %ld, last_psn = %ld)", track_id, msn, psn, last_msn, last_psn);
+			logtt("Accepted chunklist for track_id = %d, msn = %ld, psn = %ld (requested_psn = %ld, last_msn = %ld, last_psn = %ld)", track_id, msn, psn, requested_psn, last_msn, last_psn);
 			return {RequestResult::Accepted, nullptr};
 		}
 		else
 		{
-			logtt("Get chunklist for track_id = %d, msn = %ld, psn = %ld (last_msn = %ld, last_psn = %ld)", track_id, msn, psn, last_msn, last_psn);
+			logtt("Get chunklist for track_id = %d, msn = %ld, psn = %ld (requested_psn = %ld, last_msn = %ld, last_psn = %ld)", track_id, msn, psn, requested_psn, last_msn, last_psn);
 		}
 	}
 

--- a/src/projects/publishers/llhls/llhls_stream.cpp
+++ b/src/projects/publishers/llhls/llhls_stream.cpp
@@ -868,7 +868,7 @@ std::tuple<LLHlsStream::RequestResult, std::shared_ptr<const ov::Data>> LLHlsStr
 		return {RequestResult::Accepted, nullptr};
 	}
 
-	if (msn >= 0 && psn >= 0)
+	if (msn >= 0)
 	{
 		int64_t last_msn, last_psn;
 		if (chunklist->GetLastSequenceNumber(last_msn, last_psn) == false)
@@ -877,7 +877,12 @@ std::tuple<LLHlsStream::RequestResult, std::shared_ptr<const ov::Data>> LLHlsStr
 			return {RequestResult::NotFound, nullptr};
 		}
 
-		if (msn > last_msn || (msn >= last_msn && psn > last_psn))
+		// When _HLS_part is omitted, treat it as part 0 so the request blocks until
+		// the first partial segment of the requested MSN is available (Safari sends
+		// _HLS_msn without _HLS_part to wait for a new segment's first part).
+		const int64_t requested_psn = (psn >= 0) ? psn : 0;
+
+		if (msn > last_msn || (msn >= last_msn && requested_psn > last_psn))
 		{
 			// Hold the request until a Playlist contains a Segment with the requested Sequence Number
 			logtt("Accepted chunklist for track_id = %d, msn = %ld, psn = %ld (last_msn = %ld, last_psn = %ld)", track_id, msn, psn, last_msn, last_psn);


### PR DESCRIPTION
Safari native LLHLS playback stalls a few seconds after start. The player requests a new segment's first part with `_HLS_msn` only (no `_HLS_part`), but the server skipped the blocking-reload check for part-less requests and returned a stale playlist immediately. This produced a tight request spin that saturated the connection pool, starved the video rendition, and froze playback. It regressed since #2037, which makes a completed segment emit its `EXTINF` before the next part exists and flips Safari from a part-indexed request to a part-less one.

Treat an omitted `_HLS_part` as part 0 in the chunklist blocking-reload check so the request blocks until the requested segment's first part is available. The existing pending-wake logic already handles a missing part index, so no other change is needed.