### PR TITLE
docs: Add v1 /version API spec and docs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,9 +19,6 @@ jobs:
   CLAAssistant:
     name: CLA Assistant
     runs-on: ubuntu-latest
-    env:
-      # Temporary compatibility switch for legacy Node 20 actions on GitHub-hosted runners.
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
     steps:
       # contributor-assistant/github-action pinned to the forked v2.6.1 commit
       # (upstream is archived; the fork lives at OvenMediaLabs/cla-github-action).

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,6 +19,9 @@ jobs:
   CLAAssistant:
     name: CLA Assistant
     runs-on: ubuntu-latest
+    env:
+      # Temporary compatibility switch for legacy Node 20 actions on GitHub-hosted runners.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
     steps:
       # contributor-assistant/github-action pinned to the forked v2.6.1 commit
       # (upstream is archived; the fork lives at OvenMediaLabs/cla-github-action).

--- a/api/ome.yml
+++ b/api/ome.yml
@@ -1293,7 +1293,9 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/HttpStatus'
-                - properties:
+                - type: object
+                  required: [response]
+                  properties:
                     response:
                       type: object
                       required: [version, gitVersion]

--- a/api/ome.yml
+++ b/api/ome.yml
@@ -1279,6 +1279,33 @@ paths:
         '200':
           $ref: '#/components/responses/Transcoded'
       security: []
+  /version:
+    get:
+      operationId: VersionGet
+      tags: [api]
+      summary: Get OvenMediaEngine version information
+      description: Returns the current OvenMediaEngine release version and git version.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/HttpStatus'
+                - properties:
+                    response:
+                      type: object
+                      required: [version, gitVersion]
+                      properties:
+                        version:
+                          type: string
+                          description: OvenMediaEngine release version.
+                        gitVersion:
+                          type: string
+                          description: Git describe/version information.
+        '401':
+          $ref: '#/components/responses/Status'
   /vhosts:
     get:
       operationId: VHostsGet

--- a/docs/rest-api/v1/version.md
+++ b/docs/rest-api/v1/version.md
@@ -4,7 +4,7 @@ description: "Get the current OvenMediaEngine version and git version via the v1
 sidebar_position: 41
 ---
 
-## Returns OvenMediaEngine version metadata.
+## Get Version
 
 > **Request**
 

--- a/docs/rest-api/v1/version.md
+++ b/docs/rest-api/v1/version.md
@@ -1,0 +1,76 @@
+---
+title: Version
+description: "Get the current OvenMediaEngine version and git version via the v1 REST API."
+sidebar_position: 40
+---
+
+Returns OvenMediaEngine version metadata.
+
+> **Request**
+
+<details>
+
+<summary><span class="http-method http-method-get">GET</span> /v1/version</summary>
+
+**Header**
+
+```http
+Authorization: Basic {credentials}
+
+# Authorization
+    Credentials for HTTP Basic Authentication created with <AccessToken>
+```
+
+</details>
+
+> **Responses**
+
+<details>
+
+<summary><span class="http-method http-method-200">200</span> Ok</summary>
+
+The request has succeeded.
+
+**Header**
+
+```http
+Content-Type: application/json
+```
+
+**Body**
+
+```json
+{
+    "statusCode": 200,
+    "message": "OK",
+    "response": {
+        "version": "0.20.5",
+        "gitVersion": "v0.20.5-0-g1234567"
+    }
+}
+```
+
+</details>
+
+<details>
+
+<summary><span class="http-method http-method-401">401</span> Unauthorized</summary>
+
+Authentication required.
+
+**Header**
+
+```http
+WWW-Authenticate: Basic realm="OvenMediaEngine"
+```
+
+**Body**
+
+```json
+{
+    "message": "[HTTP] Authorization header is required to call API (401)",
+    "statusCode": 401
+}
+```
+
+</details>

--- a/docs/rest-api/v1/version.md
+++ b/docs/rest-api/v1/version.md
@@ -1,10 +1,10 @@
 ---
 title: Version
 description: "Get the current OvenMediaEngine version and git version via the v1 REST API."
-sidebar_position: 40
+sidebar_position: 41
 ---
 
-Returns OvenMediaEngine version metadata.
+## Returns OvenMediaEngine version metadata.
 
 > **Request**
 
@@ -44,8 +44,8 @@ Content-Type: application/json
     "statusCode": 200,
     "message": "OK",
     "response": {
-        "version": "0.20.5",
-        "gitVersion": "v0.20.5-0-g1234567"
+        "version": "x.y.z",
+        "gitVersion": "vx.y.z-0-g1234567"
     }
 }
 ```
@@ -68,8 +68,8 @@ WWW-Authenticate: Basic realm="OvenMediaEngine"
 
 ```json
 {
-    "message": "[HTTP] Authorization header is required to call API (401)",
-    "statusCode": 401
+    "statusCode": 401,
+    "message": "[HTTP] Authorization header is required to call API (401)"
 }
 ```
 


### PR DESCRIPTION
## Summary
- add OpenAPI path GET /version
- define response payload with version and gitVersion
- add REST API docs page for /v1/version

## Notes
- no runtime code changes; spec + docs only