### PR TITLE
fix(mpegts): harden the demuxer against lossy and reordered UDP input

### DIFF
--- a/src/projects/config/items/virtual_hosts/applications/providers/mpegts_provider.h
+++ b/src/projects/config/items/virtual_hosts/applications/providers/mpegts_provider.h
@@ -12,39 +12,33 @@
 #include "provider.h"
 #include "track_map/audio_map.h"
 
-namespace cfg
+namespace cfg::vhost::app::pvd
 {
-	namespace vhost
+	struct MpegtsProvider : public Provider
 	{
-		namespace app
+	protected:
+		mpegts::StreamMap _stream_map;
+		AudioMap _audio_map;
+		bool _packet_reordering = false;
+
+	public:
+		ProviderType GetType() const override
 		{
-			namespace pvd
-			{
-				struct MpegtsProvider : public Provider
-				{
-				protected:
-					mpegts::StreamMap _stream_map;
-					AudioMap _audio_map;
+			return ProviderType::Mpegts;
+		}
 
-				public:
-					ProviderType GetType() const override
-					{
-						return ProviderType::Mpegts;
-					}
+		CFG_DECLARE_CONST_REF_GETTER_OF(GetStreamMap, _stream_map)
+		CFG_DECLARE_CONST_REF_GETTER_OF(GetAudioMap, _audio_map)
+		CFG_DECLARE_CONST_REF_GETTER_OF(GetPacketReordering, _packet_reordering)
 
-					CFG_DECLARE_CONST_REF_GETTER_OF(GetStreamMap, _stream_map)
-					CFG_DECLARE_CONST_REF_GETTER_OF(GetAudioMap, _audio_map)
+	protected:
+		void MakeList() override
+		{
+			Provider::MakeList();
 
-				protected:
-					void MakeList() override
-					{
-						Provider::MakeList();
-
-						Register<Optional>({"StreamMap", "streams"}, &_stream_map);
-						Register<Optional>("AudioMap", &_audio_map);
-					}
-				};
-			}  // namespace pvd
-		}  // namespace app
-	}  // namespace vhost
-}  // namespace cfg
+			Register<Optional>({"StreamMap", "streams"}, &_stream_map);
+			Register<Optional>("AudioMap", &_audio_map);
+			Register<Optional>("PacketReordering", &_packet_reordering);
+		}
+	};
+}  // namespace cfg::vhost::app::pvd

--- a/src/projects/modules/containers/mpegts/CMakeLists.txt
+++ b/src/projects/modules/containers/mpegts/CMakeLists.txt
@@ -4,3 +4,10 @@ ome_add_static_library(mpegts_container
         bitstream
         ovlibrary
 )
+
+if(OME_BUILD_TESTS)
+    file(GLOB _srcs "${CMAKE_CURRENT_SOURCE_DIR}/*_test.cpp")
+    ome_add_tests(ome_test_modules
+        SRCS ${_srcs}
+    )
+endif()

--- a/src/projects/modules/containers/mpegts/mpegts_datagram_reorder_buffer.cpp
+++ b/src/projects/modules/containers/mpegts/mpegts_datagram_reorder_buffer.cpp
@@ -1,0 +1,353 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include "mpegts_datagram_reorder_buffer.h"
+
+#include <base/ovlibrary/clock.h>
+
+#include "mpegts_packet.h"
+
+namespace mpegts
+{
+	DatagramReorderBuffer::DatagramReorderBuffer(size_t max_datagrams, int64_t timeout_msec, std::function<int64_t()> clock)
+		: _max_datagrams(max_datagrams < 1 ? 1 : max_datagrams),
+		  _timeout_msec(timeout_msec),
+		  _clock(std::move(clock))
+	{
+	}
+
+	int64_t DatagramReorderBuffer::Now() const
+	{
+		return _clock ? _clock() : static_cast<int64_t>(ov::Clock::NowMSec());
+	}
+
+	uint8_t DatagramReorderBuffer::Displacement(uint8_t cc, uint8_t expected)
+	{
+		return static_cast<uint8_t>((cc - expected) & 0x0F);
+	}
+
+	DatagramReorderBuffer::Summary DatagramReorderBuffer::Parse(const std::shared_ptr<const ov::Data> &datagram)
+	{
+		Summary summary;
+
+		if (datagram == nullptr)
+		{
+			return summary;
+		}
+
+		const uint8_t *data = datagram->GetDataAs<uint8_t>();
+		const size_t length = datagram->GetLength();
+
+		// A UDP datagram must be a whole number of TS packets to be trusted for CC-based ordering.
+		if ((data == nullptr) || (length < MPEGTS_MIN_PACKET_SIZE) || ((length % MPEGTS_MIN_PACKET_SIZE) != 0))
+		{
+			return summary;
+		}
+
+		for (size_t offset = 0; offset < length; offset += MPEGTS_MIN_PACKET_SIZE)
+		{
+			if (data[offset] != MPEGTS_SYNC_BYTE)
+			{
+				// Not aligned; the summary is left un-aligned so the caller bypasses reordering.
+				return summary;
+			}
+
+			const bool transport_error			   = (data[offset + 1] & 0x80) != 0;
+			const uint16_t pid					   = static_cast<uint16_t>(((data[offset + 1] & 0x1F) << 8) | data[offset + 2]);
+			const uint8_t adaptation_field_control = (data[offset + 3] >> 4) & 0x03;
+			const uint8_t continuity_counter	   = data[offset + 3] & 0x0F;
+			const bool has_adaptation			   = (adaptation_field_control & 0b10) != 0;
+			const bool has_payload				   = (adaptation_field_control & 0b01) != 0;
+
+			if (has_adaptation)
+			{
+				const uint8_t adaptation_field_length	  = data[offset + 4];
+
+				// A valid adaptation field cannot exceed the packet body: at most 183 bytes when
+				// adaptation-only (AFC=10), and 182 when a payload must also follow (AFC=11).
+				// A larger value means the packet is corrupt; treat the whole datagram as untrusted
+				// so it bypasses reordering rather than being sequenced on possibly-bogus counters.
+				const uint8_t max_adaptation_field_length = has_payload
+																? (MPEGTS_MIN_PACKET_SIZE - MPEGTS_HEADER_SIZE - 2)
+																: (MPEGTS_MIN_PACKET_SIZE - MPEGTS_HEADER_SIZE - 1);
+				if (adaptation_field_length > max_adaptation_field_length)
+				{
+					return summary;
+				}
+
+				if ((adaptation_field_length > 0) && ((data[offset + 5] & 0x80) != 0))
+				{
+					summary.discontinuity = true;
+				}
+			}
+
+			// Only payload-bearing packets advance the continuity counter.
+			// Transport-error and null packets carry no usable continuity information.
+			if (transport_error || (has_payload == false) || (pid == 0x1FFF))
+			{
+				continue;
+			}
+
+			if (summary.first_cc.find(pid) == summary.first_cc.end())
+			{
+				summary.first_cc[pid] = continuity_counter;
+				summary.pid_order.push_back(pid);
+			}
+			summary.last_cc[pid] = continuity_counter;
+		}
+
+		summary.aligned = true;
+		return summary;
+	}
+
+	DatagramReorderBuffer::Placement DatagramReorderBuffer::Classify(const Summary &summary) const
+	{
+		bool has_tracked = false;
+		bool all_exact	 = true;
+		bool any_behind	 = false;
+
+		for (uint16_t pid : summary.pid_order)
+		{
+			const auto it = _expected_cc.find(pid);
+			if (it == _expected_cc.end())
+			{
+				// A PID we have never seen carries no ordering constraint on its own.
+				continue;
+			}
+
+			has_tracked				   = true;
+			const uint8_t displacement = Displacement(summary.first_cc.at(pid), it->second);
+			if (displacement != 0)
+			{
+				all_exact = false;
+			}
+			if (displacement > AHEAD_LIMIT)
+			{
+				any_behind = true;
+			}
+		}
+
+		if (has_tracked == false)
+		{
+			return Placement::Init;
+		}
+		if (any_behind)
+		{
+			// At least one PID is behind expected: this datagram overlaps already-delivered data
+			// (a stale or duplicate datagram), so it is not a future packet.
+			return Placement::Stale;
+		}
+		if (all_exact)
+		{
+			return Placement::InOrder;
+		}
+		return Placement::Ahead;
+	}
+
+	void DatagramReorderBuffer::Deliver(const std::shared_ptr<const ov::Data> &data, const Summary &summary,
+										std::vector<std::shared_ptr<const ov::Data>> *out)
+	{
+		out->push_back(data);
+		for (uint16_t pid : summary.pid_order)
+		{
+			_expected_cc[pid] = static_cast<uint8_t>((summary.last_cc.at(pid) + 1) & 0x0F);
+		}
+	}
+
+	void DatagramReorderBuffer::Cascade(std::vector<std::shared_ptr<const ov::Data>> *out)
+	{
+		bool progress = true;
+		while (progress)
+		{
+			progress = false;
+
+			for (auto it = _buffer.begin(); it != _buffer.end();)
+			{
+				const Placement placement = Classify(it->summary);
+				if (placement == Placement::InOrder)
+				{
+					Deliver(it->data, it->summary, out);
+					it		 = _buffer.erase(it);
+					progress = true;
+				}
+				else if (placement == Placement::Stale)
+				{
+					// Expected advanced past it. It is NOT necessarily a duplicate:
+					// with multi-packet datagrams the 4-bit counter can make a still-needed datagram look behind after
+					// a flush picked a different victim.
+					// Never erase it (that would silently drop a received datagram); pass it through out of order
+					// without advancing the baseline and let the downstream continuity check handle any residual disorder.
+					out->push_back(it->data);
+					it		 = _buffer.erase(it);
+					progress = true;
+				}
+				else
+				{
+					++it;
+				}
+			}
+		}
+	}
+
+	std::deque<DatagramReorderBuffer::Pending>::iterator DatagramReorderBuffer::SelectClosest()
+	{
+		// Rank each buffered datagram by its smallest per-PID displacement.
+		// Across datagrams with disjoint PID sets this compares different counters,
+		// so it is a best-effort pick, not a total order - but it only runs on the flush (loss) path,
+		// and Cascade never drops the losers (it passes them through),
+		// so at worst it adds some out-of-order at a loss boundary.
+		auto best		  = _buffer.begin();
+
+		uint8_t best_rank = 0xFF;
+		for (auto it = _buffer.begin(); it != _buffer.end(); ++it)
+		{
+			uint8_t rank = 0xFF;
+			for (uint16_t pid : it->summary.pid_order)
+			{
+				const auto expected = _expected_cc.find(pid);
+				if (expected == _expected_cc.end())
+				{
+					continue;
+				}
+
+				const uint8_t displacement = Displacement(it->summary.first_cc.at(pid), expected->second);
+				if (displacement < rank)
+				{
+					rank = displacement;
+				}
+			}
+
+			if (rank < best_rank)
+			{
+				best_rank = rank;
+				best	  = it;
+			}
+		}
+		return best;
+	}
+
+	size_t DatagramReorderBuffer::FlushIfNeeded(std::vector<std::shared_ptr<const ov::Data>> *out)
+	{
+		const int64_t now	 = Now();
+
+		// The head gap is presumed lost once the buffer is full (depth) or the oldest arrival has
+		// waited too long (timeout, evaluated on each arrival - there is no timer thread).
+		// Force the datagram nearest the expected counters out (declaring the gap before it lost) and cascade.
+		size_t declared_lost = 0;
+
+		while ((_buffer.empty() == false) &&
+			   ((_buffer.size() >= _max_datagrams) ||
+				((now - _buffer.front().arrival_msec) >= _timeout_msec)))
+		{
+			auto victim	   = SelectClosest();
+
+			Pending picked = *victim;
+
+			_buffer.erase(victim);
+
+			Deliver(picked.data, picked.summary, out);
+			Cascade(out);
+
+			declared_lost++;
+		}
+		return declared_lost;
+	}
+
+	void DatagramReorderBuffer::DrainInOrder(std::vector<std::shared_ptr<const ov::Data>> *out)
+	{
+		Cascade(out);
+
+		while (_buffer.empty() == false)
+		{
+			auto victim	   = SelectClosest();
+			Pending picked = *victim;
+			_buffer.erase(victim);
+			Deliver(picked.data, picked.summary, out);
+			Cascade(out);
+		}
+	}
+
+	void DatagramReorderBuffer::Rebase(const Summary &summary)
+	{
+		for (uint16_t pid : summary.pid_order)
+		{
+			_expected_cc[pid] = static_cast<uint8_t>((summary.last_cc.at(pid) + 1) & 0x0F);
+		}
+	}
+
+	size_t DatagramReorderBuffer::Enqueue(const std::shared_ptr<const ov::Data> &datagram,
+										  std::vector<std::shared_ptr<const ov::Data>> *out)
+	{
+		const Summary summary = Parse(datagram);
+
+		if ((summary.aligned == false) || summary.discontinuity)
+		{
+			// Misaligned or a signalled discontinuity: ordering cannot be trusted.
+			// Drain what we have in restored order and pass this datagram through.
+			DrainInOrder(out);
+			out->push_back(datagram);
+
+			if (summary.pid_order.empty())
+			{
+				// Untrusted with no usable PID (e.g. misaligned): drop all baselines
+				// so they are re-established on the next clean datagram.
+				_expected_cc.clear();
+			}
+			else
+			{
+				// A signalled discontinuity that still carries PIDs: continuity resumes from it.
+				Rebase(summary);
+			}
+			return 0;
+		}
+
+		if (summary.pid_order.empty())
+		{
+			// Aligned but carries no payload PID (e.g. a PCR-only or null-padding datagram):
+			// it holds no continuity information, so pass it straight through WITHOUT disturbing sequencing state.
+			out->push_back(datagram);
+			return FlushIfNeeded(out);
+		}
+
+		switch (Classify(summary))
+		{
+			case Placement::Init:
+			case Placement::InOrder:
+				// First datagram / all tracked PIDs continue exactly: deliver and cascade.
+				Deliver(datagram, summary, out);
+				Cascade(out);
+				break;
+
+			case Placement::Ahead:
+				// A gap on at least one PID with none behind: buffer until the gap fills.
+				// A duplicate of an already-buffered datagram is intentionally NOT deduped here:
+				// with multi-packet datagrams a counter match is not proof of duplication
+				// (a genuinely different datagram aliases to the same counter every 16 packets),
+				// so dropping on a match could lose real data.
+				// If a real duplicate is buffered, Cascade's Stale path passes it through out of
+				// order (never drops), and the downstream continuity check absorbs it.
+				_buffer.push_back({datagram, summary, Now()});
+				break;
+
+			case Placement::Stale:
+				// Overlaps already-delivered data (stale/duplicate, or a high-rate PID aliasing a deep reorder).
+				// Never buffer or drop it: pass it through and let the downstream continuity check handle it.
+				// Do not advance the baseline.
+				out->push_back(datagram);
+				break;
+		}
+
+		return FlushIfNeeded(out);
+	}
+
+	void DatagramReorderBuffer::Flush(std::vector<std::shared_ptr<const ov::Data>> *out)
+	{
+		// Teardown drain: emit everything still buffered in restored (oldest-first) order.
+		DrainInOrder(out);
+	}
+}  // namespace mpegts

--- a/src/projects/modules/containers/mpegts/mpegts_datagram_reorder_buffer.h
+++ b/src/projects/modules/containers/mpegts/mpegts_datagram_reorder_buffer.h
@@ -1,0 +1,156 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include <base/ovlibrary/ovlibrary.h>
+
+#include <deque>
+#include <functional>
+#include <map>
+#include <vector>
+
+namespace mpegts
+{
+	// Reorders whole UDP datagrams (each a contiguous run of 188-byte TS packets)
+	// that a lossy network delivered out of order, using the joint per-PID continuity counters
+	// as the sequencing hint.
+	//
+	// UDP reorders datagrams atomically (the TS packets inside one datagram are always in send order).
+	// A datagram carries several PIDs, each with its own continuity counter;
+	// the buffer keeps the expected next counter per PID and classifies an incoming datagram
+	// by ALL the PIDs it carries at once:
+	//
+	//   - every carried (already-tracked) PID continues exactly  -> in order, deliver
+	//   - every carried PID is ahead of expected                 -> a gap; buffer until it fills
+	//   - any carried PID is behind expected                     -> stale/duplicate; pass through
+	//
+	// The joint check is what makes this robust. The counter is only 4 bits, so a high-rate PID
+	// (video: several packets per datagram) wraps every ~2-3 datagrams and cannot alone tell
+	// "a few datagrams ahead" from "a few datagrams behind".
+	// A low-rate PID (audio/PCR: ~1 packet per datagram) advances its counter by ~1 per datagram,
+	// so it effectively numbers datagrams with a ~16-datagram horizon and reliably reveals a behind/stale datagram even
+	// when the high-rate PID aliases it as "ahead".
+	// Requiring all PIDs to agree therefore rejects stale/duplicate datagrams
+	// (they are passed straight through, never buffered) and admits only genuine gaps.
+	//
+	// A gap that never fills is declared lost after a bounded window (depth) or timeout.
+	// A datagram that cannot be placed (ambiguous, or beyond the window) is passed through, never dropped,
+	// so no received data is lost; downstream continuity checks turn any residual disorder into a clean gap.
+	// Reordering is a best-effort improvement, never worse than not reordering at all.
+	// A datagram carrying only a high-rate PID (a pure video burst with no low-rate anchor) can still be
+	// misjudged within that burst, but the pass-through-never-drop rule keeps that safe.
+	//
+	// Not thread-safe: the owning depacketizer serializes all access under its own lock.
+	class DatagramReorderBuffer
+	{
+	public:
+		// Maximum datagrams held before the head gap is declared lost and flushed.
+		static constexpr size_t DEFAULT_MAX_DATAGRAMS = 8;
+
+		// Maximum time a datagram waits behind a gap before the gap is declared lost (milliseconds).
+		static constexpr int64_t DEFAULT_TIMEOUT_MSEC = 100;
+
+		// Continuity-counter displacement (mod 16) at or below which a PID is treated as "ahead"
+		// (a plausible future) rather than "behind" (already delivered/stale).
+		// A loss larger than this window puts the stream beyond it, so reordering suspends
+		// (datagrams pass straight through, none dropped) until a signalled discontinuity
+		// or the counter naturally re-enters the window.
+		static constexpr uint8_t AHEAD_LIMIT		  = 7;
+
+		// `clock` returns the current time in milliseconds; `nullptr` uses the system clock.
+		// Injecting a clock keeps timeout-driven behavior deterministic in tests.
+		explicit DatagramReorderBuffer(size_t max_datagrams			  = DEFAULT_MAX_DATAGRAMS,
+									   int64_t timeout_msec			  = DEFAULT_TIMEOUT_MSEC,
+									   std::function<int64_t()> clock = nullptr);
+
+		// Feeds one whole datagram. Appends any datagrams that become deliverable, in restored order, to `out`.
+		// Returns the number of datagrams whose preceding gap was declared lost (depth/timeout flush) during this call,
+		// so the caller can log that event.
+		size_t Enqueue(const std::shared_ptr<const ov::Data> &datagram,
+					   std::vector<std::shared_ptr<const ov::Data>> *out);
+
+		// Emits everything still buffered (in restored order). Available for an explicit teardown drain;
+		// it is not called automatically on destruction, so if a stream ends while datagrams are held behind a gap,
+		// up to (`max_datagrams - 1`) already-received datagrams are dropped at end-of-stream.
+		// That is bounded and only affects shutdown.
+		void Flush(std::vector<std::shared_ptr<const ov::Data>> *out);
+
+		size_t GetBufferedCount() const
+		{
+			return _buffer.size();
+		}
+
+	private:
+		// Per-datagram continuity-counter summary extracted by a light header-only parse.
+		struct Summary
+		{
+			// starts on a 188 boundary and every sync byte is present
+			bool aligned	   = false;
+			// a packet signals discontinuity_indicator
+			bool discontinuity = false;
+			// payload-bearing PIDs in packet order
+			std::vector<uint16_t> pid_order;
+			std::map<uint16_t, uint8_t> first_cc;
+			std::map<uint16_t, uint8_t> last_cc;
+		};
+
+		struct Pending
+		{
+			std::shared_ptr<const ov::Data> data;
+			Summary summary;
+			int64_t arrival_msec = 0;
+		};
+
+		enum class Placement
+		{
+			// no PID is tracked yet (stream start/all-new PIDs)
+			Init,
+			// every tracked PID continues exactly
+			InOrder,
+			// every tracked PID is ahead (a gap); none behind
+			Ahead,
+			// at least one tracked PID is behind (already delivered/duplicate)
+			Stale,
+		};
+
+		static Summary Parse(const std::shared_ptr<const ov::Data> &datagram);
+		static uint8_t Displacement(uint8_t cc, uint8_t expected);
+
+		int64_t Now() const;
+		Placement Classify(const Summary &summary) const;
+
+		// Delivers a datagram and advances the expected counter for every PID it carries.
+		void Deliver(const std::shared_ptr<const ov::Data> &data, const Summary &summary,
+					 std::vector<std::shared_ptr<const ov::Data>> *out);
+
+		void Cascade(std::vector<std::shared_ptr<const ov::Data>> *out);
+
+		// The buffered datagram nearest the expected counters (smallest displacement over its tracked
+		// PIDs); the best guess for the datagram right after a lost head gap.
+		std::deque<Pending>::iterator SelectClosest();
+
+		// Returns the number of gaps declared lost (datagrams force-flushed) during this call.
+		size_t FlushIfNeeded(std::vector<std::shared_ptr<const ov::Data>> *out);
+
+		// Drains the whole buffer in restored (oldest-first) order.
+		void DrainInOrder(std::vector<std::shared_ptr<const ov::Data>> *out);
+
+		// Re-seeds the expected counters for the PIDs a datagram carries (used after a discontinuity).
+		void Rebase(const Summary &summary);
+
+		size_t _max_datagrams;
+		int64_t _timeout_msec;
+		std::function<int64_t()> _clock;
+
+		// Expected next continuity counter per PID (the joint sequencing state).
+		std::map<uint16_t, uint8_t> _expected_cc;
+
+		std::deque<Pending> _buffer;
+	};
+}  // namespace mpegts

--- a/src/projects/modules/containers/mpegts/mpegts_datagram_reorder_buffer_test.cpp
+++ b/src/projects/modules/containers/mpegts/mpegts_datagram_reorder_buffer_test.cpp
@@ -1,0 +1,565 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include "mpegts_datagram_reorder_buffer.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <random>
+#include <vector>
+
+namespace
+{
+	constexpr uint16_t VIDEO_PID = 0x0100;
+	constexpr uint16_t AUDIO_PID = 0x0101;
+
+	// Builds a datagram (a contiguous run of 188-byte TS packets) from a list of (pid, cc) pairs.
+	std::shared_ptr<const ov::Data> MakeDatagram(const std::vector<std::pair<uint16_t, uint8_t>> &packets,
+												 bool discontinuity = false, bool transport_error = false)
+	{
+		std::vector<uint8_t> buffer(packets.size() * 188, 0x00);
+
+		for (size_t i = 0; i < packets.size(); i++)
+		{
+			uint8_t *p		   = buffer.data() + (i * 188);
+			const uint16_t pid = packets[i].first;
+			const uint8_t cc   = packets[i].second;
+
+			p[0]			   = 0x47;
+			p[1]			   = static_cast<uint8_t>((transport_error ? 0x80 : 0x00) | ((pid >> 8) & 0x1F));
+			p[2]			   = static_cast<uint8_t>(pid & 0xFF);
+
+			if (discontinuity)
+			{
+				// Adaptation field + payload, with the discontinuity_indicator set.
+				p[3] = static_cast<uint8_t>((0b11 << 4) | (cc & 0x0F));
+				p[4] = 1;	  // adaptation_field_length
+				p[5] = 0x80;  // discontinuity_indicator
+			}
+			else
+			{
+				// Payload only.
+				p[3] = static_cast<uint8_t>((0b01 << 4) | (cc & 0x0F));
+			}
+		}
+
+		return std::make_shared<ov::Data>(buffer.data(), buffer.size());
+	}
+
+	// A single-PID datagram carrying one packet with the given continuity counter.
+	std::shared_ptr<const ov::Data> MakeVideo(uint8_t cc)
+	{
+		return MakeDatagram({{VIDEO_PID, cc}});
+	}
+
+	// A datagram carrying `count` consecutive video packets starting at continuity counter `base_cc`
+	// (realistic framing: real UDP datagrams carry several TS packets, so the counter steps by `count`
+	// per datagram).
+	std::shared_ptr<const ov::Data> MakeVideoRun(uint8_t base_cc, int count)
+	{
+		std::vector<std::pair<uint16_t, uint8_t>> packets;
+		for (int i = 0; i < count; i++)
+		{
+			packets.push_back({VIDEO_PID, static_cast<uint8_t>((base_cc + i) & 0x0F)});
+		}
+		return MakeDatagram(packets);
+	}
+
+	// Drives the buffer and maps delivered datagrams back to their logical index via pointer identity.
+	class Harness
+	{
+	public:
+		explicit Harness(mpegts::DatagramReorderBuffer *buffer)
+			: _buffer(buffer)
+		{
+		}
+
+		// Registers a datagram under a logical index and feeds it in one step.
+		std::vector<int> Feed(int index, const std::shared_ptr<const ov::Data> &datagram)
+		{
+			_by_pointer[datagram.get()] = index;
+
+			std::vector<std::shared_ptr<const ov::Data>> out;
+			_buffer->Enqueue(datagram, &out);
+			return ToIndices(out);
+		}
+
+		std::vector<int> FlushRemaining()
+		{
+			std::vector<std::shared_ptr<const ov::Data>> out;
+			_buffer->Flush(&out);
+			return ToIndices(out);
+		}
+
+	private:
+		std::vector<int> ToIndices(const std::vector<std::shared_ptr<const ov::Data>> &out)
+		{
+			std::vector<int> indices;
+			for (const auto &d : out)
+			{
+				auto it = _by_pointer.find(d.get());
+				indices.push_back(it == _by_pointer.end() ? -1 : it->second);
+			}
+			return indices;
+		}
+
+		mpegts::DatagramReorderBuffer *_buffer;
+		std::map<const ov::Data *, int> _by_pointer;
+	};
+}  // namespace
+
+TEST(MpegTsDatagramReorderBuffer, InOrderPassthroughHasNoLatency)
+{
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	EXPECT_EQ(h.Feed(0, MakeVideo(0)), (std::vector<int>{0}));
+	EXPECT_EQ(h.Feed(1, MakeVideo(1)), (std::vector<int>{1}));
+	EXPECT_EQ(h.Feed(2, MakeVideo(2)), (std::vector<int>{2}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, AdjacentSwapIsRestored)
+{
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	append(h.Feed(0, MakeVideo(0)));  // in order
+	append(h.Feed(2, MakeVideo(2)));  // ahead -> buffered
+	append(h.Feed(1, MakeVideo(1)));  // fills the gap -> 1 then cascade 2
+	append(h.Feed(3, MakeVideo(3)));
+
+	EXPECT_EQ(delivered, (std::vector<int>{0, 1, 2, 3}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, MultiStepReorderCascades)
+{
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	// Arrival: 0, 3, 1, 2  ->  3 waits, then 1, then 2 fills and 3 cascades.
+	append(h.Feed(0, MakeVideo(0)));
+	append(h.Feed(3, MakeVideo(3)));
+	append(h.Feed(1, MakeVideo(1)));
+	append(h.Feed(2, MakeVideo(2)));
+
+	EXPECT_EQ(delivered, (std::vector<int>{0, 1, 2, 3}));
+}
+
+TEST(MpegTsDatagramReorderBuffer, DepthFlushDeclaresLoss)
+{
+	// Small depth so the lost datagram is declared quickly.
+	mpegts::DatagramReorderBuffer buffer(/*max_datagrams=*/3, /*timeout_msec=*/1000000);
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	append(h.Feed(0, MakeVideo(0)));  // delivered, expected -> 1
+	append(h.Feed(1, MakeVideo(2)));  // cc 1 lost; this is cc 2 -> buffered
+	append(h.Feed(2, MakeVideo(3)));  // buffered
+	append(h.Feed(3, MakeVideo(4)));  // buffer depth reaches 3 -> flush: emit 2,3,4 in order
+
+	EXPECT_EQ(delivered, (std::vector<int>{0, 1, 2, 3}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, TimeoutFlushDeclaresLoss)
+{
+	int64_t now = 0;
+	mpegts::DatagramReorderBuffer buffer(/*max_datagrams=*/16, /*timeout_msec=*/100,
+										 /*clock=*/[&now]() { return now; });
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	append(h.Feed(0, MakeVideo(0)));  // delivered
+	append(h.Feed(1, MakeVideo(2)));  // cc 1 lost; cc 2 buffered at t=0
+	EXPECT_EQ(buffer.GetBufferedCount(), 1u);
+
+	now = 100;						  // advance past timeout
+	append(h.Feed(2, MakeVideo(3)));  // triggers sweep: 2 flushed (loss of 1), then 3 cascades
+
+	EXPECT_EQ(delivered, (std::vector<int>{0, 1, 2}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, DuplicateDatagramPassesThrough)
+{
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	append(h.Feed(0, MakeVideo(0)));
+	append(h.Feed(1, MakeVideo(1)));
+	// A stale/duplicate datagram (behind expected) is indistinguishable from a far-ahead one with a
+	// 4-bit counter, so it is not dropped here - it is passed through, and the downstream continuity
+	// check handles it. The important property is that nothing received is silently discarded.
+	append(h.Feed(2, MakeVideo(0)));
+
+	EXPECT_EQ(delivered, (std::vector<int>{0, 1, 2}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, DuplicateInAheadWindowIsNeverDropped)
+{
+	// A duplicate of an already-buffered (ahead) datagram with a single high-rate PID (no low-rate
+	// anchor to reveal it as stale) is not deduped in the buffer - deduping on a counter match could
+	// drop genuinely different multi-packet data. Once the gap fills, the original is delivered in
+	// order and the surplus copy becomes 'behind' and is passed through (never dropped). The
+	// downstream continuity check absorbs the redundant copy.
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	append(h.Feed(0, MakeVideo(0)));   // delivered, expected -> 1
+	append(h.Feed(2, MakeVideo(2)));   // ahead -> buffered
+	append(h.Feed(99, MakeVideo(2)));  // surplus copy of cc2 -> also buffered
+	append(h.Feed(1, MakeVideo(1)));   // fills the gap -> 1, cascade 2, surplus copy passed through
+
+	std::sort(delivered.begin(), delivered.end());
+	EXPECT_EQ(delivered, (std::vector<int>{0, 1, 2, 99}));	// every received datagram emitted; none dropped
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, StaleDuplicateRejectedByLowRatePid)
+{
+	// The joint multi-PID check rejects a stale/duplicate datagram that a high-rate PID alone would
+	// alias as "ahead". With 6 video + 1 audio per datagram, video steps by 6 (wraps in ~3 datagrams)
+	// but audio steps by 1, so a duplicate of a 2-back datagram shows video "ahead" yet audio
+	// "behind" -> classified stale -> passed straight through (never buffered, never re-injected).
+	auto run = [](uint8_t v_base, uint8_t a_cc) {
+		std::vector<std::pair<uint16_t, uint8_t>> packets;
+		for (int i = 0; i < 6; i++)
+		{
+			packets.push_back({VIDEO_PID, static_cast<uint8_t>((v_base + i) & 0x0F)});
+		}
+		packets.push_back({AUDIO_PID, a_cc});
+		return MakeDatagram(packets);
+	};
+
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	append(h.Feed(0, run(0, 0)));	// video 0-5,  audio 0
+	append(h.Feed(1, run(6, 1)));	// video 6-11, audio 1
+	append(h.Feed(2, run(12, 2)));	// video 12-15,0,1, audio 2
+
+	// Duplicate of datagram 1 (video first_cc 6, audio 1). video displacement aliases into "ahead",
+	// audio displacement is clearly "behind" -> stale -> passthrough, not buffered.
+	append(h.Feed(99, run(6, 1)));
+
+	EXPECT_EQ(delivered, (std::vector<int>{0, 1, 2, 99}));	// duplicate passed through, in place
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, PcrOnlyDatagramPreservesReorderBaseline)
+{
+	// An aligned datagram with no payload PID (e.g. PCR-only / null padding) must pass through
+	// without tearing down the sequencing state, so reordering keeps working around it.
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	append(h.Feed(0, MakeVideo(0)));  // primary = video, delivered, expected -> 1
+	append(h.Feed(1, MakeVideo(2)));  // ahead -> buffered
+
+	// A PCR-only datagram: one adaptation-field-only packet (AFC=10, no payload) on a PCR PID.
+	std::vector<uint8_t> pcr(188, 0x00);
+	pcr[0] = 0x47;
+	pcr[1] = (0x0100 >> 8) & 0x1F;
+	pcr[2] = 0x00;
+	pcr[3] = static_cast<uint8_t>((0b10 << 4) | 0);							// adaptation only, no payload
+	pcr[4] = 1;																// adaptation_field_length
+	append(h.Feed(2, std::make_shared<ov::Data>(pcr.data(), pcr.size())));	// passthrough, no state change
+
+	append(h.Feed(3, MakeVideo(1)));  // still fills the video gap -> 1 then cascade the buffered 2
+
+	EXPECT_EQ(delivered, (std::vector<int>{0, 2, 3, 1}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, DiscontinuityBypassesAndRebases)
+{
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	append(h.Feed(0, MakeVideo(0)));
+	append(h.Feed(1, MakeVideo(1)));
+	// A signalled discontinuity with a far-off cc: passes through immediately and rebases.
+	append(h.Feed(2, MakeDatagram({{VIDEO_PID, 9}}, /*discontinuity=*/true)));
+	// Following datagrams reorder against the new base (cc 10, 11).
+	append(h.Feed(3, MakeDatagram({{VIDEO_PID, 11}})));	 // ahead -> buffered
+	append(h.Feed(4, MakeDatagram({{VIDEO_PID, 10}})));	 // fills -> 4 then cascade 3
+
+	EXPECT_EQ(delivered, (std::vector<int>{0, 1, 2, 4, 3}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, UnalignedDatagramPassesThrough)
+{
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	// Not a multiple of 188 -> cannot be trusted for CC ordering -> passed through as-is.
+	std::vector<uint8_t> junk(200, 0x00);
+	auto datagram = std::make_shared<ov::Data>(junk.data(), junk.size());
+
+	EXPECT_EQ(h.Feed(0, datagram), (std::vector<int>{0}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, MultiPidInterleaveIsRestored)
+{
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	// Each datagram carries video and audio packets that move together.
+	auto d0		= MakeDatagram({{VIDEO_PID, 0}, {AUDIO_PID, 5}});
+	auto d1		= MakeDatagram({{VIDEO_PID, 1}, {AUDIO_PID, 6}});
+	auto d2		= MakeDatagram({{VIDEO_PID, 2}, {AUDIO_PID, 7}});
+
+	append(h.Feed(0, d0));
+	append(h.Feed(2, d2));	// ahead -> buffered
+	append(h.Feed(1, d1));	// fills -> 1 then cascade 2
+
+	EXPECT_EQ(delivered, (std::vector<int>{0, 1, 2}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, NonPrimaryPidDatagramPassesThrough)
+{
+	// The primary (sequencing) PID is the first payload PID seen (video here). A datagram that does
+	// not carry it (a separate audio-only datagram) is not reordered; it passes straight through in
+	// arrival order while the primary PID is reordered independently.
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	append(h.Feed(0, MakeVideo(0)));					// primary = video, delivered, expected -> 1
+	append(h.Feed(1, MakeVideo(2)));					// video ahead -> buffered
+	append(h.Feed(2, MakeDatagram({{AUDIO_PID, 7}})));	// audio-only, no primary -> passthrough
+	append(h.Feed(3, MakeVideo(1)));					// fills the video gap -> 1 then cascade 2
+
+	EXPECT_EQ(delivered, (std::vector<int>{0, 2, 3, 1}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, FarAheadDatagramPassesThrough)
+{
+	// Documents the 4-bit continuity-counter limit: a datagram displaced beyond the ahead window is
+	// ambiguous (far-ahead vs stale). It is passed through rather than restored or dropped, so no
+	// received data is lost even though order is not recovered.
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	h.Feed(0, MakeVideo(0));			  // expected -> 1
+	auto out = h.Feed(1, MakeVideo(10));  // displacement 9 (> ahead limit) -> passed through
+
+	EXPECT_EQ(out, (std::vector<int>{1}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, AdjacentSwapRestoredWithMultiPacketDatagrams)
+{
+	// Realistic framing: 7 TS packets per datagram (the counter steps by 7 each datagram). An
+	// adjacent datagram swap is still restored.
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	auto d0		= MakeVideoRun(0, 7);	// cc 0..6
+	auto d1		= MakeVideoRun(7, 7);	// cc 7..13
+	auto d2		= MakeVideoRun(14, 7);	// cc 14,15,0,1,2,3,4
+	auto d3		= MakeVideoRun(5, 7);	// cc 5..11
+
+	append(h.Feed(0, d0));
+	append(h.Feed(2, d2));	// d1/d2 swapped in arrival
+	append(h.Feed(1, d1));
+	append(h.Feed(3, d3));
+
+	EXPECT_EQ(delivered, (std::vector<int>{0, 1, 2, 3}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, DeepReorderPassesThroughWithoutLossMultiPacket)
+{
+	// With 7-packet datagrams a depth-2 reorder exceeds the 4-bit counter window and cannot be
+	// restored, but the key guarantee holds: every received datagram is still delivered (nothing is
+	// dropped), even if the order is not fully recovered.
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	auto d0		= MakeVideoRun(0, 7);
+	auto d1		= MakeVideoRun(7, 7);
+	auto d2		= MakeVideoRun(14, 7);
+	auto d3		= MakeVideoRun(5, 7);
+
+	append(h.Feed(0, d0));
+	append(h.Feed(2, d2));
+	append(h.Feed(3, d3));
+	append(h.Feed(1, d1));
+	append(h.FlushRemaining());
+
+	std::sort(delivered.begin(), delivered.end());
+	EXPECT_EQ(delivered, (std::vector<int>{0, 1, 2, 3}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, BypassDrainsBufferedInRestoredOrder)
+{
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	append(h.Feed(0, MakeVideo(0)));  // delivered, expected -> 1
+	append(h.Feed(3, MakeVideo(3)));  // buffered (arrival first)
+	append(h.Feed(2, MakeVideo(2)));  // buffered (arrival second)
+
+	// An unaligned datagram forces the buffer to drain. It must drain in restored order (2 then 3),
+	// not arrival order (3 then 2), before the passthrough datagram.
+	std::vector<uint8_t> junk(200, 0x00);
+	append(h.Feed(9, std::make_shared<ov::Data>(junk.data(), junk.size())));
+
+	EXPECT_EQ(delivered, (std::vector<int>{0, 2, 3, 9}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, CorruptAdaptationLengthBypasses)
+{
+	mpegts::DatagramReorderBuffer buffer;
+	Harness h(&buffer);
+
+	// AFC=11 (adaptation + payload) with an adaptation_field_length that exceeds the packet body.
+	std::vector<uint8_t> bytes(188, 0x00);
+	bytes[0]	  = 0x47;
+	bytes[1]	  = (VIDEO_PID >> 8) & 0x1F;
+	bytes[2]	  = VIDEO_PID & 0xFF;
+	bytes[3]	  = static_cast<uint8_t>((0b11 << 4) | 0);
+	bytes[4]	  = 200;  // invalid adaptation_field_length (> 183)
+	auto datagram = std::make_shared<ov::Data>(bytes.data(), bytes.size());
+
+	// Untrusted -> bypass reordering -> passed through unchanged.
+	EXPECT_EQ(h.Feed(0, datagram), (std::vector<int>{0}));
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+TEST(MpegTsDatagramReorderBuffer, MultiPacketFlushNeverDropsReceivedDatagram)
+{
+	// Regression: with multi-packet datagrams the 4-bit counter can make a timeout/depth flush pick a
+	// victim that advances the baseline past a still-buffered datagram. That datagram must be passed
+	// through, never silently dropped.
+	int64_t now = 0;
+	mpegts::DatagramReorderBuffer buffer(/*max_datagrams=*/8, /*timeout_msec=*/100,
+										 [&now]() { return now; });
+	Harness h(&buffer);
+
+	std::vector<int> delivered;
+	auto append = [&delivered](const std::vector<int> &v) { delivered.insert(delivered.end(), v.begin(), v.end()); };
+
+	append(h.Feed(2, MakeVideoRun(6, 3)));	 // first delivered, expected -> 9
+	append(h.Feed(0, MakeVideoRun(0, 3)));	 // displacement 7 -> buffered
+	now = 100;								 // age past timeout
+	append(h.Feed(5, MakeVideoRun(15, 3)));	 // displacement 6 -> buffered; timeout flush fires
+	append(h.FlushRemaining());
+
+	std::sort(delivered.begin(), delivered.end());
+	EXPECT_EQ(delivered, (std::vector<int>{0, 2, 5}));	// every received datagram emitted; none dropped
+	EXPECT_EQ(buffer.GetBufferedCount(), 0u);
+}
+
+// -----------------------------------------------------------------------------
+// Property test: within-window shuffles must restore the original order exactly.
+// Uses only the raw mt19937 engine output (no std distributions/std::shuffle) so
+// the permutation is byte-for-byte reproducible on every platform and compiler.
+// -----------------------------------------------------------------------------
+TEST(MpegTsDatagramReorderBuffer, WithinWindowShufflePropertyRestoresOrder)
+{
+	constexpr int BLOCK = 6;   // reorder distance bound (<= ahead limit)
+	constexpr int COUNT = 50;  // crosses several 4-bit continuity-counter wraps
+
+	for (uint32_t seed = 1; seed <= 25; seed++)
+	{
+		std::mt19937 gen(seed);
+
+		// Build a bounded-displacement permutation using only raw gen() outputs (Fisher-Yates within
+		// fixed blocks). Every datagram stays inside its block, so its displacement is < BLOCK and
+		// the continuity counters live in the buffer never span a full 4-bit wrap (no CC aliasing).
+		// Index 0 is kept first so it establishes the reorder baseline (in a real stream the
+		// first-arriving datagram is the baseline; there is no datagram "before" it).
+		std::vector<int> feed_order(COUNT);
+		for (int i = 0; i < COUNT; i++)
+		{
+			feed_order[i] = i;
+		}
+		for (int start = 1; start < COUNT; start += BLOCK)
+		{
+			const int end = std::min(start + BLOCK, COUNT);
+			for (int i = end - 1; i > start; i--)
+			{
+				const int j = start + static_cast<int>(gen() % static_cast<uint32_t>(i - start + 1));
+				std::swap(feed_order[i], feed_order[j]);
+			}
+		}
+
+		// No loss and no time advance -> full restoration is required.
+		mpegts::DatagramReorderBuffer buffer(/*max_datagrams=*/64, /*timeout_msec=*/1000000,
+											 /*clock=*/[]() { return static_cast<int64_t>(0); });
+		Harness h(&buffer);
+
+		std::vector<int> delivered;
+		for (int index : feed_order)
+		{
+			auto out = h.Feed(index, MakeVideo(static_cast<uint8_t>(index % 16)));
+			delivered.insert(delivered.end(), out.begin(), out.end());
+		}
+		auto tail = h.FlushRemaining();
+		delivered.insert(delivered.end(), tail.begin(), tail.end());
+
+		std::vector<int> expected(COUNT);
+		for (int i = 0; i < COUNT; i++)
+		{
+			expected[i] = i;
+		}
+
+		ASSERT_EQ(delivered, expected) << "seed=" << seed;
+	}
+}

--- a/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
+++ b/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
@@ -225,7 +225,7 @@ namespace mpegts
 
 		if (packet_type == PacketType::UNSUPPORTED_SECTION || packet_type == PacketType::UNKNOWN)
 		{
-			// FFMPEG ususally sends PID 17 (DVB - SDT), but we don't use this table now
+			// FFMPEG usually sends PID 17 (DVB - SDT), but we don't use this table now
 			logat("Ignored unsupported or unknown MPEG-TS packets.(PID: %d)", packet->PacketIdentifier());
 			return false;
 		}
@@ -472,7 +472,7 @@ namespace mpegts
 				}
 				else
 				{
-					// Somethind wrong
+					// Something wrong
 					logae("Could not complete section(PID: %d)", packet->PacketIdentifier());
 				}
 			}

--- a/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
+++ b/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
@@ -23,21 +23,84 @@ namespace mpegts
 	{
 	}
 
-	bool MpegTsDepacketizer::AddPacket(const std::shared_ptr<const ov::Data> &packet)
+	bool MpegTsDepacketizer::AddPacket(const std::shared_ptr<const ov::Data> &datagram)
 	{
-		_buffer->Append(packet);
+		_buffer->Append(datagram);
 
 		while (_buffer->GetLength() >= MPEGTS_MIN_PACKET_SIZE)
 		{
-			auto packet = std::make_shared<Packet>(_buffer);
+			auto packet			   = std::make_shared<Packet>(_buffer);
 
 			uint32_t parsed_length = packet->Parse();
 			if (parsed_length == 0)
 			{
-				_buffer = _buffer->Subdata(MPEGTS_MIN_PACKET_SIZE);
+				// Parse can fail either because the grid is misaligned (bad sync byte) or because an
+				// otherwise-aligned packet failed a later field check (e.g. transport_error_indicator).
+				// If we are locked to the 188-byte grid and the leading byte is a sync byte, `data[0]` is
+				// a genuine boundary and this is an aligned-but-corrupt packet: drop exactly one packet
+				// and stay aligned (this preserves the grid for the TEI packets a lossy link produces).
+				if (_synced && (_buffer->GetDataAs<uint8_t>()[0] == MPEGTS_SYNC_BYTE))
+				{
+					logtd("Dropped an aligned but unparsable MPEG-TS packet (sync byte present); staying on the grid");
+					_buffer = _buffer->Subdata(MPEGTS_MIN_PACKET_SIZE);
+					continue;
+				}
+
+				// Not locked to the grid (or the leading byte is not a sync byte):
+				// the grid is (or may be) misaligned. Rather than blindly skipping a fixed 188 bytes,
+				// scan for the next sync byte confirmed by another sync byte one/two packet lengths ahead,
+				// and drop the bytes before it.
+				if (_synced)
+				{
+					logtd("Lost MPEG-TS sync; scanning to resynchronize");
+				}
+
+				_synced				 = false;
+
+				size_t resync_offset = FindResyncOffset();
+				if (resync_offset == 0)
+				{
+					// No boundary can be confirmed yet (a candidate needs another sync byte a packet length ahead).
+					// Best-effort minimal advance: keep from the earliest sync byte and wait for more data.
+					// That byte may be a stray payload 0x47 rather than a true boundary;
+					// if so the next append re-runs Parse/resync from there and converges. If
+					// there is no sync byte at all, the buffer is pure garbage and is dropped.
+					const uint8_t *data = _buffer->GetDataAs<uint8_t>();
+					const size_t length = _buffer->GetLength();
+					size_t keep_from	= length;
+					for (size_t i = 1; i < length; i++)
+					{
+						if (data[i] == MPEGTS_SYNC_BYTE)
+						{
+							keep_from = i;
+							break;
+						}
+					}
+
+					if (keep_from < length)
+					{
+						logtd("Resync: no confirmed boundary yet; dropped %zu byte(s), waiting for more data", keep_from);
+						_buffer = _buffer->Subdata(keep_from);
+					}
+					else
+					{
+						logtd("Resync: no sync byte in %zu byte(s); dropped the whole buffer", length);
+						_buffer = std::make_shared<ov::Data>();
+					}
+					break;
+				}
+
+				// Candidate boundary from the double/triple-sync scan.
+				// Do NOT mark synced yet: only a successful Parse at this offset confirms it,
+				// so a false payload-0x47 lock re-scans on the next parse failure
+				// instead of being trusted by the aligned-but-corrupt path.
+				logtd("Resync: candidate boundary at offset %zu; dropped %zu leading byte(s)", resync_offset, resync_offset);
+				_buffer = _buffer->Subdata(resync_offset);
 				continue;
 			}
 
+			// A full packet parsed: data now points at the next 188-byte boundary.
+			_synced = true;
 			_buffer = _buffer->Subdata(parsed_length);
 
 			if (AddPacket(packet) == false)
@@ -47,6 +110,39 @@ namespace mpegts
 		}
 
 		return true;
+	}
+
+	size_t MpegTsDepacketizer::FindResyncOffset() const
+	{
+		const auto data	  = _buffer->GetDataAs<uint8_t>();
+		const auto length = _buffer->GetLength();
+
+		// A boundary is confirmed by a second sync byte one packet length ahead (double-sync),
+		// and by a third one two packet lengths ahead when the buffer is long enough.
+		// This avoids relocking onto a 0x47 byte that merely appears inside a packet payload.
+		for (size_t offset = 1; offset + MPEGTS_MIN_PACKET_SIZE < length; offset++)
+		{
+			if (data[offset] != MPEGTS_SYNC_BYTE)
+			{
+				continue;
+			}
+
+			if (data[offset + MPEGTS_MIN_PACKET_SIZE] != MPEGTS_SYNC_BYTE)
+			{
+				continue;
+			}
+
+			const auto third = offset + (2 * MPEGTS_MIN_PACKET_SIZE);
+
+			if ((third < length) && (data[third] != MPEGTS_SYNC_BYTE))
+			{
+				continue;
+			}
+
+			return offset;
+		}
+
+		return 0;
 	}
 
 	bool MpegTsDepacketizer::AddPacket(const std::shared_ptr<Packet> &packet)

--- a/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
+++ b/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
@@ -78,6 +78,23 @@ namespace mpegts
 		return ProcessDatagram(datagram);
 	}
 
+	void MpegTsDepacketizer::FlushReorderBuffer()
+	{
+		if (_reorder_buffer == nullptr)
+		{
+			return;
+		}
+
+		std::vector<std::shared_ptr<const ov::Data>> ordered;
+
+		_reorder_buffer->Flush(&ordered);
+
+		for (const auto &datagram : ordered)
+		{
+			ProcessDatagram(datagram);
+		}
+	}
+
 	bool MpegTsDepacketizer::ProcessDatagram(const std::shared_ptr<const ov::Data> &datagram)
 	{
 		_buffer->Append(datagram);

--- a/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
+++ b/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
@@ -36,7 +36,14 @@ namespace mpegts
 		// Must be enabled before any data is processed: otherwise the byte buffer may already hold a
 		// partial datagram and the continuity map is primed, while the reorder buffer would start
 		// fresh and second-guess the counter order.
-		OV_ASSERT2((_buffer->GetLength() == 0) && _last_continuity_counter_map.empty());
+		// Enforce this in every build type (`OV_ASSERT2` alone is compiled out in release):
+		// refuse to enable mid-stream rather than corrupt the baseline.
+		if ((_buffer->GetLength() != 0) || (_last_continuity_counter_map.empty() == false))
+		{
+			OV_ASSERT2(false);
+			logaw("Ignored a request to enable MPEG-TS packet reordering after data was already processed");
+			return;
+		}
 
 		if (_reorder_buffer == nullptr)
 		{

--- a/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
+++ b/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
@@ -9,14 +9,22 @@
 #include "mpegts_depacketizer.h"
 
 #include <base/ovlibrary/bit_reader.h>
+#include <base/ovlibrary/clock.h>
 
 #define OV_LOG_TAG "MPEGTS_DEPACKETIZER"
+
+// Every log in this file is prefixed with the owning stream's name path (set via `SetNamePath()`).
+#define OV_LOG_PREFIX_FORMAT "[%s] "
+#define OV_LOG_PREFIX_VALUE _name_path.CStr()
 
 namespace mpegts
 {
 
 	MpegTsDepacketizer::MpegTsDepacketizer()
 	{
+		// Cache whether debug logging is enabled for this tag so the per-packet continuity-break
+		// detail can be skipped entirely (no argument formatting) on a hot, lossy path.
+		_debug_enabled = ov_log_get_enabled(OV_LOG_TAG, OVLogLevelDebug);
 	}
 
 	MpegTsDepacketizer::~MpegTsDepacketizer()
@@ -45,7 +53,7 @@ namespace mpegts
 
 			if (gap_loss > 0)
 			{
-				logtd("MPEG-TS reorder: declared %zu datagram gap(s) lost (depth/timeout flush)", gap_loss);
+				logad("MPEG-TS reorder: declared %zu datagram gap(s) lost (depth/timeout flush)", gap_loss);
 			}
 
 			bool result = true;
@@ -81,7 +89,7 @@ namespace mpegts
 				// and stay aligned (this preserves the grid for the TEI packets a lossy link produces).
 				if (_synced && (_buffer->GetDataAs<uint8_t>()[0] == MPEGTS_SYNC_BYTE))
 				{
-					logtd("Dropped an aligned but unparsable MPEG-TS packet (sync byte present); staying on the grid");
+					logad("Dropped an aligned but unparsable MPEG-TS packet (sync byte present); staying on the grid");
 					_buffer = _buffer->Subdata(MPEGTS_MIN_PACKET_SIZE);
 					continue;
 				}
@@ -92,7 +100,7 @@ namespace mpegts
 				// and drop the bytes before it.
 				if (_synced)
 				{
-					logtd("Lost MPEG-TS sync; scanning to resynchronize");
+					logad("Lost MPEG-TS sync; scanning to resynchronize");
 				}
 
 				_synced				 = false;
@@ -119,12 +127,12 @@ namespace mpegts
 
 					if (keep_from < length)
 					{
-						logtd("Resync: no confirmed boundary yet; dropped %zu byte(s), waiting for more data", keep_from);
+						logad("Resync: no confirmed boundary yet; dropped %zu byte(s), waiting for more data", keep_from);
 						_buffer = _buffer->Subdata(keep_from);
 					}
 					else
 					{
-						logtd("Resync: no sync byte in %zu byte(s); dropped the whole buffer", length);
+						logad("Resync: no sync byte in %zu byte(s); dropped the whole buffer", length);
 						_buffer = std::make_shared<ov::Data>();
 					}
 					break;
@@ -134,7 +142,7 @@ namespace mpegts
 				// Do NOT mark synced yet: only a successful Parse at this offset confirms it,
 				// so a false payload-0x47 lock re-scans on the next parse failure
 				// instead of being trusted by the aligned-but-corrupt path.
-				logtd("Resync: candidate boundary at offset %zu; dropped %zu leading byte(s)", resync_offset, resync_offset);
+				logad("Resync: candidate boundary at offset %zu; dropped %zu leading byte(s)", resync_offset, resync_offset);
 				_buffer = _buffer->Subdata(resync_offset);
 				continue;
 			}
@@ -194,7 +202,7 @@ namespace mpegts
 		if (packet_type == PacketType::UNSUPPORTED_SECTION || packet_type == PacketType::UNKNOWN)
 		{
 			// FFMPEG ususally sends PID 17 (DVB - SDT), but we don't use this table now
-			logtt("Ignored unsupported or unknown MPEG-TS packets.(PID: %d)", packet->PacketIdentifier());
+			logat("Ignored unsupported or unknown MPEG-TS packets.(PID: %d)", packet->PacketIdentifier());
 			return false;
 		}
 
@@ -243,15 +251,24 @@ namespace mpegts
 					// (With only a 4-bit counter, losing exactly a multiple of 16 payload packets is
 					// indistinguishable from a duplicate; that residual ambiguity is unavoidable.)
 					_cc_duplicate_seen.insert(pid);
-					logtd("Dropped duplicate MPEG-TS packet (PID: %d CC: %d)", pid, counter);
+					logad("Dropped duplicate MPEG-TS packet (PID: %d CC: %d)", pid, counter);
 					return true;
 				}
 				else
 				{
 					// Genuine continuity break (loss, a second consecutive same-counter packet, or corruption):
 					// drop any partial assembly so nothing corrupt is forwarded.
-					logtw("MPEG-TS continuity break (PID: %d Expected: %d Received: %d); discarding partial data",
-						  pid, expected_counter, counter);
+					// A lossy link can hit this on nearly every packet, so the per-occurrence detail goes to debug only
+					// (guarded by `_debug_enabled` so the arguments are not even formatted when debug is off),
+					// and the warning is rate-limited to roughly one line per interval.
+					if (_debug_enabled)
+					{
+						logad("MPEG-TS continuity break (PID: %d Expected: %d Received: %d); discarding partial data",
+							  pid, expected_counter, counter);
+					}
+
+					LogContinuityBreak();
+
 					DiscardPesDraft(pid);
 					DiscardSectionDraft(pid);
 					_cc_duplicate_seen.erase(pid);
@@ -266,7 +283,7 @@ namespace mpegts
 		{
 			if (IsTrackInfoAvailable() == false)
 			{
-				logtt("Parsing section packet (PID: %d)", packet->PacketIdentifier());				
+				logat("Parsing section packet (PID: %d)", packet->PacketIdentifier());
 				return ParseSection(packet);
 			}
 		}
@@ -425,14 +442,14 @@ namespace mpegts
 					// Previous section completed
 					if (CompleteSection(prev_section) == false)
 					{
-						logte("Could not complete section(PID: %d)", packet->PacketIdentifier());
+						logae("Could not complete section(PID: %d)", packet->PacketIdentifier());
 						return false;
 					}
 				}
 				else
 				{
 					// Somethind wrong
-					logte("Could not complete section(PID: %d)", packet->PacketIdentifier());
+					logae("Could not complete section(PID: %d)", packet->PacketIdentifier());
 				}
 			}
 
@@ -448,7 +465,7 @@ namespace mpegts
 				if (consumed_bytes == 0)
 				{
 					// Something wrong
-					logte("Could not parse section(PID: %d)", packet->PacketIdentifier());
+					logae("Could not parse section(PID: %d)", packet->PacketIdentifier());
 					return false;
 				}
 
@@ -458,7 +475,7 @@ namespace mpegts
 				{
 					if (CompleteSection(new_section) == false)
 					{
-						logte("Could not complete section(PID: %d)", packet->PacketIdentifier());
+						logae("Could not complete section(PID: %d)", packet->PacketIdentifier());
 						return false;
 					}
 				}
@@ -478,7 +495,7 @@ namespace mpegts
 				// Expected when the section draft for this PID was discarded on a continuity break:
 				// the following continuation packets then have no draft to append to. This is normal recovery
 				// (a warning was already logged at the break), so trace it rather than error.
-				logtd("No section draft for continuation (PID: %d); likely discarded on a continuity break", packet->PacketIdentifier());
+				logad("No section draft for continuation (PID: %d); likely discarded on a continuity break", packet->PacketIdentifier());
 				return false;
 			}
 
@@ -514,7 +531,7 @@ namespace mpegts
 			auto consumed_length = pes->AppendData(packet->Payload(), packet->PayloadLength());
 			if (consumed_length != packet->PayloadLength())
 			{
-				logte("Something wrong with parsing PES");
+				logae("Something wrong with parsing PES");
 				return false;
 			}
 
@@ -538,14 +555,14 @@ namespace mpegts
 			{
 				// This can be called if the encoder sends faster than the server starts.
 				// These packets can be ignored.
-				logtt("Could not find the pes draft (PID: %d)", packet->PacketIdentifier());
+				logat("Could not find the pes draft (PID: %d)", packet->PacketIdentifier());
 				return false;
 			}
 
 			auto consumed_length = pes->AppendData(packet->Payload(), packet->PayloadLength());
 			if (consumed_length != packet->PayloadLength())
 			{
-				logte("Something wrong with parsing PES");
+				logae("Something wrong with parsing PES");
 				return false;
 			}
 
@@ -607,7 +624,7 @@ namespace mpegts
 			// PAT
 			_pat_map.emplace(pat->_program_num, section);
 			// Reserve PMT's PID
-			logtt("Registering PAT. PID: 0x%04X, PacketType::SUPPORTED_SECTION", pat->_program_map_pid);
+			logat("Registering PAT. PID: 0x%04X, PacketType::SUPPORTED_SECTION", pat->_program_map_pid);
 			_packet_type_table.emplace(pat->_program_map_pid, PacketType::SUPPORTED_SECTION);
 
 			// The last section for PAT
@@ -624,12 +641,12 @@ namespace mpegts
 			{
 				if(es_info->_stream_type == static_cast<uint8_t>(WellKnownStreamTypes::SCTE35))
 				{
-					logtt("Registering PMT. PID: 0x%04X, PacketType::SECTION", es_info->_elementary_pid);
+					logat("Registering PMT. PID: 0x%04X, PacketType::SECTION", es_info->_elementary_pid);
 					_packet_type_table.emplace(es_info->_elementary_pid, PacketType::SECTION);
 				}
 				else 
 				{
-					logtt("Registering PMT. PID: 0x%04X, PacketType::PES", es_info->_elementary_pid);
+					logat("Registering PMT. PID: 0x%04X, PacketType::PES", es_info->_elementary_pid);
 					_packet_type_table.emplace(es_info->_elementary_pid, PacketType::PES);
 				}
 			}
@@ -663,7 +680,7 @@ namespace mpegts
 		else
 		{
 			// Unsupported section
-			logti("Ignored unsupported or unknown section (table id: %d)", section->TableId());
+			logai("Ignored unsupported or unknown section (table id: %d)", section->TableId());
 			return false;
 		}
 
@@ -689,6 +706,23 @@ namespace mpegts
 		_pes_draft_map.emplace(pes->PID(), pes);
 
 		return true;
+	}
+
+	void MpegTsDepacketizer::LogContinuityBreak()
+	{
+		_cc_break_count++;
+
+		const int64_t now = ov::Clock::NowMSec();
+
+		if ((_cc_break_last_warn_msec == 0) ||
+			((now - _cc_break_last_warn_msec) >= MPEGTS_CC_BREAK_WARN_INTERVAL_MSEC))
+		{
+			logaw("MPEG-TS continuity break; discarding partial data (%u occurrence(s) since last report)",
+				  static_cast<uint32_t>(_cc_break_count));
+
+			_cc_break_last_warn_msec = now;
+			_cc_break_count			 = 0;
+		}
 	}
 
 	void MpegTsDepacketizer::DiscardPesDraft(uint16_t pid)
@@ -719,7 +753,7 @@ namespace mpegts
 		// there is no media track, extracts it
 		if (_media_tracks.find(pes->PID()) == _media_tracks.end())
 		{
-			logti("Unsupported PES has been received. (pid : %d stream_id : %d)", pes->PID(), pes->StreamId());
+			logai("Unsupported PES has been received. (pid : %d stream_id : %d)", pes->PID(), pes->StreamId());
 			return false;
 		}
 
@@ -780,7 +814,7 @@ namespace mpegts
 
 				default:
 					// Doesn't support
-					logtw("Unsupported stream_type has been received. (pid : %d stream_type : 0x%02x)", pid, es_info->_stream_type);
+					logaw("Unsupported stream_type has been received. (pid : %d stream_type : 0x%02x)", pid, es_info->_stream_type);
 					continue;
 			}
 

--- a/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
+++ b/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
@@ -156,37 +156,67 @@ namespace mpegts
 			return false;
 		}
 
-		// Check continuity counter
-		// TODO(Getroot): Later, it can be used for jitter buffer to correct the UDP packet order
+		// Continuity handling. This hardening applies to every transport (not only the reordering path):
+		// a continuity break on a reliable transport (SRT/TCP) originates at the encoder,
+		// and discarding the partial frame there is also correct.
+		// Duplicate handling is inert on transports that never duplicate.
+		const auto pid = packet->PacketIdentifier();
+
+		// A signalled adaptation-field discontinuity may be carried on a payload packet OR on an
+		// adaptation-field-only packet (e.g. a PCR discontinuity).
+		// Honor it regardless of payload: drop any partial assembly and reset continuity tracking
+		// so the next packet re-establishes the baseline without a spurious continuity-break warning.
+		// The discontinuity_indicator only exists when the adaptation field actually carries its flag
+		// byte (length > 0); guard on it to avoid trusting a defaulted bit.
+		if (packet->HasAdaptationField() &&
+			(packet->GetAdaptationField()._length > 0) &&
+			packet->GetAdaptationField()._discontinuity_indicator)
+		{
+			DiscardPesDraft(pid);
+			DiscardSectionDraft(pid);
+			_last_continuity_counter_map.erase(pid);
+			_cc_duplicate_seen.erase(pid);
+		}
+
+		// The continuity counter only advances on packets that carry a payload (adaptation-field-only
+		// packets do not increment it).
 		if (packet->HasPayload())
 		{
-			auto it = _last_continuity_counter_map.find(packet->PacketIdentifier());
-			if (it == _last_continuity_counter_map.end())
-			{
-				_last_continuity_counter_map.emplace(packet->PacketIdentifier(), packet->ContinuityCounter());
-			}
-			else
-			{
-				auto prev_counter = it->second;
-				uint8_t expected_counter;
+			const uint8_t counter = packet->ContinuityCounter();
 
-				if (prev_counter < 0x0f)
+			auto it = _last_continuity_counter_map.find(pid);
+			if (it != _last_continuity_counter_map.end())
+			{
+				const uint8_t prev_counter = it->second;
+				const uint8_t expected_counter = (prev_counter + 1) & 0x0F;
+
+				if (counter == expected_counter)
 				{
-					expected_counter = prev_counter + 1;
+					_cc_duplicate_seen.erase(pid);
+				}
+				else if ((counter == prev_counter) && (_cc_duplicate_seen.count(pid) == 0))
+				{
+					// A packet may legally be duplicated once with the same continuity counter and
+					// identical content. Drop the duplicate so its payload is not appended twice.
+					// (With only a 4-bit counter, losing exactly a multiple of 16 payload packets is
+					// indistinguishable from a duplicate; that residual ambiguity is unavoidable.)
+					_cc_duplicate_seen.insert(pid);
+					logtd("Dropped duplicate MPEG-TS packet (PID: %d CC: %d)", pid, counter);
+					return true;
 				}
 				else
 				{
-					expected_counter = 0;
+					// Genuine continuity break (loss, a second consecutive same-counter packet, or corruption):
+					// drop any partial assembly so nothing corrupt is forwarded.
+					logtw("MPEG-TS continuity break (PID: %d Expected: %d Received: %d); discarding partial data",
+						  pid, expected_counter, counter);
+					DiscardPesDraft(pid);
+					DiscardSectionDraft(pid);
+					_cc_duplicate_seen.erase(pid);
 				}
-
-				if (packet->ContinuityCounter() != expected_counter)
-				{
-					logtw("An out-of-order packet was received.(PID : %d Expected : %d, Received : %d",
-						  packet->PacketIdentifier(), expected_counter, packet->ContinuityCounter());
-				}
-
-				_last_continuity_counter_map[packet->PacketIdentifier()] = packet->ContinuityCounter();
 			}
+
+			_last_continuity_counter_map[pid] = counter;
 		}
 
 		// If PAT and PMT are completed, it doesn't need to parse anymore
@@ -403,8 +433,10 @@ namespace mpegts
 			auto section = GetSectionDraft(packet->PacketIdentifier());
 			if (section == nullptr)
 			{
-				// Something wrong
-				logte("Could not find section(PID: %d) for depacketizing", packet->PacketIdentifier());
+				// Expected when the section draft for this PID was discarded on a continuity break:
+				// the following continuation packets then have no draft to append to. This is normal recovery
+				// (a warning was already logged at the break), so trace it rather than error.
+				logtd("No section draft for continuation (PID: %d); likely discarded on a continuity break", packet->PacketIdentifier());
 				return false;
 			}
 
@@ -615,6 +647,18 @@ namespace mpegts
 		_pes_draft_map.emplace(pes->PID(), pes);
 
 		return true;
+	}
+
+	void MpegTsDepacketizer::DiscardPesDraft(uint16_t pid)
+	{
+		std::scoped_lock lock(_pes_draft_map_lock);
+		_pes_draft_map.erase(pid);
+	}
+
+	void MpegTsDepacketizer::DiscardSectionDraft(uint16_t pid)
+	{
+		std::scoped_lock lock(_section_draft_map_lock);
+		_section_draft_map.erase(pid);
 	}
 
 	// process completed section and remove, extract a elementary stream (es)

--- a/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
+++ b/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
@@ -23,7 +23,47 @@ namespace mpegts
 	{
 	}
 
+	void MpegTsDepacketizer::EnablePacketReordering()
+	{
+		// Must be enabled before any data is processed: otherwise the byte buffer may already hold a
+		// partial datagram and the continuity map is primed, while the reorder buffer would start
+		// fresh and second-guess the counter order.
+		OV_ASSERT2((_buffer->GetLength() == 0) && _last_continuity_counter_map.empty());
+
+		if (_reorder_buffer == nullptr)
+		{
+			_reorder_buffer = std::make_unique<DatagramReorderBuffer>();
+		}
+	}
+
 	bool MpegTsDepacketizer::AddPacket(const std::shared_ptr<const ov::Data> &datagram)
+	{
+		if (_reorder_buffer != nullptr)
+		{
+			std::vector<std::shared_ptr<const ov::Data>> ordered;
+			const auto gap_loss = _reorder_buffer->Enqueue(datagram, &ordered);
+
+			if (gap_loss > 0)
+			{
+				logtd("MPEG-TS reorder: declared %zu datagram gap(s) lost (depth/timeout flush)", gap_loss);
+			}
+
+			bool result = true;
+			for (const auto &d : ordered)
+			{
+				if (ProcessDatagram(d) == false)
+				{
+					result = false;
+				}
+			}
+
+			return result;
+		}
+
+		return ProcessDatagram(datagram);
+	}
+
+	bool MpegTsDepacketizer::ProcessDatagram(const std::shared_ptr<const ov::Data> &datagram)
 	{
 		_buffer->Append(datagram);
 
@@ -103,6 +143,8 @@ namespace mpegts
 			_synced = true;
 			_buffer = _buffer->Subdata(parsed_length);
 
+			// Resolves to the Packet overload (the per-packet sink), NOT the datagram entry point,
+			// so this must never re-enter the reorder buffer.
 			if (AddPacket(packet) == false)
 			{
 				continue;

--- a/src/projects/modules/containers/mpegts/mpegts_depacketizer.h
+++ b/src/projects/modules/containers/mpegts/mpegts_depacketizer.h
@@ -55,6 +55,12 @@ namespace mpegts
 		// Only meaningful for datagram-framed (UDP) input.
 		void EnablePacketReordering();
 
+		// Sets the owning stream's name path; it is prefixed on every log line from this depacketizer.
+		void SetNamePath(const ov::String &name_path)
+		{
+			_name_path = name_path;
+		}
+
 		bool IsTrackInfoAvailable();
 		bool IsESAvailable();
 		bool IsSectionAvailable();
@@ -71,6 +77,9 @@ namespace mpegts
 		bool ProcessDatagram(const std::shared_ptr<const ov::Data> &datagram);
 		// Finds the next confirmed packet boundary in `_buffer`, or 0 if none can be confirmed yet.
 		size_t FindResyncOffset() const;
+
+		// Emits a rate-limited, count-aggregated continuity-break warning (see `_cc_break_*`).
+		void LogContinuityBreak();
 
 		PacketType GetPacketType(const std::shared_ptr<Packet> &packet);
 
@@ -108,7 +117,7 @@ namespace mpegts
 		// NOTE: unlike the draft maps above (each self-locked), the members below have no internal lock.
 		// They are protected by the owner's lock: the `MpegTsDepacketizer` instance is
 		// `OV_GUARDED_BY(_depacketizer_lock)` in `MpegTsStream`, and every method that touches them
-		// (`AddPacket`/`ProcessDatagram`/`EnablePacketReordering`) runs with that lock held.
+		// (`AddPacket`/`ProcessDatagram`/`EnablePacketReordering`/`SetNamePath`) runs with that lock held.
 		// Any new accessor must also hold it.
 
 		// True once the byte parser is locked to the 188-byte packet grid
@@ -121,6 +130,16 @@ namespace mpegts
 		// PIDs for which a legal single duplicate has already been consumed (a second
 		// consecutive same-counter packet is then treated as a continuity error).
 		std::set<uint16_t> _cc_duplicate_seen;
+
+		// Owning stream's name path, prefixed on every log line (set via `SetNamePath()`).
+		ov::String _name_path{"?"};
+		// Cached at construction: whether debug logging is enabled for this tag, so the per-packet
+		// continuity-break detail is skipped entirely (no formatting) when debug is off.
+		bool _debug_enabled											= false;
+		// Continuity-break warnings are rate-limited to one line per this interval, with an aggregated count.
+		static constexpr int64_t MPEGTS_CC_BREAK_WARN_INTERVAL_MSEC = 5000;
+		int64_t _cc_break_last_warn_msec							= 0;
+		uint64_t _cc_break_count									= 0;
 
 		// PAT
 		bool _pat_list_completed = false;

--- a/src/projects/modules/containers/mpegts/mpegts_depacketizer.h
+++ b/src/projects/modules/containers/mpegts/mpegts_depacketizer.h
@@ -12,6 +12,8 @@
 #include <base/mediarouter/media_type.h>
 #include <base/info/media_track.h>
 
+#include <set>
+
 #include "mpegts_common.h"
 #include "mpegts_packet.h"
 #include "mpegts_section.h"
@@ -68,6 +70,10 @@ namespace mpegts
 		bool ParseSection(const std::shared_ptr<Packet> &packet);
 		bool ParsePes(const std::shared_ptr<Packet> &packet);
 
+		// Drops any in-progress assembly for a PID after a continuity discontinuity.
+		void DiscardPesDraft(uint16_t pid);
+		void DiscardSectionDraft(uint16_t pid);
+
 		const std::shared_ptr<Section> GetSectionDraft(uint16_t pid);
 		// incompleted section will be inserted
 		bool SaveSectionDraft(const std::shared_ptr<Section> &section);
@@ -105,6 +111,9 @@ namespace mpegts
 
 		// PID : Last continuity counter
 		std::map<uint16_t, uint8_t> _last_continuity_counter_map;
+		// PIDs for which a legal single duplicate has already been consumed (a second
+		// consecutive same-counter packet is then treated as a continuity error).
+		std::set<uint16_t> _cc_duplicate_seen;
 
 		// PAT
 		bool _pat_list_completed = false;

--- a/src/projects/modules/containers/mpegts/mpegts_depacketizer.h
+++ b/src/projects/modules/containers/mpegts/mpegts_depacketizer.h
@@ -60,12 +60,15 @@ namespace mpegts
 		const std::shared_ptr<Pes> PopES();
 		const std::shared_ptr<Section> PopSection();
 	private:
+		// Finds the next confirmed packet boundary in `_buffer`, or 0 if none can be confirmed yet.
+		size_t FindResyncOffset() const;
+
 		PacketType GetPacketType(const std::shared_ptr<Packet> &packet);
 
 		bool ParseSection(const std::shared_ptr<Packet> &packet);
 		bool ParsePes(const std::shared_ptr<Packet> &packet);
-		
-		const std::shared_ptr<Section> GetSectionDraft(uint16_t pid);	
+
+		const std::shared_ptr<Section> GetSectionDraft(uint16_t pid);
 		// incompleted section will be inserted
 		bool SaveSectionDraft(const std::shared_ptr<Section> &section);
 		// process completed section and remove, extract a table
@@ -88,6 +91,17 @@ namespace mpegts
 		// there is only one pes saved per pid
 		std::shared_mutex _pes_draft_map_lock;
 		std::map<uint16_t, std::shared_ptr<Pes>> _pes_draft_map;
+
+		// NOTE: unlike the draft maps above (each self-locked), the members below have no internal lock.
+		// They are protected by the owner's lock: the `MpegTsDepacketizer` instance is
+		// `OV_GUARDED_BY(_depacketizer_lock)` in `MpegTsStream`, and every method that touches them
+		// (`AddPacket`) runs with that lock held.
+		// Any new accessor must also hold it.
+
+		// True once the byte parser is locked to the 188-byte packet grid
+		// (a packet parsed or a boundary was confirmed by resync);
+		// makes an aligned-but-corrupt packet drop one packet instead of triggering a resync scan.
+		bool _synced = false;
 
 		// PID : Last continuity counter
 		std::map<uint16_t, uint8_t> _last_continuity_counter_map;

--- a/src/projects/modules/containers/mpegts/mpegts_depacketizer.h
+++ b/src/projects/modules/containers/mpegts/mpegts_depacketizer.h
@@ -55,6 +55,11 @@ namespace mpegts
 		// Only meaningful for datagram-framed (UDP) input.
 		void EnablePacketReordering();
 
+		// Drains any datagrams the reorder buffer is still holding behind a gap into the byte parser,
+		// so their frames become available. Used on stream teardown so buffered, already-received
+		// datagrams are not dropped. No-op when reordering is disabled.
+		void FlushReorderBuffer();
+
 		// Sets the owning stream's name path; it is prefixed on every log line from this depacketizer.
 		void SetNamePath(const ov::String &name_path)
 		{

--- a/src/projects/modules/containers/mpegts/mpegts_depacketizer.h
+++ b/src/projects/modules/containers/mpegts/mpegts_depacketizer.h
@@ -18,6 +18,7 @@
 #include "mpegts_packet.h"
 #include "mpegts_section.h"
 #include "mpegts_pes.h"
+#include "mpegts_datagram_reorder_buffer.h"
 
 /*  PES Depacketization Process
 
@@ -50,6 +51,10 @@ namespace mpegts
 		bool AddPacket(const std::shared_ptr<const ov::Data> &packet);
 		bool AddPacket(const std::shared_ptr<Packet> &packet);
 
+		// Enable UDP datagram reordering. Must be called before feeding data.
+		// Only meaningful for datagram-framed (UDP) input.
+		void EnablePacketReordering();
+
 		bool IsTrackInfoAvailable();
 		bool IsESAvailable();
 		bool IsSectionAvailable();
@@ -62,6 +67,8 @@ namespace mpegts
 		const std::shared_ptr<Pes> PopES();
 		const std::shared_ptr<Section> PopSection();
 	private:
+		// Feeds one contiguous run of TS packets into the byte parser (with sync-byte resync).
+		bool ProcessDatagram(const std::shared_ptr<const ov::Data> &datagram);
 		// Finds the next confirmed packet boundary in `_buffer`, or 0 if none can be confirmed yet.
 		size_t FindResyncOffset() const;
 
@@ -101,7 +108,7 @@ namespace mpegts
 		// NOTE: unlike the draft maps above (each self-locked), the members below have no internal lock.
 		// They are protected by the owner's lock: the `MpegTsDepacketizer` instance is
 		// `OV_GUARDED_BY(_depacketizer_lock)` in `MpegTsStream`, and every method that touches them
-		// (`AddPacket`) runs with that lock held.
+		// (`AddPacket`/`ProcessDatagram`/`EnablePacketReordering`) runs with that lock held.
 		// Any new accessor must also hold it.
 
 		// True once the byte parser is locked to the 188-byte packet grid
@@ -148,5 +155,8 @@ namespace mpegts
 		std::map<uint16_t, PacketType>	_packet_type_table;
 
 		std::shared_ptr<ov::Data> _buffer = std::make_shared<ov::Data>();
+
+		// UDP datagram reordering (disabled by default; enabled via `EnablePacketReordering()`).
+		std::unique_ptr<DatagramReorderBuffer> _reorder_buffer;
 	};
 }

--- a/src/projects/modules/containers/mpegts/mpegts_packet.cpp
+++ b/src/projects/modules/containers/mpegts/mpegts_packet.cpp
@@ -531,6 +531,12 @@ namespace mpegts
 		// [ssssssss][tpTPPPPP][PPPPPPPP][SSaacccc]...
 
 		_sync_byte = _ts_parser->ReadBytes<uint8_t>();
+		if (_sync_byte != MPEGTS_SYNC_BYTE)
+		{
+			// Not aligned to a packet boundary; the caller resynchronizes on the next sync byte.
+			return 0;
+		}
+
 		_transport_error_indicator = _ts_parser->ReadBoolBit();
 		if (_transport_error_indicator)
 		{

--- a/src/projects/modules/containers/mpegts/mpegts_packet_test.cpp
+++ b/src/projects/modules/containers/mpegts/mpegts_packet_test.cpp
@@ -44,6 +44,74 @@ namespace
 		auto packet					= mpegts::Packet::Build(section, cc);
 		return packet->GetData();
 	}
+
+	// A valid single-packet PMT for program 1 with one H.264 elementary stream on PID 0x0100
+	// (matches MakePatPacket's program_map_pid 0x1000). Feeding PAT + PMT registers the PES PID.
+	std::shared_ptr<const ov::Data> MakePmtPacket(uint8_t cc)
+	{
+		mpegts::PMT pmt;
+		pmt._table_id_extension		= 1;
+		pmt._version_number			= 0;
+		pmt._current_next_indicator = true;
+		pmt._section_number			= 0;
+		pmt._last_section_number	= 0;
+		pmt._pcr_pid				= 0x0100;
+		pmt._program_info_length	= 0;
+
+		auto es						= std::make_shared<mpegts::ESInfo>();
+		es->_stream_type			= static_cast<uint8_t>(mpegts::WellKnownStreamTypes::H264);
+		es->_elementary_pid			= 0x0100;
+		es->_es_info_length			= 0;
+		pmt._es_info_list.push_back(es);
+
+		auto section = mpegts::Section::Build(0x1000, pmt);
+		auto packet	 = mpegts::Packet::Build(section, cc);
+		return packet->GetData();
+	}
+
+	// A raw 188-byte TS packet carrying PES data (payload only, AFC=01). When `pusi` is set, a minimal
+	// video PES header (start code, stream_id 0xE0, unbounded length, PTS=0) is prefixed; the rest of
+	// the payload is `fill` (stand-in elementary-stream bytes).
+	std::shared_ptr<const ov::Data> MakePesTsPacket(uint16_t pid, uint8_t cc, bool pusi, uint8_t fill)
+	{
+		std::vector<uint8_t> b(188, fill);
+		b[0] = 0x47;
+		b[1] = static_cast<uint8_t>((pusi ? 0x40 : 0x00) | ((pid >> 8) & 0x1F));
+		b[2] = static_cast<uint8_t>(pid & 0xFF);
+		b[3] = static_cast<uint8_t>((0b01 << 4) | (cc & 0x0F));
+
+		if (pusi)
+		{
+			const uint8_t header[] = {0x00, 0x00, 0x01, 0xE0, 0x00, 0x00, 0x80, 0x80, 0x05, 0x21, 0x00, 0x01, 0x00, 0x01};
+			for (size_t i = 0; i < sizeof(header); i++)
+			{
+				b[4 + i] = header[i];
+			}
+		}
+
+		return std::make_shared<ov::Data>(b.data(), b.size());
+	}
+
+	// A 188-byte TS packet with transport_error_indicator set (aligned but corrupt).
+	std::shared_ptr<const ov::Data> MakeTeiPacket(uint16_t pid, uint8_t cc)
+	{
+		auto bytes = MakePacketBytes(pid, cc);
+		bytes[1] |= 0x80;  // transport_error_indicator
+		return std::make_shared<ov::Data>(bytes.data(), bytes.size());
+	}
+
+	// An adaptation-field-only (no payload) TS packet with the discontinuity_indicator set.
+	std::shared_ptr<const ov::Data> MakeDiscontinuityPacket(uint16_t pid, uint8_t cc)
+	{
+		std::vector<uint8_t> b(188, 0xFF);
+		b[0] = 0x47;
+		b[1] = static_cast<uint8_t>((pid >> 8) & 0x1F);
+		b[2] = static_cast<uint8_t>(pid & 0xFF);
+		b[3] = static_cast<uint8_t>((0b10 << 4) | (cc & 0x0F));	 // adaptation field only, no payload
+		b[4] = 183;												 // adaptation_field_length (fills the packet body)
+		b[5] = 0x80;											 // discontinuity_indicator
+		return std::make_shared<ov::Data>(b.data(), b.size());
+	}
 }  // namespace
 
 TEST(MpegTsPacket, ParseAcceptsValidSyncByte)
@@ -112,4 +180,89 @@ TEST(MpegTsDepacketizerResync, RecoversFromMisalignedPrefix)
 	depacketizer.AddPacket(buffer);
 
 	ASSERT_NE(depacketizer.GetFirstPAT(), nullptr);
+}
+
+// -----------------------------------------------------------------------------
+// Continuity-counter hardening (AddPacket(Packet&)): duplicate drop, continuity-break and
+// discontinuity draft discard, transport-error handling.
+// -----------------------------------------------------------------------------
+
+TEST(MpegTsDepacketizerCc, TrackInfoAvailableAfterPatPmt)
+{
+	// Harness sanity: PAT + a single-packet PMT make the track info available.
+	mpegts::MpegTsDepacketizer depacketizer;
+	depacketizer.AddPacket(MakePatPacket(0));
+	depacketizer.AddPacket(MakePmtPacket(0));
+
+	EXPECT_TRUE(depacketizer.IsTrackInfoAvailable());
+}
+
+TEST(MpegTsDepacketizerCc, DuplicatePacketNotAppendedTwice)
+{
+	// A legal single duplicate (same continuity counter) must be dropped, not appended to the PES.
+	auto emitted_payload_length = [](bool with_duplicate) -> uint32_t {
+		mpegts::MpegTsDepacketizer depacketizer;
+		depacketizer.AddPacket(MakePatPacket(0));
+		depacketizer.AddPacket(MakePmtPacket(0));
+		depacketizer.AddPacket(MakePesTsPacket(0x0100, 0, true, 0xAA));	  // PES1 start
+		depacketizer.AddPacket(MakePesTsPacket(0x0100, 1, false, 0xBB));  // PES1 continuation
+		if (with_duplicate)
+		{
+			depacketizer.AddPacket(MakePesTsPacket(0x0100, 1, false, 0xBB));  // duplicate of the continuation
+		}
+		depacketizer.AddPacket(MakePesTsPacket(0x0100, 2, true, 0xCC));	 // PES2 start completes PES1
+		auto pes = depacketizer.PopES();
+		return (pes != nullptr) ? pes->PayloadLength() : 0;
+	};
+
+	const uint32_t without_duplicate = emitted_payload_length(false);
+	EXPECT_GT(without_duplicate, 0u);
+	EXPECT_EQ(emitted_payload_length(true), without_duplicate);
+}
+
+TEST(MpegTsDepacketizerCc, ContinuityBreakDiscardsPesDraft)
+{
+	// A genuine continuity break discards the in-progress PES so a corrupt frame is not forwarded.
+	mpegts::MpegTsDepacketizer depacketizer;
+	depacketizer.AddPacket(MakePatPacket(0));
+	depacketizer.AddPacket(MakePmtPacket(0));
+	depacketizer.AddPacket(MakePesTsPacket(0x0100, 0, true, 0xAA));	  // PES1 start (cc 0)
+	depacketizer.AddPacket(MakePesTsPacket(0x0100, 5, false, 0x11));  // continuity break (cc 5) -> discard PES1
+	depacketizer.AddPacket(MakePesTsPacket(0x0100, 6, true, 0xCC));	  // PES2 start (cc 6)
+	depacketizer.AddPacket(MakePesTsPacket(0x0100, 7, true, 0xDD));	  // PES3 start completes PES2
+
+	auto pes = depacketizer.PopES();
+	ASSERT_NE(pes, nullptr);
+	ASSERT_GT(pes->PayloadLength(), 0u);
+	// PES1 (0xAA) was discarded on the break; the first emitted PES is PES2 (0xCC).
+	EXPECT_EQ(pes->Payload()[0], 0xCC);
+}
+
+TEST(MpegTsDepacketizerCc, DiscontinuityIndicatorDiscardsPesDraft)
+{
+	// A signalled discontinuity (adaptation-field-only packet) also discards the in-progress PES.
+	mpegts::MpegTsDepacketizer depacketizer;
+	depacketizer.AddPacket(MakePatPacket(0));
+	depacketizer.AddPacket(MakePmtPacket(0));
+	depacketizer.AddPacket(MakePesTsPacket(0x0100, 0, true, 0xAA));	 // PES1 start
+	depacketizer.AddPacket(MakeDiscontinuityPacket(0x0100, 1));		 // discontinuity_indicator -> discard PES1
+	depacketizer.AddPacket(MakePesTsPacket(0x0100, 2, true, 0xCC));	 // PES2 start
+	depacketizer.AddPacket(MakePesTsPacket(0x0100, 3, true, 0xDD));	 // PES3 start completes PES2
+
+	auto pes = depacketizer.PopES();
+	ASSERT_NE(pes, nullptr);
+	ASSERT_GT(pes->PayloadLength(), 0u);
+	EXPECT_EQ(pes->Payload()[0], 0xCC);
+}
+
+TEST(MpegTsDepacketizerCc, TransportErrorPacketDoesNotDerailGrid)
+{
+	// An aligned transport-error packet is dropped without losing 188-byte grid lock; the following
+	// PMT still parses.
+	mpegts::MpegTsDepacketizer depacketizer;
+	depacketizer.AddPacket(MakePatPacket(0));		   // locks the grid, PAT registered
+	depacketizer.AddPacket(MakeTeiPacket(0x1FFF, 0));  // aligned TEI packet -> dropped, grid preserved
+	depacketizer.AddPacket(MakePmtPacket(0));
+
+	EXPECT_TRUE(depacketizer.IsTrackInfoAvailable());
 }

--- a/src/projects/modules/containers/mpegts/mpegts_packet_test.cpp
+++ b/src/projects/modules/containers/mpegts/mpegts_packet_test.cpp
@@ -1,0 +1,115 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include "mpegts_packet.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "mpegts_depacketizer.h"
+#include "mpegts_section.h"
+
+namespace
+{
+	// A minimal, self-consistent 188-byte TS packet (payload only, no adaptation field).
+	std::vector<uint8_t> MakePacketBytes(uint16_t pid, uint8_t cc)
+	{
+		std::vector<uint8_t> bytes(188, 0x00);
+		bytes[0] = 0x47;
+		bytes[1] = static_cast<uint8_t>((pid >> 8) & 0x1F);	 // TEI=0, PUSI=0, prio=0
+		bytes[2] = static_cast<uint8_t>(pid & 0xFF);
+		bytes[3] = static_cast<uint8_t>((0b01 << 4) | (cc & 0x0F));	 // TSC=0, AFC=payload-only
+		return bytes;
+	}
+
+	// A valid single-packet PAT (Section::Build computes the CRC), as raw TS bytes.
+	std::shared_ptr<const ov::Data> MakePatPacket(uint8_t cc)
+	{
+		mpegts::PAT pat;
+		pat._table_id_extension		= 1;
+		pat._version_number			= 0;
+		pat._current_next_indicator = true;
+		pat._section_number			= 0;
+		pat._last_section_number	= 0;
+		pat._program_num			= 1;
+		pat._program_map_pid		= 0x1000;
+
+		auto section				= mpegts::Section::Build(pat);
+		auto packet					= mpegts::Packet::Build(section, cc);
+		return packet->GetData();
+	}
+}  // namespace
+
+TEST(MpegTsPacket, ParseAcceptsValidSyncByte)
+{
+	auto bytes = MakePacketBytes(0x0100, 3);
+	auto data  = std::make_shared<ov::Data>(bytes.data(), bytes.size());
+
+	mpegts::Packet packet(data);
+	EXPECT_EQ(packet.Parse(), 188u);
+	EXPECT_EQ(packet.PacketIdentifier(), 0x0100);
+	EXPECT_EQ(packet.ContinuityCounter(), 3);
+}
+
+TEST(MpegTsPacket, ParseRejectsInvalidSyncByte)
+{
+	auto bytes = MakePacketBytes(0x0100, 0);
+	bytes[0]   = 0x00;	// corrupt the sync byte
+	auto data  = std::make_shared<ov::Data>(bytes.data(), bytes.size());
+
+	mpegts::Packet packet(data);
+	EXPECT_EQ(packet.Parse(), 0u);
+}
+
+// A valid PAT should be recognized on its own.
+TEST(MpegTsDepacketizerResync, ParsesAlignedPat)
+{
+	mpegts::MpegTsDepacketizer depacketizer;
+	depacketizer.AddPacket(MakePatPacket(0));
+
+	ASSERT_NE(depacketizer.GetFirstPAT(), nullptr);
+}
+
+// Leading garbage bytes must not permanently break parsing: the parser resynchronizes on the
+// next confirmed sync byte and still recognizes the PAT.
+TEST(MpegTsDepacketizerResync, RecoversFromLeadingGarbage)
+{
+	auto pat1 = MakePatPacket(0);
+	auto pat2 = MakePatPacket(1);
+
+	// [garbage][PAT][PAT] in a single buffer so the sync byte can be double-confirmed.
+	std::vector<uint8_t> junk(50, 0x00);
+	auto buffer = std::make_shared<ov::Data>(junk.data(), junk.size());
+	buffer->Append(pat1);
+	buffer->Append(pat2);
+
+	mpegts::MpegTsDepacketizer depacketizer;
+	depacketizer.AddPacket(buffer);
+
+	ASSERT_NE(depacketizer.GetFirstPAT(), nullptr);
+}
+
+// A fixed 188-byte skip on misalignment would never re-lock the grid; resync must handle a
+// non-packet-aligned prefix.
+TEST(MpegTsDepacketizerResync, RecoversFromMisalignedPrefix)
+{
+	auto pat1 = MakePatPacket(0);
+	auto pat2 = MakePatPacket(1);
+
+	// 3 bytes of junk (not a multiple of 188) shifts the whole grid.
+	std::vector<uint8_t> junk(3, 0x11);
+	auto buffer = std::make_shared<ov::Data>(junk.data(), junk.size());
+	buffer->Append(pat1);
+	buffer->Append(pat2);
+
+	mpegts::MpegTsDepacketizer depacketizer;
+	depacketizer.AddPacket(buffer);
+
+	ASSERT_NE(depacketizer.GetFirstPAT(), nullptr);
+}

--- a/src/projects/providers/mpegts/mpegts_stream.cpp
+++ b/src/projects/providers/mpegts/mpegts_stream.cpp
@@ -52,6 +52,31 @@ namespace pvd
 
 	bool MpegTsStream::Start()
 	{
+		// UDP datagram reordering is opt-in per application and only applies to datagram-framed(UDP) input;
+		// SRT/TCP are byte streams that the transport already delivers in order.
+		//
+		// Thread-safety note: the depacketizer (including the reorder buffer) has no internal lock;
+		// its state is protected by _depacketizer_lock, held here and in OnDataReceived
+		// (the member is `OV_GUARDED_BY(_depacketizer_lock)`).
+		// Enabling here also runs before the channel is registered, so it happens-before any data reaches the depacketizer.
+		if ((_remote != nullptr) && (_remote->GetType() == ov::SocketType::Udp))
+		{
+			const auto &app_info = ocst::Orchestrator::GetInstance()->GetApplicationInfo(_vhost_app_name);
+
+			if (app_info.IsValid() == false)
+			{
+				logtd("[%s/%s] Could not resolve application config at stream start; MPEG-TS packet reordering left disabled",
+					  _vhost_app_name.CStr(), GetName().CStr());
+			}
+			else if (app_info.GetConfig().GetProviders().GetMpegtsProvider().GetPacketReordering())
+			{
+				ov::LockGuard<ov::SharedMutex> lock(_depacketizer_lock);
+				_depacketizer.EnablePacketReordering();
+
+				logti("[%s/%s] MPEG-TS UDP packet reordering is enabled", _vhost_app_name.CStr(), GetName().CStr());
+			}
+		}
+
 		SetState(Stream::State::PLAYING);
 		return PushStream::Start();
 	}

--- a/src/projects/providers/mpegts/mpegts_stream.cpp
+++ b/src/projects/providers/mpegts/mpegts_stream.cpp
@@ -52,6 +52,12 @@ namespace pvd
 
 	bool MpegTsStream::Start()
 	{
+		// Prefix every depacketizer log line with this stream's name path.
+		{
+			ov::LockGuard<ov::SharedMutex> lock(_depacketizer_lock);
+			_depacketizer.SetNamePath(GetNamePath().CStr());
+		}
+
 		// UDP datagram reordering is opt-in per application and only applies to datagram-framed(UDP) input;
 		// SRT/TCP are byte streams that the transport already delivers in order.
 		//

--- a/src/projects/providers/mpegts/mpegts_stream.cpp
+++ b/src/projects/providers/mpegts/mpegts_stream.cpp
@@ -94,6 +94,17 @@ namespace pvd
 			return true;
 		}
 
+		// Drain any datagrams the reorder buffer is still holding behind a gap and forward the
+		// resulting frames before teardown, so already-received data is delivered rather than
+		// dropped. This runs while the stream is still playing (before `PushStream::Stop()`)
+		// and is a no-op unless reordering is enabled and something is buffered.
+		// `Stop()` is never entered with `_depacketizer_lock` held, so acquiring it here is safe.
+		{
+			ov::ScopedLock lock(_depacketizer_lock);
+			_depacketizer.FlushReorderBuffer();
+			ForwardDepacketizedFrames();
+		}
+
 		if (_remote->GetState() == ov::SocketState::Connected)
 		{
 			_remote->Close();
@@ -124,18 +135,38 @@ namespace pvd
 			return false;
 		}
 
-		ov::LockGuard<ov::SharedMutex> lock(_depacketizer_lock);
-		_depacketizer.AddPacket(data);
-
-		// Publish
-		if (IsPublished() == false && _depacketizer.IsTrackInfoAvailable())
+		bool publish_failed = false;
 		{
-			if (Publish() == false)
+			ov::ScopedLock lock(_depacketizer_lock);
+			_depacketizer.AddPacket(data);
+
+			// Publish once the track information becomes available.
+			if (IsPublished() == false && _depacketizer.IsTrackInfoAvailable())
+			{
+				publish_failed = (Publish() == false);
+			}
+
+			// Forward whatever is ready. A fatal per-frame error bails out without stopping;
+			// a publish failure stops the stream below, outside the lock.
+			if ((publish_failed == false) && (ForwardDepacketizedFrames() == false))
 			{
 				return false;
 			}
 		}
 
+		if (publish_failed == true)
+		{
+			// PublishChannel failed. Stop outside the depacketizer lock so the reorder-drain in
+			// `Stop()` can acquire it without re-entering (the lock is not held here).
+			Stop();
+			return false;
+		}
+
+		return true;
+	}
+
+	bool MpegTsStream::ForwardDepacketizedFrames()
+	{
 		if (IsPublished() == true)
 		{
 			while (_depacketizer.IsESAvailable())
@@ -347,7 +378,7 @@ namespace pvd
 		// Publish
 		if (PublishChannel(_vhost_app_name) == false)
 		{
-			Stop();
+			// The caller stops the stream (outside the depacketizer lock).
 			return false;
 		}
 

--- a/src/projects/providers/mpegts/mpegts_stream.h
+++ b/src/projects/providers/mpegts/mpegts_stream.h
@@ -36,8 +36,13 @@ namespace pvd
 		bool OnDataReceived(const std::shared_ptr<const ov::Data> &data) override;
 
 	private:
-		bool Start() override;	
+		bool Start() override;
 		bool Publish() OV_REQUIRES(_depacketizer_lock);
+
+		// Forwards the elementary-stream frames the depacketizer has ready to the publishers.
+		// Returns false only on a fatal per-frame error (missing track).
+		// Shared by `OnDataReceived()` and the teardown drain in `Stop()`.
+		bool ForwardDepacketizedFrames() OV_REQUIRES(_depacketizer_lock);
 
 		// Client socket
 		std::shared_ptr<ov::Socket> _remote = nullptr;


### PR DESCRIPTION
## Summary

Makes the MPEG-TS demuxer robust to the packet loss and reordering typical of UDP ingest.
Previously a single lost or misaligned datagram could push corrupt frames downstream, and the parser never recovered its 188-byte alignment once misaligned.
This adds sync-byte resynchronization, partial-frame flushing on continuity breaks, and an opt-in per-application datagram reorder buffer.

## Motivation

On a lossy or reordered UDP link the demuxer had three problems:

1. `Packet::Parse()` accepted a leading byte that was not the `0x47` sync byte.
2. On any parse failure it skipped a fixed 188 bytes, which never re-locks the grid once the stream is misaligned.
3. A lost or reordered packet left a partial PES/section that was still forwarded once assembly resumed, splicing a corrupt frame.

## Changes

- Resync: `Parse()` rejects a non-`0x47` leading byte; the demuxer keeps a grid lock and, on failure, scans for the next sync byte confirmed one/two packet lengths ahead instead of blindly skipping 188 bytes.
- Continuity flush: a continuity-counter break or signalled discontinuity discards the in-progress PES/section, and a single legal duplicate is dropped. Applies to all transports (an SRT/TCP break originates at the encoder).
- Opt-in reordering: a datagram reorder buffer (`PacketReordering`, default off, UDP only) sequences whole datagrams by their joint per-PID continuity counters. It never drops received data, so it is never worse than off.
- Logging: the continuity-break warning is rate-limited (aggregated count) with the per-occurrence detail moved to debug; every demuxer log line carries the stream name path.

## Configuration

```xml
<Providers>
  <MPEGTS>
    <StreamMap>
      <Stream>
        <Name>stream_${Port}</Name>
        <Port>4000</Port>
      </Stream>
    </StreamMap>
    <!-- opt-in, default false; applies to UDP input only -->
    <PacketReordering>true</PacketReordering>
  </MPEGTS>
</Providers>
```

## Limitations

A 1316-byte datagram carries 7 TS packets, so a video PID's continuity counter advances about 7 per datagram and the 4-bit counter wraps within about 2 datagrams. The reorder buffer therefore reliably recovers displacement-1 (adjacent) datagram reordering; beyond that, and for outright loss, it cannot reconstruct the order and passes the data through unchanged. In every case the result is never worse than with the feature off (no drops, bounded latency).

## Testing

### Unit tests

Build with tests enabled and run `ome_test_modules` with the gtest filter `MpegTs*:*Depacketizer*`. Covers sync validation, resynchronization, continuity-break / discontinuity / duplicate handling, and the reorder buffer (in-order, adjacent swap, cascade, depth/timeout flush, duplicate pass-through, never-drop, multi-packet framing, and a seeded permutation property test).

### Manual A/B

Configure two applications ingesting the same impaired stream, one with `PacketReordering` on and one off, both served over LLHLS:

- `app`     : MPEGTS `4000/udp`, `PacketReordering` true
- `app_off` : MPEGTS `4001/udp`, `PacketReordering` false
- LLHLS on `3333`; bind MPEGTS on `4000-4001/udp`

A small UDP relay applies adjacent-datagram swaps and fan-outs the identical datagrams to both ports (same seed), so the only difference is the option:

```bash
# relay: adjacent-datagram swaps -> both apps
python3 -u impair.py --in-port 4100 \
        --out 127.0.0.1:4000 --out 127.0.0.1:4001 \
        --swap 0.3 --seed 42

# source: 1316-byte datagrams == 7 TS packets
ffmpeg -re -f lavfi -i "testsrc2=size=640x360:rate=30" \
       -f lavfi -i "sine=frequency=1000:sample_rate=48000" \
       -c:v libx264 -preset veryfast -tune zerolatency -g 30 -pix_fmt yuv420p \
       -c:a aac -b:a 128k -ar 48000 -ac 2 \
       -f mpegts "udp://127.0.0.1:4100?pkt_size=1316"

# compare playback
#   ON : http://127.0.0.1:3333/app/stream_4000/llhls.m3u8
#   OFF: http://127.0.0.1:3333/app_off/stream_4001/llhls.m3u8
```

Result under adjacent-swap reordering (30%, no loss):

| | reorder ON (4000) | reorder OFF (4001) |
|---|---|---|
| llhls.m3u8 | 200, plays | 404, unplayable |
| decode of 10s of output | 0 errors | n/a |

Under severe reordering both degrade, but ON degrades safely via pass-through (no drops, no crash), confirming the never-worse property.

<details>
<summary>impair.py (UDP loss/reorder/dup relay used above)</summary>

```python
#!/usr/bin/env python3
import argparse, random, signal, socket, sys

ap = argparse.ArgumentParser()
ap.add_argument("--in-port", type=int, required=True)
ap.add_argument("--out", action="append", required=True, metavar="HOST:PORT")
ap.add_argument("--loss", type=float, default=0.0)
ap.add_argument("--dup", type=float, default=0.0)
ap.add_argument("--swap", type=float, default=0.0)   # adjacent (displacement-1) swap prob
ap.add_argument("--seed", type=int, default=1)
a = ap.parse_args()

rng = random.Random(a.seed)
tgt = [(h, int(p)) for h, p in (t.rsplit(":", 1) for t in a.out)]
rx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); rx.bind(("", a.in_port))
tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
pending = None

def send(pkt):
    for d in tgt: tx.sendto(pkt, d)
    if a.dup > 0 and rng.random() < a.dup:
        for d in tgt: tx.sendto(pkt, d)

def bye(*_):
    if pending is not None: send(pending)
    sys.exit(0)
signal.signal(signal.SIGINT, bye); signal.signal(signal.SIGTERM, bye)

while True:
    pkt, _ = rx.recvfrom(65535)
    if a.loss > 0 and rng.random() < a.loss:
        continue
    if a.swap > 0:
        if pending is None:
            if rng.random() < a.swap: pending = pkt
            else: send(pkt)
        else:
            send(pkt); send(pending); pending = None
    else:
        send(pkt)
```
</details>