### PR TITLE
feat: add last-interval dwell-time stats to internal queues

### DIFF
--- a/src/projects/base/info/managed_queue.h
+++ b/src/projects/base/info/managed_queue.h
@@ -257,7 +257,9 @@ namespace info
 		}
 
 		// Dwell-time distribution: microseconds each item waited in the queue, recorded per
-		// Dequeue into log2 buckets so percentiles stay cheap on the hot path.
+		// Dequeue into log2 buckets so percentiles stay cheap on the hot path. Fed into two
+		// sets: a cumulative (whole-lifetime) set and a current-interval set that
+		// RollDwellLatest publishes as the "latest" values and resets each stats tick.
 		void RecordDwellUs(int64_t dwell_us)
 		{
 			if (dwell_us < 0)
@@ -274,55 +276,47 @@ namespace info
 				bucket++;
 			}
 
-			_dwell_hist[bucket].fetch_add(1, std::memory_order_relaxed);
-			_dwell_count.fetch_add(1, std::memory_order_relaxed);
-			_dwell_sum_us.fetch_add(static_cast<uint64_t>(dwell_us), std::memory_order_relaxed);
+			AccumulateDwell(_dwell_hist, _dwell_count, _dwell_sum_us, _dwell_min_us, _dwell_max_us, bucket, dwell_us);
+			AccumulateDwell(_dwell_cur_hist, _dwell_cur_count, _dwell_cur_sum_us, _dwell_cur_min_us, _dwell_cur_max_us, bucket, dwell_us);
+		}
 
-			// compare_exchange loops so min/max stay correct even without the caller's lock.
-			int64_t prev_min = _dwell_min_us.load(std::memory_order_relaxed);
-			while (dwell_us < prev_min && !_dwell_min_us.compare_exchange_weak(prev_min, dwell_us, std::memory_order_relaxed))
+		// Publish the current interval's dwell stats as the "latest" (last completed
+		// interval) values, then reset the interval accumulators for the next window. Called
+		// once per stats tick under the queue lock, mirroring how per-second stats roll over.
+		void RollDwellLatest()
+		{
+			const uint64_t count = _dwell_cur_count.load(std::memory_order_relaxed);
+			if (count == 0)
 			{
+				_dwell_latest_min_us.store(0, std::memory_order_relaxed);
+				_dwell_latest_avg_us.store(0, std::memory_order_relaxed);
+				_dwell_latest_p50_us.store(0, std::memory_order_relaxed);
+				_dwell_latest_p90_us.store(0, std::memory_order_relaxed);
+				_dwell_latest_p99_us.store(0, std::memory_order_relaxed);
+				_dwell_latest_max_us.store(0, std::memory_order_relaxed);
+				return;
 			}
 
-			int64_t prev_max = _dwell_max_us.load(std::memory_order_relaxed);
-			while (dwell_us > prev_max && !_dwell_max_us.compare_exchange_weak(prev_max, dwell_us, std::memory_order_relaxed))
+			_dwell_latest_min_us.store(_dwell_cur_min_us.load(std::memory_order_relaxed), std::memory_order_relaxed);
+			_dwell_latest_max_us.store(_dwell_cur_max_us.load(std::memory_order_relaxed), std::memory_order_relaxed);
+			_dwell_latest_avg_us.store(static_cast<int64_t>(_dwell_cur_sum_us.load(std::memory_order_relaxed) / count), std::memory_order_relaxed);
+			_dwell_latest_p50_us.store(DwellPercentileUs(_dwell_cur_hist, count, 0.5), std::memory_order_relaxed);
+			_dwell_latest_p90_us.store(DwellPercentileUs(_dwell_cur_hist, count, 0.9), std::memory_order_relaxed);
+			_dwell_latest_p99_us.store(DwellPercentileUs(_dwell_cur_hist, count, 0.99), std::memory_order_relaxed);
+
+			for (int i = 0; i < DWELL_BUCKETS; i++)
 			{
+				_dwell_cur_hist[i].store(0, std::memory_order_relaxed);
 			}
+			_dwell_cur_count.store(0, std::memory_order_relaxed);
+			_dwell_cur_sum_us.store(0, std::memory_order_relaxed);
+			_dwell_cur_min_us.store(std::numeric_limits<int64_t>::max(), std::memory_order_relaxed);
+			_dwell_cur_max_us.store(0, std::memory_order_relaxed);
 		}
 
 		int64_t GetDwellPercentileUs(double percentile) const
 		{
-			uint64_t total = _dwell_count.load(std::memory_order_relaxed);
-			if (total == 0)
-			{
-				return 0;
-			}
-
-			// Nearest-rank: ceil so the rank is not biased downward, clamped to [1, total].
-			uint64_t target = static_cast<uint64_t>(std::ceil(static_cast<double>(total) * percentile));
-			if (target < 1)
-			{
-				target = 1;
-			}
-			if (target > total)
-			{
-				target = total;
-			}
-
-			// RecordDwellUs puts dwell 0 in bucket 0 and dwell in [2^(k-1), 2^k - 1] in
-			// bucket k, so a bucket's reported value is its lower bound: 0 for bucket 0,
-			// 2^(i-1) otherwise.
-			uint64_t cumulative = 0;
-			for (int i = 0; i < DWELL_BUCKETS; i++)
-			{
-				cumulative += _dwell_hist[i].load(std::memory_order_relaxed);
-				if (cumulative >= target)
-				{
-					return (i == 0) ? 0 : (static_cast<int64_t>(1) << (i - 1));
-				}
-			}
-
-			return static_cast<int64_t>(1) << (DWELL_BUCKETS - 2);
+			return DwellPercentileUs(_dwell_hist, _dwell_count.load(std::memory_order_relaxed), percentile);
 		}
 
 		int64_t GetDwellAvgUs() const
@@ -354,6 +348,37 @@ namespace info
 		int64_t GetDwellMaxUs() const
 		{
 			return _dwell_max_us.load(std::memory_order_relaxed);
+		}
+
+		// "Latest" dwell stats: the last completed interval only (see RollDwellLatest).
+		int64_t GetDwellLatestMinUs() const
+		{
+			return _dwell_latest_min_us.load(std::memory_order_relaxed);
+		}
+
+		int64_t GetDwellLatestAvgUs() const
+		{
+			return _dwell_latest_avg_us.load(std::memory_order_relaxed);
+		}
+
+		int64_t GetDwellLatestP50Us() const
+		{
+			return _dwell_latest_p50_us.load(std::memory_order_relaxed);
+		}
+
+		int64_t GetDwellLatestP90Us() const
+		{
+			return _dwell_latest_p90_us.load(std::memory_order_relaxed);
+		}
+
+		int64_t GetDwellLatestP99Us() const
+		{
+			return _dwell_latest_p99_us.load(std::memory_order_relaxed);
+		}
+
+		int64_t GetDwellLatestMaxUs() const
+		{
+			return _dwell_latest_max_us.load(std::memory_order_relaxed);
 		}
 
 		int64_t GetThresholdExceededTimeMs() const
@@ -454,11 +479,82 @@ namespace info
 
 		// Dwell-time histogram (log2 microsecond buckets), see RecordDwellUs()
 		static constexpr int DWELL_BUCKETS = 48;
+		// Cumulative (whole-lifetime) dwell distribution.
 		std::atomic<uint64_t> _dwell_hist[DWELL_BUCKETS] = {};
 		std::atomic<uint64_t> _dwell_count{0};
 		std::atomic<uint64_t> _dwell_sum_us{0};
 		std::atomic<int64_t> _dwell_min_us{std::numeric_limits<int64_t>::max()};
 		std::atomic<int64_t> _dwell_max_us{0};
+
+		// Current-interval dwell distribution, published and reset each stats tick.
+		std::atomic<uint64_t> _dwell_cur_hist[DWELL_BUCKETS] = {};
+		std::atomic<uint64_t> _dwell_cur_count{0};
+		std::atomic<uint64_t> _dwell_cur_sum_us{0};
+		std::atomic<int64_t> _dwell_cur_min_us{std::numeric_limits<int64_t>::max()};
+		std::atomic<int64_t> _dwell_cur_max_us{0};
+
+		// Dwell stats of the last completed interval (published by RollDwellLatest).
+		std::atomic<int64_t> _dwell_latest_min_us{0};
+		std::atomic<int64_t> _dwell_latest_avg_us{0};
+		std::atomic<int64_t> _dwell_latest_p50_us{0};
+		std::atomic<int64_t> _dwell_latest_p90_us{0};
+		std::atomic<int64_t> _dwell_latest_p99_us{0};
+		std::atomic<int64_t> _dwell_latest_max_us{0};
+
+		// Add one dwell sample to a (histogram, count, sum, min, max) set. The min/max
+		// compare_exchange loops keep them correct even for a lock-free caller.
+		static void AccumulateDwell(std::atomic<uint64_t> *hist, std::atomic<uint64_t> &count,
+									std::atomic<uint64_t> &sum_us, std::atomic<int64_t> &min_us,
+									std::atomic<int64_t> &max_us, int bucket, int64_t dwell_us)
+		{
+			hist[bucket].fetch_add(1, std::memory_order_relaxed);
+			count.fetch_add(1, std::memory_order_relaxed);
+			sum_us.fetch_add(static_cast<uint64_t>(dwell_us), std::memory_order_relaxed);
+
+			int64_t prev_min = min_us.load(std::memory_order_relaxed);
+			while (dwell_us < prev_min && !min_us.compare_exchange_weak(prev_min, dwell_us, std::memory_order_relaxed))
+			{
+			}
+
+			int64_t prev_max = max_us.load(std::memory_order_relaxed);
+			while (dwell_us > prev_max && !max_us.compare_exchange_weak(prev_max, dwell_us, std::memory_order_relaxed))
+			{
+			}
+		}
+
+		// Nearest-rank percentile over a log2 dwell histogram. RecordDwellUs puts dwell 0 in
+		// bucket 0 and dwell in [2^(k-1), 2^k - 1] in bucket k, so a bucket's reported value
+		// is its lower bound: 0 for bucket 0, 2^(i-1) otherwise.
+		static int64_t DwellPercentileUs(const std::atomic<uint64_t> *hist, uint64_t total, double percentile)
+		{
+			if (total == 0)
+			{
+				return 0;
+			}
+
+			// Nearest-rank: ceil so the rank is not biased downward, clamped to [1, total].
+			uint64_t target = static_cast<uint64_t>(std::ceil(static_cast<double>(total) * percentile));
+			if (target < 1)
+			{
+				target = 1;
+			}
+			if (target > total)
+			{
+				target = total;
+			}
+
+			uint64_t cumulative = 0;
+			for (int i = 0; i < DWELL_BUCKETS; i++)
+			{
+				cumulative += hist[i].load(std::memory_order_relaxed);
+				if (cumulative >= target)
+				{
+					return (i == 0) ? 0 : (static_cast<int64_t>(1) << (i - 1));
+				}
+			}
+
+			return static_cast<int64_t>(1) << (DWELL_BUCKETS - 2);
+		}
 	};
 
 }  // namespace info

--- a/src/projects/base/info/managed_queue.h
+++ b/src/projects/base/info/managed_queue.h
@@ -532,6 +532,16 @@ namespace info
 				return 0;
 			}
 
+			// Clamp to [0, 1] first so a stray or NaN percentile can't wrap the unsigned target.
+			if (std::isnan(percentile) || percentile < 0.0)
+			{
+				percentile = 0.0;
+			}
+			else if (percentile > 1.0)
+			{
+				percentile = 1.0;
+			}
+
 			// Nearest-rank: ceil so the rank is not biased downward, clamped to [1, total].
 			uint64_t target = static_cast<uint64_t>(std::ceil(static_cast<double>(total) * percentile));
 			if (target < 1)

--- a/src/projects/modules/json_serdes/metrics.cpp
+++ b/src/projects/modules/json_serdes/metrics.cpp
@@ -100,6 +100,12 @@ namespace serdes
 		SetInt64(value, "dwellP90Us", metrics->GetDwellP90());
 		SetInt64(value, "dwellP99Us", metrics->GetDwellP99());
 		SetInt64(value, "dwellMaxUs", metrics->GetDwellMax());
+		SetInt64(value, "dwellLatestMinUs", metrics->GetDwellLatestMin());
+		SetInt64(value, "dwellLatestAvgUs", metrics->GetDwellLatestAvg());
+		SetInt64(value, "dwellLatestP50Us", metrics->GetDwellLatestP50());
+		SetInt64(value, "dwellLatestP90Us", metrics->GetDwellLatestP90());
+		SetInt64(value, "dwellLatestP99Us", metrics->GetDwellLatestP99());
+		SetInt64(value, "dwellLatestMaxUs", metrics->GetDwellLatestMax());
 		SetInt(value, "inputPerSecond", metrics->GetInputMessagePerSecond());
 		SetInt(value, "outputPerSecond", metrics->GetOutputMessagePerSecond());
 		SetInt(value, "drop", metrics->GetDropCount());

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -542,7 +542,10 @@ namespace ov
 				_output_message_per_second = (double)(_output_message_count - _last_output_message_count) * (1000.0 / (double)elapsed_time);
 				_last_input_message_count = _input_message_count.load();
 				_last_output_message_count = _output_message_count.load();
-	
+
+				// Publish this interval's dwell stats as the "latest" values and reset them.
+				RollDwellLatest();
+
 				UpdateThreshold();
 
 				if (IsThresholdExceeded())
@@ -555,9 +558,10 @@ namespace ov
 					{
 						_last_logging_time = 0;
 
-						logw(LOG_TAG, "Exceeded. %s dwell_us[n=%llu min=%lld avg=%lld p50=%lld p90=%lld p99=%lld max=%lld]", GetInfoString().CStr(),
+						logw(LOG_TAG, "Exceeded. %s dwell_us[n=%llu min=%lld avg=%lld p50=%lld p90=%lld p99=%lld max=%lld] latest_dwell_us[p50=%lld p90=%lld p99=%lld max=%lld]", GetInfoString().CStr(),
 							static_cast<unsigned long long>(GetDwellCount()), static_cast<long long>(GetDwellMinUs()), static_cast<long long>(GetDwellAvgUs()),
-							static_cast<long long>(GetDwellPercentileUs(0.5)), static_cast<long long>(GetDwellPercentileUs(0.9)), static_cast<long long>(GetDwellPercentileUs(0.99)), static_cast<long long>(GetDwellMaxUs()));
+							static_cast<long long>(GetDwellPercentileUs(0.5)), static_cast<long long>(GetDwellPercentileUs(0.9)), static_cast<long long>(GetDwellPercentileUs(0.99)), static_cast<long long>(GetDwellMaxUs()),
+							static_cast<long long>(GetDwellLatestP50Us()), static_cast<long long>(GetDwellLatestP90Us()), static_cast<long long>(GetDwellLatestP99Us()), static_cast<long long>(GetDwellLatestMaxUs()));
 
 						_last_logged_peak = _peak;
 					}

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -558,10 +558,10 @@ namespace ov
 					{
 						_last_logging_time = 0;
 
-						logw(LOG_TAG, "Exceeded. %s dwell_us[n=%llu min=%lld avg=%lld p50=%lld p90=%lld p99=%lld max=%lld] latest_dwell_us[p50=%lld p90=%lld p99=%lld max=%lld]", GetInfoString().CStr(),
+						logw(LOG_TAG, "Exceeded. %s dwell_us[n=%llu min=%lld avg=%lld p50=%lld p90=%lld p99=%lld max=%lld] latest_dwell_us[min=%lld avg=%lld p50=%lld p90=%lld p99=%lld max=%lld]", GetInfoString().CStr(),
 							static_cast<unsigned long long>(GetDwellCount()), static_cast<long long>(GetDwellMinUs()), static_cast<long long>(GetDwellAvgUs()),
 							static_cast<long long>(GetDwellPercentileUs(0.5)), static_cast<long long>(GetDwellPercentileUs(0.9)), static_cast<long long>(GetDwellPercentileUs(0.99)), static_cast<long long>(GetDwellMaxUs()),
-							static_cast<long long>(GetDwellLatestP50Us()), static_cast<long long>(GetDwellLatestP90Us()), static_cast<long long>(GetDwellLatestP99Us()), static_cast<long long>(GetDwellLatestMaxUs()));
+							static_cast<long long>(GetDwellLatestMinUs()), static_cast<long long>(GetDwellLatestAvgUs()), static_cast<long long>(GetDwellLatestP50Us()), static_cast<long long>(GetDwellLatestP90Us()), static_cast<long long>(GetDwellLatestP99Us()), static_cast<long long>(GetDwellLatestMaxUs()));
 
 						_last_logged_peak = _peak;
 					}

--- a/src/projects/modules/managed_queue/managed_queue_dwell_test.cpp
+++ b/src/projects/modules/managed_queue/managed_queue_dwell_test.cpp
@@ -1,0 +1,71 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <base/info/managed_queue.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+// The dwell-time statistics live in info::ManagedQueue and are pure (no
+// MonitorInstance), so they are exercised directly here. RecordDwellUs feeds both
+// the cumulative (whole-lifetime) set and the current-interval set; RollDwellLatest
+// publishes the interval as the "latest" values and resets it for the next window.
+
+TEST(ManagedQueueDwell, LatestPublishesIntervalThenResets)
+{
+	info::ManagedQueue queue;
+
+	// Samples land in log2 buckets whose reported value is the bucket lower bound;
+	// 8, 16 and 1024 are exact powers of two, so they report unchanged.
+	queue.RecordDwellUs(8);
+	queue.RecordDwellUs(16);
+	queue.RecordDwellUs(1024);
+
+	queue.RollDwellLatest();
+
+	// Latest reflects this interval. avg is exact (sum/count); percentiles are the
+	// nearest-rank bucket lower bound over the sorted samples {8, 16, 1024}.
+	EXPECT_EQ(queue.GetDwellLatestMinUs(), 8);
+	EXPECT_EQ(queue.GetDwellLatestMaxUs(), 1024);
+	EXPECT_EQ(queue.GetDwellLatestAvgUs(), (8 + 16 + 1024) / 3);
+	EXPECT_EQ(queue.GetDwellLatestP50Us(), 16);
+	EXPECT_EQ(queue.GetDwellLatestP90Us(), 1024);
+	EXPECT_EQ(queue.GetDwellLatestP99Us(), 1024);
+
+	// The cumulative set reflects the same samples.
+	EXPECT_EQ(queue.GetDwellMinUs(), 8);
+	EXPECT_EQ(queue.GetDwellMaxUs(), 1024);
+
+	// A second roll with no new samples clears the latest values but leaves the
+	// cumulative distribution intact.
+	queue.RollDwellLatest();
+
+	EXPECT_EQ(queue.GetDwellLatestMinUs(), 0);
+	EXPECT_EQ(queue.GetDwellLatestAvgUs(), 0);
+	EXPECT_EQ(queue.GetDwellLatestP50Us(), 0);
+	EXPECT_EQ(queue.GetDwellLatestP90Us(), 0);
+	EXPECT_EQ(queue.GetDwellLatestP99Us(), 0);
+	EXPECT_EQ(queue.GetDwellLatestMaxUs(), 0);
+
+	EXPECT_EQ(queue.GetDwellMinUs(), 8);
+	EXPECT_EQ(queue.GetDwellMaxUs(), 1024);
+}
+
+// GetDwellPercentileUs clamps its input to [0, 1]; out-of-range and NaN must not
+// wrap the unsigned rank or read out of bounds.
+TEST(ManagedQueueDwell, PercentileInputIsClamped)
+{
+	info::ManagedQueue queue;
+
+	queue.RecordDwellUs(8);
+	queue.RecordDwellUs(1024);
+
+	// Below 0 (and NaN) behave as 0.0 -> smallest sample; above 1 behaves as max.
+	EXPECT_EQ(queue.GetDwellPercentileUs(-1.0), queue.GetDwellPercentileUs(0.0));
+	EXPECT_EQ(queue.GetDwellPercentileUs(2.0), queue.GetDwellPercentileUs(1.0));
+	EXPECT_EQ(queue.GetDwellPercentileUs(std::nan("")), queue.GetDwellPercentileUs(0.0));
+}

--- a/src/projects/monitoring/queue_metrics.h
+++ b/src/projects/monitoring/queue_metrics.h
@@ -78,6 +78,12 @@ namespace mon
 			const auto dwell_avg = info.GetDwellAvgUs();
 			const auto dwell_min = info.GetDwellMinUs();
 			const auto dwell_max = info.GetDwellMaxUs();
+			const auto dwell_latest_p50 = info.GetDwellLatestP50Us();
+			const auto dwell_latest_p90 = info.GetDwellLatestP90Us();
+			const auto dwell_latest_p99 = info.GetDwellLatestP99Us();
+			const auto dwell_latest_avg = info.GetDwellLatestAvgUs();
+			const auto dwell_latest_min = info.GetDwellLatestMinUs();
+			const auto dwell_latest_max = info.GetDwellLatestMaxUs();
 
 			ov::LockGuard lock(_mutex);
 			_peak					   = peak;
@@ -93,6 +99,12 @@ namespace mon
 			_dwell_avg = dwell_avg;
 			_dwell_min = dwell_min;
 			_dwell_max = dwell_max;
+			_dwell_latest_p50 = dwell_latest_p50;
+			_dwell_latest_p90 = dwell_latest_p90;
+			_dwell_latest_p99 = dwell_latest_p99;
+			_dwell_latest_avg = dwell_latest_avg;
+			_dwell_latest_min = dwell_latest_min;
+			_dwell_latest_max = dwell_latest_max;
 		}
 
 		size_t GetPeak() const
@@ -173,6 +185,42 @@ namespace mon
 			return _dwell_max;
 		}
 
+		int64_t GetDwellLatestP50() const
+		{
+			ov::SharedLockGuard lock(_mutex);
+			return _dwell_latest_p50;
+		}
+
+		int64_t GetDwellLatestP90() const
+		{
+			ov::SharedLockGuard lock(_mutex);
+			return _dwell_latest_p90;
+		}
+
+		int64_t GetDwellLatestP99() const
+		{
+			ov::SharedLockGuard lock(_mutex);
+			return _dwell_latest_p99;
+		}
+
+		int64_t GetDwellLatestAvg() const
+		{
+			ov::SharedLockGuard lock(_mutex);
+			return _dwell_latest_avg;
+		}
+
+		int64_t GetDwellLatestMin() const
+		{
+			ov::SharedLockGuard lock(_mutex);
+			return _dwell_latest_min;
+		}
+
+		int64_t GetDwellLatestMax() const
+		{
+			ov::SharedLockGuard lock(_mutex);
+			return _dwell_latest_max;
+		}
+
 	private:
 		mutable ov::SharedMutex _mutex;
 
@@ -195,5 +243,11 @@ namespace mon
 		int64_t _dwell_avg OV_GUARDED_BY(_mutex) = 0;
 		int64_t _dwell_min OV_GUARDED_BY(_mutex) = 0;
 		int64_t _dwell_max OV_GUARDED_BY(_mutex) = 0;
+		int64_t _dwell_latest_p50 OV_GUARDED_BY(_mutex) = 0;
+		int64_t _dwell_latest_p90 OV_GUARDED_BY(_mutex) = 0;
+		int64_t _dwell_latest_p99 OV_GUARDED_BY(_mutex) = 0;
+		int64_t _dwell_latest_avg OV_GUARDED_BY(_mutex) = 0;
+		int64_t _dwell_latest_min OV_GUARDED_BY(_mutex) = 0;
+		int64_t _dwell_latest_max OV_GUARDED_BY(_mutex) = 0;
 	};
 }  // namespace mon


### PR DESCRIPTION
Internal-queue dwell-time stats are cumulative over the queue's whole lifetime, so a single early spike pins the max and the high percentiles and they stop reflecting current behavior.

Add a parallel last-interval set that captures only the most recent completed stats interval, rolled over each tick the same way the per-second counters are, and expose it as dwellLatest{Min,Avg,P50,P90,P99,Max}Us in the queue stats API and the queue Exceeded log. The cumulative set is kept unchanged.

Test method: ran OME with a live stream, then polled /v1/stats/current/internals/queues and sampled an active queue once per second.
Pass condition: the queue exposes the dwellLatest* fields, they change every second to track the current interval, and the cumulative dwellMaxUs stays pinned at the lifetime peak.
