### PR TITLE
feat(webrtc): allow switching to an audio-only rendition in a video session

### DIFF
--- a/docs/live-source/webrtc.md
+++ b/docs/live-source/webrtc.md
@@ -235,6 +235,7 @@ Reference each layer by index using `<VideoIndexHint>` / `<AudioIndexHint>`:
         <FileName>template</FileName>
         <Options>
             <WebRtcAutoAbr>true</WebRtcAutoAbr>
+            <WebRtcAudioOnlyFallback>false</WebRtcAudioOnlyFallback>
             <HLSChunklistPathDepth>0</HLSChunklistPathDepth>
             <EnableTsPackaging>true</EnableTsPackaging>
         </Options>
@@ -270,6 +271,7 @@ Manually defining a Rendition per simulcast layer requires a config change and s
         <FileName>template</FileName>
         <Options>
             <WebRtcAutoAbr>true</WebRtcAutoAbr>
+            <WebRtcAudioOnlyFallback>false</WebRtcAudioOnlyFallback>
             <HLSChunklistPathDepth>0</HLSChunklistPathDepth>
             <EnableTsPackaging>true</EnableTsPackaging>
         </Options>

--- a/docs/streaming/webrtc-publishing.md
+++ b/docs/streaming/webrtc-publishing.md
@@ -218,6 +218,28 @@ It is not recommended to use a \<Bypass>true\</Bypass> encode item if you want a
 
 If `<Options>/<WebRtcAutoAbr>` is set to true, OvenMediaEngine will measure the bandwidth of the player session and automatically switch to the appropriate rendition.
 
+If `<Options>/<WebRtcAudioOnlyFallback>` is set to true, OvenMediaEngine cross-adds any audio-only rendition of the playlist (a `<Rendition>` with no `<Video>`) into every video playlist (codec bucket) that shares its audio codec. A WebRTC player can then switch to the audio-only rendition on the same PeerConnection without renegotiation — for example to keep audio while dropping video bandwidth when the player is in the background. The option is off by default. Automatic ABR never switches to the audio-only rendition; it is reachable only by an explicit rendition change, and a session that has switched to it stays there until the player switches back.
+
+```xml
+<Playlist>
+    <Name>for webrtc</Name>
+    <FileName>master</FileName>
+    <Options>
+        <WebRtcAutoAbr>true</WebRtcAutoAbr>
+        <WebRtcAudioOnlyFallback>true</WebRtcAudioOnlyFallback>
+    </Options>
+    <Rendition>
+        <Name>720p</Name>
+        <Video>720p</Video>
+        <Audio>opus</Audio>
+    </Rendition>
+    <Rendition>
+        <Name>audio</Name>
+        <Audio>opus</Audio>
+    </Rendition>
+</Playlist>
+```
+
 Here is an example play URL for ABR in the playlist settings below. `wss://domain:13334/app/stream/master`
 
 

--- a/docs/transcoding/abr.md
+++ b/docs/transcoding/abr.md
@@ -50,6 +50,13 @@ TS files used in HLS must have A/V pre-muxed, so the `EnableTsPackaging` option 
 			[Default] : true
 			-->
 			<WebRtcAutoAbr>true</WebRtcAutoAbr> 
+			<!-- 
+			Add audio-only renditions into the video WebRTC playlists that share their
+			audio codec, so a player can switch to them without renegotiation.
+			Automatic ABR never selects them. See WebRTC Streaming for details.
+			[Default] : false
+			-->
+			<WebRtcAudioOnlyFallback>false</WebRtcAudioOnlyFallback>
 			<EnableTsPackaging>true</EnableTsPackaging>
 		</Options>
 		<Rendition>

--- a/misc/conf_examples/Origin.xml
+++ b/misc/conf_examples/Origin.xml
@@ -228,6 +228,7 @@
 								<FileName>master</FileName>
 								<Options>
 									<WebRtcAutoAbr>true</WebRtcAutoAbr>
+									<WebRtcAudioOnlyFallback>false</WebRtcAudioOnlyFallback>
 									<HLSChunklistPathDepth>0</HLSChunklistPathDepth>
 									<EnableTsPackaging>true</EnableTsPackaging>
 								</Options>

--- a/misc/conf_examples/Server.xml
+++ b/misc/conf_examples/Server.xml
@@ -346,6 +346,7 @@
 								<FileName>master</FileName>
 								<Options>
 									<WebRtcAutoAbr>true</WebRtcAutoAbr>
+									<WebRtcAudioOnlyFallback>false</WebRtcAudioOnlyFallback>
 									<HLSChunklistPathDepth>0</HLSChunklistPathDepth>
 									<EnableTsPackaging>true</EnableTsPackaging>
 								</Options>

--- a/src/base/info/playlist.h
+++ b/src/base/info/playlist.h
@@ -111,6 +111,7 @@ namespace info
 			_file_name = other._file_name;
 			_is_default = other._is_default;
 			_webrtc_auto_abr = other._webrtc_auto_abr;
+			_webrtc_audio_only_fallback = other._webrtc_audio_only_fallback;
 			_hls_chunklist_path_depth = other._hls_chunklist_path_depth;
 			_enable_ts_packaging = other._enable_ts_packaging;
 
@@ -125,6 +126,7 @@ namespace info
 			ov::String out_str = ov::String::FormatString("Playlist(%s) : %s\n", _name.CStr(), _file_name.CStr());
 			out_str.AppendFormat("\tDefault : %s\n", _is_default ? "true" : "false");
 			out_str.AppendFormat("\tWebRTC Auto ABR : %s\n", _webrtc_auto_abr ? "true" : "false");
+			out_str.AppendFormat("\tWebRTC Audio-Only Fallback : %s\n", _webrtc_audio_only_fallback ? "true" : "false");
 			out_str.AppendFormat("\tHLS Chunklist Path Depth : %d\n", _hls_chunklist_path_depth);
 			out_str.AppendFormat("\tTS Packaging : %s\n", _enable_ts_packaging ? "true" : "false");
 
@@ -148,6 +150,16 @@ namespace info
 		bool IsWebRtcAutoAbr() const
 		{
 			return _webrtc_auto_abr;
+		}
+
+		void SetWebRtcAudioOnlyFallback(bool enabled)
+		{
+			_webrtc_audio_only_fallback = enabled;
+		}
+
+		bool IsWebRtcAudioOnlyFallback() const
+		{
+			return _webrtc_audio_only_fallback;
 		}
 
 		void EnableTsPackaging(bool enabled)
@@ -245,6 +257,11 @@ namespace info
 				return false;
 			}
 
+			if (_webrtc_audio_only_fallback != rhs._webrtc_audio_only_fallback)
+			{
+				return false;
+			}
+
 			if (_hls_chunklist_path_depth != rhs._hls_chunklist_path_depth)
 			{
 				return false;
@@ -284,6 +301,7 @@ namespace info
 		bool _is_default = false;
 
 		bool _webrtc_auto_abr = false;
+		bool _webrtc_audio_only_fallback = false;
 		int _hls_chunklist_path_depth = -1;
 		bool _enable_ts_packaging = false;
 		bool _enable_subtitles = true;

--- a/src/config/items/virtual_hosts/applications/output_profiles/playlist/options.h
+++ b/src/config/items/virtual_hosts/applications/output_profiles/playlist/options.h
@@ -21,6 +21,12 @@ namespace cfg
 				protected:
 					bool _webrtc_auto_abr		  = true;
 
+					// Expose audio-only renditions inside video playlists that share their audio
+					// codec, so a video WebRTC session can switch to audio-only on the same
+					// PeerConnection. Off by default: it changes the playlist advertised to a
+					// video session that also declares an audio-only rendition.
+					bool _webrtc_audio_only_fallback = false;
+
 					// If this option is true, ts publisher will use this playlist
 					bool _enable_ts_packaging	  = false;
 
@@ -33,6 +39,7 @@ namespace cfg
 
 				public:
 					CFG_DECLARE_CONST_REF_GETTER_OF(IsWebRtcAutoAbr, _webrtc_auto_abr);
+					CFG_DECLARE_CONST_REF_GETTER_OF(IsWebRtcAudioOnlyFallback, _webrtc_audio_only_fallback);
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetHlsChunklistPathDepth, _hls_chunklist_path_depth);
 					CFG_DECLARE_CONST_REF_GETTER_OF(IsTsPackagingEnabled, _enable_ts_packaging);
 					CFG_DECLARE_CONST_REF_GETTER_OF(IsSubtitlesEnabled, _enable_subtitles);
@@ -41,6 +48,7 @@ namespace cfg
 					void MakeList() override
 					{
 						Register<Optional>("WebRtcAutoAbr", &_webrtc_auto_abr);
+						Register<Optional>("WebRtcAudioOnlyFallback", &_webrtc_audio_only_fallback);
 						Register<Optional>({"HLSChunklistPathDepth", "hlsChunklistPathDepth"}, &_hls_chunklist_path_depth);
 						Register<Optional>("EnableTsPackaging", &_enable_ts_packaging);
 						Register<Optional>("EnableSubtitles", &_enable_subtitles);

--- a/src/config/items/virtual_hosts/applications/output_profiles/playlist/playlist.h
+++ b/src/config/items/virtual_hosts/applications/output_profiles/playlist/playlist.h
@@ -45,6 +45,7 @@ namespace cfg
 						auto playlist = std::make_shared<info::Playlist>(GetName(), GetFileName(), false);
 						playlist->SetHlsChunklistPathDepth(_options.GetHlsChunklistPathDepth());
 						playlist->SetWebRtcAutoAbr(_options.IsWebRtcAutoAbr());
+						playlist->SetWebRtcAudioOnlyFallback(_options.IsWebRtcAudioOnlyFallback());
 						playlist->EnableTsPackaging(_options.IsTsPackagingEnabled());
 						playlist->EnableSubtitles(_options.IsSubtitlesEnabled());
 

--- a/src/providers/ovt/ovt_stream.cpp
+++ b/src/providers/ovt/ovt_stream.cpp
@@ -352,6 +352,11 @@ namespace pvd
 					playlist->SetWebRtcAutoAbr(json_options["webrtcAutoAbr"].asBool());
 				}
 
+				if (json_options["webrtcAudioOnlyFallback"].isBool())
+				{
+					playlist->SetWebRtcAudioOnlyFallback(json_options["webrtcAudioOnlyFallback"].asBool());
+				}
+
 				if (json_options["hlsChunklistPathDepth"].isInt())
 				{
 					playlist->SetHlsChunklistPathDepth(json_options["hlsChunklistPathDepth"].asInt());

--- a/src/publishers/ovt/ovt_stream.cpp
+++ b/src/publishers/ovt/ovt_stream.cpp
@@ -129,6 +129,7 @@ bool OvtStream::GenerateDescription(Json::Value &out_description)
 
 		Json::Value json_options;
 		json_options["webrtcAutoAbr"] = playlist->IsWebRtcAutoAbr();
+		json_options["webrtcAudioOnlyFallback"] = playlist->IsWebRtcAudioOnlyFallback();
 		json_options["hlsChunklistPathDepth"] = playlist->GetHlsChunklistPathDepth();
 		json_options["enableTsPackaging"] = playlist->IsTsPackagingEnabled();
 

--- a/src/publishers/webrtc/rtc_playlist.h
+++ b/src/publishers/webrtc/rtc_playlist.h
@@ -8,6 +8,8 @@
 //==============================================================================
 #pragma once
 
+#include <vector>
+
 #include <base/common_types.h>
 #include <base/info/media_track.h>
 #include <modules/json_serdes/stream.h>
@@ -92,6 +94,11 @@ public:
 		_audio_codec_id = audio_codec_id;
 	}
 
+	// Expose the codecs this per-session playlist was built for, so the master
+	// playlist can cross-add audio-only renditions into matching video playlists.
+	cmn::MediaCodecId GetVideoCodecId() const { return _video_codec_id; }
+	cmn::MediaCodecId GetAudioCodecId() const { return _audio_codec_id; }
+
 	void SetWebRtcAutoAbr(bool auto_abr)
 	{
 		_webrtc_auto_abr = auto_abr;
@@ -123,12 +130,28 @@ public:
 	// Get next higher bitrates rendition
 	std::shared_ptr<const RtcRendition> GetNextHigherBitrateRendition(const std::shared_ptr<const RtcRendition> &base_rendition) const
 	{
+		// A session on an audio-only rendition inside a video playlist was put there by an
+		// explicit change_rendition; automatic ABR must keep it there (never auto-resume
+		// video) until the client explicitly switches back. An audio-only playlist
+		// (_video_codec_id == None) keeps normal bitrate ABR among its renditions.
+		if (_video_codec_id != cmn::MediaCodecId::None && base_rendition->GetVideoTrack() == nullptr)
+		{
+			return nullptr;
+		}
+
 		std::shared_ptr<const RtcRendition> next_rendition = nullptr;
 		uint64_t base_bitrates = base_rendition->GetBitrates();
 
 		for (const auto &[name, rendition] : _rendition_map)
 		{
 			if (rendition == base_rendition)
+			{
+				continue;
+			}
+
+			// Never auto-select an audio-only rendition as an ABR destination in a video
+			// playlist (an audio-only playlist keeps normal bitrate ABR among its renditions).
+			if (_video_codec_id != cmn::MediaCodecId::None && rendition->GetVideoTrack() == nullptr)
 			{
 				continue;
 			}
@@ -153,12 +176,27 @@ public:
 	// Get next lower bitrates rendition
 	std::shared_ptr<const RtcRendition> GetNextLowerBitrateRendition(const std::shared_ptr<const RtcRendition> &base_rendition) const
 	{
+		// See GetNextHigherBitrateRendition: a video session that explicitly switched to an
+		// audio-only rendition stays there; automatic ABR never moves it. An audio-only
+		// playlist (_video_codec_id == None) keeps normal bitrate ABR among its renditions.
+		if (_video_codec_id != cmn::MediaCodecId::None && base_rendition->GetVideoTrack() == nullptr)
+		{
+			return nullptr;
+		}
+
 		std::shared_ptr<const RtcRendition> next_rendition = nullptr;
 		uint64_t base_bitrates							   = base_rendition->GetBitrates();
 
 		for (const auto &[name, rendition] : _rendition_map)
 		{
 			if (rendition == base_rendition)
+			{
+				continue;
+			}
+
+			// Never auto-select an audio-only rendition as an ABR destination in a video
+			// playlist (an audio-only playlist keeps normal bitrate ABR among its renditions).
+			if (_video_codec_id != cmn::MediaCodecId::None && rendition->GetVideoTrack() == nullptr)
 			{
 				continue;
 			}
@@ -246,13 +284,46 @@ public:
 		return _webrtc_auto_abr;
 	}
 
+	// When enabled, audio-only renditions are cross-added into video playlists that share
+	// their audio codec (see AddRendition), so a video session can switch to audio-only.
+	void SetWebRtcAudioOnlyFallback(bool enabled)
+	{
+		_webrtc_audio_only_fallback = enabled;
+	}
+
+	bool IsWebRtcAudioOnlyFallback() const
+	{
+		return _webrtc_audio_only_fallback;
+	}
+
 	bool AddRendition(const std::shared_ptr<const RtcRendition> &rendition)
 	{
 		auto video_codec_id = rendition->GetVideoTrack() ? rendition->GetVideoTrack()->GetCodecId() : cmn::MediaCodecId::None;
 		auto audio_codec_id = rendition->GetAudioTrack() ? rendition->GetAudioTrack()->GetCodecId() : cmn::MediaCodecId::None;
 
-		auto playlist		= GetPlaylist(video_codec_id, audio_codec_id);
-		if (playlist == nullptr)
+		// An audio-only rendition (no video track) is otherwise bucketed into its own
+		// (None, audio) playlist, so a session that negotiated video never sees it and
+		// cannot switch down to audio-only on the SAME PeerConnection. When the feature is
+		// enabled, expose audio-only renditions inside every existing video playlist that
+		// shares the same audio codec.
+		if (_webrtc_audio_only_fallback && video_codec_id == cmn::MediaCodecId::None && audio_codec_id != cmn::MediaCodecId::None)
+		{
+			_audio_only_renditions.push_back(rendition);
+			for (auto &[key, pl] : _playlist_map)
+			{
+				// Match on audio codec id only: WebRTC advertises a single payload type per
+				// codec, so the audio-only rendition's packets ride the video playlist's
+				// already-negotiated audio payload type even though it is a different track.
+				if (pl->GetVideoCodecId() != cmn::MediaCodecId::None && pl->GetAudioCodecId() == audio_codec_id)
+				{
+					pl->AddRendition(rendition);
+				}
+			}
+		}
+
+		auto playlist		  = GetPlaylist(video_codec_id, audio_codec_id);
+		bool created_playlist = (playlist == nullptr);
+		if (created_playlist)
 		{
 			playlist = CreatePlaylist(video_codec_id, audio_codec_id);
 
@@ -262,7 +333,25 @@ public:
 			_playlist_map.emplace(GetPlaylistKey(video_codec_id, audio_codec_id), playlist);
 		}
 
+		// Add the triggering rendition first so it stays the playlist's default
+		// rendition (GetFirstRendition), before any cross-added audio-only rendition.
 		playlist->AddRendition(rendition);
+
+		// Back-fill a newly-created video playlist with audio-only renditions already
+		// seen that share its audio codec (handles an audio-only rendition declared
+		// before the video one). Done after the video rendition is added so the video
+		// rendition - not the audio-only one - remains the default.
+		if (_webrtc_audio_only_fallback && created_playlist && video_codec_id != cmn::MediaCodecId::None)
+		{
+			for (const auto &ao : _audio_only_renditions)
+			{
+				auto ao_audio = ao->GetAudioTrack() ? ao->GetAudioTrack()->GetCodecId() : cmn::MediaCodecId::None;
+				if (ao_audio == audio_codec_id)
+				{
+					playlist->AddRendition(ao);
+				}
+			}
+		}
 
 		AddPayloadTrack(rendition->GetVideoTrack());
 		AddPayloadTrack(rendition->GetAudioTrack());
@@ -325,6 +414,7 @@ private:
 	ov::String _name;
 	ov::String _file_name;
 	bool _webrtc_auto_abr = false;
+	bool _webrtc_audio_only_fallback = false;
 
 	// Track list for payload list
 	// OME specifies only one payload per codec in WebRTC SDP.
@@ -333,4 +423,7 @@ private:
 	// Key : string(%d_%d), video_codec_id, audio_codec_id
 	// Value : Rendition list
 	std::map<ov::String, std::shared_ptr<RtcPlaylist>> _playlist_map;
+
+	// Audio-only renditions, cross-added into matching video playlists (see AddRendition).
+	std::vector<std::shared_ptr<const RtcRendition>> _audio_only_renditions;
 };

--- a/src/publishers/webrtc/rtc_stream.cpp
+++ b/src/publishers/webrtc/rtc_stream.cpp
@@ -395,6 +395,7 @@ std::shared_ptr<RtcMasterPlaylist> RtcStream::CreateRtcMasterPlaylist(const ov::
 
 	auto rtc_master_playlist = std::make_shared<RtcMasterPlaylist>(file_name, playlist->GetName());
 	rtc_master_playlist->SetWebRtcAutoAbr(playlist->IsWebRtcAutoAbr());
+	rtc_master_playlist->SetWebRtcAudioOnlyFallback(playlist->IsWebRtcAudioOnlyFallback());
 
 	for (const auto &rendition : playlist->GetRenditionList())
 	{

--- a/src/publishers/webrtc/webrtc_test.cpp
+++ b/src/publishers/webrtc/webrtc_test.cpp
@@ -1,2 +1,260 @@
-// Placeholder — add tests here.
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
 #include <gtest/gtest.h>
+
+#include <base/info/media_track.h>
+
+#include "rtc_playlist.h"
+
+namespace
+{
+	using cmn::MediaCodecId;
+	using cmn::MediaType;
+
+	std::shared_ptr<const MediaTrack> MakeTrack(MediaType type, MediaCodecId codec, int32_t bitrate)
+	{
+		auto track = std::make_shared<MediaTrack>();
+		track->SetMediaType(type);
+		track->SetCodecId(codec);
+		track->SetBitrateByConfig(bitrate);
+		return track;
+	}
+
+	// v == None -> no video track; a == None -> no audio track.
+	std::shared_ptr<const RtcRendition> MakeRendition(const ov::String &name,
+													  MediaCodecId v, int32_t v_bitrate,
+													  MediaCodecId a, int32_t a_bitrate)
+	{
+		std::shared_ptr<const MediaTrack> vt = (v == MediaCodecId::None) ? nullptr : MakeTrack(MediaType::Video, v, v_bitrate);
+		std::shared_ptr<const MediaTrack> at = (a == MediaCodecId::None) ? nullptr : MakeTrack(MediaType::Audio, a, a_bitrate);
+		return std::make_shared<RtcRendition>(name, vt, at);
+	}
+
+	bool HasRendition(const std::shared_ptr<const RtcPlaylist> &pl, const char *name)
+	{
+		return (pl != nullptr) && (pl->GetRendition(name) != nullptr);
+	}
+}  // namespace
+
+// Audio-only rendition declared AFTER the video rendition is cross-added into the
+// video playlist; the video rendition remains the default (GetFirstRendition).
+TEST(RtcMasterPlaylist, CrossAddVideoThenAudio)
+{
+	RtcMasterPlaylist master("m", "m");
+	master.SetWebRtcAudioOnlyFallback(true);
+	master.AddRendition(MakeRendition("video", MediaCodecId::H264, 2000000, MediaCodecId::Opus, 128000));
+	master.AddRendition(MakeRendition("audio", MediaCodecId::None, 0, MediaCodecId::Opus, 48000));
+
+	auto vpl = master.GetPlaylist(MediaCodecId::H264, MediaCodecId::Opus);
+	ASSERT_NE(vpl, nullptr);
+	EXPECT_TRUE(HasRendition(vpl, "video"));
+	EXPECT_TRUE(HasRendition(vpl, "audio"));  // cross-added
+	ASSERT_NE(vpl->GetFirstRendition(), nullptr);
+	EXPECT_STREQ(vpl->GetFirstRendition()->GetName().CStr(), "video");
+	EXPECT_NE(vpl->GetFirstRendition()->GetVideoTrack(), nullptr);
+}
+
+// Audio-only rendition declared BEFORE the video rendition is back-filled into the
+// later-created video playlist; the video rendition (not the earlier audio-only one)
+// must remain the playlist default regardless of declaration order.
+TEST(RtcMasterPlaylist, BackFillAudioThenVideo)
+{
+	RtcMasterPlaylist master("m", "m");
+	master.SetWebRtcAudioOnlyFallback(true);
+	master.AddRendition(MakeRendition("audio", MediaCodecId::None, 0, MediaCodecId::Opus, 48000));
+	master.AddRendition(MakeRendition("video", MediaCodecId::H264, 2000000, MediaCodecId::Opus, 128000));
+
+	auto vpl = master.GetPlaylist(MediaCodecId::H264, MediaCodecId::Opus);
+	ASSERT_NE(vpl, nullptr);
+	EXPECT_TRUE(HasRendition(vpl, "video"));
+	EXPECT_TRUE(HasRendition(vpl, "audio"));  // back-filled
+	ASSERT_NE(vpl->GetFirstRendition(), nullptr);
+	EXPECT_STREQ(vpl->GetFirstRendition()->GetName().CStr(), "video");
+	EXPECT_NE(vpl->GetFirstRendition()->GetVideoTrack(), nullptr);
+}
+
+// In a video playlist, automatic bitrate ABR never selects the audio-only rendition,
+// even though it is the lowest bitrate; it stays reachable only by name.
+TEST(RtcPlaylist, VideoPlaylistAbrExcludesAudioOnly)
+{
+	RtcMasterPlaylist master("m", "m");
+	master.SetWebRtcAudioOnlyFallback(true);
+	master.AddRendition(MakeRendition("high", MediaCodecId::H264, 2000000, MediaCodecId::Opus, 128000));
+	master.AddRendition(MakeRendition("low", MediaCodecId::H264, 300000, MediaCodecId::Opus, 128000));
+	master.AddRendition(MakeRendition("audio", MediaCodecId::None, 0, MediaCodecId::Opus, 48000));
+
+	auto vpl = master.GetPlaylist(MediaCodecId::H264, MediaCodecId::Opus);
+	ASSERT_NE(vpl, nullptr);
+	auto high = vpl->GetRendition("high");
+	auto low = vpl->GetRendition("low");
+	auto audio = vpl->GetRendition("audio");
+	ASSERT_NE(high, nullptr);
+	ASSERT_NE(low, nullptr);
+	ASSERT_NE(audio, nullptr);
+
+	// audio-only is the lowest bitrate but must be skipped: no lower rendition than low video
+	EXPECT_EQ(vpl->GetNextLowerBitrateRendition(low), nullptr);
+	// from high, the next lower is the low *video* rendition
+	EXPECT_EQ(vpl->GetNextLowerBitrateRendition(high), low);
+	// from low, the next higher is the high video rendition
+	EXPECT_EQ(vpl->GetNextHigherBitrateRendition(low), high);
+	// audio-only is never an ABR destination
+	EXPECT_NE(vpl->GetNextLowerBitrateRendition(high), audio);
+}
+
+// The audio-only rendition's bitrate is placed BETWEEN the two video renditions, so without
+// the guard it would be the closest ABR neighbour in BOTH directions (next-lower from the high
+// rendition, next-higher from the low rendition). The guard must skip it either way, so ABR
+// steps between the video renditions and never onto audio-only. Every assertion here flips if
+// the guard is removed, unlike the lowest-rung case above.
+TEST(RtcPlaylist, VideoPlaylistAbrSkipsInterstitialAudioOnly)
+{
+	RtcMasterPlaylist master("m", "m");
+	master.SetWebRtcAudioOnlyFallback(true);
+	master.AddRendition(MakeRendition("vhigh", MediaCodecId::H264, 2000000, MediaCodecId::Opus, 128000));
+	master.AddRendition(MakeRendition("vlow", MediaCodecId::H264, 300000, MediaCodecId::Opus, 128000));
+	master.AddRendition(MakeRendition("audio", MediaCodecId::None, 0, MediaCodecId::Opus, 800000));
+
+	auto vpl = master.GetPlaylist(MediaCodecId::H264, MediaCodecId::Opus);
+	ASSERT_NE(vpl, nullptr);
+	auto vhigh = vpl->GetRendition("vhigh");
+	auto vlow = vpl->GetRendition("vlow");
+	auto audio = vpl->GetRendition("audio");
+	ASSERT_NE(vhigh, nullptr);
+	ASSERT_NE(vlow, nullptr);
+	ASSERT_NE(audio, nullptr);
+	// precondition: audio-only really is the closest neighbour by bitrate in both directions
+	ASSERT_GT(audio->GetBitrates(), vlow->GetBitrates());
+	ASSERT_LT(audio->GetBitrates(), vhigh->GetBitrates());
+
+	// down from vhigh: without the guard the closest lower is audio; with the guard, vlow
+	EXPECT_EQ(vpl->GetNextLowerBitrateRendition(vhigh), vlow);
+	EXPECT_NE(vpl->GetNextLowerBitrateRendition(vhigh), audio);
+	// up from vlow: without the guard the closest higher is audio; with the guard, vhigh
+	EXPECT_EQ(vpl->GetNextHigherBitrateRendition(vlow), vhigh);
+	EXPECT_NE(vpl->GetNextHigherBitrateRendition(vlow), audio);
+}
+
+// A video session that explicitly switched to the audio-only rendition stays there:
+// automatic ABR must not move it in either direction (so it does not auto-resume video when
+// bandwidth recovers, even if the client left auto-ABR enabled). The audio-only bitrate is
+// placed between the two video renditions so both directions would otherwise pick a video
+// rendition; the pin must return null both ways.
+TEST(RtcPlaylist, VideoPlaylistAbrPinsAudioOnlyBase)
+{
+	RtcMasterPlaylist master("m", "m");
+	master.SetWebRtcAudioOnlyFallback(true);
+	master.AddRendition(MakeRendition("vhigh", MediaCodecId::H264, 2000000, MediaCodecId::Opus, 128000));
+	master.AddRendition(MakeRendition("vlow", MediaCodecId::H264, 300000, MediaCodecId::Opus, 128000));
+	master.AddRendition(MakeRendition("audio", MediaCodecId::None, 0, MediaCodecId::Opus, 800000));
+
+	auto vpl = master.GetPlaylist(MediaCodecId::H264, MediaCodecId::Opus);
+	ASSERT_NE(vpl, nullptr);
+	auto audio = vpl->GetRendition("audio");
+	ASSERT_NE(audio, nullptr);
+	EXPECT_EQ(vpl->GetNextHigherBitrateRendition(audio), nullptr);
+	EXPECT_EQ(vpl->GetNextLowerBitrateRendition(audio), nullptr);
+}
+
+// Regression guard: in an audio-only playlist (an audio-only subscriber's bucket),
+// bitrate ABR still works normally among the Opus renditions.
+TEST(RtcPlaylist, AudioOnlyPlaylistAbrWorks)
+{
+	RtcMasterPlaylist master("m", "m");
+	master.SetWebRtcAudioOnlyFallback(true);
+	master.AddRendition(MakeRendition("a_hi", MediaCodecId::None, 0, MediaCodecId::Opus, 128000));
+	master.AddRendition(MakeRendition("a_mid", MediaCodecId::None, 0, MediaCodecId::Opus, 64000));
+	master.AddRendition(MakeRendition("a_lo", MediaCodecId::None, 0, MediaCodecId::Opus, 32000));
+
+	auto apl = master.GetPlaylist(MediaCodecId::None, MediaCodecId::Opus);
+	ASSERT_NE(apl, nullptr);
+	auto hi = apl->GetRendition("a_hi");
+	auto mid = apl->GetRendition("a_mid");
+	auto lo = apl->GetRendition("a_lo");
+	ASSERT_NE(hi, nullptr);
+	ASSERT_NE(mid, nullptr);
+	ASSERT_NE(lo, nullptr);
+
+	EXPECT_EQ(apl->GetNextLowerBitrateRendition(hi), mid);
+	EXPECT_EQ(apl->GetNextLowerBitrateRendition(mid), lo);
+	EXPECT_EQ(apl->GetNextLowerBitrateRendition(lo), nullptr);
+	EXPECT_EQ(apl->GetNextHigherBitrateRendition(lo), mid);
+}
+
+// A stream with only video renditions: nothing is cross-added, normal video ABR holds.
+TEST(RtcMasterPlaylist, NoAudioOnlyNoCrossAdd)
+{
+	RtcMasterPlaylist master("m", "m");
+	master.SetWebRtcAudioOnlyFallback(true);
+	master.AddRendition(MakeRendition("high", MediaCodecId::H264, 2000000, MediaCodecId::Opus, 128000));
+	master.AddRendition(MakeRendition("low", MediaCodecId::H264, 300000, MediaCodecId::Opus, 128000));
+
+	auto vpl = master.GetPlaylist(MediaCodecId::H264, MediaCodecId::Opus);
+	ASSERT_NE(vpl, nullptr);
+	EXPECT_EQ(vpl->GetRenditions().size(), 2u);
+	EXPECT_EQ(vpl->GetNextLowerBitrateRendition(vpl->GetRendition("high")), vpl->GetRendition("low"));
+}
+
+// An audio-only rendition is cross-added only into video playlists that share its
+// audio codec: an Opus audio-only rendition is not added to an AAC video playlist.
+TEST(RtcMasterPlaylist, MismatchedAudioCodecNoCrossAdd)
+{
+	RtcMasterPlaylist master("m", "m");
+	master.SetWebRtcAudioOnlyFallback(true);
+	master.AddRendition(MakeRendition("video", MediaCodecId::H264, 2000000, MediaCodecId::Aac, 128000));
+	master.AddRendition(MakeRendition("audio", MediaCodecId::None, 0, MediaCodecId::Opus, 48000));
+
+	auto vpl = master.GetPlaylist(MediaCodecId::H264, MediaCodecId::Aac);
+	ASSERT_NE(vpl, nullptr);
+	EXPECT_TRUE(HasRendition(vpl, "video"));
+	EXPECT_FALSE(HasRendition(vpl, "audio"));
+}
+
+// An audio-only rendition is cross-added into EVERY video playlist that shares its audio codec.
+TEST(RtcMasterPlaylist, CrossAddToMultipleVideoPlaylists)
+{
+	RtcMasterPlaylist master("m", "m");
+	master.SetWebRtcAudioOnlyFallback(true);
+	master.AddRendition(MakeRendition("h264", MediaCodecId::H264, 2000000, MediaCodecId::Opus, 128000));
+	master.AddRendition(MakeRendition("vp8", MediaCodecId::Vp8, 2000000, MediaCodecId::Opus, 128000));
+	master.AddRendition(MakeRendition("audio", MediaCodecId::None, 0, MediaCodecId::Opus, 48000));
+
+	EXPECT_TRUE(HasRendition(master.GetPlaylist(MediaCodecId::H264, MediaCodecId::Opus), "audio"));
+	EXPECT_TRUE(HasRendition(master.GetPlaylist(MediaCodecId::Vp8, MediaCodecId::Opus), "audio"));
+}
+
+// Video-only renditions (no audio track): no crash, their own (video,None) bucket, ABR among
+// them works, and an Opus audio-only rendition is not injected into the audio-less video playlist.
+TEST(RtcMasterPlaylist, VideoOnlyRenditionsNoAudioTrack)
+{
+	RtcMasterPlaylist master("m", "m");
+	master.SetWebRtcAudioOnlyFallback(true);
+	master.AddRendition(MakeRendition("v_hi", MediaCodecId::H264, 2000000, MediaCodecId::None, 0));
+	master.AddRendition(MakeRendition("v_lo", MediaCodecId::H264, 300000, MediaCodecId::None, 0));
+	master.AddRendition(MakeRendition("audio", MediaCodecId::None, 0, MediaCodecId::Opus, 48000));
+
+	auto vpl = master.GetPlaylist(MediaCodecId::H264, MediaCodecId::None);
+	ASSERT_NE(vpl, nullptr);
+	EXPECT_FALSE(HasRendition(vpl, "audio"));  // audio codec None != Opus -> not cross-added
+	EXPECT_EQ(vpl->GetNextLowerBitrateRendition(vpl->GetRendition("v_hi")), vpl->GetRendition("v_lo"));
+}
+
+// With the fallback disabled (the default), an audio-only rendition is NOT cross-added into a
+// video playlist; it stays only in its own (None, audio) playlist.
+TEST(RtcMasterPlaylist, AudioOnlyFallbackDisabledNoCrossAdd)
+{
+	RtcMasterPlaylist master("m", "m");
+	master.SetWebRtcAudioOnlyFallback(false);  // explicit; this is the default
+	master.AddRendition(MakeRendition("video", MediaCodecId::H264, 2000000, MediaCodecId::Opus, 128000));
+	master.AddRendition(MakeRendition("audio", MediaCodecId::None, 0, MediaCodecId::Opus, 48000));
+
+	// not exposed to a video session...
+	EXPECT_FALSE(HasRendition(master.GetPlaylist(MediaCodecId::H264, MediaCodecId::Opus), "audio"));
+	// ...but still available in its own audio-only playlist
+	EXPECT_TRUE(HasRendition(master.GetPlaylist(MediaCodecId::None, MediaCodecId::Opus), "audio"));
+}


### PR DESCRIPTION
One more PR for now, again full disclosure all coded by claude, this is a much smaller change though. 

The very short version is that this lets us downgrade background-tab WebRTC streams to audio only, saving a bunch of bandwidth


## Problem

`RtcMasterPlaylist` buckets renditions by `(video_codec_id, audio_codec_id)`, so an
audio-only rendition (video codec `None`) lands in its own `(None, audio)` playlist that
a session which negotiated video never sees. A WebRTC video session therefore cannot
switch to an audio-only rendition on the same `PeerConnection` — which is useful for
keeping audio while dropping all video traffic without renegotiating, for example when a
player is backgrounded or hidden.

## Change

A new playlist option `WebRtcAudioOnlyFallback` (off by default) enables the behaviour.
When it is set:

- Each audio-only rendition is cross-added into every video playlist that shares its
  audio codec, and back-filled into video playlists created after the audio-only
  rendition is first seen (so config declaration order does not matter).
- The triggering video rendition is added before any cross-added audio-only rendition, so
  it stays the playlist default (`GetFirstRendition`) — a session always starts on video.

Because the option defaults to off, existing configurations are unaffected.

## ABR semantics

Within a video playlist, automatic bitrate ABR never moves a session onto, or off of, the
audio-only rendition:

- `GetNextHigherBitrateRendition` / `GetNextLowerBitrateRendition` skip audio-only
  candidates, so congestion never drops a video session down to audio-only.
- They also pin a session whose current rendition is audio-only (return `nullptr` in both
  directions), so a session that switched to audio-only is not auto-resumed to video even
  if the client left auto-ABR enabled.

So the audio-only rendition is reachable only by an explicit `change_rendition`, and the
session stays there until the client switches back. Both behaviours are gated on the
playlist being a video playlist, so an audio-only playlist still performs normal bitrate
ABR among its own renditions.

No SDP or renegotiation changes are needed: `rtc_session` already supports switching to a
video-less rendition on an established `PeerConnection`, and the audio-only rendition is
advertised in the `playlist` notification so a client can request it by name.

## Config example

```xml
<Playlist>
    <Name>webrtc</Name>
    <FileName>webrtc</FileName>
    <Options>
        <WebRtcAutoAbr>true</WebRtcAutoAbr>
        <WebRtcAudioOnlyFallback>true</WebRtcAudioOnlyFallback>
    </Options>
    <Rendition>
        <Name>720p</Name>
        <Video>720p</Video>
        <Audio>opus</Audio>
    </Rendition>
    <Rendition>
        <Name>audio</Name>
        <Audio>opus</Audio>
    </Rendition>
</Playlist>
```

The video and audio-only renditions must share the same audio codec for the cross-add to
apply. The option is documented in `docs/streaming/webrtc-publishing.md`.

## Testing

Adds gtest coverage in `src/projects/publishers/webrtc/webrtc_test.cpp` for
`RtcMasterPlaylist` / `RtcPlaylist`: cross-add and back-fill ordering, the
video-rendition-stays-default invariant, ABR exclusion of audio-only in a video playlist
(including an audio-only rendition whose bitrate sits between two video renditions, and the
pinning of an explicitly-selected audio-only rendition against auto-ABR), normal bitrate
ABR within an audio-only playlist, codec-mismatch and multiple-video-playlist cases,
video-only renditions with no audio track, and the option being disabled by default.
