### PR TITLE
fix: prevent crash in internal-queue stats API under concurrent queue updates

### DIFF
--- a/src/projects/modules/json_serdes/metrics.cpp
+++ b/src/projects/modules/json_serdes/metrics.cpp
@@ -83,7 +83,10 @@ namespace serdes
 		Json::Value value;
 
 		SetInt64(value, "id", metrics->GetId());
-		SetString(value, "urn", metrics->GetUrn()->ToString(), Optional::False);
+		// A queue can be registered before its URN is set (e.g. default-constructed
+		// queue, URN assigned later via SetUrn), so GetUrn() may be null.
+		auto urn = metrics->GetUrn();
+		SetString(value, "urn", (urn != nullptr) ? urn->ToString() : ov::String(""), Optional::False);
 		SetString(value, "type", metrics->GetTypeName(), Optional::False);
 		SetInt(value, "size", metrics->GetSize());
 		SetInt(value, "peak", metrics->GetPeak());

--- a/src/projects/modules/json_serdes/metrics.cpp
+++ b/src/projects/modules/json_serdes/metrics.cpp
@@ -84,9 +84,11 @@ namespace serdes
 
 		SetInt64(value, "id", metrics->GetId());
 		// A queue can be registered before its URN is set (e.g. default-constructed
-		// queue, URN assigned later via SetUrn), so GetUrn() may be null.
+		// queue, URN assigned later via SetUrn), so GetUrn() may be null. Use the same
+		// "No Urn" sentinel as info::ManagedQueue::ToString(); an empty string would trip
+		// the non-optional SetString assert and omit the key.
 		auto urn = metrics->GetUrn();
-		SetString(value, "urn", (urn != nullptr) ? urn->ToString() : ov::String(""), Optional::False);
+		SetString(value, "urn", (urn != nullptr) ? urn->ToString() : ov::String("No Urn"), Optional::False);
 		SetString(value, "type", metrics->GetTypeName(), Optional::False);
 		SetInt(value, "size", metrics->GetSize());
 		SetInt(value, "peak", metrics->GetPeak());

--- a/src/projects/monitoring/queue_metrics.h
+++ b/src/projects/monitoring/queue_metrics.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <mutex>
+#include <shared_mutex>
+
 #include "base/info/managed_queue.h"
 
 namespace mon
@@ -29,29 +32,35 @@ namespace mon
 		{
 		}
 
-		const uint32_t &GetId() const
+		uint32_t GetId() const
 		{
 			return _id;
 		}
 
-		const std::shared_ptr<info::ManagedQueue::URN> &GetUrn() const
+		// Returns by value: the caller must hold its own reference because the monitor
+		// thread may reassign _urn concurrently (see UpdateMetadata).
+		std::shared_ptr<info::ManagedQueue::URN> GetUrn() const
 		{
+			std::shared_lock lock(_mutex);
 			return _urn;
 		}
 
-		const ov::String &GetTypeName() const
+		ov::String GetTypeName() const
 		{
+			std::shared_lock lock(_mutex);
 			return _type_name;
 		}
 
 		void UpdateMetadata(const info::ManagedQueue &info)
 		{
+			std::unique_lock lock(_mutex);
 			_urn	   = info.GetUrn();
 			_type_name = info.GetTypeName();
 		}
 
 		void UpdateMetrics(const info::ManagedQueue &info)
 		{
+			std::unique_lock lock(_mutex);
 			_peak					   = info.GetPeak();
 			_size					   = info.GetSize();
 			_threshold				   = info.GetThreshold();
@@ -61,42 +70,51 @@ namespace mon
 			_waiting_time			   = info.GetWaitingTimeInUs();
 		}
 
-		const size_t &GetPeak() const
+		size_t GetPeak() const
 		{
+			std::shared_lock lock(_mutex);
 			return _peak;
 		}
 
-		const size_t &GetSize() const
+		size_t GetSize() const
 		{
+			std::shared_lock lock(_mutex);
 			return _size;
 		}
 
-		const size_t &GetThreshold() const
+		size_t GetThreshold() const
 		{
+			std::shared_lock lock(_mutex);
 			return _threshold;
 		}
 
-		const size_t &GetInputMessagePerSecond() const
+		size_t GetInputMessagePerSecond() const
 		{
+			std::shared_lock lock(_mutex);
 			return _input_message_per_second;
 		}
 
-		const size_t &GetOutputMessagePerSecond() const
+		size_t GetOutputMessagePerSecond() const
 		{
+			std::shared_lock lock(_mutex);
 			return _output_message_per_second;
 		}
 
-		const size_t &GetDropCount() const
+		size_t GetDropCount() const
 		{
+			std::shared_lock lock(_mutex);
 			return _drop_count;
 		}
 
-		const int64_t &GetWaitingTime() const
+		int64_t GetWaitingTime() const
 		{
+			std::shared_lock lock(_mutex);
 			return _waiting_time;
 		}
 
 	private:
+		mutable std::shared_mutex _mutex;
+
 		// metadata
 		uint32_t _id;
 		std::shared_ptr<info::ManagedQueue::URN> _urn;

--- a/src/projects/monitoring/queue_metrics.h
+++ b/src/projects/monitoring/queue_metrics.h
@@ -52,21 +52,35 @@ namespace mon
 
 		void UpdateMetadata(const info::ManagedQueue &info)
 		{
+			// Read from info first (its getters take ManagedQueue's own lock); then take
+			// _mutex only for the assignment to keep the exclusive section minimal and
+			// avoid nested locking.
+			auto urn	   = info.GetUrn();
+			auto type_name = info.GetTypeName();
+
 			ov::LockGuard lock(_mutex);
-			_urn	   = info.GetUrn();
-			_type_name = info.GetTypeName();
+			_urn	   = std::move(urn);
+			_type_name = std::move(type_name);
 		}
 
 		void UpdateMetrics(const info::ManagedQueue &info)
 		{
+			const auto peak						 = info.GetPeak();
+			const auto size						 = info.GetSize();
+			const auto threshold				 = info.GetThreshold();
+			const auto input_message_per_second	 = info.GetInputMessagePerSecond();
+			const auto output_message_per_second = info.GetOutputMessagePerSecond();
+			const auto drop_count				 = info.GetDropCount();
+			const auto waiting_time				 = info.GetWaitingTimeInUs();
+
 			ov::LockGuard lock(_mutex);
-			_peak					   = info.GetPeak();
-			_size					   = info.GetSize();
-			_threshold				   = info.GetThreshold();
-			_input_message_per_second  = info.GetInputMessagePerSecond();
-			_output_message_per_second = info.GetOutputMessagePerSecond();
-			_drop_count				   = info.GetDropCount();
-			_waiting_time			   = info.GetWaitingTimeInUs();
+			_peak					   = peak;
+			_size					   = size;
+			_threshold				   = threshold;
+			_input_message_per_second  = input_message_per_second;
+			_output_message_per_second = output_message_per_second;
+			_drop_count				   = drop_count;
+			_waiting_time			   = waiting_time;
 		}
 
 		size_t GetPeak() const

--- a/src/projects/monitoring/queue_metrics.h
+++ b/src/projects/monitoring/queue_metrics.h
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <mutex>
-#include <shared_mutex>
+#include <base/ovlibrary/ovlibrary.h>
 
 #include "base/info/managed_queue.h"
 
@@ -41,26 +40,26 @@ namespace mon
 		// thread may reassign _urn concurrently (see UpdateMetadata).
 		std::shared_ptr<info::ManagedQueue::URN> GetUrn() const
 		{
-			std::shared_lock lock(_mutex);
+			ov::SharedLockGuard lock(_mutex);
 			return _urn;
 		}
 
 		ov::String GetTypeName() const
 		{
-			std::shared_lock lock(_mutex);
+			ov::SharedLockGuard lock(_mutex);
 			return _type_name;
 		}
 
 		void UpdateMetadata(const info::ManagedQueue &info)
 		{
-			std::unique_lock lock(_mutex);
+			ov::LockGuard lock(_mutex);
 			_urn	   = info.GetUrn();
 			_type_name = info.GetTypeName();
 		}
 
 		void UpdateMetrics(const info::ManagedQueue &info)
 		{
-			std::unique_lock lock(_mutex);
+			ov::LockGuard lock(_mutex);
 			_peak					   = info.GetPeak();
 			_size					   = info.GetSize();
 			_threshold				   = info.GetThreshold();
@@ -72,61 +71,61 @@ namespace mon
 
 		size_t GetPeak() const
 		{
-			std::shared_lock lock(_mutex);
+			ov::SharedLockGuard lock(_mutex);
 			return _peak;
 		}
 
 		size_t GetSize() const
 		{
-			std::shared_lock lock(_mutex);
+			ov::SharedLockGuard lock(_mutex);
 			return _size;
 		}
 
 		size_t GetThreshold() const
 		{
-			std::shared_lock lock(_mutex);
+			ov::SharedLockGuard lock(_mutex);
 			return _threshold;
 		}
 
 		size_t GetInputMessagePerSecond() const
 		{
-			std::shared_lock lock(_mutex);
+			ov::SharedLockGuard lock(_mutex);
 			return _input_message_per_second;
 		}
 
 		size_t GetOutputMessagePerSecond() const
 		{
-			std::shared_lock lock(_mutex);
+			ov::SharedLockGuard lock(_mutex);
 			return _output_message_per_second;
 		}
 
 		size_t GetDropCount() const
 		{
-			std::shared_lock lock(_mutex);
+			ov::SharedLockGuard lock(_mutex);
 			return _drop_count;
 		}
 
 		int64_t GetWaitingTime() const
 		{
-			std::shared_lock lock(_mutex);
+			ov::SharedLockGuard lock(_mutex);
 			return _waiting_time;
 		}
 
 	private:
-		mutable std::shared_mutex _mutex;
+		mutable ov::SharedMutex _mutex;
 
 		// metadata
 		uint32_t _id;
-		std::shared_ptr<info::ManagedQueue::URN> _urn;
-		ov::String _type_name;
+		std::shared_ptr<info::ManagedQueue::URN> _urn OV_GUARDED_BY(_mutex);
+		ov::String _type_name OV_GUARDED_BY(_mutex);
 
 		// metrics
-		size_t _threshold;
-		size_t _peak;
-		size_t _size;
-		size_t _input_message_per_second;
-		size_t _output_message_per_second;
-		size_t _drop_count;
-		int64_t _waiting_time;
+		size_t _threshold OV_GUARDED_BY(_mutex);
+		size_t _peak OV_GUARDED_BY(_mutex);
+		size_t _size OV_GUARDED_BY(_mutex);
+		size_t _input_message_per_second OV_GUARDED_BY(_mutex);
+		size_t _output_message_per_second OV_GUARDED_BY(_mutex);
+		size_t _drop_count OV_GUARDED_BY(_mutex);
+		int64_t _waiting_time OV_GUARDED_BY(_mutex);
 	};
 }  // namespace mon

--- a/src/projects/monitoring/server_metrics.cpp
+++ b/src/projects/monitoring/server_metrics.cpp
@@ -174,13 +174,14 @@ namespace mon
 		auto delete_lazy_stream_timeout_conf = _server_config->GetModules().GetRecovery().GetDeleteLazyStreamTimeout();
 		if (delete_lazy_stream_timeout_conf > 0)
 		{
-			if ((queue_info.GetThresholdExceededTimeMs() > delete_lazy_stream_timeout_conf) && (!queue_info.GetUrn()->GetStreamName().IsEmpty()))
+			auto urn = queue_info.GetUrn();
+			if ((urn != nullptr) && (queue_info.GetThresholdExceededTimeMs() > delete_lazy_stream_timeout_conf) && (!urn->GetStreamName().IsEmpty()))
 			{
-				auto vhost_app	 = queue_info.GetUrn()->GetVHostAppName();
-				auto stream_name = queue_info.GetUrn()->GetStreamName();
+				auto vhost_app	 = urn->GetVHostAppName();
+				auto stream_name = urn->GetStreamName();
 
 				logtc("The %s queue has been exceeded for %" PRId64 " ms. stream will be forcibly deleted. VhostApp(%s), Stream(%s)",
-					  queue_info.GetUrn()->ToString().CStr(), queue_info.GetThresholdExceededTimeMs(), vhost_app.CStr(), stream_name.CStr());
+					  urn->ToString().CStr(), queue_info.GetThresholdExceededTimeMs(), vhost_app.CStr(), stream_name.CStr());
 
 				if (vhost_app.IsValid())
 				{


### PR DESCRIPTION
## Problem
A read-only `GET /v1/stats/current/internals/queues` crashes the whole OME process with SIGSEGV when polled while streams/queues are being created or destroyed. The monitor thread reassigns `mon::QueueMetrics::_urn` / `_type_name` while the API thread reads them with no synchronization, corrupting the URN shared_ptr refcount (use-after-free).

## Solution
Guard `mon::QueueMetrics` fields with a per-instance `std::shared_mutex`: writers (`UpdateMetadata`/`UpdateMetrics`) take an exclusive lock, getters take a shared lock. `GetUrn()` and `GetTypeName()` now return by value so the reader holds its own reference for the `->ToString()` call.

## Test
Poll `/v1/stats/current/internals/queues` ~1/s while ramping and removing transcoded RTMP streams for several minutes.
Pass condition: no SIGSEGV; the endpoint keeps returning valid JSON throughout.