### PR TITLE
fix(rtspc): split aggregated AAC access units into per-frame samples for fMP4/LL-HLS

### DIFF
--- a/src/projects/providers/rtspc/rtspc_stream.cpp
+++ b/src/projects/providers/rtspc/rtspc_stream.cpp
@@ -11,6 +11,7 @@
 
 #include <base/info/application.h>
 #include <base/ovlibrary/byte_io.h>
+#include <modules/bitstream/aac/aac_adts.h>
 #include <modules/rtp_rtcp/rtp_depacketizer_mpeg4_generic_audio.h>
 
 #include "rtspc_provider.h"
@@ -1080,6 +1081,119 @@ namespace pvd
 
 		logtt("Channel(%d) Payload Type(%d) Ssrc(%u) Timestamp(%u) PTS(%" PRId64 ") Time scale(%f) Adjust Timestamp(%f)",
 			  channel, first_rtp_packet->PayloadType(), first_rtp_packet->Ssrc(), first_rtp_packet->Timestamp(), adjusted_timestamp, track->GetTimeBase().GetExpr(), static_cast<double>(adjusted_timestamp) * track->GetTimeBase().GetExpr());
+
+		// A single RTP packet may carry several AAC access units (e.g. MediaMTX/gortsplib aggregates AUs),
+		// and our depacketizer assembles them into one ADTS buffer with one timestamp.
+		// fMP4/LL-HLS requires one access unit (1024 samples) per sample,
+		// so split the assembled ADTS stream into per-frame MediaPackets here,
+		// advancing the timestamp by one frame duration.
+		// Otherwise the packager emits a single oversized sample per RTP packet (N frames glued together),
+		// which strict fMP4 audio decoders (e.g. Safari) reject.
+		if (track->GetCodecId() == cmn::MediaCodecId::Aac)
+		{
+			const int64_t timescale			= track->GetTimeBase().GetDen();
+			const int64_t samples_per_frame = (track->GetAudioSamplesPerFrame() > 0) ? track->GetAudioSamplesPerFrame() : 1024;
+
+			// Forward each frame as a copy-on-write slice of the assembled ADTS buffer (no per-frame copy).
+			auto data						= bitstream->GetDataAs<uint8_t>();
+			const auto length				= bitstream->GetLength();
+
+			// frame_duration is resolved once from the first ADTS header; the sample rate is constant per track.
+			int64_t frame_duration			= 0;
+			size_t offset					= 0;
+
+			auto frame_pts					= adjusted_timestamp;
+			auto frame_dts					= adjusted_timestamp;
+
+			while ((offset + ADTS_MIN_SIZE) <= length)
+			{
+				AACAdts adts;
+
+				if (AACAdts::Parse(data + offset, length - offset, adts) == false)
+				{
+					logtd(
+						"[%s] Stopped AAC ADTS splitting: no valid ADTS header at offset %zu/%zu (channel %u). "
+						"The assembled buffer is likely truncated or corrupted (e.g. RTP packet loss).",
+						GetNamePath().CStr(), offset, length, channel);
+					break;
+				}
+
+				const auto frame_length = adts.AacFrameLength();
+				if ((frame_length < ADTS_MIN_SIZE) || ((offset + frame_length) > length))
+				{
+					logtd(
+						"[%s] Stopped AAC ADTS splitting: frame length %u at offset %zu exceeds assembled buffer %zu (channel %u). "
+						"The assembled buffer is likely truncated or corrupted (e.g. RTP packet loss).",
+						GetNamePath().CStr(), static_cast<uint32_t>(frame_length), offset, length, channel);
+					break;
+				}
+
+				// Resolve the per-frame duration once; the sample rate is constant within a track.
+				//
+				// NOTE: an invalid sampling-frequency index trips `OV_ASSERT2()` in debug builds,
+				// which is intentional (it surfaces malformed input).
+				// Release builds `return 0;`. A non-positive duration (invalid sample rate or timebase) means we cannot time the frames,
+				// so we stop splitting and forward the whole assembled buffer unsplit below instead of emitting identical-timestamp samples.
+				if (frame_duration == 0)
+				{
+					const auto samplerate = adts.Samplerate();
+
+					if (samplerate != 0)
+					{
+						frame_duration = cmn::Rational::Rescale(samples_per_frame, cmn::Rational(1, static_cast<int32_t>(samplerate)), cmn::Rational(1, static_cast<int32_t>(timescale)));
+					}
+
+					if (frame_duration <= 0)
+					{
+						break;
+					}
+				}
+
+				auto media_packet = std::make_shared<MediaPacket>(
+					GetMsid(),
+					track->GetMediaType(),
+					track->GetId(),
+					bitstream->Subdata(offset, frame_length),
+					frame_pts,
+					frame_dts,
+					-1LL,
+					MediaPacketFlag::Unknown,
+					bitstream_format,
+					packet_type);
+				SendFrame(media_packet);
+
+				frame_pts += frame_duration;
+				frame_dts += frame_duration;
+				offset += frame_length;
+			}
+
+			if (offset == 0)
+			{
+				// No frame could be emitted (unparseable first frame, assembled buffer shorter than an ADTS header,
+				// or indeterminable timing): forward the whole assembled buffer unsplit, preserving the previous behavior.
+				auto media_packet = std::make_shared<MediaPacket>(GetMsid(),
+																  track->GetMediaType(),
+																  track->GetId(),
+																  bitstream,
+																  adjusted_timestamp,
+																  adjusted_timestamp,
+																  -1LL,
+																  MediaPacketFlag::Unknown,
+																  bitstream_format,
+																  packet_type);
+				SendFrame(media_packet);
+			}
+			else if ((offset < length) && ((length - offset) < ADTS_MIN_SIZE))
+			{
+				// The loop ended on a truncated tail: fewer than one ADTS header (`< ADTS_MIN_SIZE`) remained.
+				// A mid-stream break on a malformed header/length leaves `>= ADTS_MIN_SIZE` bytes and was already
+				// logged at the break, so it is excluded here to avoid double logging.
+				logtd("[%s] Dropped %zu trailing byte(s) of the assembled AAC buffer after splitting (offset %zu/%zu, channel %u).",
+					  GetNamePath().CStr(), static_cast<size_t>(length - offset), offset, length, channel);
+			}
+
+			return;
+		}
 
 		auto frame = std::make_shared<MediaPacket>(GetMsid(),
 												   track->GetMediaType(),

--- a/src/projects/providers/rtspc/rtspc_stream.cpp
+++ b/src/projects/providers/rtspc/rtspc_stream.cpp
@@ -1077,14 +1077,13 @@ namespace pvd
 			MonitorInstance->IncreaseBytesIn(*Stream::GetSharedPtr(), bitstream->GetLength());
 			return;
 		}
-		
 
 		logtt("Channel(%d) Payload Type(%d) Ssrc(%u) Timestamp(%u) PTS(%" PRId64 ") Time scale(%f) Adjust Timestamp(%f)",
 			  channel, first_rtp_packet->PayloadType(), first_rtp_packet->Ssrc(), first_rtp_packet->Timestamp(), adjusted_timestamp, track->GetTimeBase().GetExpr(), static_cast<double>(adjusted_timestamp) * track->GetTimeBase().GetExpr());
 
 		// A single RTP packet may carry several AAC access units (e.g. MediaMTX/gortsplib aggregates AUs),
 		// and our depacketizer assembles them into one ADTS buffer with one timestamp.
-		// fMP4/LL-HLS requires one access unit (1024 samples) per sample,
+		// fMP4/LL-HLS requires one access unit (one AAC frame) per sample,
 		// so split the assembled ADTS stream into per-frame MediaPackets here,
 		// advancing the timestamp by one frame duration.
 		// Otherwise the packager emits a single oversized sample per RTP packet (N frames glued together),
@@ -1145,6 +1144,9 @@ namespace pvd
 
 					if (frame_duration <= 0)
 					{
+						logtd(
+							"[%s] Stopped AAC ADTS splitting: cannot resolve per-frame duration (samplerate %u, timescale %" PRId64 ", channel %u). Forwarding the buffer unsplit.",
+							GetNamePath().CStr(), samplerate, timescale, channel);
 						break;
 					}
 				}


### PR DESCRIPTION
## Problem
When an RTSP-Pull (RTSPC) source is published to LL-HLS, audio fails to play on strict fMP4 audio decoders (playback does not start, stalls, or cuts out after a moment), while plain HLS (TS) plays the same stream fine and more tolerant players are unaffected.

## Cause
For an `mpeg4-generic` (AAC) RTP source, a single RTP packet may carry one or more access units. The depacketizer assembles them into a single ADTS buffer with one timestamp, and the provider forwarded the whole buffer as one access unit. The fMP4 packager then wrote `N` AAC frames into a single fMP4 sample (e.g. 3-4 frames -> one sample with a 3072/4096-sample duration). fMP4/CMAF requires exactly one access unit (one AAC frame = 1024 samples) per sample, so the audio is malformed for strict decoders. TS output is unaffected because the decoder re-frames from the in-band ADTS headers, and RTMP is unaffected because FLV already delivers one frame per packet. Whether multiple access units are aggregated per RTP packet depends on the source RTSP server.

## Fix
Split the assembled ADTS buffer into individual ADTS frames in the RTSPC provider and emit one MediaPacket per frame, advancing the timestamp by one frame duration. Each frame is forwarded as a copy-on-write slice of the assembled buffer (no per-frame copy). Non-AAC audio keeps the previous behavior. A truncated or corrupted buffer stops splitting at the damaged boundary and logs at debug level; already-parsed frames are still delivered. If the first frame cannot be parsed, or the per-frame duration cannot be resolved, the whole buffer is forwarded unsplit, preserving the previous behavior.

## Verification
With an AAC RTSP-Pull source, the LL-HLS audio chunklist changes from one oversized sample per RTP packet to one frame per sample:
- before: per-sample duration about `0.064`-`0.085`s (3-4 frames glued)
- after: `0.021333`s (one 1024-sample frame)

Playback works on strict native fMP4 players; HLS (TS) and RTMP behavior is unchanged.

## How to test
Set up an application with an RTSP-Pull provider (OriginMap with `<Scheme>rtsp</Scheme>`) and an LL-HLS publisher, then ingest an RTSP source that has AAC audio and aggregates several access units per RTP packet. For example, publish an AAC file to an RTSP server and let OME pull it:

```bash
ffmpeg -re -stream_loop -1 -i input.mp4 -c:v copy -c:a copy -f rtsp -rtsp_transport tcp "rtsp://<rtsp-server-host>:8554/test"
```

OriginMap (`Server.xml`):

```xml
<Origins>
  <Origin>
    <Location>/app/test</Location>
    <Pass>
      <Scheme>rtsp</Scheme>
      <Urls><Url><rtsp-server-host>:8554/test</Url></Urls>
    </Pass>
  </Origin>
</Origins>
```

### Verify playback
Open the LL-HLS playlist (`.../<app>/test/llhls.m3u8`) in a strict native fMP4/HLS player.
- Before this change: audio fails (does not start or cuts out), while plain HLS (TS) of the same stream plays fine.
- After this change: the same RTSP-Pull stream plays correctly, with audio.

### Verify with ffprobe
Pull the audio init segment and one media segment listed in the LL-HLS audio chunklist (`chunklist_*_audio_*.m3u8`), concatenate them, and inspect the per-sample (per-packet) duration:

```bash
ffprobe -v error -select_streams a -read_intervals '%+#8' -show_entries packet=duration_time -of csv=p=0 "http://path/to/stream/llhls.m3u8"
```

A single AAC frame is 1024 samples (1024 / 48000 = about `0.0213`s at 48 kHz):

- Before: about `0.064`/`0.085` repeated -> several AAC frames glued into one fMP4 sample
- After:  about `0.021333` repeated -> one AAC frame per sample (correct)
