### PR TITLE
feat(transcoder): add AV1 software decode and AVIF thumbnails

### DIFF
--- a/cmake/InstallPrerequisites.cmake
+++ b/cmake/InstallPrerequisites.cmake
@@ -566,13 +566,13 @@ set(_FFMPEG_CONFIGURE_CMD
     "${_FFMPEG_ADDI_EXTRA_LIBS}"
     "${_FFMPEG_ADDI_LICENSE}"
     "${_FFMPEG_ADDI_LIBS}"
-    "--enable-encoder=libvpx_vp8,libaom-av1,libopus,libfdk_aac,libopenh264,mjpeg,png,libwebp${_FFMPEG_ADDI_ENCODER}"
-    "--enable-decoder=aac,aac_latm,aac_fixed,mp2,mp2float,mp3float,mp3,h264,hevc,libaom-av1,opus,vp8,mjpeg,png${_FFMPEG_ADDI_DECODER}"
+    "--enable-encoder=libvpx_vp8,libaom_av1,libopus,libfdk_aac,libopenh264,mjpeg,png,libwebp${_FFMPEG_ADDI_ENCODER}"
+    "--enable-decoder=aac,aac_latm,aac_fixed,mp2,mp2float,mp3float,mp3,h264,hevc,libaom_av1,opus,vp8,mjpeg,png${_FFMPEG_ADDI_DECODER}"
     "--enable-parser=aac,aac_latm,aac_fixed,h264,hevc,mpegaudio,opus,vp8,png,jpg"
     "--enable-protocol=tcp,udp,rtp,file,rtmp,tls,rtmps,libsrt"
     "--enable-demuxer=rtsp,flv,live_flv,mp4,mp3,image2"
-    "--enable-muxer=mp4,webm,mpegts,flv,mpjpeg"
-    "--enable-filter=asetnsamples,aresample,aformat,channelmap,channelsplit,scale,transpose,fps,settb,asettb,crop,format${_FFMPEG_ADDI_FILTERS}"
+    "--enable-muxer=mp4,webm,mpegts,flv,mpjpeg,avif"
+    "--enable-filter=asetnsamples,aresample,aformat,channelmap,channelsplit,scale,transpose,fps,settb,asettb,crop,format,colorspace${_FFMPEG_ADDI_FILTERS}"
 )
 list(JOIN _FFMPEG_CONFIGURE_CMD " " _FFMPEG_CONFIGURE_LINE)
 

--- a/misc/test_av1_avif.sh
+++ b/misc/test_av1_avif.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# test_av1_avif.sh
+#
+# Reproduces the AV1-decode + AVIF-thumbnail tests for the OvenMediaEngine
+# branch  feature/av1-decode-avif-thumbnails.
+#
+# It is deliberately linear and verbose. Read it top to bottom: each "STAGE"
+# is one self-contained step that prints its own raw output. The output is
+# ugly on purpose -- the point is that anyone can run this and see what happens.
+#
+# Needs:
+#   - docker
+#   - the built image  ome-av1-avif:dev   (a USE_LOCAL docker build of the branch:
+#         docker build -t ome-av1-avif:dev --build-arg USE_LOCAL=true . )
+#   - jrottenberg/ffmpeg:8.0-ubuntu  (pulled on first use) to push test streams
+#   - host  file  and  ffprobe  for verification
+#
+# Run:    bash test_av1_avif.sh
+# Clean:  docker rm -f ome-test pusher pusherav1 2>/dev/null
+
+set -u
+
+# ---- knobs ----------------------------------------------------------------
+OME_IMAGE=ome-av1-avif:dev
+FF_IMAGE=jrottenberg/ffmpeg:8.0-ubuntu
+OME=ome-test
+RTMP=21935        # host:21935 -> container 1935   (1935 is often busy)
+HTTP=23333        # host:23333 -> container 3333
+DIR=$(mktemp -d)
+cd "$DIR"
+echo "work dir: $DIR"
+
+
+###############################################################################
+echo; echo "### STAGE 0: write a tiny OME config (jpeg + png + webp + avif thumbs) ###"
+###############################################################################
+cat > Server.xml <<'XML'
+<?xml version="1.0" encoding="UTF-8" ?>
+<Server version="8">
+  <Name>OvenMediaEngine</Name>
+  <Type>origin</Type>
+  <IP>*</IP>
+  <PrivacyProtection>false</PrivacyProtection>
+  <Modules>
+    <!-- Enhanced-RTMP: required to ingest AV1 (and H.265 / VP9) over RTMP. -->
+    <ERTMP><Enable>true</Enable></ERTMP>
+  </Modules>
+  <Bind>
+    <Providers>
+      <RTMP><Port>1935</Port><WorkerCount>1</WorkerCount></RTMP>
+    </Providers>
+    <Publishers>
+      <Thumbnail><Port>3333</Port><WorkerCount>1</WorkerCount></Thumbnail>
+    </Publishers>
+  </Bind>
+  <Defaults><CrossDomains><Url>*</Url></CrossDomains></Defaults>
+  <VirtualHosts>
+    <VirtualHost>
+      <Name>default</Name>
+      <Host><Names><Name>*</Name></Names></Host>
+      <CrossDomains><Url>*</Url></CrossDomains>
+      <Applications>
+        <Application>
+          <Name>app</Name>
+          <Type>live</Type>
+          <OutputProfiles>
+            <HWAccels><Decoder><Enable>false</Enable></Decoder><Encoder><Enable>false</Enable></Encoder></HWAccels>
+            <OutputProfile>
+              <Name>thumb</Name>
+              <OutputStreamName>${OriginStreamName}</OutputStreamName>
+              <Encodes>
+                <Image><Codec>jpeg</Codec><Framerate>1</Framerate><Width>1280</Width><Height>720</Height></Image>
+                <Image><Codec>png</Codec><Framerate>1</Framerate><Width>1280</Width><Height>720</Height></Image>
+                <Image><Codec>webp</Codec><Framerate>1</Framerate><Width>1280</Width><Height>720</Height></Image>
+                <Image><Codec>avif</Codec><Framerate>1</Framerate><Width>1280</Width><Height>720</Height></Image>
+              </Encodes>
+            </OutputProfile>
+          </OutputProfiles>
+          <Providers><RTMP /></Providers>
+          <Publishers><Thumbnail><CrossDomains><Url>*</Url></CrossDomains></Thumbnail></Publishers>
+        </Application>
+      </Applications>
+    </VirtualHost>
+  </VirtualHosts>
+</Server>
+XML
+echo "wrote $DIR/Server.xml"
+
+
+###############################################################################
+echo; echo "### STAGE 1: start OME and show the bundled FFmpeg build flags ###"
+###############################################################################
+docker rm -f "$OME" >/dev/null 2>&1
+docker run -d --name "$OME" \
+  -p $RTMP:1935 -p $HTTP:3333 \
+  -v "$DIR/Server.xml:/opt/ovenmediaengine/bin/origin_conf/Server.xml:ro" \
+  "$OME_IMAGE" >/dev/null
+sleep 6
+echo "--- expect libaom_av1 in encoder+decoder, 'avif' in muxer, 'colorspace' in filter ---"
+docker logs "$OME" 2>&1 | grep -o -- '--enable-encoder=[^ ]*' | head -1
+docker logs "$OME" 2>&1 | grep -o -- '--enable-decoder=[^ ]*' | head -1
+docker logs "$OME" 2>&1 | grep -o -- '--enable-muxer=[^ ]*'   | head -1
+docker logs "$OME" 2>&1 | grep -o -- '--enable-filter=[^ ]*'  | head -1
+
+
+###############################################################################
+echo; echo "### STAGE 2: push H.264 (libx264, CPU) over RTMP for 60s ###"
+###############################################################################
+docker rm -f pusher >/dev/null 2>&1
+docker run -d --rm --name pusher --network host "$FF_IMAGE" \
+  -re -f lavfi -i "testsrc2=size=1280x720:rate=30,format=yuv420p" \
+  -c:v libx264 -preset veryfast -g 30 -pix_fmt yuv420p \
+  -color_primaries bt709 -color_trc bt709 -colorspace bt709 \
+  -t 60 -f flv "rtmp://localhost:$RTMP/app/h264" >/dev/null
+echo "pushing H.264 ... waiting 30s for the stream + 1fps thumbnails to appear"
+sleep 30
+
+
+###############################################################################
+echo; echo "### STAGE 3: fetch thumbnails -- jpg/png/webp = REGRESSION, avif = NEW ###"
+echo "###          (any thumbnail here also proves H.264 was decoded)            ###"
+###############################################################################
+curl -s -o h264.jpg  "http://localhost:$HTTP/app/h264/thumb.jpg"
+curl -s -o h264.png  "http://localhost:$HTTP/app/h264/thumb.png"
+curl -s -o h264.webp "http://localhost:$HTTP/app/h264/thumb.webp"
+curl -s -o h264.avif "http://localhost:$HTTP/app/h264/thumb.avif"
+ls -l h264.jpg h264.png h264.webp h264.avif
+echo "--- file types: jpg/png/webp must be valid images; avif must be 'ISO Media, AVIF' ---"
+file h264.jpg h264.png h264.webp h264.avif
+
+
+###############################################################################
+echo; echo "### STAGE 4: AVIF colour tags -- expect av1 / yuv420p / bt709 / range=pc ###"
+###############################################################################
+ffprobe -hide_banner -loglevel error \
+  -show_entries stream=codec_name,pix_fmt,color_space,color_primaries,color_transfer,color_range \
+  -of default=noprint_wrappers=1 h264.avif
+
+
+###############################################################################
+echo; echo "### STAGE 5: AV1 ingest -> AV1 DECODE -> thumbnail (NEW feature) ###"
+echo "###          relies on <Modules><ERTMP> from STAGE 0 so AV1 ingests over RTMP ###"
+###############################################################################
+docker rm -f pusherav1 >/dev/null 2>&1
+docker run -d --rm --name pusherav1 --network host "$FF_IMAGE" \
+  -re -f lavfi -i "testsrc2=size=640x360:rate=15,format=yuv420p" \
+  -c:v libaom-av1 -cpu-used 8 -b:v 800k -g 30 -pix_fmt yuv420p \
+  -color_primaries bt709 -color_trc bt709 -colorspace bt709 \
+  -t 40 -f flv "rtmp://localhost:$RTMP/app/av1" >/dev/null
+echo "pushing AV1 ... waiting 25s"
+sleep 25
+echo "--- did OME ingest the stream as AV1? expect a track logged as BSF(AV1_OBU) ---"
+docker logs "$OME" 2>&1 | grep -iE 'AV1_OBU' | grep -ivE 'enable-|Configuration' | tail -5
+curl -s -o av1.jpg  "http://localhost:$HTTP/app/av1/thumb.jpg"
+curl -s -o av1.avif "http://localhost:$HTTP/app/av1/thumb.avif"
+ls -l av1.jpg av1.avif
+echo "--- valid thumbnails here prove the AV1 stream was decoded and re-encoded ---"
+file av1.jpg av1.avif
+
+
+###############################################################################
+echo; echo "### STAGE 6: protocols / codecs this script does NOT auto-drive (run by hand) ###"
+###############################################################################
+echo "WebRTC/WHIP : browser or OBS WHIP -- needed for VP8 ingest (and an alt AV1/H.265 path)"
+echo "SRT         : ffmpeg ... -f mpegts 'srt://HOST:PORT?streamid=...'   (needs <SRT> bind)"
+echo "MPEG-TS     : ffmpeg ... -f mpegts 'udp://HOST:PORT'                 (needs <MPEGTS> bind)"
+echo "RTSP        : OME <RTSPPull> SourceStream from an rtsp:// server (e.g. mediamtx)"
+echo "OVT         : a second OME instance pulling this one as an edge"
+echo "Scheduled / Multiplex : config-driven providers"
+
+
+###############################################################################
+echo; echo "### DONE.  OME container '$OME' is left running for poking at. ###"
+echo "clean up:  docker rm -f $OME pusher pusherav1 2>/dev/null"
+echo "artifacts: $DIR"
+###############################################################################

--- a/src/projects/base/info/media_track.cpp
+++ b/src/projects/base/info/media_track.cpp
@@ -658,7 +658,8 @@ bool MediaTrack::IsValid()
 		break;
 		case MediaCodecId::Jpeg:
 		case MediaCodecId::Png:
-		case MediaCodecId::Webp: {
+		case MediaCodecId::Webp:
+		case MediaCodecId::Avif: {
 			if (IsValidResolution() && IsValidTimeBase())
 			{
 				_is_valid = true;

--- a/src/projects/base/mediarouter/media_type.h
+++ b/src/projects/base/mediarouter/media_type.h
@@ -64,7 +64,8 @@ namespace cmn
 
 		// Backward compatibility: Logically part of Video Track. Do not change the order.
 		AV1_OBU,
-		AV1_RTP_AOM	 // AV1 over RTP (https://aomediacodec.github.io/av1-rtp-spec/); track origin, depacketized to AV1_OBU
+		AV1_RTP_AOM,  // AV1 over RTP (https://aomediacodec.github.io/av1-rtp-spec/); track origin, depacketized to AV1_OBU
+		AVIF		  // Image track; each packet is a complete single-image AVIF file
 	};
 
 	enum class PacketType : int8_t
@@ -114,7 +115,8 @@ namespace cmn
 		Webp,
 		WebVTT,
 		Whisper,
-		Mp2
+		Mp2,
+		Avif
 	};
 
 	// DeviceId is used to identify a hwardware accelerator device.
@@ -289,6 +291,7 @@ namespace cmn
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Png, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Webp, false);
+			OV_CASE_RETURN(cmn::MediaCodecId::Avif, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::WebVTT, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Whisper, false);
 		}
@@ -317,6 +320,7 @@ namespace cmn
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, true);
 			OV_CASE_RETURN(cmn::MediaCodecId::Png, true);
 			OV_CASE_RETURN(cmn::MediaCodecId::Webp, true);
+			OV_CASE_RETURN(cmn::MediaCodecId::Avif, true);
 			OV_CASE_RETURN(cmn::MediaCodecId::WebVTT, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Whisper, false);
 		}
@@ -345,6 +349,7 @@ namespace cmn
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Png, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Webp, false);
+			OV_CASE_RETURN(cmn::MediaCodecId::Avif, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::WebVTT, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Whisper, false);
 		}
@@ -422,6 +427,7 @@ namespace cmn
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, SCTE35);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, WebVTT);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, AV1_RTP_AOM);
+			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, AVIF);
 		}
 
 		return "Unknown";
@@ -537,6 +543,7 @@ namespace cmn
 			OV_CASE_RETURN(MediaCodecId::Jpeg, "JPEG");
 			OV_CASE_RETURN(MediaCodecId::Png, "PNG");
 			OV_CASE_RETURN(MediaCodecId::Webp, "WEBP");
+			OV_CASE_RETURN(MediaCodecId::Avif, "AVIF");
 			// Audio codecs
 			OV_CASE_RETURN(MediaCodecId::Aac, "AAC");
 			OV_CASE_RETURN(MediaCodecId::Mp2, "MP2");
@@ -587,6 +594,10 @@ namespace cmn
 		else if (name.HasPrefix("WEBP"))
 		{
 			return cmn::MediaCodecId::Webp;
+		}
+		else if (name.HasPrefix("AVIF"))
+		{
+			return cmn::MediaCodecId::Avif;
 		}
 		// Audio codecs
 		else if (name.HasPrefix("AAC"))

--- a/src/projects/mediarouter/mediarouter_nomalize.cpp
+++ b/src/projects/mediarouter/mediarouter_nomalize.cpp
@@ -109,6 +109,7 @@ bool MediaRouterNormalize::NormalizeMediaPacket(const std::shared_ptr<info::Stre
 		case cmn::BitstreamFormat::JPEG:
 		case cmn::BitstreamFormat::PNG:
 		case cmn::BitstreamFormat::WEBP:
+		case cmn::BitstreamFormat::AVIF:
 			result = true;
 			break;
 		case cmn::BitstreamFormat::AAC_LATM:

--- a/src/projects/modules/ffmpeg/compat.cpp
+++ b/src/projects/modules/ffmpeg/compat.cpp
@@ -83,6 +83,9 @@ namespace ffmpeg
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, AV_CODEC_ID_MJPEG);
 			OV_CASE_RETURN(cmn::MediaCodecId::Png, AV_CODEC_ID_PNG);
 			OV_CASE_RETURN(cmn::MediaCodecId::Webp, AV_CODEC_ID_WEBP);
+			// Encoder selection only. The reverse map (AV_CODEC_ID_AV1 -> Av1)
+			// stays untouched: it classifies ingest, where AV1 means video.
+			OV_CASE_RETURN(cmn::MediaCodecId::Avif, AV_CODEC_ID_AV1);
 			OV_CASE_RETURN(cmn::MediaCodecId::WebVTT, AV_CODEC_ID_NONE);
 			OV_CASE_RETURN(cmn::MediaCodecId::Whisper, AV_CODEC_ID_NONE);
 		}

--- a/src/projects/modules/segment_writer/writer.cpp
+++ b/src/projects/modules/segment_writer/writer.cpp
@@ -149,6 +149,8 @@ static AVCodecID AvCodecIdFromMediaCodecId(cmn::MediaCodecId codec_id)
 		WRITER_CASE(cmn::MediaCodecId::Jpeg, AV_CODEC_ID_JPEG2000)
 		WRITER_CASE(cmn::MediaCodecId::Png, AV_CODEC_ID_PNG)
 		WRITER_CASE(cmn::MediaCodecId::Webp, AV_CODEC_ID_WEBP)
+		// AVIF payloads are complete container files, not an elementary stream
+		WRITER_CASE(cmn::MediaCodecId::Avif, AV_CODEC_ID_NONE)
 		WRITER_CASE(cmn::MediaCodecId::Whisper, AV_CODEC_ID_NONE)
 		WRITER_CASE(cmn::MediaCodecId::WebVTT, AV_CODEC_ID_NONE)
 	}
@@ -868,6 +870,8 @@ bool Writer::WritePacket(const std::shared_ptr<const MediaPacket> &packet)
 			[[fallthrough]];
 		case cmn::BitstreamFormat::WEBP:
 			[[fallthrough]];			
+		case cmn::BitstreamFormat::AVIF:
+			[[fallthrough]];
 		case cmn::BitstreamFormat::ID3v2:
 			[[fallthrough]];
 		case cmn::BitstreamFormat::MP3:

--- a/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
+++ b/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
@@ -108,6 +108,7 @@ namespace pvd::rtmp
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Png, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Webp, false);
+			OV_CASE_RETURN(cmn::MediaCodecId::Avif, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::WebVTT, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Whisper, false);
 		}

--- a/src/projects/providers/rtmp/tracks/rtmp_track.cpp
+++ b/src/projects/providers/rtmp/tracks/rtmp_track.cpp
@@ -35,6 +35,7 @@ namespace pvd::rtmp
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::Png, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::Webp, nullptr);
+			OV_CASE_RETURN(cmn::MediaCodecId::Avif, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::WebVTT, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::Whisper, nullptr);
 		}

--- a/src/projects/publishers/thumbnail/thumbnail_interceptor.cpp
+++ b/src/projects/publishers/thumbnail/thumbnail_interceptor.cpp
@@ -29,7 +29,8 @@ bool ThumbnailInterceptor::IsInterceptorForRequest(const std::shared_ptr<const h
 
 	if ((target.IndexOf(".jpg") >= 0) ||
 		(target.IndexOf(".png") >= 0) ||
-		(target.IndexOf(".webp") >= 0))
+		(target.IndexOf(".webp") >= 0) ||
+		(target.IndexOf(".avif") >= 0))
 	{
 		return true;
 	}

--- a/src/projects/publishers/thumbnail/thumbnail_publisher.cpp
+++ b/src/projects/publishers/thumbnail/thumbnail_publisher.cpp
@@ -199,7 +199,7 @@ bool ThumbnailPublisher::OnDeletePublisherApplication(const std::shared_ptr<pub:
 
 std::shared_ptr<ThumbnailInterceptor> ThumbnailPublisher::CreateInterceptor()
 {
-	ov::String thumbnail_url_pattern = R"(.+thumb\.(jpg|png|webp)$)";
+	ov::String thumbnail_url_pattern = R"(.+thumb\.(jpg|png|webp|avif)$)";
 
 	auto http_interceptor = std::make_shared<ThumbnailInterceptor>();
 
@@ -340,6 +340,10 @@ std::shared_ptr<ThumbnailInterceptor> ThumbnailPublisher::CreateInterceptor()
 		{
 			media_codec_id = cmn::MediaCodecId::Png;
 		}
+		else if (request_url->File().LowerCaseString().IndexOf(".avif") >= 0)
+		{
+			media_codec_id = cmn::MediaCodecId::Avif;
+		}
 		else if (request_url->File().LowerCaseString().IndexOf(".webp") >= 0)
 		{
 			media_codec_id = cmn::MediaCodecId::Webp;
@@ -429,6 +433,8 @@ ov::String ThumbnailPublisher::MimeTypeFromMediaCodecId(const cmn::MediaCodecId 
 			return "image/png";
 		case cmn::MediaCodecId::Webp:
 			return "image/webp";
+		case cmn::MediaCodecId::Avif:
+			return "image/avif";
 		default:
 			return "application/octet-stream";
 	}

--- a/src/projects/publishers/thumbnail/thumbnail_stream.cpp
+++ b/src/projects/publishers/thumbnail/thumbnail_stream.cpp
@@ -40,7 +40,8 @@ bool ThumbnailStream::Start()
 	{
 		if ((track->GetCodecId() == cmn::MediaCodecId::Png ||
 			 track->GetCodecId() == cmn::MediaCodecId::Jpeg ||
-			 track->GetCodecId() == cmn::MediaCodecId::Webp))
+			 track->GetCodecId() == cmn::MediaCodecId::Webp ||
+			 track->GetCodecId() == cmn::MediaCodecId::Avif))
 		{
 			found = true;
 			break;
@@ -80,7 +81,8 @@ void ThumbnailStream::SendVideoFrame(const std::shared_ptr<MediaPacket> &media_p
 
 	if (!(track->GetCodecId() == cmn::MediaCodecId::Png ||
 		  track->GetCodecId() == cmn::MediaCodecId::Jpeg ||
-		  track->GetCodecId() == cmn::MediaCodecId::Webp))
+		  track->GetCodecId() == cmn::MediaCodecId::Webp ||
+		  track->GetCodecId() == cmn::MediaCodecId::Avif))
 	{
 		// Could not support codec for image
 		return;

--- a/src/projects/transcoder/codec/decoder/decoder_avcodec_video.cpp
+++ b/src/projects/transcoder/codec/decoder/decoder_avcodec_video.cpp
@@ -14,7 +14,9 @@
 bool AVCodecVideoDecoder::Initialize()
 {
 	// Create the bitstream framer bound to this decoder's codec (once).
-	if (_framer.IsValid() == false)
+	// Pre-framed codecs (AV1) skip this: their packets are already complete
+	// frames and the build has no parser for them.
+	if (IsPreFramed() == false && _framer.IsValid() == false)
 	{
 		if (_framer.Init(GetCodecID()) == false)
 		{
@@ -34,6 +36,11 @@ bool AVCodecVideoDecoder::Initialize()
 			break;
 		case cmn::MediaCodecId::Vp8:
 			decoder_name = "vp8";
+			break;
+		case cmn::MediaCodecId::Av1:
+			// The only AV1 decoder enabled in the bundled FFmpeg; select it by
+			// name rather than relying on avcodec_find_decoder()'s preference.
+			decoder_name = "libaom-av1";
 			break;
 		default:
 			logte("Unsupported codec for video decoder: %s", cmn::GetCodecIdString(GetCodecID()));
@@ -63,6 +70,13 @@ bool AVCodecVideoDecoder::Initialize()
 
 bool AVCodecVideoDecoder::ReinitCodecIfNeed()
 {
+	// Pre-framed codecs (AV1) have no framer to report a new resolution from,
+	// and libaom-av1 adapts to format changes internally; nothing to do.
+	if (IsPreFramed() == true)
+	{
+		return true;
+	}
+
 	if (_codec.GetWidth() != 0 &&
 		_codec.GetHeight() != 0 &&
 		(_framer.GetWidth() != _codec.GetWidth() || _framer.GetHeight() != _codec.GetHeight()))
@@ -85,6 +99,22 @@ bool AVCodecVideoDecoder::ReinitCodecIfNeed()
 
 std::shared_ptr<MediaPacket> AVCodecVideoDecoder::GetFramedPacket()
 {
+	// Pre-framed codecs (AV1): each input packet is already one complete frame,
+	// so hand it straight to the decoder without running the bitstream framer.
+	// SendPacket only reads the packet (ToAVPacket aliases its bytes into an
+	// AVPacket without writing them), so dropping const to satisfy the non-const
+	// return type is safe.
+	if (IsPreFramed() == true)
+	{
+		auto obj = _input_buffer.Dequeue();
+		if (obj.has_value() == false)
+		{
+			return nullptr;
+		}
+
+		return std::const_pointer_cast<MediaPacket>(obj.value());
+	}
+
 	if (_framing_buffer.GetRemainedSize() <= 0)
 	{
 		auto obj = _input_buffer.Dequeue();

--- a/src/projects/transcoder/codec/decoder/decoder_avcodec_video.h
+++ b/src/projects/transcoder/codec/decoder/decoder_avcodec_video.h
@@ -13,7 +13,7 @@
 #include <modules/ffmpeg/ffmpeg_bitstream_framer.h>
 #include <transcoder/padded_aligned_buffer.h>
 
-// Software (FFmpeg/libavcodec) video decoder (H264/H265/VP8). Selected for the DEFAULT module.
+// Software (FFmpeg/libavcodec) video decoder (H264/H265/VP8/AV1). Selected for the DEFAULT module.
 class AVCodecVideoDecoder : public TranscodeDecoder
 {
 public:
@@ -46,6 +46,11 @@ private:
 
 	// ----- Internal helpers -----
 	bool ReinitCodecIfNeed();
+
+	// AV1 ingest arrives as complete temporal units (AV1_OBU) and the bundled
+	// FFmpeg has no AV1 parser, so these tracks decode without a bitstream
+	// framer: packets are fed to the decoder as-is.
+	bool IsPreFramed() const noexcept { return _codec_id == cmn::MediaCodecId::Av1; }
 
 	// ----- Members -----
 	cmn::MediaCodecId _codec_id;

--- a/src/projects/transcoder/codec/encoder/encoder_avcodec_image.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_avcodec_image.cpp
@@ -8,9 +8,85 @@
 //==============================================================================
 #include "encoder_avcodec_image.h"
 
+#include <climits>
 #include <unistd.h>
 
 #include "../../transcoder_private.h"
+
+extern "C"
+{
+#include <libavformat/avformat.h>
+}
+
+namespace
+{
+	// Locates the OBU_SEQUENCE_HEADER unit (header bytes included) in a low-overhead
+	// AV1 bitstream. libaom leaves codec-context extradata empty even with
+	// GLOBAL_HEADER, and the avif muxer derives the av1C box from extradata -- so the
+	// in-band copy each key frame carries is the source.
+	bool FindSequenceHeaderObu(const uint8_t *data, size_t size, size_t &offset, size_t &length)
+	{
+		size_t pos = 0;
+		while (pos < size)
+		{
+			const size_t start = pos;
+			const uint8_t header = data[pos++];
+			if ((header & 0x80) != 0)
+			{
+				return false;
+			}
+			const int type = (header >> 3) & 0x0F;
+			const bool has_extension = (header & 0x04) != 0;
+			const bool has_size = (header & 0x02) != 0;
+			if (has_extension)
+			{
+				if (pos >= size)
+				{
+					return false;
+				}
+				pos++;
+			}
+			if (has_size == false)
+			{
+				// A sizeless OBU is only valid as the last unit in the frame.
+				if (type == 1)
+				{
+					offset = start;
+					length = size - start;
+					return true;
+				}
+				return false;
+			}
+			uint64_t obu_size = 0;
+			int shift = 0;
+			bool more = true;
+			while (more)
+			{
+				// AV1 caps leb128 at 8 bytes.
+				if (pos >= size || shift >= 56)
+				{
+					return false;
+				}
+				const uint8_t b = data[pos++];
+				obu_size |= static_cast<uint64_t>(b & 0x7F) << shift;
+				more = (b & 0x80) != 0;
+				shift += 7;
+			}
+			if (obu_size > size - pos)
+			{
+				return false;
+			}
+			pos += obu_size;
+			if (type == 1)	// OBU_SEQUENCE_HEADER
+			{
+				offset = start;
+				length = pos - start;
+				return true;
+			}
+		}
+		return false;
+	}
+}  // namespace
 
 void AVCodecImageEncoder::SetParamsCommon()
 {
@@ -69,6 +145,32 @@ bool AVCodecImageEncoder::SetParamsWebp()
 	return true;
 }
 
+bool AVCodecImageEncoder::SetParamsAvif()
+{
+	SetParamsCommon();
+
+	// allintra makes every frame an intra key frame (a sequence of stills); gop 0.
+	_codec.SetOption("usage", "allintra");
+	_codec.SetGopSize(0);
+
+	// GLOBAL_HEADER is required: the avif muxer builds the av1C box from extradata.
+	// Without it the box is empty and libavif (Chrome's AVIF decoder) rejects the
+	// file even though dav1d still decodes the mdat.
+	_codec.Get()->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+	// Thumbnails at ~1fps gain nothing from threading.
+	_codec.SetThreadCount(1);
+
+	// cpu-used is libaom's speed/effort knob (0 slowest/best .. 8 fastest); crf is
+	// its constant-quality knob (0-63, lower = higher quality). bit_rate 0 selects
+	// pure constant quality (AOM_Q).
+	_codec.SetOption("cpu-used", static_cast<int64_t>(8));
+	_codec.SetOption("crf", static_cast<int64_t>(23));
+	_codec.SetBitrate(0);
+
+	return true;
+}
+
 bool AVCodecImageEncoder::OpenCodec()
 {
 	if (_codec.AllocEncoder(GetCodecID()) == false)
@@ -86,6 +188,9 @@ bool AVCodecImageEncoder::OpenCodec()
 		case cmn::MediaCodecId::Png:
 			result = SetParamsPng();
 			break;
+		case cmn::MediaCodecId::Avif:
+			result = SetParamsAvif();
+			break;
 		case cmn::MediaCodecId::Webp:
 		default:
 			result = SetParamsWebp();
@@ -96,6 +201,19 @@ bool AVCodecImageEncoder::OpenCodec()
 	{
 		logte("Could not set codec parameters for %s", cmn::GetCodecIdString(GetCodecID()));
 		return false;
+	}
+
+	// AVIF defers avcodec_open2 to the first frame (OpenAvifCodecWithFrameColor) so
+	// the AV1 CICP can copy that frame's colour tags. JPEG/PNG/WEBP open now.
+	if (_codec_id == cmn::MediaCodecId::Avif)
+	{
+		_avif_packet = ::av_packet_alloc();
+		if (_avif_packet == nullptr)
+		{
+			logte("Could not allocate packet for %s", cmn::GetCodecIdString(GetCodecID()));
+			return false;
+		}
+		return true;
 	}
 
 	if (_codec.Open() == false)
@@ -120,12 +238,34 @@ bool AVCodecImageEncoder::Initialize()
 
 void AVCodecImageEncoder::Uninitialize()
 {
-	_codec.Flush();
+	// AVIF defers open; capture whether it actually opened before tearing down.
+	bool avif_opened = (_avif_codec_params != nullptr);
+
+	if (_avif_packet != nullptr)
+	{
+		::av_packet_free(&_avif_packet);
+	}
+	if (_avif_codec_params != nullptr)
+	{
+		::avcodec_parameters_free(&_avif_codec_params);
+	}
+
+	// Only an opened codec can be flushed; an AVIF track that never received a
+	// frame was never opened.
+	if (_codec_id != cmn::MediaCodecId::Avif || avif_opened)
+	{
+		_codec.Flush();
+	}
 	_codec.Reset();
 }
 
 EncodeResult AVCodecImageEncoder::SendFrame(const std::shared_ptr<const MediaFrame> &frame, bool force_keyframe)
 {
+	if (_codec_id == cmn::MediaCodecId::Avif)
+	{
+		return SendFrameAvif(frame);
+	}
+
 	// Flush the encoder if the frame is nullptr.
 	if (frame == nullptr)
 	{
@@ -161,6 +301,11 @@ EncodeResult AVCodecImageEncoder::SendFrame(const std::shared_ptr<const MediaFra
 
 EncodeResult AVCodecImageEncoder::ReceivePacket()
 {
+	if (_codec_id == cmn::MediaCodecId::Avif)
+	{
+		return ReceivePacketAvif();
+	}
+
 	auto [result, media_packet] = _codec.ReceivePacket(_bitstream_format, _packet_type);
 	if (result == ffmpeg::CodecResult::Again || result == ffmpeg::CodecResult::Eof)
 	{
@@ -208,4 +353,249 @@ EncodeResult AVCodecImageEncoder::ReceivePacket()
 #endif
 
 	return EncodeResult::Encoded(std::move(media_packet));
+}
+
+EncodeResult AVCodecImageEncoder::SendFrameAvif(const std::shared_ptr<const MediaFrame> &media_frame)
+{
+	// Flush: only an opened codec can be drained.
+	if (media_frame == nullptr)
+	{
+		if (_avif_codec_params != nullptr)
+		{
+			_codec.SendFrame(nullptr);
+		}
+		return EncodeResult::NoOutput();
+	}
+
+	// A dead codec keeps consuming input so the upstream never stalls.
+	if (_avif_codec_dead)
+	{
+		return EncodeResult::NoOutput();
+	}
+
+	auto *frame = static_cast<AVFrame *>(media_frame->GetPrivData());
+	if (frame == nullptr)
+	{
+		return EncodeResult::Error();
+	}
+
+	// Deferred open on the first frame so the AV1 CICP copies its colour tags. On
+	// failure, mark the codec dead and drop frames (NoOutput) rather than erroring
+	// out the encode thread: a failed thumbnail must not stall the stream.
+	if (_avif_codec_params == nullptr)
+	{
+		if (OpenAvifCodecWithFrameColor(frame) == false)
+		{
+			_avif_codec_dead = true;
+			return EncodeResult::NoOutput();
+		}
+	}
+
+	auto result = _codec.SendFrame(media_frame, false);
+	if (result != ffmpeg::CodecResult::Ok && result != ffmpeg::CodecResult::Again)
+	{
+		logte("Error sending a frame to the AVIF encoder. reason(%s)", _codec.GetLastErrorString().CStr());
+		return EncodeResult::Error();
+	}
+
+	return EncodeResult::NoOutput();
+}
+
+bool AVCodecImageEncoder::OpenAvifCodecWithFrameColor(const AVFrame *frame)
+{
+	// The rescaler already converted to BT.709 (full range) and applied the
+	// untagged-source policy, so the frame tags describe the pixels exactly. Copying
+	// them makes the AV1 sequence header (and thus the AVIF CICP) signal precisely
+	// what was encoded.
+	AVCodecContext *context = _codec.Get();
+	context->color_primaries = frame->color_primaries;
+	context->color_trc		 = frame->color_trc;
+	context->colorspace		 = frame->colorspace;
+	context->color_range	 = frame->color_range;
+
+	// AVIF must signal a valid CICP; default any still-unspecified field to BT.709
+	// full range, matching the rescaler's canonical target.
+	if (context->color_primaries == AVCOL_PRI_UNSPECIFIED)
+		context->color_primaries = AVCOL_PRI_BT709;
+	if (context->color_trc == AVCOL_TRC_UNSPECIFIED)
+		context->color_trc = AVCOL_TRC_BT709;
+	if (context->colorspace == AVCOL_SPC_UNSPECIFIED)
+		context->colorspace = AVCOL_SPC_BT709;
+	if (context->color_range == AVCOL_RANGE_UNSPECIFIED)
+		context->color_range = AVCOL_RANGE_JPEG;
+
+	if (_codec.Open() == false)
+	{
+		logte("Could not open the AVIF (libaom-av1) encoder. %s", _codec.GetLastErrorString().CStr());
+		return false;
+	}
+
+	// Snapshot codec parameters once: the av1C extradata is fixed after open and
+	// every muxed image reuses it.
+	_avif_codec_params = ::avcodec_parameters_alloc();
+	if (_avif_codec_params == nullptr ||
+		::avcodec_parameters_from_context(_avif_codec_params, context) < 0)
+	{
+		logte("Could not snapshot AVIF codec parameters for %s", cmn::GetCodecIdString(GetCodecID()));
+		return false;
+	}
+
+	return true;
+}
+
+EncodeResult AVCodecImageEncoder::ReceivePacketAvif()
+{
+	// No frame sent yet -> codec not opened.
+	if (_avif_codec_params == nullptr)
+	{
+		return EncodeResult::NoOutput();
+	}
+
+	int ret = ::avcodec_receive_packet(_codec.Get(), _avif_packet);
+	if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
+	{
+		return EncodeResult::NoOutput();
+	}
+	if (ret < 0)
+	{
+		logte("Error receiving an AV1 packet for AVIF: %s", ffmpeg::compat::AVErrorToString(ret).CStr());
+		return EncodeResult::Error();
+	}
+
+	// libaom leaves codec-context extradata empty, so the av1C box is built from the
+	// in-band sequence header each key frame carries.
+	if (_avif_codec_params->extradata_size == 0)
+	{
+		size_t obu_offset = 0;
+		size_t obu_length = 0;
+		if (FindSequenceHeaderObu(_avif_packet->data, _avif_packet->size, obu_offset, obu_length))
+		{
+			auto *extradata = static_cast<uint8_t *>(::av_mallocz(obu_length + AV_INPUT_BUFFER_PADDING_SIZE));
+			if (extradata != nullptr)
+			{
+				::memcpy(extradata, _avif_packet->data + obu_offset, obu_length);
+				_avif_codec_params->extradata = extradata;
+				_avif_codec_params->extradata_size = static_cast<int>(obu_length);
+			}
+		}
+		if (_avif_codec_params->extradata_size == 0)
+		{
+			logtw("Could not extract the AV1 sequence header for av1C; dropping this thumbnail frame");
+			::av_packet_unref(_avif_packet);
+			return EncodeResult::NoOutput();
+		}
+	}
+
+	std::vector<uint8_t> avif_bytes;
+	bool muxed = MuxAvif(_avif_codec_params, _codec.Get()->time_base, _avif_packet->data, _avif_packet->size, avif_bytes);
+
+	int64_t pts = _avif_packet->pts;
+	int64_t dts = _avif_packet->dts;
+	int64_t duration = _avif_packet->duration;
+	::av_packet_unref(_avif_packet);
+
+	if (muxed == false)
+	{
+		logtw("Failed to mux the AVIF thumbnail; dropping this frame");
+		return EncodeResult::NoOutput();
+	}
+
+	auto media_packet = std::make_shared<MediaPacket>(
+		0,
+		cmn::MediaType::Video,
+		0,
+		avif_bytes.data(),
+		static_cast<int32_t>(avif_bytes.size()),
+		pts, dts, duration,
+		MediaPacketFlag::Key,
+		cmn::BitstreamFormat::AVIF,
+		cmn::PacketType::RAW);
+
+	return EncodeResult::Encoded(std::move(media_packet));
+}
+
+bool AVCodecImageEncoder::MuxAvif(const AVCodecParameters *codec_params, AVRational time_base, const void *data, size_t size, std::vector<uint8_t> &out)
+{
+	out.clear();
+
+	// The packet API takes int sizes; reject anything that would not fit.
+	if (size > static_cast<size_t>(INT_MAX))
+	{
+		logte("AVIF input of %zu bytes exceeds the muxer's size limit", size);
+		return false;
+	}
+
+	AVFormatContext *fmt_ctx = nullptr;
+	if (::avformat_alloc_output_context2(&fmt_ctx, nullptr, "avif", nullptr) < 0 || fmt_ctx == nullptr)
+	{
+		logte("Could not allocate AVIF muxer context");
+		return false;
+	}
+
+	// In-memory, seekable output: the avif muxer back-patches HEIF box sizes, which
+	// the dynamic buffer supports; avio_close_dyn_buf returns the finished bytes and
+	// frees the internal buffer.
+	if (::avio_open_dyn_buf(&fmt_ctx->pb) < 0)
+	{
+		::avformat_free_context(fmt_ctx);
+		return false;
+	}
+
+	bool ok = true;
+	AVStream *stream = ::avformat_new_stream(fmt_ctx, nullptr);
+	if (stream == nullptr || ::avcodec_parameters_copy(stream->codecpar, codec_params) < 0)
+	{
+		ok = false;
+	}
+	else
+	{
+		stream->time_base = time_base;
+
+		if (::avformat_write_header(fmt_ctx, nullptr) < 0)
+		{
+			logte("Could not write AVIF header");
+			ok = false;
+		}
+		else
+		{
+			AVPacket *pkt = ::av_packet_alloc();
+			if (pkt == nullptr || ::av_new_packet(pkt, static_cast<int>(size)) < 0)
+			{
+				ok = false;
+			}
+			else
+			{
+				::memcpy(pkt->data, data, size);
+				pkt->stream_index = stream->index;
+				pkt->pts = 0;
+				pkt->dts = 0;
+				pkt->flags |= AV_PKT_FLAG_KEY;
+				if (::av_interleaved_write_frame(fmt_ctx, pkt) < 0)
+				{
+					logte("Could not write AVIF frame");
+					ok = false;
+				}
+			}
+			::av_packet_free(&pkt);
+
+			if (::av_write_trailer(fmt_ctx) < 0)
+			{
+				logte("Could not write AVIF trailer");
+				ok = false;
+			}
+		}
+	}
+
+	// Always close the dynamic buffer to recover and free it, even on error.
+	uint8_t *buf = nullptr;
+	int buf_size = ::avio_close_dyn_buf(fmt_ctx->pb, &buf);
+	fmt_ctx->pb = nullptr;
+	if (ok && buf_size > 0 && buf != nullptr)
+	{
+		out.assign(buf, buf + buf_size);
+	}
+	::av_free(buf);
+	::avformat_free_context(fmt_ctx);
+
+	return ok && !out.empty();
 }

--- a/src/projects/transcoder/codec/encoder/encoder_avcodec_image.h
+++ b/src/projects/transcoder/codec/encoder/encoder_avcodec_image.h
@@ -11,7 +11,14 @@
 #include "../../transcoder_encoder.h"
 #include <modules/ffmpeg/ffmpeg_codec.h>
 
-// AVCodecImageEncoder handles the software FFmpeg image encoders: JPEG, PNG, WEBP.
+#include <vector>
+
+// AVCodecImageEncoder handles the software FFmpeg image encoders: JPEG, PNG, WEBP, AVIF.
+//
+// JPEG/PNG/WEBP flow entirely through FFmpegCodec. AVIF is AV1 video muxed into a
+// HEIF (MIAF) container: libaom-av1 emits only the raw bitstream, so each encoded
+// AV1 still is deferred-opened to copy the first frame's colour tags into the AV1
+// CICP, then wrapped into a one-image AVIF via libavformat's "avif" muxer.
 class AVCodecImageEncoder : public TranscodeEncoder
 {
 public:
@@ -40,6 +47,8 @@ public:
 				return cmn::VideoPixelFormatId::YUVJ420P;
 			case cmn::MediaCodecId::Webp:
 				return cmn::VideoPixelFormatId::YUV420P;
+			case cmn::MediaCodecId::Avif:
+				return cmn::VideoPixelFormatId::YUV420P;
 			default:
 				return cmn::VideoPixelFormatId::None;
 		}
@@ -54,6 +63,8 @@ public:
 				return cmn::BitstreamFormat::JPEG;
 			case cmn::MediaCodecId::Webp:
 				return cmn::BitstreamFormat::WEBP;
+			case cmn::MediaCodecId::Avif:
+				return cmn::BitstreamFormat::AVIF;
 			default:
 				return cmn::BitstreamFormat::Unknown;
 		}
@@ -73,10 +84,26 @@ private:
 	bool SetParamsJpeg();
 	bool SetParamsPng();
 	bool SetParamsWebp();
+	bool SetParamsAvif();
+
+	// AVIF needs a deferred avcodec_open2 (to copy the first frame's colour tags
+	// into the AV1 CICP) plus a per-frame container mux, so it drives the codec
+	// context directly instead of FFmpegCodec's SendFrame/ReceivePacket helpers.
+	EncodeResult SendFrameAvif(const std::shared_ptr<const MediaFrame> &frame);
+	EncodeResult ReceivePacketAvif();
+	bool OpenAvifCodecWithFrameColor(const AVFrame *frame);
+	// Wrap a single AV1 temporal unit into a one-image AVIF in memory. codec_params
+	// must carry AV_CODEC_ID_AV1, the picture dimensions and the av1C extradata.
+	static bool MuxAvif(const AVCodecParameters *codec_params, AVRational time_base, const void *data, size_t size, std::vector<uint8_t> &out);
 
 	// ----- Members -----
 	cmn::MediaCodecId _codec_id;
 	ffmpeg::FFmpegCodec _codec;
 	cmn::BitstreamFormat _bitstream_format = cmn::BitstreamFormat::Unknown;
 	cmn::PacketType _packet_type = cmn::PacketType::Unknown;
+
+	// ----- AVIF-only state -----
+	AVPacket *_avif_packet = nullptr;
+	AVCodecParameters *_avif_codec_params = nullptr;  // snapshot taken at deferred open
+	bool _avif_codec_dead = false;					  // open failed: drop frames so upstream never stalls
 };

--- a/src/projects/transcoder/filter/filter_lavfi_rescaler.cpp
+++ b/src/projects/transcoder/filter/filter_lavfi_rescaler.cpp
@@ -66,7 +66,26 @@ bool FilterLavfiRescaler::BuildDescription(ov::String &desc)
 
 	// Scaler description of default module
 	auto resolution = _output_track->GetResolution();
-	desc += ov::String::FormatString("scale=%dx%d:flags=bilinear", resolution.width, resolution.height);
+	if (_output_track->GetCodecId() == cmn::MediaCodecId::Avif)
+	{
+		// Colour-managed AVIF thumbnails only. AVIF carries an explicit CICP tag
+		// that browsers honour, so the samples and the tag must agree. The scale
+		// step does geometry; the colorspace filter does the matrix conversion to
+		// BT.709 full range, reading the input matrix per frame from the source tag
+		// (SendFrame stamps untagged frames so the matrix is always defined).
+		// iprimaries/itrc are pinned BT.709, so a BT.601-matrix source is treated as
+		// BT.709 gamut and is not gamut-converted. JPEG/PNG/WEBP are unchanged: they
+		// stay on the plain bilinear path below.
+		_image_color_managed = true;
+		desc += ov::String::FormatString(
+			"scale=%dx%d:flags=bilinear,"
+			"colorspace=all=bt709:range=pc:iprimaries=bt709:itrc=bt709",
+			resolution.width, resolution.height);
+	}
+	else
+	{
+		desc += ov::String::FormatString("scale=%dx%d:flags=bilinear", resolution.width, resolution.height);
+	}
 
 	return true;
 }
@@ -259,6 +278,31 @@ bool FilterLavfiRescaler::SendFrame(std::shared_ptr<MediaFrame> media_frame)
 			  media_frame->GetWidth(), media_frame->GetHeight(), _src_width, _src_height);
 
 		return false;
+	}
+
+	// The colorspace filter (AVIF colour leg) rejects an unspecified input matrix.
+	// Rather than seed the buffersrc with colorspace/range options (those are
+	// FFmpeg 7.0+), stamp the matrix/range onto each untagged frame here so the
+	// filter always sees a defined matrix. A genuine BT.601 frame keeps its own tag
+	// and is converted; only untagged frames are stamped BT.709 (full range for
+	// yuvj), matching OME's own WebRTC/LL-HLS playback of untagged content.
+	if (_image_color_managed)
+	{
+		auto *frame = static_cast<AVFrame *>(media_frame->GetPrivData());
+		if (frame != nullptr)
+		{
+			if (frame->colorspace == AVCOL_SPC_UNSPECIFIED)
+			{
+				frame->colorspace = AVCOL_SPC_BT709;
+			}
+			if (frame->color_range == AVCOL_RANGE_UNSPECIFIED)
+			{
+				bool yuvj = (frame->format == AV_PIX_FMT_YUVJ420P ||
+							 frame->format == AV_PIX_FMT_YUVJ422P ||
+							 frame->format == AV_PIX_FMT_YUVJ444P);
+				frame->color_range = yuvj ? AVCOL_RANGE_JPEG : AVCOL_RANGE_MPEG;
+			}
+		}
 	}
 
 	// PushFrame transfers the frame from GPU to host memory when _use_hwframe_transfer is set.

--- a/src/projects/transcoder/filter/filter_lavfi_rescaler.h
+++ b/src/projects/transcoder/filter/filter_lavfi_rescaler.h
@@ -34,6 +34,9 @@ private:
 
 	// ----- Members -----
 	ffmpeg::FFmpegFilterGraph _graph;
+
+	// Colour-managed scale active for this image (thumbnail) track (AVIF only).
+	bool _image_color_managed = false;
 #if _SIMULATE_PROCESSING_DELAY_ENABLED
 	int32_t _simulate_overload = 0;
 #endif

--- a/src/projects/transcoder/transcoder_encoder.cpp
+++ b/src/projects/transcoder/transcoder_encoder.cpp
@@ -173,6 +173,7 @@ std::shared_ptr<TranscodeEncoder> TranscodeEncoder::Instantiate(
 	else if (codec_id == cmn::MediaCodecId::Jpeg)    return std::make_shared<AVCodecImageEncoder>(stream_info, codec_id);
 	else if (codec_id == cmn::MediaCodecId::Png)     return std::make_shared<AVCodecImageEncoder>(stream_info, codec_id);
 	else if (codec_id == cmn::MediaCodecId::Webp)    return std::make_shared<AVCodecImageEncoder>(stream_info, codec_id);
+	else if (codec_id == cmn::MediaCodecId::Avif)    return std::make_shared<AVCodecImageEncoder>(stream_info, codec_id);
 	else if (codec_id == cmn::MediaCodecId::Whisper) return std::make_shared<EncoderWhisper>(stream_info);
 	else
 	{

--- a/src/projects/transcoder/transcoder_modules.cpp
+++ b/src/projects/transcoder/transcoder_modules.cpp
@@ -22,7 +22,7 @@ namespace tc
 		// Video Codecs
 		// --------------------------------------------------------------------------
 		Register(info::CodecModule("FFmpeg Video Codecs", cmn::MediaType::Video, cmn::MediaCodecModuleId::DEFAULT, 0, "-",
-						   {cmn::MediaCodecId::H264, cmn::MediaCodecId::H265, cmn::MediaCodecId::Vp8},
+						   {cmn::MediaCodecId::H264, cmn::MediaCodecId::H265, cmn::MediaCodecId::Vp8, cmn::MediaCodecId::Av1},
 						   true, true, false, false));
 
 		Register(info::CodecModule("Open Source H.264 Codec", cmn::MediaType::Video, cmn::MediaCodecModuleId::OPENH264, 0, "-",
@@ -58,7 +58,7 @@ namespace tc
 		// Image Codecs
 		// --------------------------------------------------------------------------
 		Register(info::CodecModule("FFmpeg Image Codec", cmn::MediaType::Video, cmn::MediaCodecModuleId::DEFAULT, 0, "-",
-						   {cmn::MediaCodecId::Jpeg, cmn::MediaCodecId::Png, cmn::MediaCodecId::Webp},
+						   {cmn::MediaCodecId::Jpeg, cmn::MediaCodecId::Png, cmn::MediaCodecId::Webp, cmn::MediaCodecId::Avif},
 						   true, false, true, false));
 
 		// --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This adds two related capabilities to the software (FFmpeg) transcoder:

1. **AV1 software decode** — AV1 ingest can now be decoded to raw frames, so AV1 input can drive thumbnails and be transcoded to other codecs. Master already ingests AV1 over enhanced RTMP (#2204), packages it for LL-HLS (#2206), and installs libaom (#2205), but it does not register AV1 in the decoder, so an AV1 source could be packaged but never decoded. This wires AV1 into the existing software video decoder.
2. **AVIF thumbnails** — a fourth still-image thumbnail format alongside JPEG/PNG/WebP, encoded with the libaom AV1 encoder already present in the build and muxed into an AVIF (HEIF/MIAF) container. AVIF is the only one of the four that is colour-managed; JPEG/PNG/WebP are left exactly as they are today.

No new third-party library is introduced. libaom is already a dependency as of #2205. The only build change is correcting the FFmpeg configure component name and enabling the `avif` muxer and `colorspace` filter


## What's new

**AVIF codec plumbing**
- New `cmn::MediaCodecId::Avif` and `cmn::BitstreamFormat::AVIF`, threaded through the codec-id/string helpers, the thumbnail publisher/stream/interceptor, the segment writer, and the RTMP track/chunk handlers so an `<Image><Codec>avif</Codec></Image>` encode is recognised end to end.
- Registered in the transcoder module table under the existing `FFmpeg Image Codec` (DEFAULT) module next to JPEG/PNG/WebP.

**AV1 software decode** (`AVCodecVideoDecoder`)
- `Av1` added to the `FFmpeg Video Codecs` (DEFAULT) decoder module list (was `{H264, H265, Vp8}`).
- An `IsPreFramed()` path for AV1: ingest arrives as complete AV1 temporal units (`AV1_OBU`) and the bundled FFmpeg has no AV1 parser, so these tracks skip the bitstream framer and feed each packet to the decoder as-is. The decoder is selected by name (`libaom-av1`), and the framer-driven resolution-reinit step is skipped because libaom adapts to format changes internally.

**AVIF thumbnail encoder** (folded into `AVCodecImageEncoder`)
- AVIF is an AV1 still muxed into a HEIF/MIAF container. libaom emits only the raw AV1 bitstream, so the encoder drives the `AVCodecContext` directly (rather than the shared `FFmpegCodec` send/receive helpers) to do three things FFmpeg's image path can't do for us:
  - **Deferred open with verbatim CICP** — `avcodec_open2` is deferred to the first frame so the source's colour tags (primaries/transfer/matrix/range) are copied into the AV1 sequence header, making the AVIF CICP match the source. Any still-unspecified primaries/transfer/matrix field defaults to BT.709; an unspecified range defaults to full (JPEG).
  - **`av1C` extradata from an in-band sequence header** — with `AV_CODEC_FLAG_GLOBAL_HEADER` set, the `avif` muxer builds the `av1C` configuration box from the encoder's extradata. libaom can leave extradata empty, so as a fallback the encoder locates the `OBU_SEQUENCE_HEADER` in the first packet and supplies it. Without a populated `av1C`, libavif (Chrome's decoder) rejects the file.
  - **In-memory single-image mux** — each encoded AV1 temporal unit is wrapped into a one-image AVIF via libavformat's `avif` muxer over an in-memory AVIO buffer.
- Encoder settings: `usage=allintra` (every frame an intra still), GOP 0, single-threaded (thumbnails are ~1 fps), `cpu-used=8`, `crf=23`, `bit_rate=0` (CRF mode).
- **Graceful degradation**: if the deferred open fails, the track is marked dead and subsequent frames are dropped rather than erroring, so a failed thumbnail can never stall the stream.

**AVIF-only colour management** (`FilterLavfiRescaler`)
- For an AVIF output track only, the scale step is followed by `colorspace=all=bt709:range=pc:iprimaries=bt709:itrc=bt709`, converting the matrix to BT.709 full range. AVIF carries an explicit CICP tag that browsers honour, so the samples and the tag must agree; JPEG/PNG/WebP do not carry a matrix tag the same way and are intentionally left on the plain bilinear path.
- The `colorspace` filter rejects an unspecified input matrix. Rather than seed the buffersrc with colour options (those need FFmpeg 7.0+; this build is 5.1.4), each untagged frame is stamped before filtering: matrix → BT.709, range → JPEG for `yuvj*` pixel formats else MPEG. A genuinely-tagged BT.601 frame keeps its own tag and is converted; only untagged frames are assumed BT.709, which matches the default browsers apply to untagged content.

**Build** (`cmake/InstallPrerequisites.cmake`)
- FFmpeg configure: `libaom-av1` → `libaom_av1` in `--enable-encoder` and `--enable-decoder`. `libaom_av1` (underscore) is the component name FFmpeg's configure expects; with this the libaom AV1 encoder and decoder are actually compiled into the bundled FFmpeg.
- Added the `avif` muxer and the `colorspace` filter to the configure line.

## Build / dependency impact

- No new external library. libaom (3.12.0) is already installed as of #2205; this PR only makes FFmpeg actually build its libaom AV1 encoder/decoder and enables two more FFmpeg components (`avif` muxer, `colorspace` filter).

## Testing

A linear, self-contained test script is included at `misc/test_av1_avif.sh`. It builds nothing itself; given an image built from this branch it:
- starts OME with a JPEG+PNG+WebP+AVIF thumbnail profile,
- prints the bundled FFmpeg's enabled encoders/decoders/muxers/filters (to confirm `libaom_av1`, `avif`, `colorspace`),
- pushes a CPU H.264 (libx264) stream and fetches all four thumbnails — proving the H.264 decode path and all four image encoders,
- ffprobes the AVIF to confirm its colour tags (`av1` / `yuv420p` / `bt709` / `range=pc`),
- pushes a libaom AV1 stream, confirms OME ingests it as AV1 (`BSF(AV1_OBU)`), and produces thumbnails from it — a thumbnail can only be produced if the AV1 was decoded.

## Commits

1. `feat: AVIF codec id and AV1/AVIF build plumbing`
2. `feat: AV1 software decoder`
3. `feat: AVIF thumbnail encoder in the avcodec image encoder`
4. `feat: colour-managed AVIF thumbnails`
5. `test: AV1 decode + AVIF thumbnail reproduction script`
