### PR TITLE
fix: alert repeatedly sends codes=OK while internal queue congestion persists

### DIFF
--- a/src/projects/monitoring/alert/alert.cpp
+++ b/src/projects/monitoring/alert/alert.cpp
@@ -666,21 +666,14 @@ namespace mon::alrt
 	{
 		// Find and cleanup the messages that have already been released among the alerts that were sent.
 
+		// Build the lookup set outside the lock to keep the critical section short.
+		const std::set<ov::String> new_keys(new_messages_keys.begin(), new_messages_keys.end());
+
 		std::lock_guard lock(_last_verified_messages_mutex);
 
 		for (auto it = _last_verified_messages_map.begin(); it != _last_verified_messages_map.end();)
 		{
-			bool exist = false;
-			for (const auto &new_messages_key : new_messages_keys)
-			{
-				if (it->first == new_messages_key)
-				{
-					exist = true;
-					break;
-				}
-			}
-
-			if (!exist)
+			if (new_keys.find(it->first) == new_keys.end())
 			{
 				it = _last_verified_messages_map.erase(it);
 			}

--- a/src/projects/monitoring/alert/alert.cpp
+++ b/src/projects/monitoring/alert/alert.cpp
@@ -666,13 +666,14 @@ namespace mon::alrt
 	{
 		// Find and cleanup the messages that have already been released among the alerts that were sent.
 
-		std::vector<ov::String> messages_keys_to_cleanup;
-		for (const auto &[messages_key, verified_messages] : _last_verified_messages_map)
+		std::lock_guard lock(_last_verified_messages_mutex);
+
+		for (auto it = _last_verified_messages_map.begin(); it != _last_verified_messages_map.end();)
 		{
 			bool exist = false;
 			for (const auto &new_messages_key : new_messages_keys)
 			{
-				if (messages_key == new_messages_key)
+				if (it->first == new_messages_key)
 				{
 					exist = true;
 					break;
@@ -681,13 +682,12 @@ namespace mon::alrt
 
 			if (!exist)
 			{
-				messages_keys_to_cleanup.push_back(messages_key);
+				it = _last_verified_messages_map.erase(it);
 			}
-		}
-
-		for (auto const &messages_key : messages_keys_to_cleanup)
-		{
-			RemoveVerifiedMessages(messages_key);
+			else
+			{
+				++it;
+			}
 		}
 	}
 
@@ -698,25 +698,9 @@ namespace mon::alrt
 			return false;
 		}
 
-		RemoveVerifiedMessages(messages_key);
+		std::lock_guard lock(_last_verified_messages_mutex);
 
-		_last_verified_messages_map.emplace(messages_key, std::move(message_list));
-
-		return true;
-	}
-
-	bool Alert::RemoveVerifiedMessages(const ov::String &messages_key)
-	{
-		if (messages_key.IsEmpty())
-		{
-			return false;
-		}
-
-		auto messages = _last_verified_messages_map.find(messages_key);
-		if (messages != _last_verified_messages_map.end())
-		{
-			_last_verified_messages_map.erase(messages);
-		}
+		_last_verified_messages_map.insert_or_assign(messages_key, std::move(message_list));
 
 		return true;
 	}
@@ -727,6 +711,8 @@ namespace mon::alrt
 		{
 			return {};
 		}
+
+		std::lock_guard lock(_last_verified_messages_mutex);
 
 		auto item = _last_verified_messages_map.find(messages_key);
 		if (item == _last_verified_messages_map.end())

--- a/src/projects/monitoring/alert/alert.cpp
+++ b/src/projects/monitoring/alert/alert.cpp
@@ -92,6 +92,15 @@ namespace mon::alrt
 		return true;
 	}
 
+	static ov::String MakeMessagesKey(NotificationData::Type type, const ov::String &source_uri)
+	{
+		// _last_verified_messages_map is shared by all alert categories, so the key must be
+		// namespaced by the notification type. Otherwise, categories that derive the same key
+		// from the same source (e.g. INTERNAL_QUEUE and INGRESS both use "#Vhost#App/Stream")
+		// overwrite each other's last verified messages and fire spurious alerts.
+		return ov::String::FormatString("%s:%s", NotificationData::StringFromType(type), source_uri.CStr());
+	}
+
 	void Alert::MetricWorkerThread()
 	{
 		auto rules = _rules_updater->GetRules();
@@ -158,9 +167,10 @@ namespace mon::alrt
 			// Fire an alert per source URI (same pattern as stream-metric alerts)
 			for (auto &[source_uri, msgs] : per_source_messages)
 			{
-				new_messages_keys.push_back(source_uri);
+				messages_key = MakeMessagesKey(type, source_uri);
+				new_messages_keys.push_back(messages_key);
 
-				if (IsAlertNeeded(source_uri, msgs))
+				if (IsAlertNeeded(messages_key, msgs))
 				{
 					// Reduce to a single message before sending: the queue list in
 					// internalQueues already carries the per-queue detail.
@@ -173,7 +183,7 @@ namespace mon::alrt
 					SendNotification(type, send_msgs, source_uri, per_source_queues[source_uri]);
 				}
 
-				PutVerifiedMessages(source_uri, msgs);
+				PutVerifiedMessages(messages_key, msgs);
 			}
 		}
 
@@ -192,7 +202,7 @@ namespace mon::alrt
 						{
 							type		 = NotificationData::Type::INGRESS;
 
-							messages_key = stream_metric->GetUri();
+							messages_key = MakeMessagesKey(type, stream_metric->GetUri());
 							new_messages_keys.push_back(messages_key);
 
 							VerifyIngressMetricRules(*rules, stream_metric, message_list);
@@ -336,14 +346,14 @@ namespace mon::alrt
 
 		std::vector<std::shared_ptr<Message>> message_list(1, message);
 
-		ov::String messages_key;
+		ov::String source_uri;
 		if (stream_metric)
 		{
-			messages_key = stream_metric->GetUri();
+			source_uri = stream_metric->GetUri();
 		}
 		else if (parent_stream_metric)
 		{
-			messages_key = parent_stream_metric->GetUri();
+			source_uri = parent_stream_metric->GetUri();
 		}
 		else
 		{
@@ -351,7 +361,8 @@ namespace mon::alrt
 			return;
 		}
 
-		auto type = NotificationData::TypeFromMessageCode(code);
+		auto type		  = NotificationData::TypeFromMessageCode(code);
+		auto messages_key = MakeMessagesKey(type, source_uri);
 
 		if (IsAlertNeeded(messages_key, message_list))
 		{

--- a/src/projects/monitoring/alert/alert.h
+++ b/src/projects/monitoring/alert/alert.h
@@ -71,12 +71,14 @@ namespace mon::alrt
 
 		void CleanupReleasedMessages(const std::vector<ov::String> &new_messages_keys);
 		bool PutVerifiedMessages(const ov::String &messages_key, std::vector<std::shared_ptr<Message>> &message_list);
-		bool RemoveVerifiedMessages(const ov::String &messages_key);
 		std::vector<std::shared_ptr<Message>> GetVerifiedMessages(const ov::String &messages_key);
 
 		std::shared_ptr<const cfg::Server> _server_config = nullptr;
 		std::shared_ptr<AlertRulesUpdater> _rules_updater = nullptr;
 
+		// Accessed by both the metric worker thread (via _timer) and the threads calling
+		// SendStreamMessage(), so it must be guarded by _last_verified_messages_mutex.
+		std::mutex _last_verified_messages_mutex;
 		std::map<ov::String, std::vector<std::shared_ptr<Message>>> _last_verified_messages_map;
 
 		ov::DelayQueue _timer{"MonAlert"};


### PR DESCRIPTION
## Why

When `<InternalQueueCongestion/>` alert rules are enabled and an internal queue
(e.g. a transcoder decoder queue) exceeds its threshold and **stays** congested,
OME fires alternating `INTERNAL_QUEUE_CONGESTION` / `OK` notifications every
metric tick (500 ms), indefinitely:

```
11:15:59 #default#app/stream1 codes=['INTERNAL_QUEUE_CONGESTION'] | dec_H264_t0=305/300
11:15:59 #default#app/stream1 codes=['OK']
11:15:59 #default#app/stream1 codes=['INTERNAL_QUEUE_CONGESTION'] | dec_H264_t0=305/300
...
```

The `OK` message is indistinguishable from a genuine recovery, so any system
built on top of the alert webhook misinterprets the stream state.

## Root cause

`Alert::_last_verified_messages_map` — the per-key "last verified messages"
state that `IsAlertNeeded()` uses for change detection — is shared by all alert
categories but was keyed by source URI alone. The INTERNAL_QUEUE category keys
by `#Vhost#App/Stream` derived from `ManagedQueue::URN`, which is the exact
same string `StreamMetrics::GetUri()` produces for the INGRESS category.

Each 500 ms tick for a stream with a congested queue:

1. Internal-queue check: stored `[]` → computed `[CONGESTION]` → change
   detected → sends **CONGESTION**, stores `[CONGESTION]`.
2. Ingress metric check (same key): computes `[]` (no metric rule violations)
   → compared against `[CONGESTION]` just stored in step 1 → change detected
   → sends **OK**, overwrites the entry with `[]`.
3. Next tick returns to step 1.

Note: the ingress metric loop runs for every input stream regardless of which
rules are configured, so this reproduces with only `<InternalQueueCongestion/>`
enabled.

## What

- **Commit 1** — Namespace the map key with the notification type
  (`INTERNAL_QUEUE:#Vhost#App/Stream`, `INGRESS:#Vhost#App/Stream`, ...) via a
  `MakeMessagesKey()` helper so each category tracks its own last verified
  messages. The event path (`SendStreamMessage`) uses the same key scheme for
  consistency. Notification payloads are unchanged — `sourceUri` still carries
  the raw URI; only the internal map key changes.
- **Commit 2** — Guard `_last_verified_messages_map` with a mutex: it is
  mutated by the metric worker thread (via `_timer`) and read by any thread
  calling `SendStreamMessage()` through `IsAlertNeeded()`, previously without
  synchronization. `PutVerifiedMessages()` now uses `insert_or_assign()` and
  `CleanupReleasedMessages()` erases in place while iterating, which also
  removes the need for `RemoveVerifiedMessages()`.

## Test procedure

1. Configure `Server.xml` with an `<Alert>` section pointing `<Url>` to a
   webhook receiver, with rules:
   `<Ingress><StreamStatus/></Ingress>`, `<Egress><StreamStatus/></Egress>`,
   `<InternalQueueCongestion/>`.
2. Use an output profile with transcoding (e.g. H.264 encode) and ingest
   enough streams to saturate the decoder so a decoder queue stays above its
   threshold (e.g. ~16 concurrent RTMP inputs on a CPU-bound machine;
   `dec_H264` queue size must exceed 300 and stay there).
3. Observe the webhook while congestion persists for at least 1 minute.
4. Stop enough input streams so the queues drain, and observe the webhook
   again.

## Pass criteria

- Step 3: exactly **one** `INTERNAL_QUEUE_CONGESTION` notification per stream
  when its queue first exceeds the threshold — **no** repeated
  CONGESTION/OK alternation while congestion persists.
- Step 4: exactly **one** `OK` notification (type `INTERNAL_QUEUE`) per stream
  after all its queues recover.
- Regression: stream status events (`INGRESS_STREAM_CREATED` /
  `INGRESS_STREAM_DELETED`, ...) and ingress metric alerts (e.g. `MinBitrate`
  violation → alert, recovery → `OK`) behave the same as before.
- Full Debug build passes (`cmake --build build/Debug` — verified, 552/552
  targets including the final `OvenMediaEngine` link).