### PR TITLE
fix: preload Whisper model on the configured OME device, not the CUDA index

### DIFF
--- a/docs/subtitles/realtime-speech-to-text.md
+++ b/docs/subtitles/realtime-speech-to-text.md
@@ -99,7 +99,7 @@ Each `<PreloadModel>` entry has the following fields:
 | Key | Description |
 |---|---|
 | Path | Path to the model file. Can be absolute or relative to the config directory. |
-| Devices | Comma-separated list of CUDA device indices to load the model onto (e.g. `0`, `0,1`, `2`). Set to `all` to load on every available GPU. If omitted, defaults to device 0. |
+| Devices | Comma-separated list of OME device indices to load the model onto (e.g. `0`, `0,1`, `2`), the same numbering as `<Video><Modules>nv:N</Modules>`. Set to `all` to load on every available GPU. If omitted, defaults to device 0. |
 
 ```xml
 <Server>

--- a/src/projects/config/items/modules/whisper.h
+++ b/src/projects/config/items/modules/whisper.h
@@ -14,8 +14,9 @@ namespace cfg
 	{
 		// Represents a single <PreloadModel> entry.
 		// <Path> is the model file path (absolute or relative to config dir).
-		// <Devices> is a comma-separated list of CUDA device indices to preload onto.
-		// Use "all" to load on every available GPU. If omitted, defaults to device 0.
+		// <Devices> is a comma-separated list of OME device indices (the same
+		// namespace as <Modules>nv:N>) to preload onto. Use "all" to load on every
+		// available GPU. If omitted, defaults to device 0.
 		struct WhisperPreloadModel : public Item
 		{
 		protected:

--- a/src/projects/transcoder/transcoder.cpp
+++ b/src/projects/transcoder/transcoder.cpp
@@ -52,25 +52,42 @@ bool Transcoder::Start()
 		{
 			ov::String resolved = ov::GetFilePath(entry.GetPath(), config_path);
 
-			// Parse <Devices>:
-			// - Omitted/empty → device 0 (default)
+			// Parse <Devices> as OME device indices (the same namespace as
+			// <Modules>nv:N), then map each to its CUDA device id. This keeps the
+			// preloaded context and the per-stream STT encoder on the same GPU,
+			// since OME and CUDA device ordering can differ (e.g. CUDA orders by
+			// performance, OME by PCI bus).
+			// - Omitted/empty → OME device 0 (default)
 			// - "all" → empty list passed to Preload (= load on every available GPU)
-			// - "0,1" etc → specific device indices
+			// - "0,1" etc → specific OME device indices
 			std::vector<int32_t> device_ids;
 			const ov::String &devices_str = entry.GetDevices();
 			if (devices_str.IsEmpty())
 			{
-				device_ids.push_back(0);
+				int32_t cuda_id = TranscodeGPU::GetInstance()->GetExternalDeviceId(cmn::MediaCodecModuleId::NVENC, 0);
+				if (cuda_id >= 0)
+				{
+					device_ids.push_back(cuda_id);
+				}
 			}
 			else if (devices_str.LowerCaseString() != "all")
 			{
 				for (const auto &token : devices_str.Split(","))
 				{
 					ov::String trimmed = token.Trim();
-					if (!trimmed.IsEmpty())
+					if (trimmed.IsEmpty())
 					{
-						device_ids.push_back(ov::Converter::ToInt32(trimmed));
+						continue;
 					}
+
+					int32_t cuda_id = TranscodeGPU::GetInstance()->GetExternalDeviceId(
+						cmn::MediaCodecModuleId::NVENC, ov::Converter::ToInt32(trimmed));
+					if (cuda_id < 0)
+					{
+						logtw("Whisper preload: no NVIDIA device for OME device id %s, skipping. path=%s", trimmed.CStr(), resolved.CStr());
+						continue;
+					}
+					device_ids.push_back(cuda_id);
 				}
 			}
 			// "all" → device_ids remains empty → Preload loads on all available GPUs

--- a/src/projects/transcoder/transcoder.cpp
+++ b/src/projects/transcoder/transcoder.cpp
@@ -83,10 +83,11 @@ bool Transcoder::Start()
 			std::vector<int32_t> device_ids;
 			if (devices_str.IsEmpty())
 			{
-				// Default: OME device 0, only if it is an available NVIDIA device.
-				if (TranscodeGPU::GetInstance()->IsSupported(cmn::MediaCodecModuleId::NVENC, 0) == true)
+				// Default: OME device 0 (GetExternalDeviceId returns -1 if unavailable).
+				int32_t cuda_id = TranscodeGPU::GetInstance()->GetExternalDeviceId(cmn::MediaCodecModuleId::NVENC, 0);
+				if (cuda_id >= 0)
 				{
-					device_ids.push_back(TranscodeGPU::GetInstance()->GetExternalDeviceId(cmn::MediaCodecModuleId::NVENC, 0));
+					device_ids.push_back(cuda_id);
 				}
 			}
 			else if (load_all == false)
@@ -100,16 +101,14 @@ bool Transcoder::Start()
 						continue;
 					}
 
-					// Validate the index against the actual device count before
-					// resolving; GetExternalDeviceId does not range-check and may
-					// return a stale CUDA id for an out-of-range index.
-					int32_t ome_device_id = ov::Converter::ToInt32(trimmed);
-					if (TranscodeGPU::GetInstance()->IsSupported(cmn::MediaCodecModuleId::NVENC, ome_device_id) == false)
+					int32_t cuda_id = TranscodeGPU::GetInstance()->GetExternalDeviceId(
+						cmn::MediaCodecModuleId::NVENC, ov::Converter::ToInt32(trimmed));
+					if (cuda_id < 0)
 					{
 						logtw("Whisper preload: OME device id %s is not an available NVIDIA device, skipping. path=%s", trimmed.CStr(), resolved.CStr());
 						continue;
 					}
-					device_ids.push_back(TranscodeGPU::GetInstance()->GetExternalDeviceId(cmn::MediaCodecModuleId::NVENC, ome_device_id));
+					device_ids.push_back(cuda_id);
 				}
 			}
 

--- a/src/projects/transcoder/transcoder.cpp
+++ b/src/projects/transcoder/transcoder.cpp
@@ -48,6 +48,23 @@ bool Transcoder::Start()
 		const auto &config_path = cfg::ConfigManager::GetInstance()->GetConfigPath();
 
 		std::vector<std::pair<ov::String, std::vector<int32_t>>> preload_models;
+
+		// A <Devices> token must be a plain non-negative integer (an OME device index).
+		auto is_numeric = [](const ov::String &value) -> bool {
+			if (value.IsEmpty())
+			{
+				return false;
+			}
+			for (const char *p = value.CStr(); *p != '\0'; ++p)
+			{
+				if (*p < '0' || *p > '9')
+				{
+					return false;
+				}
+			}
+			return true;
+		};
+
 		for (const auto &entry : whisper_cfg.GetPreloadModels())
 		{
 			ov::String resolved = ov::GetFilePath(entry.GetPath(), config_path);
@@ -58,10 +75,12 @@ bool Transcoder::Start()
 			// since OME and CUDA device ordering can differ (e.g. CUDA orders by
 			// performance, OME by PCI bus).
 			// - Omitted/empty → OME device 0 (default)
-			// - "all" → empty list passed to Preload (= load on every available GPU)
+			// - "all" → load on every available GPU
 			// - "0,1" etc → specific OME device indices
-			std::vector<int32_t> device_ids;
 			const ov::String &devices_str = entry.GetDevices();
+			const bool load_all = devices_str.LowerCaseString() == "all";
+
+			std::vector<int32_t> device_ids;
 			if (devices_str.IsEmpty())
 			{
 				int32_t cuda_id = TranscodeGPU::GetInstance()->GetExternalDeviceId(cmn::MediaCodecModuleId::NVENC, 0);
@@ -70,13 +89,14 @@ bool Transcoder::Start()
 					device_ids.push_back(cuda_id);
 				}
 			}
-			else if (devices_str.LowerCaseString() != "all")
+			else if (load_all == false)
 			{
 				for (const auto &token : devices_str.Split(","))
 				{
 					ov::String trimmed = token.Trim();
-					if (trimmed.IsEmpty())
+					if (is_numeric(trimmed) == false)
 					{
+						logtw("Whisper preload: ignoring invalid device id \"%s\" in Devices(\"%s\"). path=%s", trimmed.CStr(), devices_str.CStr(), resolved.CStr());
 						continue;
 					}
 
@@ -90,7 +110,15 @@ bool Transcoder::Start()
 					device_ids.push_back(cuda_id);
 				}
 			}
-			// "all" → device_ids remains empty → Preload loads on all available GPUs
+
+			// Only "all" loads on every GPU (empty device_ids). If a specific or
+			// default selection resolved nothing, skip the model rather than letting
+			// an empty list fall through to "all".
+			if (load_all == false && device_ids.empty())
+			{
+				logtw("Whisper preload: no usable GPU resolved from Devices(\"%s\"), skipping model. path=%s", devices_str.CStr(), resolved.CStr());
+				continue;
+			}
 
 			preload_models.emplace_back(std::move(resolved), std::move(device_ids));
 		}

--- a/src/projects/transcoder/transcoder.cpp
+++ b/src/projects/transcoder/transcoder.cpp
@@ -77,16 +77,16 @@ bool Transcoder::Start()
 			// - Omitted/empty → OME device 0 (default)
 			// - "all" → load on every available GPU
 			// - "0,1" etc → specific OME device indices
-			const ov::String &devices_str = entry.GetDevices();
+			const ov::String devices_str = entry.GetDevices().Trim();
 			const bool load_all = devices_str.LowerCaseString() == "all";
 
 			std::vector<int32_t> device_ids;
 			if (devices_str.IsEmpty())
 			{
-				int32_t cuda_id = TranscodeGPU::GetInstance()->GetExternalDeviceId(cmn::MediaCodecModuleId::NVENC, 0);
-				if (cuda_id >= 0)
+				// Default: OME device 0, only if it is an available NVIDIA device.
+				if (TranscodeGPU::GetInstance()->IsSupported(cmn::MediaCodecModuleId::NVENC, 0) == true)
 				{
-					device_ids.push_back(cuda_id);
+					device_ids.push_back(TranscodeGPU::GetInstance()->GetExternalDeviceId(cmn::MediaCodecModuleId::NVENC, 0));
 				}
 			}
 			else if (load_all == false)
@@ -100,14 +100,16 @@ bool Transcoder::Start()
 						continue;
 					}
 
-					int32_t cuda_id = TranscodeGPU::GetInstance()->GetExternalDeviceId(
-						cmn::MediaCodecModuleId::NVENC, ov::Converter::ToInt32(trimmed));
-					if (cuda_id < 0)
+					// Validate the index against the actual device count before
+					// resolving; GetExternalDeviceId does not range-check and may
+					// return a stale CUDA id for an out-of-range index.
+					int32_t ome_device_id = ov::Converter::ToInt32(trimmed);
+					if (TranscodeGPU::GetInstance()->IsSupported(cmn::MediaCodecModuleId::NVENC, ome_device_id) == false)
 					{
-						logtw("Whisper preload: no NVIDIA device for OME device id %s, skipping. path=%s", trimmed.CStr(), resolved.CStr());
+						logtw("Whisper preload: OME device id %s is not an available NVIDIA device, skipping. path=%s", trimmed.CStr(), resolved.CStr());
 						continue;
 					}
-					device_ids.push_back(cuda_id);
+					device_ids.push_back(TranscodeGPU::GetInstance()->GetExternalDeviceId(cmn::MediaCodecModuleId::NVENC, ome_device_id));
 				}
 			}
 

--- a/src/projects/transcoder/transcoder.cpp
+++ b/src/projects/transcoder/transcoder.cpp
@@ -95,8 +95,14 @@ bool Transcoder::Start()
 				for (const auto &token : devices_str.Split(","))
 				{
 					ov::String trimmed = token.Trim();
-					if (is_numeric(trimmed) == false)
+					if (trimmed.IsEmpty())
 					{
+						// e.g. a trailing comma in "0,1," — ignore quietly.
+						continue;
+					}
+					if (is_numeric(trimmed) == false || trimmed.GetLength() > 9)
+					{
+						// Non-numeric, or too many digits to be a valid int32 device index.
 						logtw("Whisper preload: ignoring invalid device id \"%s\" in Devices(\"%s\"). path=%s", trimmed.CStr(), devices_str.CStr(), resolved.CStr());
 						continue;
 					}

--- a/src/projects/transcoder/transcoder_gpu.cpp
+++ b/src/projects/transcoder/transcoder_gpu.cpp
@@ -477,9 +477,9 @@ std::shared_ptr<HwDeviceContext> TranscodeGPU::GetDeviceContextNV(cmn::DeviceId 
 
 int32_t TranscodeGPU::GetDeviceIdNV(cmn::DeviceId gpu_id)
 {
-	// Range-check against the actual device count, not just the array bound, so
-	// an out-of-range index returns -1 instead of a stale CUDA id.
-	if (gpu_id < 0 || gpu_id >= _device_count_nv)
+	// Valid only for a populated slot. Arrays are indexed by NVML device id
+	// (sparse), so _device_count_nv (a success counter) is not the index bound.
+	if (gpu_id < 0 || gpu_id >= MAX_DEVICE_COUNT || _device_context_nv[gpu_id] == nullptr)
 	{
 		return -1;
 	}
@@ -499,12 +499,9 @@ bool TranscodeGPU::IsSupportedNILOGAN(cmn::DeviceId gpu_id)
 
 bool TranscodeGPU::IsSupportedNV(cmn::DeviceId gpu_id)
 {
-	if (_device_count_nv == 0 || gpu_id >= _device_count_nv)
-	{
-		return false;
-	}
-
-	return true;
+	// Supported iff this slot was successfully initialized. Indices are sparse
+	// (by NVML device id), so a count comparison is not enough.
+	return gpu_id >= 0 && gpu_id < MAX_DEVICE_COUNT && _device_context_nv[gpu_id] != nullptr;
 }
 
 bool TranscodeGPU::IsSupportedXMA(cmn::DeviceId gpu_id)

--- a/src/projects/transcoder/transcoder_gpu.cpp
+++ b/src/projects/transcoder/transcoder_gpu.cpp
@@ -477,7 +477,9 @@ std::shared_ptr<HwDeviceContext> TranscodeGPU::GetDeviceContextNV(cmn::DeviceId 
 
 int32_t TranscodeGPU::GetDeviceIdNV(cmn::DeviceId gpu_id)
 {
-	if (gpu_id >= MAX_DEVICE_COUNT)
+	// Range-check against the actual device count, not just the array bound, so
+	// an out-of-range index returns -1 instead of a stale CUDA id.
+	if (gpu_id < 0 || gpu_id >= _device_count_nv)
 	{
 		return -1;
 	}


### PR DESCRIPTION
## Problem
Whisper `<PreloadModel><Devices>` was interpreted as CUDA device indices, while `<Modules>nv:N` (video and STT encoders) uses OME device indices. On hosts where CUDA and OME order devices differently (CUDA defaults to fastest-first, OME uses PCI bus order), a single device index preloads the model onto a different GPU than the encoders use, so the preload is wasted and the per-stream STT encoder reloads its own context.

## Solution
Resolve `<Devices>` through the same OME-to-CUDA mapping as `<Modules>` (`TranscodeGPU::GetExternalDeviceId`) so preload and the encoders share one context on the configured device. Non-numeric tokens are rejected with a warning, and a selection that resolves to no device skips the model instead of falling through to load-on-all-GPUs. The config comment and STT docs are updated to match.

## Test
On a host where OME and CUDA enumerate GPUs in different orders (e.g. a mixed-GPU box where the faster card is OME device 1 but CUDA device 0), set `<Video><Modules>nv:1</Modules>` and `<PreloadModel><Devices>1</Devices>`, push a stream with audio, enable STT, then inspect the OME log (`Whisper model loaded successfully on device N`) and `nvidia-smi` per-GPU memory.

Pass conditions:
- The Whisper preload lands on the same physical GPU as the `nv:1` encoders, not the GPU at CUDA index 1.
- A non-numeric `<Devices>` token is skipped with a warning instead of silently mapping to device 0.
- A `<Devices>` value that resolves to no device skips the model with a warning rather than loading on every GPU.
