### PR TITLE
fix: distribute MediaRouter streams across all workers via round-robin

### DIFF
--- a/src/projects/mediarouter/mediarouter_application.cpp
+++ b/src/projects/mediarouter/mediarouter_application.cpp
@@ -415,6 +415,7 @@ std::shared_ptr<MediaRouteStream> MediaRouteApplication::CreateInboundStream(con
 		return nullptr;
 	}
 
+	new_stream->SetWorkerID((_inbound_worker_rr++) % _max_worker_thread_count);
 	_inbound_streams.insert(std::make_pair(stream_info->GetId(), new_stream));
 
 	return new_stream;
@@ -451,6 +452,7 @@ std::shared_ptr<MediaRouteStream> MediaRouteApplication::CreateOutboundStream(co
 		new_stream->SetBufferRetentionDuration(delay_buffer_time_ms);
 	}
 
+	new_stream->SetWorkerID((_outbound_worker_rr++) % _max_worker_thread_count);
 	_outbound_streams.insert(std::make_pair(out_stream_info->GetId(), new_stream));
 
 	return new_stream;
@@ -802,7 +804,7 @@ bool MediaRouteApplication::OnPacketReceived(const std::shared_ptr<MediaRouterAp
 
 		stream->Push(packet);
 
-		_inbound_stream_indicator[GetWorkerIDByStreamID(stream_info->GetId())]->Enqueue(std::weak_ptr<MediaRouteStream>(stream), packet->IsHighPriority());
+		_inbound_stream_indicator[stream->GetWorkerID()]->Enqueue(std::weak_ptr<MediaRouteStream>(stream), packet->IsHighPriority());
 	}
 	// Provider(relay), Transcoder => Outbound Stream
 	else if ((IS_CONNECTOR_PROVIDER(connector_type) && IS_REPRENT_RELAY(representation_type)) ||
@@ -816,7 +818,7 @@ bool MediaRouteApplication::OnPacketReceived(const std::shared_ptr<MediaRouterAp
 
 		stream->Push(packet);
 
-		_outbound_stream_indicator[GetWorkerIDByStreamID(stream_info->GetId())]->Enqueue(std::weak_ptr<MediaRouteStream>(stream), packet->IsHighPriority());
+		_outbound_stream_indicator[stream->GetWorkerID()]->Enqueue(std::weak_ptr<MediaRouteStream>(stream), packet->IsHighPriority());
 	}
 	else
 	{
@@ -899,11 +901,6 @@ bool MediaRouteApplication::IsExistingInboundStream(ov::String stream_name)
 	}
 
 	return false;
-}
-
-uint32_t MediaRouteApplication::GetWorkerIDByStreamID(info::stream_id_t stream_id)
-{
-	return stream_id % _max_worker_thread_count;
 }
 
 void MediaRouteApplication::InboundWorkerThread(uint32_t worker_id)

--- a/src/projects/mediarouter/mediarouter_application.cpp
+++ b/src/projects/mediarouter/mediarouter_application.cpp
@@ -409,13 +409,12 @@ std::shared_ptr<MediaRouteStream> MediaRouteApplication::CreateInboundStream(con
 {
 	std::lock_guard<std::shared_mutex> lock_guard(_streams_lock);
 
-	auto new_stream = std::make_shared<MediaRouteStream>(stream_info, cmn::MediaRouterStreamType::INBOUND);
+	auto new_stream = std::make_shared<MediaRouteStream>(stream_info, cmn::MediaRouterStreamType::INBOUND, (_inbound_worker_rr++) % _max_worker_thread_count);
 	if (!new_stream)
 	{
 		return nullptr;
 	}
 
-	new_stream->SetWorkerID((_inbound_worker_rr++) % _max_worker_thread_count);
 	_inbound_streams.insert(std::make_pair(stream_info->GetId(), new_stream));
 
 	return new_stream;
@@ -439,7 +438,7 @@ std::shared_ptr<MediaRouteStream> MediaRouteApplication::CreateOutboundStream(co
 		out_stream_info->LinkInputStream(stream_info);
 	}
 
-	auto new_stream = std::make_shared<MediaRouteStream>(out_stream_info, cmn::MediaRouterStreamType::OUTBOUND);
+	auto new_stream = std::make_shared<MediaRouteStream>(out_stream_info, cmn::MediaRouterStreamType::OUTBOUND, (_outbound_worker_rr++) % _max_worker_thread_count);
 	if (!new_stream)
 	{
 		return nullptr;
@@ -452,7 +451,6 @@ std::shared_ptr<MediaRouteStream> MediaRouteApplication::CreateOutboundStream(co
 		new_stream->SetBufferRetentionDuration(delay_buffer_time_ms);
 	}
 
-	new_stream->SetWorkerID((_outbound_worker_rr++) % _max_worker_thread_count);
 	_outbound_streams.insert(std::make_pair(out_stream_info->GetId(), new_stream));
 
 	return new_stream;
@@ -804,7 +802,9 @@ bool MediaRouteApplication::OnPacketReceived(const std::shared_ptr<MediaRouterAp
 
 		stream->Push(packet);
 
-		_inbound_stream_indicator[stream->GetWorkerID()]->Enqueue(std::weak_ptr<MediaRouteStream>(stream), packet->IsHighPriority());
+		auto inbound_worker_id = stream->GetWorkerID();
+		OV_ASSERT2(inbound_worker_id < _inbound_stream_indicator.size());
+		_inbound_stream_indicator[inbound_worker_id]->Enqueue(std::weak_ptr<MediaRouteStream>(stream), packet->IsHighPriority());
 	}
 	// Provider(relay), Transcoder => Outbound Stream
 	else if ((IS_CONNECTOR_PROVIDER(connector_type) && IS_REPRENT_RELAY(representation_type)) ||
@@ -818,7 +818,9 @@ bool MediaRouteApplication::OnPacketReceived(const std::shared_ptr<MediaRouterAp
 
 		stream->Push(packet);
 
-		_outbound_stream_indicator[stream->GetWorkerID()]->Enqueue(std::weak_ptr<MediaRouteStream>(stream), packet->IsHighPriority());
+		auto outbound_worker_id = stream->GetWorkerID();
+		OV_ASSERT2(outbound_worker_id < _outbound_stream_indicator.size());
+		_outbound_stream_indicator[outbound_worker_id]->Enqueue(std::weak_ptr<MediaRouteStream>(stream), packet->IsHighPriority());
 	}
 	else
 	{

--- a/src/projects/mediarouter/mediarouter_application.h
+++ b/src/projects/mediarouter/mediarouter_application.h
@@ -157,7 +157,6 @@ private:
 	std::shared_mutex _streams_lock;
 
 private:
-	uint32_t GetWorkerIDByStreamID(info::stream_id_t stream_id);
 	void InboundWorkerThread(uint32_t worker_id);
 	void OutboundWorkerThread(uint32_t worker_id);
 
@@ -166,6 +165,12 @@ private:
 	std::vector<std::thread> _outbound_threads;
 
 	uint32_t _max_worker_thread_count;
+
+	// Round-robin worker assignment so streams spread evenly across all workers, instead
+	// of stream_id % N clustering onto a subset (the global stream-id counter is strided
+	// across apps). Only touched at stream creation, under _streams_lock.
+	uint32_t _inbound_worker_rr = 0;
+	uint32_t _outbound_worker_rr = 0;
 
 private:
 	std::vector<std::shared_ptr<ov::ManagedQueue<std::weak_ptr<MediaRouteStream>>>> _inbound_stream_indicator;

--- a/src/projects/mediarouter/mediarouter_stream.cpp
+++ b/src/projects/mediarouter/mediarouter_stream.cpp
@@ -35,8 +35,9 @@
 
 using namespace cmn;
 
-MediaRouteStream::MediaRouteStream(const std::shared_ptr<info::Stream> &stream, cmn::MediaRouterStreamType type)
-	: _stream(stream),
+MediaRouteStream::MediaRouteStream(const std::shared_ptr<info::Stream> &stream, cmn::MediaRouterStreamType type, uint32_t worker_id)
+	: _worker_id(worker_id),
+	  _stream(stream),
 	  _packets_queue(nullptr, 600)
 {
 	SetType(type);

--- a/src/projects/mediarouter/mediarouter_stream.h
+++ b/src/projects/mediarouter/mediarouter_stream.h
@@ -71,6 +71,10 @@ public:
 	// Query original stream information
 	std::shared_ptr<info::Stream> GetStream();
 
+	// MediaRouter worker assigned round-robin at creation; stable for the stream's life.
+	void SetWorkerID(uint32_t worker_id) { _worker_id = worker_id; }
+	uint32_t GetWorkerID() const { return _worker_id; }
+
 	void OnStreamPrepared(bool completed);
 	bool IsStreamPrepared();
 	bool IsStreamReady();
@@ -93,6 +97,8 @@ private:
 
 	// Incoming/Outgoing Stream
 	cmn::MediaRouterStreamType _type;
+
+	uint32_t _worker_id = 0;
 
 	// Stream Information
 	std::shared_ptr<info::Stream> _stream = nullptr;

--- a/src/projects/mediarouter/mediarouter_stream.h
+++ b/src/projects/mediarouter/mediarouter_stream.h
@@ -32,7 +32,7 @@ static constexpr int64_t MEDIA_ROUTE_STREAM_TRACK_PREPARE_TIMEOUT_MS = 3000;
 class MediaRouteStream : public MediaRouterNormalize, public MediaRouterStats, public MediaRouterEventGenerator, public MediaRouterAlert
 {
 public:
-	MediaRouteStream(const std::shared_ptr<info::Stream> &stream, cmn::MediaRouterStreamType type);
+	MediaRouteStream(const std::shared_ptr<info::Stream> &stream, cmn::MediaRouterStreamType type, uint32_t worker_id);
 	~MediaRouteStream();
 
 	// Inout Stream Type
@@ -71,8 +71,7 @@ public:
 	// Query original stream information
 	std::shared_ptr<info::Stream> GetStream();
 
-	// MediaRouter worker assigned round-robin at creation; stable for the stream's life.
-	void SetWorkerID(uint32_t worker_id) { _worker_id = worker_id; }
+	// MediaRouter worker assigned round-robin at construction, immutable for the stream's life.
 	uint32_t GetWorkerID() const { return _worker_id; }
 
 	void OnStreamPrepared(bool completed);
@@ -98,7 +97,7 @@ private:
 	// Incoming/Outgoing Stream
 	cmn::MediaRouterStreamType _type;
 
-	uint32_t _worker_id = 0;
+	const uint32_t _worker_id;
 
 	// Stream Information
 	std::shared_ptr<info::Stream> _stream = nullptr;


### PR DESCRIPTION
## Problem
With `AppWorkerCount` > 1, MediaRouter assigns each stream to a worker by `stream_id % worker_count`. The global stream-id counter is strided across applications (an origin stream and its transcoded output get interleaved ids), so for an even worker count the modulo lands every stream on only half the workers. The idle half wastes capacity while the active half carries double the load, building queue backlog on the hot workers at high stream counts.

## Solution
Assign each stream a worker round-robin at creation time (under the existing `_streams_lock`), store it immutably on the `MediaRouteStream` (set in the constructor), and route by the stored id instead of recomputing `stream_id % N`. The now-unused `GetWorkerIDByStreamID` is removed.

## Test
- Configure two `<Application>`s in `Server.xml`.
- Create streams sequentially in each app (any ingest method, e.g. RTMP/SRT).
- Observe how each stream is assigned to MediaRouter worker threads.

Pass condition:
- Streams are distributed evenly across all workers. Previously, in this sequential-assignment case, streams landed on only half the workers.
