### PR TITLE
perf(phyport): add `SO_REUSEPORT` support for UDP physical ports

### DIFF
--- a/src/projects/base/ovsocket/socket_pool/socket_pool.cpp
+++ b/src/projects/base/ovsocket/socket_pool/socket_pool.cpp
@@ -44,14 +44,14 @@ namespace ov
 	{
 		if (_initialized)
 		{
-			logaw("Epoll is already initialized");
+			logaw("%s is already initialized", ToString().CStr());
 			return false;
 		}
 
 		if (_thread_per_socket)
 		{
 			_initialized  = true;
-			logai("Socket pool (%s) is initialized with thread per socket mode", ToString().CStr());
+			logai("%s is initialized with thread per socket mode", ToString().CStr());
 
 			_timer.Push(
 				[this](void *parameter) -> ov::DelayQueueAction {
@@ -178,8 +178,8 @@ namespace ov
 		LockGuard lock_guard(_worker_list_mutex);
 
 		description.AppendFormat(
-			"<SocketPool: %p, workers: %zu",
-			this, _worker_list.size());
+			"<SocketPool: %p, %s, workers: %zu",
+			this, _name.CStr(), _worker_list.size());
 
 		for (auto &worker : _worker_list)
 		{

--- a/src/projects/modules/ice/ice_port.cpp
+++ b/src/projects/modules/ice/ice_port.cpp
@@ -922,7 +922,7 @@ void IcePort::OnStunPacketReceived(const std::shared_ptr<ov::Socket> &remote, co
 	}
 }
 
-bool IcePort::MarkNominated(const std::shared_ptr<IceSession> &ice_session, const ov::SocketAddressPair &address_pair)
+bool IcePort::MarkNominated(const std::shared_ptr<const ov::Socket> &remote, const std::shared_ptr<IceSession> &ice_session, const ov::SocketAddressPair &address_pair)
 {
 	if (ice_session->MarkNominated(address_pair) == false)
 	{
@@ -949,8 +949,9 @@ bool IcePort::MarkNominated(const std::shared_ptr<IceSession> &ice_session, cons
 		}
 	}
 
-	logti("Session %u nominated candidate: %s%s", ice_session->GetSessionID(),
-		  address_pair.ToString().CStr(), transport);
+	logti("Session %u nominated candidate: %s%s (socket fd: %d)", ice_session->GetSessionID(),
+		  address_pair.ToString().CStr(), transport,
+		  (remote != nullptr) ? remote->GetNativeHandle() : -1);
 
 	return true;
 }
@@ -1010,7 +1011,7 @@ bool IcePort::OnReceivedStunBindingRequest(const std::shared_ptr<ov::Socket> &re
 		auto use_candidate_attr = message.GetAttribute<StunAttribute>(StunAttributeType::UseCandidate);
 		if (use_candidate_attr != nullptr)
 		{
-			MarkNominated(ice_session, address_pair);
+			MarkNominated(remote, ice_session, address_pair);
 		}
 	}
 
@@ -1101,7 +1102,7 @@ bool IcePort::SendStunBindingRequest(const std::shared_ptr<ov::Socket> &remote, 
 		// decided later by where the peer sends application data.
 		if (ice_session->IsConnectable(address_pair))
 		{
-			MarkNominated(ice_session, address_pair);
+			MarkNominated(remote, ice_session, address_pair);
 
 			auto use_candidate_attr = std::make_shared<StunUseCandidateAttribute>();
 			message.AddAttribute(use_candidate_attr);
@@ -1181,7 +1182,7 @@ bool IcePort::OnReceivedStunBindingResponse(const std::shared_ptr<ov::Socket> &r
 	// On the first time this pair is validated, nominate it and immediately
 	// send a binding request so the peer receives USE-CANDIDATE quickly.
 	// MarkNominated() is idempotent, so this burst happens once per pair.
-	if (ice_session->IsConnectable(address_pair) && MarkNominated(ice_session, address_pair))
+	if (ice_session->IsConnectable(address_pair) && MarkNominated(remote, ice_session, address_pair))
 	{
 		SendStunBindingRequest(remote, address_pair, gate_info, ice_session);
 	}

--- a/src/projects/modules/ice/ice_port.h
+++ b/src/projects/modules/ice/ice_port.h
@@ -206,7 +206,7 @@ private:
 	bool OnReceivedTurnCreatePermissionRequest(const std::shared_ptr<ov::Socket> &remote, const ov::SocketAddressPair &address_pair, GateInfo &packet_info, const StunMessage &message);
 	bool OnReceivedTurnChannelBindRequest(const std::shared_ptr<ov::Socket> &remote, const ov::SocketAddressPair &address_pair, GateInfo &packet_info, const StunMessage &message);
 
-	bool MarkNominated(const std::shared_ptr<IceSession> &ice_session, const ov::SocketAddressPair &address_pair);
+	bool MarkNominated(const std::shared_ptr<const ov::Socket> &remote, const std::shared_ptr<IceSession> &ice_session, const ov::SocketAddressPair &address_pair);
 
 	// Related TURN
 	std::shared_ptr<ov::Data> _hmac_key;

--- a/src/projects/modules/ice/ice_port_test.cpp
+++ b/src/projects/modules/ice/ice_port_test.cpp
@@ -44,7 +44,10 @@ protected:
 	std::shared_ptr<IceSession> FindUfrag(IcePort &p, const ov::String &u) { return p.FindIceSession(u); }
 	std::shared_ptr<IceSession> FindPair(IcePort &p, const ov::SocketAddressPair &ap) { return p.FindIceSession(ap); }
 
-	bool MarkNom(IcePort &p, const std::shared_ptr<IceSession> &s, const ov::SocketAddressPair &ap) { return p.MarkNominated(s, ap); }
+	bool MarkNom(IcePort &p, const std::shared_ptr<IceSession> &s, const ov::SocketAddressPair &ap)
+	{
+		return p.MarkNominated(nullptr, s, ap);
+	}
 
 	// Stop the background sweeper so these registry tests are deterministic and
 	// free of a data race between CheckTimedOut() and the helpers below. The

--- a/src/projects/modules/physical_port/physical_port.cpp
+++ b/src/projects/modules/physical_port/physical_port.cpp
@@ -179,12 +179,8 @@ bool PhysicalPort::CreateDatagramSocket(
 		return false;
 	}
 
-#ifndef SO_REUSEPORT
-	// Without `SO_REUSEPORT` only a single datagram socket is created, so a single worker is enough -
-	// initializing more would just leave idle epoll threads.
-	worker_count = 1;
-#endif	// SO_REUSEPORT
-
+	// Without `SO_REUSEPORT` only a single datagram socket is created, so the caller
+	// (`PhysicalPortManager::CreatePort()`) already clamps `worker_count` to 1 on those platforms.
 	if (_socket_pool->Initialize(worker_count) == false)
 	{
 		_socket_pool = nullptr;
@@ -238,7 +234,7 @@ bool PhysicalPort::CreateDatagramSocket(
 			continue;
 		}
 
-		logtd("Created SO_REUSEPORT datagram socket fd=%d, worker %d/%d, address=%s",
+		logtd("Created SO_REUSEPORT datagram socket fd=%d, socket %d/%d, address=%s",
 			  socket->GetNativeHandle(), index + 1, worker_count,
 			  address.ToString().CStr());
 

--- a/src/projects/modules/physical_port/physical_port.cpp
+++ b/src/projects/modules/physical_port/physical_port.cpp
@@ -364,6 +364,12 @@ void PhysicalPort::OnDatagram(const std::shared_ptr<ov::DatagramSocket> &client,
 
 bool PhysicalPort::Close()
 {
+	// `Close()` may be called directly (outside `PhysicalPortManager::DeletePort()`), so make it idempotent.
+	if (_socket_pool == nullptr)
+	{
+		return true;
+	}
+
 	if (_server_socket != nullptr)
 	{
 		_socket_pool->ReleaseSocket(_server_socket);

--- a/src/projects/modules/physical_port/physical_port.cpp
+++ b/src/projects/modules/physical_port/physical_port.cpp
@@ -191,7 +191,8 @@ bool PhysicalPort::CreateDatagramSocket(
 
 #ifdef SO_REUSEPORT
 	// Set `SO_REUSEPORT` before `Bind()` via the additional-options callback.
-	// On failure, returns an error so the loop skips this socket and the caller falls back to a single non-reuseport socket.
+	// On failure, returns an error so the loop skips this socket;
+	// the caller falls back to a single non-reuseport socket only if every socket fails (`succeeded_count == 0`).
 	auto reuseport_callback = [on_socket_created](const std::shared_ptr<ov::Socket> &socket) -> std::shared_ptr<ov::Error> {
 		if (socket->SetSockOpt<int>(SO_REUSEPORT, 1) == false)
 		{

--- a/src/projects/modules/physical_port/physical_port.cpp
+++ b/src/projects/modules/physical_port/physical_port.cpp
@@ -257,7 +257,7 @@ bool PhysicalPort::CreateDatagramSocket(
 		  address.ToString().CStr());
 #else	// SO_REUSEPORT
 	// `SO_REUSEPORT` is unavailable at build time - create a single datagram socket directly to avoid redundant work and log spam
-	logti("SO_REUSEPORT is not supported on this platform, creating a single datagram socket for %s",
+	logtw("SO_REUSEPORT is not supported on this platform, creating a single datagram socket for %s",
 		  address.ToString().CStr());
 #endif	// SO_REUSEPORT
 

--- a/src/projects/modules/physical_port/physical_port.cpp
+++ b/src/projects/modules/physical_port/physical_port.cpp
@@ -231,7 +231,7 @@ bool PhysicalPort::CreateDatagramSocket(
 			continue;
 		}
 
-		logti("Created SO_REUSEPORT datagram socket fd=%d, worker %d/%d, address=%s",
+		logtd("Created SO_REUSEPORT datagram socket fd=%d, worker %d/%d, address=%s",
 			  socket->GetNativeHandle(), index + 1, worker_count,
 			  address.ToString().CStr());
 

--- a/src/projects/modules/physical_port/physical_port.cpp
+++ b/src/projects/modules/physical_port/physical_port.cpp
@@ -255,7 +255,10 @@ bool PhysicalPort::CreateDatagramSocket(
 		return true;
 	}
 
-	// All `SO_REUSEPORT` sockets failed at runtime - fall back to a single socket without it
+	// All `SO_REUSEPORT` sockets failed at runtime - fall back to a single socket without it.
+	// The pool intentionally keeps its `worker_count` workers (some now idle): the caller requested that
+	// many and `GetWorkerCount()` must stay consistent with the request, so we do not resize the pool on
+	// this rare degraded path. The partial-failure case above leaves idle workers for the same reason.
 	logtw("SO_REUSEPORT sockets could not be created, falling back to a single datagram socket for %s",
 		  address.ToString().CStr());
 #else	// SO_REUSEPORT

--- a/src/projects/modules/physical_port/physical_port.cpp
+++ b/src/projects/modules/physical_port/physical_port.cpp
@@ -79,10 +79,11 @@ bool PhysicalPort::Create(const char *name,
 						  int recv_buffer_size,
 						  const OnSocketCreated on_socket_created)
 {
-	if ((_server_socket != nullptr) || (_datagram_socket != nullptr))
+	if ((_server_socket != nullptr) || (_datagram_sockets.empty() == false))
 	{
 		logte("Physical port already created");
-		OV_ASSERT2((_server_socket == nullptr) && (_datagram_socket == nullptr));
+		OV_ASSERT2((_server_socket == nullptr) && (_datagram_sockets.empty()));
+		return false;
 	}
 
 	_name = name;
@@ -173,37 +174,112 @@ bool PhysicalPort::CreateDatagramSocket(
 {
 	_socket_pool = ov::SocketPool::Create(GetSocketPoolName(type, name, address), type, thread_per_socket);
 
-	if (_socket_pool != nullptr)
+	if (_socket_pool == nullptr)
 	{
-		if (_socket_pool->Initialize(worker_count))
-		{
-			auto socket = _socket_pool->AllocSocket<ov::DatagramSocket>(address.GetFamily());
-
-			if (socket != nullptr)
-			{
-				if (socket->Prepare(
-							 address,
-							 on_socket_created,
-							 std::bind(&PhysicalPort::OnDatagram, this,
-									   std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)))
-				{
-					_type = type;
-					_datagram_socket = socket;
-					_address = address;
-
-					return true;
-				}
-
-				_socket_pool->ReleaseSocket(socket);
-			}
-
-			OV_SAFE_RESET(_socket_pool, nullptr, _socket_pool->Uninitialize(), _socket_pool);
-		}
-		else
-		{
-			_socket_pool = nullptr;
-		}
+		return false;
 	}
+
+	if (_socket_pool->Initialize(worker_count) == false)
+	{
+		_socket_pool = nullptr;
+		return false;
+	}
+
+	auto datagram_callback = std::bind(
+		&PhysicalPort::OnDatagram, this,
+		std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+
+	// Set `SO_REUSEPORT` before `Bind()` via the additional-options callback.
+	// On failure, returns an error so the loop skips this socket and the caller falls back to a single non-reuseport socket.
+	auto reuseport_callback = [on_socket_created](const std::shared_ptr<ov::Socket> &socket) -> std::shared_ptr<ov::Error> {
+#ifdef SO_REUSEPORT
+		if (socket->SetSockOpt<int>(SO_REUSEPORT, 1) == false)
+		{
+			logtw("Failed to set SO_REUSEPORT on socket fd %d", socket->GetNativeHandle());
+			return ov::Error::CreateError(
+				"PhyPort",
+				"Failed to set SO_REUSEPORT on socket fd %d", socket->GetNativeHandle());
+		}
+
+		return (on_socket_created != nullptr)
+				   ? on_socket_created(socket)
+				   : nullptr;
+#else	// SO_REUSEPORT
+		logtw("SO_REUSEPORT is not available on this platform (socket fd %d)", socket->GetNativeHandle());
+		return ov::Error::CreateError("PhyPort", "SO_REUSEPORT is not available on this platform");
+#endif	// SO_REUSEPORT
+	};
+
+	// Create `worker_count` sockets with `SO_REUSEPORT` - the kernel distributes incoming UDP packets across them by 4-tuple hash.
+	// `AllocSocket()` internally calls `GetLeastBusyWorker()`, but since we allocate exactly N sockets to N workers it's effectively a 1:1 assignment.
+	auto succeeded_count = 0;
+
+	for (auto index = 0; index < worker_count; index++)
+	{
+		auto socket = _socket_pool->AllocSocket<ov::DatagramSocket>(address.GetFamily());
+
+		if (socket == nullptr)
+		{
+			logtw("Failed to allocate datagram socket %d/%d for %s",
+				  index + 1, worker_count, address.ToString().CStr());
+
+			continue;
+		}
+
+		if (socket->Prepare(address, reuseport_callback, datagram_callback) == false)
+		{
+			logtw("Failed to prepare datagram socket %d/%d for %s",
+				  index + 1, worker_count, address.ToString().CStr());
+
+			_socket_pool->ReleaseSocket(socket);
+			continue;
+		}
+
+		logti("Created SO_REUSEPORT datagram socket fd=%d, worker %d/%d, address=%s",
+			  socket->GetNativeHandle(), index + 1, worker_count,
+			  address.ToString().CStr());
+
+		_datagram_sockets.push_back(socket);
+		succeeded_count++;
+	}
+
+	if (succeeded_count > 0)
+	{
+		if (succeeded_count < worker_count)
+		{
+			logtw("Only %d of %d SO_REUSEPORT sockets created for %s",
+				  succeeded_count, worker_count, address.ToString().CStr());
+		}
+
+		_type	 = type;
+		_address = address;
+		return true;
+	}
+
+	// `SO_REUSEPORT` unavailable - fall back to a single socket without it
+	logtw("SO_REUSEPORT is not available, falling back to a single datagram socket for %s",
+		  address.ToString().CStr());
+
+	auto socket = _socket_pool->AllocSocket<ov::DatagramSocket>(address.GetFamily());
+
+	if ((socket != nullptr) && socket->Prepare(address, on_socket_created, datagram_callback))
+	{
+		logti("Created fallback datagram socket fd=%d, address=%s",
+			  socket->GetNativeHandle(), address.ToString().CStr());
+
+		_datagram_sockets.push_back(socket);
+		_type	 = type;
+		_address = address;
+		return true;
+	}
+
+	if (socket != nullptr)
+	{
+		_socket_pool->ReleaseSocket(socket);
+	}
+
+	logte("All datagram socket creations failed for %s", address.ToString().CStr());
+	OV_SAFE_RESET(_socket_pool, nullptr, _socket_pool->Uninitialize(), _socket_pool);
 
 	return false;
 }
@@ -287,15 +363,17 @@ void PhysicalPort::OnDatagram(const std::shared_ptr<ov::DatagramSocket> &client,
 
 bool PhysicalPort::Close()
 {
-	auto socket = GetSocket();
-
-	if (socket != nullptr)
+	if (_server_socket != nullptr)
 	{
-		_socket_pool->ReleaseSocket(socket);
-
+		_socket_pool->ReleaseSocket(_server_socket);
 		_server_socket = nullptr;
-		_datagram_socket = nullptr;
 	}
+
+	for (auto &datagram_socket : _datagram_sockets)
+	{
+		_socket_pool->ReleaseSocket(datagram_socket);
+	}
+	_datagram_sockets.clear();
 
 	_socket_pool->Uninitialize();
 	_socket_pool = nullptr;
@@ -328,8 +406,8 @@ std::shared_ptr<const ov::Socket> PhysicalPort::GetSocket() const
 			return _server_socket;
 
 		case ov::SocketType::Udp:
-			OV_ASSERT2(_datagram_socket != nullptr);
-			return _datagram_socket;
+			OV_ASSERT2(_datagram_sockets.empty() == false);
+			return _datagram_sockets.empty() ? nullptr : _datagram_sockets.front();
 	}
 }
 
@@ -343,7 +421,7 @@ std::shared_ptr<ov::Socket> PhysicalPort::GetSocket()
 			return _server_socket;
 
 		case ov::SocketType::Udp:
-			return _datagram_socket;
+			return _datagram_sockets.empty() ? nullptr : _datagram_sockets.front();
 	}
 }
 
@@ -381,6 +459,24 @@ ov::String PhysicalPort::ToString() const
 	if (_server_socket != nullptr)
 	{
 		description.AppendFormat(", socket: %s", _server_socket->ToString().CStr());
+	}
+
+	if (_datagram_sockets.empty() == false)
+	{
+		auto count = _datagram_sockets.size();
+		description.AppendFormat(", datagram_sockets: %zu [", count);
+
+		for (size_t index = 0; index < count; index++)
+		{
+			if (index > 0)
+			{
+				description.Append(", ");
+			}
+
+			description.AppendFormat("fd: %d", _datagram_sockets[index]->GetNativeHandle());
+		}
+
+		description.Append(']');
 	}
 
 	description.Append('>');

--- a/src/projects/modules/physical_port/physical_port.cpp
+++ b/src/projects/modules/physical_port/physical_port.cpp
@@ -179,6 +179,12 @@ bool PhysicalPort::CreateDatagramSocket(
 		return false;
 	}
 
+#ifndef SO_REUSEPORT
+	// Without `SO_REUSEPORT` only a single datagram socket is created, so a single worker is enough -
+	// initializing more would just leave idle epoll threads.
+	worker_count = 1;
+#endif	// SO_REUSEPORT
+
 	if (_socket_pool->Initialize(worker_count) == false)
 	{
 		_socket_pool = nullptr;

--- a/src/projects/modules/physical_port/physical_port.cpp
+++ b/src/projects/modules/physical_port/physical_port.cpp
@@ -189,10 +189,10 @@ bool PhysicalPort::CreateDatagramSocket(
 		&PhysicalPort::OnDatagram, this,
 		std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
 
+#ifdef SO_REUSEPORT
 	// Set `SO_REUSEPORT` before `Bind()` via the additional-options callback.
 	// On failure, returns an error so the loop skips this socket and the caller falls back to a single non-reuseport socket.
 	auto reuseport_callback = [on_socket_created](const std::shared_ptr<ov::Socket> &socket) -> std::shared_ptr<ov::Error> {
-#ifdef SO_REUSEPORT
 		if (socket->SetSockOpt<int>(SO_REUSEPORT, 1) == false)
 		{
 			logtw("Failed to set SO_REUSEPORT on socket fd %d", socket->GetNativeHandle());
@@ -204,10 +204,6 @@ bool PhysicalPort::CreateDatagramSocket(
 		return (on_socket_created != nullptr)
 				   ? on_socket_created(socket)
 				   : nullptr;
-#else	// SO_REUSEPORT
-		logtw("SO_REUSEPORT is not available on this platform (socket fd %d)", socket->GetNativeHandle());
-		return ov::Error::CreateError("PhyPort", "SO_REUSEPORT is not available on this platform");
-#endif	// SO_REUSEPORT
 	};
 
 	// Create `worker_count` sockets with `SO_REUSEPORT` - the kernel distributes incoming UDP packets across them by 4-tuple hash.
@@ -256,9 +252,14 @@ bool PhysicalPort::CreateDatagramSocket(
 		return true;
 	}
 
-	// `SO_REUSEPORT` unavailable - fall back to a single socket without it
-	logtw("SO_REUSEPORT is not available, falling back to a single datagram socket for %s",
+	// All `SO_REUSEPORT` sockets failed at runtime - fall back to a single socket without it
+	logtw("SO_REUSEPORT sockets could not be created, falling back to a single datagram socket for %s",
 		  address.ToString().CStr());
+#else	// SO_REUSEPORT
+	// `SO_REUSEPORT` is unavailable at build time - create a single datagram socket directly to avoid redundant work and log spam
+	logti("SO_REUSEPORT is not supported on this platform, creating a single datagram socket for %s",
+		  address.ToString().CStr());
+#endif	// SO_REUSEPORT
 
 	auto socket = _socket_pool->AllocSocket<ov::DatagramSocket>(address.GetFamily());
 

--- a/src/projects/modules/physical_port/physical_port.h
+++ b/src/projects/modules/physical_port/physical_port.h
@@ -119,7 +119,7 @@ protected:
 	ov::SocketAddress _address;
 
 	std::shared_ptr<ov::ServerSocket> _server_socket;
-	std::shared_ptr<ov::DatagramSocket> _datagram_socket;
+	std::vector<std::shared_ptr<ov::DatagramSocket>> _datagram_sockets;
 
 	std::atomic<int> _ref_count{0};
 

--- a/src/projects/modules/physical_port/physical_port_manager.cpp
+++ b/src/projects/modules/physical_port/physical_port_manager.cpp
@@ -38,6 +38,16 @@ std::shared_ptr<PhysicalPort> PhysicalPortManager::CreatePort(const char *name,
 		worker_count = PHYSICAL_PORT_DEFAULT_WORKER_COUNT;
 	}
 
+#ifndef SO_REUSEPORT
+	// Without `SO_REUSEPORT`, UDP physical ports fall back to a single socket/worker, so clamp the
+	// requested count here to keep the requested and actual worker counts consistent (avoids a misleading
+	// mismatch warning below) and to skip spawning idle epoll workers.
+	if (type == ov::SocketType::Udp)
+	{
+		worker_count = 1;
+	}
+#endif	// SO_REUSEPORT
+
 	if (item == _port_list.end())
 	{
 		port = std::make_shared<PhysicalPort>(PhysicalPort::PrivateToken{nullptr});

--- a/src/projects/providers/mpegts/mpegts_provider.cpp
+++ b/src/projects/providers/mpegts/mpegts_provider.cpp
@@ -80,7 +80,7 @@ namespace pvd
 
 			for (const auto &address : address_list)
 			{
-				auto physical_port = physical_port_manager->CreatePort("MPEGTS", socket_type, address, 1);
+				auto physical_port = physical_port_manager->CreatePort("MPEGTS", socket_type, address, mpegts_provider_config.GetWorkerCount());
 
 				if (physical_port == nullptr)
 				{

--- a/src/projects/providers/mpegts/mpegts_provider.cpp
+++ b/src/projects/providers/mpegts/mpegts_provider.cpp
@@ -50,6 +50,13 @@ namespace pvd
 		std::vector<ov::String> address_string_list;
 		auto physical_port_manager = PhysicalPortManager::GetInstance();
 
+		// MPEG-TS uses one stream per port, so multiple workers have no effect.
+		if (mpegts_provider_config.GetWorkerCount() > 1)
+		{
+			logtw("MPEG-TS WorkerCount is set to %d, but only 1 worker is used per port",
+				  mpegts_provider_config.GetWorkerCount());
+		}
+
 		// Snapshot to bind. Items were populated by `Start()` with empty
 		// `_physical_port_list`; here we create the physical ports and attach them via
 		// `SetPhysicalPortList()`.
@@ -80,7 +87,7 @@ namespace pvd
 
 			for (const auto &address : address_list)
 			{
-				auto physical_port = physical_port_manager->CreatePort("MPEGTS", socket_type, address, mpegts_provider_config.GetWorkerCount());
+				auto physical_port = physical_port_manager->CreatePort("MPEGTS", socket_type, address, 1);
 
 				if (physical_port == nullptr)
 				{

--- a/src/projects/providers/webrtc/webrtc_provider.cpp
+++ b/src/projects/providers/webrtc/webrtc_provider.cpp
@@ -84,7 +84,7 @@ namespace pvd
 			// Initialize WHIP Server
 			if (_whip_server->Start(
 					WhipObserver::GetSharedPtr(),
-					GetProviderName(), "WhpSig",
+					ov::String::FormatString("%s-WHIP", GetProviderName()), "WhpSig",
 					ip_list,
 					is_port_configured, port_config.GetPort(),
 					is_tls_port_configured, tls_port_config.GetPort(),


### PR DESCRIPTION
## Summary

- Create `worker_count` `SO_REUSEPORT` sockets per UDP physical port so the kernel distributes incoming packets across epoll workers
- Fall back to a single socket on platforms without `SO_REUSEPORT`
- Log socket fd on ICE nomination for verifying per-client distribution

## Changes

- `PhysicalPort`: `_datagram_socket` -> `_datagram_sockets` vector; `CreateDatagramSocket()` allocates N sockets in a loop with `SO_REUSEPORT` callback
- `IcePort::MarkNominated()`: accept `remote` socket parameter, log fd
- `Close()`, `GetSocket()`, `ToString()` updated for multi-socket
