### PR TITLE
refactor(ffmpeg): use cmn::Rational instead of AVRational

### DIFF
--- a/src/projects/modules/ffmpeg/ffmpeg_codec.cpp
+++ b/src/projects/modules/ffmpeg/ffmpeg_codec.cpp
@@ -283,7 +283,7 @@ namespace ffmpeg
 	int FFmpegCodec::SetOption(const char *name, int64_t value) { return ::av_opt_set_int(_context->priv_data, name, value, 0); }
 
 	int64_t FFmpegCodec::GetBitrate() const noexcept { return _context->bit_rate; }
-	AVRational FFmpegCodec::GetFrameRate() const noexcept { return _context->framerate; }
+	cmn::Rational FFmpegCodec::GetFrameRate() const noexcept { return cmn::Rational(_context->framerate.num, _context->framerate.den); }
 	int FFmpegCodec::GetWidth() const noexcept { return _context->width; }
 	int FFmpegCodec::GetHeight() const noexcept { return _context->height; }
 	int FFmpegCodec::GetGopSize() const noexcept { return _context->gop_size; }

--- a/src/projects/modules/ffmpeg/ffmpeg_codec.h
+++ b/src/projects/modules/ffmpeg/ffmpeg_codec.h
@@ -130,7 +130,7 @@ namespace ffmpeg
 		int SetOption(const char *name, int64_t value);
 
 		int64_t GetBitrate() const noexcept;
-		AVRational GetFrameRate() const noexcept;
+		cmn::Rational GetFrameRate() const noexcept;
 		int GetWidth() const noexcept;
 		int GetHeight() const noexcept;
 		int GetGopSize() const noexcept;

--- a/src/projects/transcoder/codec/decoder/decoder_avcodec_video.cpp
+++ b/src/projects/transcoder/codec/decoder/decoder_avcodec_video.cpp
@@ -206,9 +206,10 @@ DecodeResult AVCodecVideoDecoder::ReceiveFrame()
 
 	// If the decoder did not provide a duration, calculate it from the frame rate
 	const auto framerate = _codec.GetFrameRate();
-	if (decoded_frame->GetDuration() <= 0LL && framerate.GetExpr() > 0)
+	const auto timebase_expr = GetRefTrack()->GetTimeBase().GetExpr();
+	if (decoded_frame->GetDuration() <= 0LL && framerate.GetExpr() > 0 && timebase_expr > 0)
 	{
-		decoded_frame->SetDuration((int64_t)((1.0 / framerate.GetExpr()) / GetRefTrack()->GetTimeBase().GetExpr()));
+		decoded_frame->SetDuration((int64_t)((1.0 / framerate.GetExpr()) / timebase_expr));
 	}
 
 	return DecodeResult::Decoded(std::move(decoded_frame), format_changed);

--- a/src/projects/transcoder/codec/decoder/decoder_avcodec_video.cpp
+++ b/src/projects/transcoder/codec/decoder/decoder_avcodec_video.cpp
@@ -204,10 +204,11 @@ DecodeResult AVCodecVideoDecoder::ReceiveFrame()
 		return DecodeResult::NoOutput();
 	}
 
-	// If the decoder did not provide a duration, calculate it from the frame rate 
-	if (decoded_frame->GetDuration() <= 0LL && _codec.GetFrameRate().num > 0 && _codec.GetFrameRate().den > 0)
+	// If the decoder did not provide a duration, calculate it from the frame rate
+	const auto framerate = _codec.GetFrameRate();
+	if (decoded_frame->GetDuration() <= 0LL && framerate.GetExpr() > 0)
 	{
-		decoded_frame->SetDuration((int64_t)(((double)_codec.GetFrameRate().den / (double)_codec.GetFrameRate().num) / (double)GetRefTrack()->GetTimeBase().GetExpr()));
+		decoded_frame->SetDuration((int64_t)((1.0 / framerate.GetExpr()) / GetRefTrack()->GetTimeBase().GetExpr()));
 	}
 
 	return DecodeResult::Decoded(std::move(decoded_frame), format_changed);

--- a/src/projects/transcoder/codec/encoder/encoder_avcodec_video.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_avcodec_video.cpp
@@ -48,7 +48,7 @@ bool AVCodecVideoEncoder::SetParamsX264()
 	}
 	else if (key_frame_interval_type == cmn::KeyFrameIntervalType::FRAME)
 	{
-		_codec.SetGopSize((GetRefTrack()->GetKeyFrameInterval() == 0) ? (_codec.GetFrameRate().num / _codec.GetFrameRate().den) : GetRefTrack()->GetKeyFrameInterval());
+		_codec.SetGopSize((GetRefTrack()->GetKeyFrameInterval() == 0) ? (int32_t)_codec.GetFrameRate().GetExpr() : GetRefTrack()->GetKeyFrameInterval());
 	}
 
 	_codec.SetThreadCount(GetRefTrack()->GetThreadCount() < 0 ? std::min(std::max(4, static_cast<int>(std::max(1u, std::thread::hardware_concurrency())) / 3), 8) : GetRefTrack()->GetThreadCount());
@@ -156,7 +156,7 @@ bool AVCodecVideoEncoder::SetParamsOpenH264()
 	}
 	else if (key_frame_interval_type == cmn::KeyFrameIntervalType::FRAME)
 	{
-		_codec.SetGopSize((GetRefTrack()->GetKeyFrameInterval() == 0) ? (_codec.GetFrameRate().num / _codec.GetFrameRate().den) : GetRefTrack()->GetKeyFrameInterval());
+		_codec.SetGopSize((GetRefTrack()->GetKeyFrameInterval() == 0) ? (int32_t)_codec.GetFrameRate().GetExpr() : GetRefTrack()->GetKeyFrameInterval());
 	}
 
 	_codec.SetThreadCount(GetRefTrack()->GetThreadCount() < 0 ? std::min(std::max(4, static_cast<int>(std::max(1u, std::thread::hardware_concurrency())) / 3), 8) : GetRefTrack()->GetThreadCount());
@@ -267,7 +267,7 @@ bool AVCodecVideoEncoder::SetParamsVp8()
 	}
 	else if (key_frame_interval_type == cmn::KeyFrameIntervalType::FRAME)
 	{
-		_codec.SetGopSize((GetRefTrack()->GetKeyFrameInterval() == 0) ? (_codec.GetFrameRate().num / _codec.GetFrameRate().den) : GetRefTrack()->GetKeyFrameInterval());
+		_codec.SetGopSize((GetRefTrack()->GetKeyFrameInterval() == 0) ? (int32_t)_codec.GetFrameRate().GetExpr() : GetRefTrack()->GetKeyFrameInterval());
 	}
 
 	_codec.SetThreadCount(GetRefTrack()->GetThreadCount() < 0 ? std::min(std::max(4, static_cast<int>(std::max(1u, std::thread::hardware_concurrency())) / 3), 8) : GetRefTrack()->GetThreadCount());


### PR DESCRIPTION
### Summary 
Replace AVRational with cmn::Rational for frame rate handling to remove dependencies on FFmpeg functions, updating encoder/decoder call sites accordingly.

### Test
The behavior is unchanged, so no testing is required.