### PR TITLE
fix(mpegts): split AAC PES into per-frame access units for fMP4/LL-HLS

### DIFF
--- a/src/projects/providers/mpegts/mpegts_stream.cpp
+++ b/src/projects/providers/mpegts/mpegts_stream.cpp
@@ -173,11 +173,15 @@ namespace pvd
 						const int64_t timescale			= track->GetTimeBase().GetDen();
 						const int64_t samples_per_frame = (track->GetAudioSamplesPerFrame() > 0) ? track->GetAudioSamplesPerFrame() : 1024;
 
-						// resolved once from the first ADTS header; the sample rate is constant per track
+						// Forward each frame as a copy-on-write slice of the PES payload (no per-frame copy).
+						auto pes_data					= std::make_shared<ov::Data>(payload, payload_length);
+
+						// frame_duration is resolved once from the first ADTS header; the sample rate is constant per track.
 						int64_t frame_duration			= 0;
 						size_t offset					= 0;
 						auto frame_pts					= pts;
 						auto frame_dts					= dts;
+						bool split						= true;
 
 						while ((offset + ADTS_MIN_SIZE) <= payload_length)
 						{
@@ -203,12 +207,30 @@ namespace pvd
 								break;
 							}
 
-							auto data		  = std::make_shared<ov::Data>(payload + offset, frame_length);
+							// Resolve the per-frame duration once; the sample rate is constant within a track.
+							//
+							// NOTE: an invalid sampling-frequency index trips `OV_ASSERT2()` in debug builds,
+							// which is intentional (it surfaces malformed input).
+							// Release builds `return 0;` we treat that as "timing unknown" and fall back to forwarding the PES unsplit,
+							// rather than emitting samples with identical timestamps.
+							if (frame_duration == 0)
+							{
+								const auto samplerate = adts.Samplerate();
+
+								if (samplerate == 0)
+								{
+									split = false;
+									break;
+								}
+
+								frame_duration = cmn::Rational::Rescale(samples_per_frame, cmn::Rational(1, static_cast<int32_t>(samplerate)), cmn::Rational(1, static_cast<int32_t>(timescale)));
+							}
+
 							auto media_packet = std::make_shared<MediaPacket>(
 								GetMsid(),
 								cmn::MediaType::Audio,
 								es->PID(),
-								data,
+								pes_data->Subdata(offset, frame_length),
 								frame_pts,
 								frame_dts,
 								-1LL,
@@ -218,21 +240,28 @@ namespace pvd
 
 							SendFrame(media_packet);
 
-							// Resolve the per-frame duration once; the sample rate is constant within a track.
-							if (frame_duration == 0)
-							{
-								const auto samplerate = adts.Samplerate();
-
-								if (samplerate > 0)
-								{
-									frame_duration = cmn::Rational::Rescale(samples_per_frame, cmn::Rational(1, static_cast<int32_t>(samplerate)), cmn::Rational(1, static_cast<int32_t>(timescale)));
-								}
-							}
-
 							frame_pts += frame_duration;
 							frame_dts += frame_duration;
-
 							offset += frame_length;
+						}
+
+						// Timing could not be resolved (e.g. invalid sampling-frequency index):
+						// forward the whole PES as a single packet (previous behavior) instead of emitting identical-timestamp samples.
+						if (split == false)
+						{
+							auto media_packet = std::make_shared<MediaPacket>(
+								GetMsid(),
+								cmn::MediaType::Audio,
+								es->PID(),
+								pes_data,
+								pts,
+								dts,
+								-1LL,
+								MediaPacketFlag::Unknown,
+								bitstream,
+								cmn::PacketType::RAW);
+
+							SendFrame(media_packet);
 						}
 					}
 					else

--- a/src/projects/providers/mpegts/mpegts_stream.cpp
+++ b/src/projects/providers/mpegts/mpegts_stream.cpp
@@ -159,21 +159,97 @@ namespace pvd
 				}
 				else if (es->IsAudioStream())
 				{
-					auto payload = es->Payload();
-					auto payload_length = es->PayloadLength();
+					auto payload		 = es->Payload();
+					auto payload_length	 = es->PayloadLength();
+					const auto bitstream = track->GetOriginBitstream();
 
-					auto data = std::make_shared<ov::Data>(payload, payload_length);
-					auto media_packet = std::make_shared<MediaPacket>(GetMsid(),
-																	  cmn::MediaType::Audio,
-																	  es->PID(),
-																	  data,
-																	  pts,
-																	  dts,
-																	  -1LL,
-																	  MediaPacketFlag::Unknown,
-																	  track->GetOriginBitstream(),
-																	  cmn::PacketType::RAW);
-					SendFrame(media_packet);
+					// A single MPEG-TS PES payload for AAC carries one or more ADTS frames.
+					// fMP4/LL-HLS packaging requires one access unit (1024 samples) per sample,
+					// so split the PES into individual ADTS frames here.
+					// Otherwise the muxer emits a single oversized sample per PES (N frames glued together),
+					// which strict fMP4 audio decoders (e.g. Safari) reject.
+					if (bitstream == cmn::BitstreamFormat::AAC_ADTS)
+					{
+						const int64_t timescale			= track->GetTimeBase().GetDen();
+						const int64_t samples_per_frame = (track->GetAudioSamplesPerFrame() > 0) ? track->GetAudioSamplesPerFrame() : 1024;
+
+						// resolved once from the first ADTS header; the sample rate is constant per track
+						int64_t frame_duration			= 0;
+						size_t offset					= 0;
+						auto frame_pts					= pts;
+						auto frame_dts					= dts;
+
+						while ((offset + ADTS_MIN_SIZE) <= payload_length)
+						{
+							AACAdts adts;
+
+							if (AACAdts::Parse(payload + offset, payload_length - offset, adts) == false)
+							{
+								logtd(
+									"[%s] Stopped AAC ADTS splitting: no valid ADTS header at offset %zu/%u (PID: %d). "
+									"The PES is likely truncated or corrupted (e.g. UDP packet loss).",
+									GetNamePath().CStr(), offset, payload_length, es->PID());
+								break;
+							}
+
+							const auto frame_length = adts.AacFrameLength();
+
+							if ((frame_length < ADTS_MIN_SIZE) || ((offset + frame_length) > payload_length))
+							{
+								logtd(
+									"[%s] Stopped AAC ADTS splitting: frame length %u at offset %zu exceeds PES payload %u (PID: %d). "
+									"The PES is likely truncated or corrupted (e.g. UDP packet loss).",
+									GetNamePath().CStr(), static_cast<uint32_t>(frame_length), offset, payload_length, es->PID());
+								break;
+							}
+
+							auto data		  = std::make_shared<ov::Data>(payload + offset, frame_length);
+							auto media_packet = std::make_shared<MediaPacket>(
+								GetMsid(),
+								cmn::MediaType::Audio,
+								es->PID(),
+								data,
+								frame_pts,
+								frame_dts,
+								-1LL,
+								MediaPacketFlag::Unknown,
+								bitstream,
+								cmn::PacketType::RAW);
+
+							SendFrame(media_packet);
+
+							// Resolve the per-frame duration once; the sample rate is constant within a track.
+							if (frame_duration == 0)
+							{
+								const auto samplerate = adts.Samplerate();
+
+								if (samplerate > 0)
+								{
+									frame_duration = cmn::Rational::Rescale(samples_per_frame, cmn::Rational(1, static_cast<int32_t>(samplerate)), cmn::Rational(1, static_cast<int32_t>(timescale)));
+								}
+							}
+
+							frame_pts += frame_duration;
+							frame_dts += frame_duration;
+
+							offset += frame_length;
+						}
+					}
+					else
+					{
+						auto data		  = std::make_shared<ov::Data>(payload, payload_length);
+						auto media_packet = std::make_shared<MediaPacket>(GetMsid(),
+																		  cmn::MediaType::Audio,
+																		  es->PID(),
+																		  data,
+																		  pts,
+																		  dts,
+																		  -1LL,
+																		  MediaPacketFlag::Unknown,
+																		  bitstream,
+																		  cmn::PacketType::RAW);
+						SendFrame(media_packet);
+					}
 				}
 
 				logtt("Frame - PID(%d) AdjustPTS(%" PRId64 ") AdjustDTS(%" PRId64 ") PTS(%" PRId64 ") DTS(%" PRId64 ") Size(%d)", es->PID(), pts, dts, origin_pts, origin_dts, es->PayloadLength());

--- a/src/projects/providers/mpegts/mpegts_stream.cpp
+++ b/src/projects/providers/mpegts/mpegts_stream.cpp
@@ -264,11 +264,13 @@ namespace pvd
 
 							SendFrame(media_packet);
 						}
-						else if (offset < payload_length)
+						else if ((offset < payload_length) && ((payload_length - offset) < ADTS_MIN_SIZE))
 						{
-							// Some frames were emitted; the trailing remainder was dropped (truncated/corrupt tail).
+							// The loop ended on a truncated tail: fewer than one ADTS header (`< ADTS_MIN_SIZE`) remained.
+							// A mid-PES break on a malformed header/length leaves `>= ADTS_MIN_SIZE` bytes and was already
+							// logged at the break, so it is excluded here to avoid double logging.
 							logtd("[%s] Dropped %zu trailing byte(s) of the AAC PES after splitting (offset %zu/%u, PID: %d).",
-								GetNamePath().CStr(), static_cast<size_t>(payload_length - offset), offset, payload_length, es->PID());
+								  GetNamePath().CStr(), static_cast<size_t>(payload_length - offset), offset, payload_length, es->PID());
 						}
 					}
 					else

--- a/src/projects/providers/mpegts/mpegts_stream.cpp
+++ b/src/projects/providers/mpegts/mpegts_stream.cpp
@@ -181,7 +181,6 @@ namespace pvd
 						size_t offset					= 0;
 						auto frame_pts					= pts;
 						auto frame_dts					= dts;
-						bool split						= true;
 
 						while ((offset + ADTS_MIN_SIZE) <= payload_length)
 						{
@@ -209,21 +208,23 @@ namespace pvd
 
 							// Resolve the per-frame duration once; the sample rate is constant within a track.
 							//
-							// NOTE: an invalid sampling-frequency index trips `OV_ASSERT2()` in debug builds,
-							// which is intentional (it surfaces malformed input).
-							// Release builds `return 0;` we treat that as "timing unknown" and fall back to forwarding the PES unsplit,
-							// rather than emitting samples with identical timestamps.
+							// NOTE: an invalid sampling-frequency index trips OV_ASSERT2() in debug builds, which is
+							// intentional (it surfaces malformed input).
+							// Release builds return 0. A non-positive duration (invalid sample rate or timebase) means we cannot time the frames,
+							// so we stop splitting and forward the whole PES unsplit below instead of emitting identical-timestamp samples.
 							if (frame_duration == 0)
 							{
 								const auto samplerate = adts.Samplerate();
 
-								if (samplerate == 0)
+								if (samplerate != 0)
 								{
-									split = false;
-									break;
+									frame_duration = cmn::Rational::Rescale(samples_per_frame, cmn::Rational(1, static_cast<int32_t>(samplerate)), cmn::Rational(1, static_cast<int32_t>(timescale)));
 								}
 
-								frame_duration = cmn::Rational::Rescale(samples_per_frame, cmn::Rational(1, static_cast<int32_t>(samplerate)), cmn::Rational(1, static_cast<int32_t>(timescale)));
+								if (frame_duration <= 0)
+								{
+									break;
+								}
 							}
 
 							auto media_packet = std::make_shared<MediaPacket>(
@@ -245,10 +246,10 @@ namespace pvd
 							offset += frame_length;
 						}
 
-						// Timing could not be resolved (e.g. invalid sampling-frequency index):
-						// forward the whole PES as a single packet (previous behavior) instead of emitting identical-timestamp samples.
-						if (split == false)
+						if (offset == 0)
 						{
+							// No frame could be emitted (unparseable first frame, payload shorter than an ADTS header, or indeterminable timing):
+							// forward the whole PES unsplit, preserving the previous behavior.
 							auto media_packet = std::make_shared<MediaPacket>(
 								GetMsid(),
 								cmn::MediaType::Audio,
@@ -262,6 +263,12 @@ namespace pvd
 								cmn::PacketType::RAW);
 
 							SendFrame(media_packet);
+						}
+						else if (offset < payload_length)
+						{
+							// Some frames were emitted; the trailing remainder was dropped (truncated/corrupt tail).
+							logtd("[%s] Dropped %zu trailing byte(s) of the AAC PES after splitting (offset %zu/%u, PID: %d).",
+								GetNamePath().CStr(), static_cast<size_t>(payload_length - offset), offset, payload_length, es->PID());
 						}
 					}
 					else


### PR DESCRIPTION
## Problem
When an MPEG-TS/SRT source is published to LL-HLS, audio fails to play on strict fMP4 decoders such as Safari's native player, while plain HLS (TS) plays the same stream fine.

## Cause
A single MPEG-TS PES payload for AAC contains one or more ADTS frames.
The provider forwarded the entire PES as one access unit, so the fMP4 packager wrote `N` AAC frames into a single fMP4 sample (e.g. 8 frames -> one sample with 8192-sample duration).
fMP4/CMAF requires exactly one access unit (one AAC frame = 1024 samples) per sample, so Safari rejects the malformed audio.
TS output is unaffected because the decoder re-frames from the in-band ADTS headers, and RTMP is unaffected because FLV already delivers one frame per packet.

## Fix
Split the PES payload into individual ADTS frames in the MPEG-TS/SRT provider and emit one MediaPacket per frame, advancing the timestamp by one frame duration. Non-AAC audio keeps the previous behavior.
A truncated/corrupted PES (e.g. UDP loss) stops splitting at the damaged boundary and logs at debug level; already-parsed frames are still delivered.

## Verification
With an AAC MPEG-TS source, the LL-HLS audio chunklist changes from one oversized sample per PES to one frame per sample:
- before: per-sample duration about `0.17`s (8 frames glued)
- after:  about `0.0213`s (one 1024-sample frame)

Safari LL-HLS playback works; HLS(TS)/RTMP behavior is unchanged.

## How to test
Set up an application with an MPEG-TS or SRT provider and an LL-HLS publisher, then ingest a stream that has AAC audio, e.g.:

```bash
ffmpeg -re -f lavfi -i testsrc=size=1280x720:rate=30 \
    -f lavfi -i sine=frequency=1000:sample_rate=48000 -shortest \
    -c:v libx264 -c:a aac -b:a 128k \
    -f mpegts "udp://<ome-host>:<port>?pkt_size=1316"
```

### Verify with Safari

Open the LL-HLS playlist (`.../<app>/<stream>/llhls.m3u8`) in the macOS/iOS Safari native player.

- Before this change: playback may fail on Safari(the player cannot start), because each LL-HLS audio sample contains several AAC frames. Plain HLS (TS) of the same stream plays fine.
- After this change: the same MPEG-TS/SRT stream plays correctly, with audio, in Safari.

### Verify with ffprobe

Pull the audio init segment and one media segment listed in the LL-HLS audio chunklist (`chunklist_*_audio_*.m3u8`), concatenate them, and inspect the per-sample (per-packet) duration:

```bash
ffprobe -v error -select_streams a -read_intervals '%+#8' -show_entries packet=duration_time -of csv=p=0 "http://path/to/stream/llhls.m3u8"
```

A single AAC frame is 1024 samples (1024 / 48000 = about `0.0213`s at 48 kHz):

- Before: about `0.170667` repeated  -> several AAC frames glued into one fMP4 sample
- After:  about `0.021333` repeated  -> one AAC frame per sample (correct)

Equivalently, the number of `#EXT-X-PART` entries per segment in the audio chunklist increases (one part now carries single-frame samples instead of multi-frame ones).
