### PR TITLE
fix(stream): scope subtitle label lookup to subtitle tracks only

### DIFF
--- a/src/projects/base/info/stream.cpp
+++ b/src/projects/base/info/stream.cpp
@@ -325,19 +325,23 @@ namespace info
 			group->AddTrack(track);
 		}
 
-		// public label to track id map
-		auto label = track->GetPublicName();
-		if (label.IsEmpty() == false)
+		// public label to track id map (subtitle tracks only - GetTrackByLabel() callers all
+		// expect a subtitle track back, so a same-named audio/video/data track must not shadow it)
+		if (track->GetMediaType() == cmn::MediaType::Subtitle)
 		{
-			auto label_it = _public_label_map.find(label);
-			if (label_it == _public_label_map.end())
+			auto label = track->GetPublicName();
+			if (label.IsEmpty() == false)
 			{
-				_public_label_map.emplace(label, track->GetId());
+				auto label_it = _public_label_map.find(label);
+				if (label_it == _public_label_map.end())
+				{
+					_public_label_map.emplace(label, track->GetId());
+				}
+				// else
+				// {
+				// 	logw("DEBUG", "Public label '%s' already exists for track ID %d", label.CStr(), track->GetId());
+				// }
 			}
-			// else
-			// {
-			// 	logw("DEBUG", "Public label '%s' already exists for track ID %d", label.CStr(), track->GetId());
-			// }
 		}
 
 		return true;

--- a/src/projects/base/info/stream_test.cpp
+++ b/src/projects/base/info/stream_test.cpp
@@ -6,6 +6,7 @@
 //  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
 //
 //==============================================================================
+#include <base/info/media_track.h>
 #include <base/info/stream.h>
 #include <gtest/gtest.h>
 
@@ -121,4 +122,37 @@ TEST(InfoStreamSourceUrl, CopyConstructorRacingWriterObservesOnlyWholeValues)
 
 	EXPECT_TRUE(all_copies_valid.load());
 	EXPECT_GT(copy_count.load(), 0u);
+}
+
+// Regression test for the fix on this branch:
+// `GetTrackByLabel()` is only ever used by callers expecting a *subtitle* track back
+// (STT output routing, the sendSubtitles API, subtitle commands). Before the fix, the
+// lookup map was populated from every track's PublicName regardless of media type, so an
+// audio track sharing a name with a subtitle rendition (e.g. an <AudioMap> <Item><Name>
+// matching a <Subtitles><Rendition><Label>, as happens with Scheduler + AudioMap) would
+// shadow the subtitle track and make it unreachable by label - which in turn made
+// pvd::Application::AddStream() believe the subtitle rendition already existed and skip
+// creating it entirely.
+TEST(InfoStreamTrackByLabel, SubtitleLabelIsNotShadowedByNonSubtitleTrackWithSameName)
+{
+	const ov::String kSharedLabel = "American English";
+
+	info::Stream stream(StreamSourceType::Ovt);
+
+	auto audio_track = std::make_shared<MediaTrack>();
+	audio_track->SetId(stream.IssueUniqueTrackId());
+	audio_track->SetMediaType(cmn::MediaType::Audio);
+	audio_track->SetPublicName(kSharedLabel);
+	ASSERT_TRUE(stream.AddTrack(audio_track));
+
+	auto subtitle_track = std::make_shared<MediaTrack>();
+	subtitle_track->SetId(stream.IssueUniqueTrackId());
+	subtitle_track->SetMediaType(cmn::MediaType::Subtitle);
+	subtitle_track->SetPublicName(kSharedLabel);
+	ASSERT_TRUE(stream.AddTrack(subtitle_track));
+
+	auto found = stream.GetTrackByLabel(kSharedLabel);
+	ASSERT_NE(found, nullptr);
+	EXPECT_EQ(found->GetId(), subtitle_track->GetId());
+	EXPECT_EQ(found->GetMediaType(), cmn::MediaType::Subtitle);
 }


### PR DESCRIPTION
### Problem

`Stream::GetTrackByLabel()` is used in exactly four places, all of which expect a **subtitle** track back: STT output routing (`transcoder_stream.cpp`), the `sendSubtitles` REST API, and subtitle-selection commands (`provider/stream.cpp`, `publisher/stream.cpp`).

However, `Stream::AddTrack()` populated the underlying `_public_label_map` from **any** track's `PublicName` — video, audio, data, or subtitle — not just subtitle tracks.

This caused a real bug: when an application defines multiple `<Subtitles><Rendition>` entries **and** uses a Scheduler with `<AudioMap>`, each audio map item gets a `PublicName` from `<AudioMap><Item><Name>` (e.g. "American English"). If that name matches a `<Subtitles><Rendition><Label>`, the subtitle-track creation loop in `pvd::Application::AddStream()` calls `GetTrackByLabel(rendition.GetLabel())`, finds the pre-existing **audio** track instead, assumes the subtitle rendition already exists, and silently skips creating it (only a `logtw` warning, easy to miss). Result: only the subtitle renditions whose label doesn't collide with an audio map item name show up — in the reported case, only French survived while "American English" silently disappeared.

Regular (non-Scheduler) streams don't hit this because they don't assign `PublicName` to audio tracks, so no collision occurs.

### Fix

`Stream::AddTrack()` now only inserts into the label lookup map when the track's media type is `Subtitle`, matching what every caller of `GetTrackByLabel()` already assumes.

### Testing

- Added `InfoStreamTrackByLabel.SubtitleLabelIsNotShadowedByNonSubtitleTrackWithSameName` in `stream_test.cpp`: adds an audio track and a subtitle track sharing the same `PublicName`, asserts `GetTrackByLabel()` returns the subtitle track.
- Manually reproduced and verified the fix against a live Scheduler + `AudioMap` + multi-rendition `Subtitles` config: both renditions now appear.

### Affected components

- `src/projects/base/info/stream.cpp`
- `src/projects/base/info/stream_test.cpp` (new regression test)