### PR TITLE
feat: add OME_LATENCY_PROBE build option for serving-path latency instrumentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,9 @@ message(STATUS "  OME_WHISPER_STATIC: ${OME_WHISPER_STATIC}")
 # worker stalls to a single latency_probe.log (directory via the OME_LATENCY_PROBE_DIR
 # environment variable, default /dev/shm).
 if(OME_LATENCY_PROBE)
+    if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        message(FATAL_ERROR "[OME] OME_LATENCY_PROBE is Linux-only (uses epoll, SO_TIMESTAMPING, SCM_TIMESTAMPING, prctl(PR_GET_NAME), getrusage(RUSAGE_THREAD)). Disable it on ${CMAKE_SYSTEM_NAME}.")
+    endif()
     add_compile_definitions(OME_LATENCY_PROBE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ option(OME_SKIP_DEPENDENCY_CHECK    "Skip auto-install of missing/wrong-version 
 option(OME_SANITIZE_THREAD          "Enable ThreadSanitizer (TSan) - Debug only"         OFF)
 option(OME_THREAD_SAFETY            "Enable Clang thread-safety analysis"                OFF)
 option(OME_BUILD_TESTS              "Build unit tests (requires GTest)"                  OFF)
+option(OME_LATENCY_PROBE            "Build serving-path latency/stall instrumentation"  OFF)
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     option(OME_WHISPER_STATIC       "Build Whisper/ggml as a static library"             ON)
 else()
@@ -135,7 +136,16 @@ message(STATUS "  OME_SKIP_DEPENDENCY_CHECK: ${OME_SKIP_DEPENDENCY_CHECK}")
 message(STATUS "  OME_SANITIZE_THREAD: ${OME_SANITIZE_THREAD}")
 message(STATUS "  OME_THREAD_SAFETY: ${OME_THREAD_SAFETY}")
 message(STATUS "  OME_BUILD_TESTS: ${OME_BUILD_TESTS}")
+message(STATUS "  OME_LATENCY_PROBE: ${OME_LATENCY_PROBE}")
 message(STATUS "  OME_WHISPER_STATIC: ${OME_WHISPER_STATIC}")
+
+# Serving-path latency/stall instrumentation. OFF by default: none of the probe code is
+# compiled and there is zero runtime cost. When ON, records serving-path stage timings and
+# worker stalls to a single latency_probe.log (directory via the OME_LATENCY_PROBE_DIR
+# environment variable, default /dev/shm).
+if(OME_LATENCY_PROBE)
+    add_compile_definitions(OME_LATENCY_PROBE)
+endif()
 
 # ==============================================================================
 # Include cmake modules

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -45,6 +45,7 @@ cmake --build build/Release
 | `OME_ENABLE_JEMALLOC_LG_PAGE_MAX` | OFF | Build jemalloc with 16 KiB maximum page size on aarch64/arm64 targets (`--with-lg-page=16`) |
 | `OME_USE_JEMALLOC_PROFILE` | OFF | Enable jemalloc heap profiling (`OME_USE_JEMALLOC_PROFILE` compile definition). Requires `OME_ENABLE_JEMALLOC=ON` |
 | `OME_BUILD_TESTS` | OFF | Build unit tests (requires internet access to fetch GTest v1.14.0) |
+| `OME_LATENCY_PROBE` | OFF | Build serving-path latency/stall instrumentation. OFF has zero runtime cost (code is not compiled). When ON, records serving-path stage timings and worker stalls to a single `latency_probe.log`; set the output directory with the `OME_LATENCY_PROBE_DIR` environment variable (default `/dev/shm`) |
 | `OME_WHISPER_STATIC` | OFF | Build Whisper/ggml as a static library. |
 ---
 

--- a/src/projects/base/ovlibrary/latency_probe.cpp
+++ b/src/projects/base/ovlibrary/latency_probe.cpp
@@ -41,7 +41,9 @@ namespace ov
 	// Single append-only log file shared by every subsystem, opened once.
 	static int LatencyProbeFd()
 	{
-		static const int s_fd = ::open(PathManager::Combine(LatencyProbeDir(), "latency_probe.log").CStr(), O_WRONLY | O_CREAT | O_APPEND, 0644);
+		// 0600 + O_CLOEXEC: records can include request URIs, so keep the file owner-only and
+		// prevent the fd from leaking into forked/exec'd child processes.
+		static const int s_fd = ::open(PathManager::Combine(LatencyProbeDir(), "latency_probe.log").CStr(), O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, 0600);
 
 		return s_fd;
 	}

--- a/src/projects/base/ovlibrary/latency_probe.cpp
+++ b/src/projects/base/ovlibrary/latency_probe.cpp
@@ -1,0 +1,91 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Copyright (c) 2024 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#include "latency_probe.h"
+
+#ifdef OME_LATENCY_PROBE
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <chrono>
+
+#include "path_manager.h"
+#include "string.h"
+
+namespace ov
+{
+	// Resolved once, thread-safe via function-local static initialization.
+	static const String &LatencyProbeDir()
+	{
+		static const String dir = []() -> String {
+			const char *env = ::getenv("OME_LATENCY_PROBE_DIR");
+			String d = (env != nullptr && env[0] != '\0') ? String(env) : String("/dev/shm");
+
+			PathManager::MakeDirectoryRecursive(d);
+			::fprintf(stderr, "[OME_LATENCY_PROBE] serving-path instrumentation active, writing logs to %s/latency_probe.log\n", d.CStr());
+
+			return d;
+		}();
+
+		return dir;
+	}
+
+	// Single append-only log file shared by every subsystem, opened once.
+	static int LatencyProbeFd()
+	{
+		static const int s_fd = ::open(PathManager::Combine(LatencyProbeDir(), "latency_probe.log").CStr(), O_WRONLY | O_CREAT | O_APPEND, 0644);
+
+		return s_fd;
+	}
+
+	void LatencyProbeLog(const char *tag, const char *fmt, ...)
+	{
+		const int fd = LatencyProbeFd();
+		if (fd < 0)
+		{
+			return;
+		}
+
+		const auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+
+		// One record = "<epoch_ms> <TAG> <fields>\n", built into a fixed buffer and written with a
+		// single ::write(). O_APPEND makes each such write atomic, so records from concurrent
+		// threads never interleave.
+		char buf[512];
+		int off = ::snprintf(buf, sizeof(buf), "%lld %s ", static_cast<long long>(now_ms), tag);
+		if (off < 0)
+		{
+			return;
+		}
+		if (off > static_cast<int>(sizeof(buf)) - 2)
+		{
+			off = static_cast<int>(sizeof(buf)) - 2;
+		}
+
+		va_list ap;
+		va_start(ap, fmt);
+		const int written = ::vsnprintf(buf + off, sizeof(buf) - static_cast<size_t>(off) - 1, fmt, ap);
+		va_end(ap);
+		if (written > 0)
+		{
+			off += written;
+			if (off > static_cast<int>(sizeof(buf)) - 1)
+			{
+				off = static_cast<int>(sizeof(buf)) - 1;  // truncated to fit the newline
+			}
+		}
+
+		buf[off++] = '\n';
+		[[maybe_unused]] auto w = ::write(fd, buf, static_cast<size_t>(off));
+	}
+}  // namespace ov
+
+#endif	// OME_LATENCY_PROBE

--- a/src/projects/base/ovlibrary/latency_probe.h
+++ b/src/projects/base/ovlibrary/latency_probe.h
@@ -1,0 +1,27 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Copyright (c) 2024 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+// Serving-path latency/stall instrumentation, compiled only when the OME_LATENCY_PROBE build
+// option is enabled (-DOME_LATENCY_PROBE=ON). Every subsystem appends to a single file resolved
+// once at first use:
+//   - OME_LATENCY_PROBE_DIR environment variable, if set
+//   - otherwise /dev/shm (tmpfs, so the log I/O does not perturb the latency being measured)
+// The directory is created if missing, and the resolved path is announced once on stderr.
+#ifdef OME_LATENCY_PROBE
+
+namespace ov
+{
+	// Appends one record to "<dir>/latency_probe.log". The current wall-clock time and the tag
+	// are prepended automatically, so records from every subsystem form one time-sorted stream:
+	//   "<epoch_ms> <TAG> <fields...>"
+	// Filter a single subsystem with e.g. `grep RECV_LATE`.
+	void LatencyProbeLog(const char *tag, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+}  // namespace ov
+
+#endif	// OME_LATENCY_PROBE

--- a/src/projects/base/ovlibrary/latency_probe.h
+++ b/src/projects/base/ovlibrary/latency_probe.h
@@ -15,13 +15,15 @@
 // The directory is created if missing, and the resolved path is announced once on stderr.
 #ifdef OME_LATENCY_PROBE
 
+#include "format_string.h"
+
 namespace ov
 {
 	// Appends one record to "<dir>/latency_probe.log". The current wall-clock time and the tag
 	// are prepended automatically, so records from every subsystem form one time-sorted stream:
 	//   "<epoch_ms> <TAG> <fields...>"
 	// Filter a single subsystem with e.g. `grep RECV_LATE`.
-	void LatencyProbeLog(const char *tag, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+	void LatencyProbeLog(const char *tag, const char *fmt, ...) OV_PRINTF_FORMAT(2, 3);
 }  // namespace ov
 
 #endif	// OME_LATENCY_PROBE

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -30,6 +30,37 @@
 #include "socket_profiler.h"
 #include "stats_counter.h"
 
+#ifdef OME_LATENCY_PROBE
+#include <linux/net_tstamp.h>
+#include <sched.h>
+#include <sys/prctl.h>
+
+#include <base/ovlibrary/latency_probe.h>
+
+// Latency probe (OME_LATENCY_PROBE only): measure "kernel received the request bytes"
+// (SO_TIMESTAMPING software RX timestamp) vs "we actually read them" (recvmsg return). A large
+// gap means the request sat in the kernel socket buffer while our epoll worker was late to read
+// it (epoll/scheduling lateness before our session-level read). Logged only when the gap is big.
+static void RecvLateLog(int handle, long long late_ms, long bytes)
+{
+	char comm[24] = {0};
+	::prctl(PR_GET_NAME, comm, 0, 0, 0);
+	ov::LatencyProbeLog("RECV_LATE", "comm=%s psr=%d fd=%d late_ms=%lld bytes=%ld",
+						comm, ::sched_getcpu(), handle, late_ms, bytes);
+}
+
+// Latency probe (OME_LATENCY_PROBE only): log when a socket Send cannot fully flush inline
+// (kernel send buffer full -> EAGAIN/partial), i.e. the peer is not draining.
+// comm identifies the pool worker (SPLLHLS/SPRTMP/...).
+static void SendStallLog(int handle, long sent_now, long left)
+{
+	char comm[24] = {0};
+	::prctl(PR_GET_NAME, comm, 0, 0, 0);
+	ov::LatencyProbeLog("SEND_STALL", "comm=%s fd=%d sent_now=%ld left=%ld",
+						comm, handle, sent_now, left);
+}
+#endif	// OME_LATENCY_PROBE
+
 namespace ov
 {
 	// Used to wait for connection
@@ -383,6 +414,17 @@ namespace ov
 		auto old_callback = std::atomic_exchange(&_callback, callback);
 
 		_blocking_mode	  = BlockingMode::NonBlocking;
+
+#ifdef OME_LATENCY_PROBE
+		// Latency probe (OME_LATENCY_PROBE only): enable software RX timestamping on TCP client
+		// sockets so Recv() can measure how long a request sat in the kernel buffer before our
+		// worker read it.
+		if (GetType() == SocketType::Tcp)
+		{
+			int ts_flags = SOF_TIMESTAMPING_RX_SOFTWARE | SOF_TIMESTAMPING_SOFTWARE;
+			SetSockOpt(SOL_SOCKET, SO_TIMESTAMPING, &ts_flags, sizeof(ts_flags));
+		}
+#endif	// OME_LATENCY_PROBE
 
 		if (
 			SetBlockingInternal(BlockingMode::NonBlocking) &&
@@ -989,6 +1031,13 @@ namespace ov
 		{
 			// logat("Could not send data: %ld bytes (%s)", data->GetLength(), command.ToString().CStr());
 		}
+
+#ifdef OME_LATENCY_PROBE
+		if (command.type == DispatchCommand::Type::Send)
+		{
+			SendStallLog(GetNativeHandle(), static_cast<long>(sent_bytes), static_cast<long>(data->GetLength()));
+		}
+#endif	// OME_LATENCY_PROBE
 
 		return DispatchResult::PartialDispatched;
 	}
@@ -1604,8 +1653,51 @@ namespace ov
 
 			case SocketType::Udp:
 			case SocketType::Tcp:
-				read_bytes = ::recv(GetNativeHandle(), data, length,
-									((_blocking_mode == BlockingMode::NonBlocking) || non_block) ? MSG_DONTWAIT : 0);
+			{
+				const int recv_flags = ((_blocking_mode == BlockingMode::NonBlocking) || non_block) ? MSG_DONTWAIT : 0;
+#ifdef OME_LATENCY_PROBE
+				// Latency probe (OME_LATENCY_PROBE only): use recvmsg to pull the SO_TIMESTAMPING
+				// software RX timestamp, so the serving layer can compare kernel-arrival vs serve time.
+				struct iovec iov;
+				iov.iov_base = data;
+				iov.iov_len	 = length;
+				char ts_cbuf[256];
+				struct msghdr msg = {};
+				msg.msg_iov		   = &iov;
+				msg.msg_iovlen	   = 1;
+				msg.msg_control	   = ts_cbuf;
+				msg.msg_controllen = sizeof(ts_cbuf);
+
+				read_bytes = ::recvmsg(GetNativeHandle(), &msg, recv_flags);
+
+				if (read_bytes > 0L && GetType() == SocketType::Tcp)
+				{
+					for (struct cmsghdr *cm = CMSG_FIRSTHDR(&msg); cm != nullptr; cm = CMSG_NXTHDR(&msg, cm))
+					{
+						if (cm->cmsg_level == SOL_SOCKET && cm->cmsg_type == SCM_TIMESTAMPING)
+						{
+							// scm_timestamping layout: struct timespec ts[3]; ts[0]=software RX time
+							auto *ts = reinterpret_cast<struct timespec *>(CMSG_DATA(cm));
+							int64_t kernel_ms = static_cast<int64_t>(ts[0].tv_sec) * 1000 + ts[0].tv_nsec / 1000000;
+							if (kernel_ms > 0)
+							{
+								// Store for the serving layer to read (per-request K timestamp).
+								_last_rx_kernel_ms.store(kernel_ms, std::memory_order_relaxed);
+
+								auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+								int64_t late = now_ms - kernel_ms;
+								if (late > 15)
+								{
+									RecvLateLog(GetNativeHandle(), static_cast<long long>(late), static_cast<long>(read_bytes));
+								}
+							}
+							break;
+						}
+					}
+				}
+#else	// OME_LATENCY_PROBE
+				read_bytes = ::recv(GetNativeHandle(), data, length, recv_flags);
+#endif	// OME_LATENCY_PROBE
 
 				if (read_bytes == 0L)
 				{
@@ -1664,6 +1756,7 @@ namespace ov
 				}
 
 				break;
+			}
 
 			case SocketType::Srt: {
 				SRT_MSGCTRL msg_ctrl{};

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -1673,6 +1673,10 @@ namespace ov
 
 				if (read_bytes > 0L && GetType() == SocketType::Tcp)
 				{
+					// Clear first so a read without a timestamp cmsg reports 0 (unknown) to the
+					// serving layer, instead of reusing the previous read's kernel arrival time.
+					_last_rx_kernel_ms.store(0, std::memory_order_relaxed);
+
 					for (struct cmsghdr *cm = CMSG_FIRSTHDR(&msg); cm != nullptr; cm = CMSG_NXTHDR(&msg, cm))
 					{
 						if (cm->cmsg_level == SOL_SOCKET && cm->cmsg_type == SCM_TIMESTAMPING &&

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -1661,7 +1661,8 @@ namespace ov
 				struct iovec iov;
 				iov.iov_base = data;
 				iov.iov_len	 = length;
-				char ts_cbuf[256];
+				// Control buffer must be aligned for struct cmsghdr access via the CMSG_* macros.
+				alignas(struct cmsghdr) char ts_cbuf[256];
 				struct msghdr msg = {};
 				msg.msg_iov		   = &iov;
 				msg.msg_iovlen	   = 1;

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -1675,7 +1675,8 @@ namespace ov
 				{
 					for (struct cmsghdr *cm = CMSG_FIRSTHDR(&msg); cm != nullptr; cm = CMSG_NXTHDR(&msg, cm))
 					{
-						if (cm->cmsg_level == SOL_SOCKET && cm->cmsg_type == SCM_TIMESTAMPING)
+						if (cm->cmsg_level == SOL_SOCKET && cm->cmsg_type == SCM_TIMESTAMPING &&
+							cm->cmsg_len >= CMSG_LEN(sizeof(struct timespec)))
 						{
 							// scm_timestamping layout: struct timespec ts[3]; ts[0]=software RX time
 							auto *ts = reinterpret_cast<struct timespec *>(CMSG_DATA(cm));

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -416,9 +416,10 @@ namespace ov
 		_blocking_mode	  = BlockingMode::NonBlocking;
 
 #ifdef OME_LATENCY_PROBE
-		// Latency probe (OME_LATENCY_PROBE only): enable software RX timestamping on TCP client
-		// sockets so Recv() can measure how long a request sat in the kernel buffer before our
-		// worker read it.
+		// Latency probe (OME_LATENCY_PROBE only): enable software RX timestamping on all
+		// non-blocking TCP sockets (accepted server-side ClientSockets and outgoing client
+		// sockets) so Recv() can measure how long a request sat in the kernel buffer before
+		// our worker read it.
 		if (GetType() == SocketType::Tcp)
 		{
 			int ts_flags = SOF_TIMESTAMPING_RX_SOFTWARE | SOF_TIMESTAMPING_SOFTWARE;

--- a/src/projects/base/ovsocket/socket.h
+++ b/src/projects/base/ovsocket/socket.h
@@ -271,9 +271,23 @@ namespace ov
 			return _has_close_command;
 		}
 
+#ifdef OME_LATENCY_PROBE
+		// Latency probe (OME_LATENCY_PROBE only): kernel software RX timestamp (ms) of the most
+		// recent read on this socket (from SO_TIMESTAMPING). Lets the serving layer log when the
+		// request bytes actually arrived in the kernel vs when OME served the response.
+		int64_t GetLastRxKernelMs() const
+		{
+			return _last_rx_kernel_ms.load(std::memory_order_relaxed);
+		}
+#endif	// OME_LATENCY_PROBE
+
 		virtual String ToString() const;
 
 	protected:
+#ifdef OME_LATENCY_PROBE
+		std::atomic<int64_t> _last_rx_kernel_ms{0};
+#endif	// OME_LATENCY_PROBE
+
 		struct DispatchCommand
 		{
 			static constexpr int CLOSE_TYPE_MASK = 0x40;

--- a/src/projects/base/ovsocket/socket.h
+++ b/src/projects/base/ovsocket/socket.h
@@ -28,6 +28,10 @@
 #include <memory>
 #include <utility>
 
+#ifdef OME_LATENCY_PROBE
+#include <atomic>
+#endif	// OME_LATENCY_PROBE
+
 #include <tl/expected.hpp>
 
 // Failure to send data for the specified time period will be considered an error.

--- a/src/projects/base/ovsocket/socket_pool/socket_pool_worker.cpp
+++ b/src/projects/base/ovsocket/socket_pool/socket_pool_worker.cpp
@@ -11,6 +11,45 @@
 #include "../socket_private.h"
 #include "socket_pool.h"
 
+#ifdef OME_LATENCY_PROBE
+#include <sched.h>
+#include <sys/prctl.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+
+#include <chrono>
+
+#include <base/ovlibrary/latency_probe.h>
+
+// Latency probe (OME_LATENCY_PROBE only): log when EpollWait returned WITH events but only after a
+// long wall time (>20ms). Events were ready yet the thread took that long to return them =>
+// the worker was off-CPU (couldn't be scheduled). psr=CPU, nivcsw>0 => preempted/starved.
+static void EpollWaitLog(long long ew_ms, int count, long nivcsw, long nvcsw)
+{
+	char comm[32] = {0};
+	::prctl(PR_GET_NAME, comm, 0, 0, 0);
+	ov::LatencyProbeLog("EPOLL", "comm=%s psr=%d ew_ms=%lld count=%d nivcsw=%ld nvcsw=%ld",
+						comm, ::sched_getcpu(), ew_ms, count, nivcsw, nvcsw);
+}
+
+// Latency probe (OME_LATENCY_PROBE only): log any epoll-loop iteration whose processing
+// (everything after EpollWait returns) exceeds the threshold.
+// psr = CPU the worker is on; nivcsw/nvcsw = involuntary/voluntary context switches
+// during the stalled iteration:
+//   nivcsw>0 => OS preempted the worker off-core (scheduling/IRQ pressure)
+//   nvcsw>0  => worker blocked waiting (lock/syscall)
+//   both 0   => worker ran in userspace the whole time (slow compute)
+// comm identifies which pool worker (SPLLHLS/SPRTMP/SPAPISvr/SPOvtPub/SPSRTPub...) stalled,
+// since SocketPoolWorker is shared across all listeners.
+static void SpwStallLog(long long stall_ms, int event_count, long nivcsw, long nvcsw, long minflt, long majflt)
+{
+	char comm[32] = {0};
+	::prctl(PR_GET_NAME, comm, 0, 0, 0);
+	ov::LatencyProbeLog("SPW", "tid=%ld comm=%s psr=%d stall_ms=%lld events=%d nivcsw=%ld nvcsw=%ld minflt=%ld majflt=%ld",
+						static_cast<long>(::syscall(SYS_gettid)), comm, ::sched_getcpu(), stall_ms, event_count, nivcsw, nvcsw, minflt, majflt);
+}
+#endif	// OME_LATENCY_PROBE
+
 #undef OV_LOG_TAG
 #define OV_LOG_TAG "Socket.Pool.Worker"
 
@@ -268,7 +307,32 @@ namespace ov
 
 		while (_stop_epoll_thread == false)
 		{
+#ifdef OME_LATENCY_PROBE
+			// Measure how long EpollWait itself takes and whether the thread was preempted
+			// during it. If it returns WITH events (count>0) after a long wall time, the
+			// events were ready but the thread could not be scheduled to return them = off-CPU.
+			const auto ew_start = std::chrono::steady_clock::now();
+			struct rusage ru_ew_start;
+			::getrusage(RUSAGE_THREAD, &ru_ew_start);
+#endif	// OME_LATENCY_PROBE
+
 			int count = EpollWait(100);
+
+#ifdef OME_LATENCY_PROBE
+			auto ew_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - ew_start).count();
+			if (count > 0 && ew_ms > 20)
+			{
+				struct rusage ru_ew_end;
+				::getrusage(RUSAGE_THREAD, &ru_ew_end);
+				EpollWaitLog(ew_ms, count,
+							 ru_ew_end.ru_nivcsw - ru_ew_start.ru_nivcsw,
+							 ru_ew_end.ru_nvcsw - ru_ew_start.ru_nvcsw);
+			}
+
+			const auto iteration_started = std::chrono::steady_clock::now();
+			struct rusage ru_start;
+			::getrusage(RUSAGE_THREAD, &ru_start);
+#endif	// OME_LATENCY_PROBE
 
 			if (count < 0)
 			{
@@ -480,6 +544,20 @@ namespace ov
 			GarbageCollection();
 
 			MergeSocketList();
+
+#ifdef OME_LATENCY_PROBE
+			auto iteration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - iteration_started).count();
+			if (iteration_ms > 20)
+			{
+				struct rusage ru_end;
+				::getrusage(RUSAGE_THREAD, &ru_end);
+				SpwStallLog(iteration_ms, count,
+							ru_end.ru_nivcsw - ru_start.ru_nivcsw,
+							ru_end.ru_nvcsw - ru_start.ru_nvcsw,
+							ru_end.ru_minflt - ru_start.ru_minflt,
+							ru_end.ru_majflt - ru_start.ru_majflt);
+			}
+#endif	// OME_LATENCY_PROBE
 		}
 
 		// Clean up all sockets

--- a/src/projects/base/ovsocket/socket_pool/socket_pool_worker.cpp
+++ b/src/projects/base/ovsocket/socket_pool/socket_pool_worker.cpp
@@ -16,6 +16,7 @@
 #include <sys/prctl.h>
 #include <sys/resource.h>
 #include <sys/syscall.h>
+#include <unistd.h>
 
 #include <chrono>
 

--- a/src/projects/modules/http/server/http_exchange.cpp
+++ b/src/projects/modules/http/server/http_exchange.cpp
@@ -12,6 +12,21 @@
 #include "http_connection.h"
 #include "http_server_manager.h"
 
+#ifdef OME_LATENCY_PROBE
+#include <chrono>
+
+#include <base/ovlibrary/latency_probe.h>
+
+// Latency probe (OME_LATENCY_PROBE only): per-request OME-internal handling time
+// (request received -> response ready) for "response too late / not sent" analysis.
+static void HttpRespLog(int64_t handle_ms, int status, int64_t sent, const char *method, const char *uri)
+{
+	ov::LatencyProbeLog("HTTP", "handle_ms=%lld status=%d sent=%lld method=%s uri=%s",
+						static_cast<long long>(handle_ms), status, static_cast<long long>(sent),
+						method ? method : "?", uri ? uri : "?");
+}
+#endif	// OME_LATENCY_PROBE
+
 namespace http
 {
 	namespace svr
@@ -48,6 +63,19 @@ namespace http
 			{
 				logtt("\n%s", GetDebugInfo().CStr());
 			}
+
+#ifdef OME_LATENCY_PROBE
+			{
+				auto req = GetRequest();
+				auto resp = GetResponse();
+				auto handle_ms = std::chrono::duration_cast<std::chrono::milliseconds>(resp->GetResponseTime() - req->GetCreateTime()).count();
+				HttpRespLog(handle_ms,
+							static_cast<int>(ov::ToUnderlyingType(resp->GetStatusCode())),
+							resp->GetSentSize(),
+							http::StringFromMethod(req->GetMethod()).CStr(),
+							req->GetUri().CStr());
+			}
+#endif	// OME_LATENCY_PROBE
 
 			_status = Status::Completed;
 			_connection->OnExchangeCompleted(GetSharedPtr());

--- a/src/projects/publishers/llhls/llhls_session.cpp
+++ b/src/projects/publishers/llhls/llhls_session.cpp
@@ -12,6 +12,25 @@
 #include "llhls_stream.h"
 #include "llhls_private.h"
 
+#ifdef OME_LATENCY_PROBE
+#include <modules/http/server/http_connection.h>
+#include <base/ovsocket/client_socket.h>
+#include <base/ovlibrary/latency_probe.h>
+
+#include <sys/syscall.h>
+
+// Latency probe (OME_LATENCY_PROBE only): log each serving stage
+// (K=kernel RX time of request bytes, R=request routed to session, D=response ready,
+// S=sent to socket layer). The K field (only meaningful on R lines) lets us prove, per
+// request, how long after the request bytes hit OME's kernel OME served it.
+static void LLHlsTraceLog(char stage, uint32_t session_id, const char *file, int64_t sent, int64_t kernel_ms = 0)
+{
+	ov::LatencyProbeLog("LLHLS", "stage=%c sid=%u tid=%ld sent=%ld K=%lld file=%s",
+						stage, session_id, static_cast<long>(::syscall(SYS_gettid)),
+						static_cast<long>(sent), static_cast<long long>(kernel_ms), file);
+}
+#endif	// OME_LATENCY_PROBE
+
 std::shared_ptr<LLHlsSession> LLHlsSession::Create(session_id_t session_id, 
 												const bool &origin_mode,
 												const ov::String &session_key,
@@ -223,6 +242,18 @@ void LLHlsSession::OnMessageReceived(const std::any &message)
 		ResponseData(exchange);
 		return;
 	}
+
+#ifdef OME_LATENCY_PROBE
+	int64_t rx_kernel_ms = 0;
+	if (auto conn = exchange->GetConnection(); conn != nullptr)
+	{
+		if (auto sock = conn->GetSocket(); sock != nullptr)
+		{
+			rx_kernel_ms = sock->GetLastRxKernelMs();
+		}
+	}
+	LLHlsTraceLog('R', GetId(), file.CStr(), 0, rx_kernel_ms);
+#endif	// OME_LATENCY_PROBE
 
 	auto llhls_stream = std::static_pointer_cast<LLHlsStream>(GetStream());
 	if (llhls_stream == nullptr)
@@ -796,7 +827,22 @@ void LLHlsSession::ResponsePartialSegment(const std::shared_ptr<http::svr::HttpE
 void LLHlsSession::ResponseData(const std::shared_ptr<http::svr::HttpExchange> &exchange)
 {
 	auto response = exchange->GetResponse();
+
+#ifdef OME_LATENCY_PROBE
+	ov::String trace_file = "-";
+	auto trace_request = exchange->GetRequest();
+	if (trace_request != nullptr && trace_request->GetParsedUri() != nullptr)
+	{
+		trace_file = trace_request->GetParsedUri()->File();
+	}
+	LLHlsTraceLog('D', GetId(), trace_file.CStr(), 0);
+#endif	// OME_LATENCY_PROBE
+
 	auto sent_size = response->Response();
+
+#ifdef OME_LATENCY_PROBE
+	LLHlsTraceLog('S', GetId(), trace_file.CStr(), sent_size);
+#endif	// OME_LATENCY_PROBE
 
 	if (sent_size > 0)
 	{

--- a/src/projects/publishers/llhls/llhls_session.cpp
+++ b/src/projects/publishers/llhls/llhls_session.cpp
@@ -25,9 +25,9 @@
 // request, how long after the request bytes hit OME's kernel OME served it.
 static void LLHlsTraceLog(char stage, uint32_t session_id, const char *file, int64_t sent, int64_t kernel_ms = 0)
 {
-	ov::LatencyProbeLog("LLHLS", "stage=%c sid=%u tid=%ld sent=%ld K=%lld file=%s",
+	ov::LatencyProbeLog("LLHLS", "stage=%c sid=%u tid=%ld sent=%lld K=%lld file=%s",
 						stage, session_id, static_cast<long>(::syscall(SYS_gettid)),
-						static_cast<long>(sent), static_cast<long long>(kernel_ms), file);
+						static_cast<long long>(sent), static_cast<long long>(kernel_ms), file);
 }
 #endif	// OME_LATENCY_PROBE
 

--- a/src/projects/publishers/llhls/llhls_session.cpp
+++ b/src/projects/publishers/llhls/llhls_session.cpp
@@ -18,6 +18,7 @@
 #include <base/ovlibrary/latency_probe.h>
 
 #include <sys/syscall.h>
+#include <unistd.h>
 
 // Latency probe (OME_LATENCY_PROBE only): log each serving stage
 // (K=kernel RX time of request bytes, R=request routed to session, D=response ready,

--- a/src/projects/publishers/llhls/llhls_stream.cpp
+++ b/src/projects/publishers/llhls/llhls_stream.cpp
@@ -23,6 +23,18 @@
 #include "llhls_private.h"
 #include "llhls_session.h"
 
+#ifdef OME_LATENCY_PROBE
+#include <base/ovlibrary/latency_probe.h>
+
+// Latency probe (OME_LATENCY_PROBE only) jitter analysis: log every segment/chunk creation,
+// so delayed/bursty creation can be inspected after a collapse. type=S (segment) has chunk=-1.
+static void SegCreateLog(char type, const char *stream, int32_t track, int64_t seg, int32_t chunk)
+{
+	ov::LatencyProbeLog("SEG", "type=%c stream=%s track=%d seg=%lld chunk=%d",
+						type, stream, track, static_cast<long long>(seg), chunk);
+}
+#endif	// OME_LATENCY_PROBE
+
 std::shared_ptr<LLHlsStream> LLHlsStream::Create(const std::shared_ptr<pub::Application> application, const info::Stream &info, bool origin_mode, uint32_t worker_count)
 {
 	auto stream = std::make_shared<LLHlsStream>(application, info, origin_mode, worker_count);
@@ -1785,6 +1797,10 @@ bool LLHlsStream::CheckPlaylistReady()
 
 void LLHlsStream::OnMediaSegmentCreated(const int32_t &track_id, const uint32_t &segment_number)
 {
+#ifdef OME_LATENCY_PROBE
+	SegCreateLog('S', GetName().CStr(), track_id, segment_number, -1);
+#endif	// OME_LATENCY_PROBE
+
 	// Check whether at least one segment of every track has been created.
 	CheckPlaylistReady();
 
@@ -1837,6 +1853,10 @@ void LLHlsStream::OnMediaSegmentCreated(const int32_t &track_id, const uint32_t 
 
 void LLHlsStream::OnMediaChunkUpdated(const int32_t &track_id, const uint32_t &segment_number, const uint32_t &chunk_number, bool last_chunk)
 {
+#ifdef OME_LATENCY_PROBE
+	SegCreateLog('C', GetName().CStr(), track_id, segment_number, chunk_number);
+#endif	// OME_LATENCY_PROBE
+
 	auto playlist = GetChunklistWriter(track_id);
 	if (playlist == nullptr)
 	{

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -1263,7 +1263,7 @@ bool TranscoderStream::CreateDecoder(MediaTrackId decoder_id, std::shared_ptr<in
 #ifdef OME_LATENCY_PROBE
 	// Latency probe (OME_LATENCY_PROBE only): pipeline creation latency. Serialized decoder/encoder
 	// creation can back up the pipeline; this records how long each element took to build.
-	ov::LatencyProbeLog("CREATE", "kind=decoder ms=%lld decoder=%d codec=%s in_track=%u name=%s",
+	ov::LatencyProbeLog("CREATE", "kind=decoder ms=%lld decoder=%u codec=%s in_track=%u name=%s",
 						static_cast<long long>(creation_timer.Elapsed()), decoder_id,
 						cmn::GetCodecIdString(input_track->GetCodecId()), input_track->GetId(), input_stream->GetName().CStr());
 #endif	// OME_LATENCY_PROBE
@@ -1441,7 +1441,7 @@ bool TranscoderStream::CreateEncoder(MediaTrackId encoder_id, std::shared_ptr<in
 	SetEncoderWithFilter(encoder_id, post_filter, encoder);
 
 #ifdef OME_LATENCY_PROBE
-	ov::LatencyProbeLog("CREATE", "kind=encoder ms=%lld encoder=%d codec=%s module=%s:%d out_track=%d name=%s",
+	ov::LatencyProbeLog("CREATE", "kind=encoder ms=%lld encoder=%u codec=%s module=%s:%d out_track=%u name=%s",
 						static_cast<long long>(creation_timer.Elapsed()), encoder_id,
 						cmn::GetCodecIdString(output_track->GetCodecId()),
 						cmn::GetCodecModuleIdString(encoder->GetModuleID()), encoder->GetDeviceID(),
@@ -1590,7 +1590,7 @@ bool TranscoderStream::CreateFilter(MediaTrackId filter_id, std::shared_ptr<info
 	logtd("%s Filter has been created. Id(%d), %s", _log_prefix.CStr(), filter_id, filter->GetDescription().CStr());
 
 #ifdef OME_LATENCY_PROBE
-	ov::LatencyProbeLog("CREATE", "kind=filter ms=%lld filter=%d name=%s",
+	ov::LatencyProbeLog("CREATE", "kind=filter ms=%lld filter=%u name=%s",
 						static_cast<long long>(creation_timer.Elapsed()), filter_id, input_stream->GetName().CStr());
 #endif	// OME_LATENCY_PROBE
 

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -18,6 +18,10 @@
 #include "transcoder_modules.h"
 #include "transcoder_private.h"
 
+#ifdef OME_LATENCY_PROBE
+#include <base/ovlibrary/latency_probe.h>
+#endif	// OME_LATENCY_PROBE
+
 #define UNUSED_VARIABLE(var) (void)var;
 #define MAX_FILLER_FRAMES 100
 #define FILLER_ENABLED true
@@ -1237,6 +1241,11 @@ bool TranscoderStream::CreateDecoder(MediaTrackId decoder_id, std::shared_ptr<in
 		return false;
 	}
 
+#ifdef OME_LATENCY_PROBE
+	ov::StopWatch creation_timer;
+	creation_timer.Start();
+#endif	// OME_LATENCY_PROBE
+
 	// Create a decoder
 	auto decoder = TranscodeDecoder::Create(
 		decoder_id,
@@ -1250,6 +1259,14 @@ bool TranscoderStream::CreateDecoder(MediaTrackId decoder_id, std::shared_ptr<in
 	}
 
 	SetDecoder(decoder_id, decoder);
+
+#ifdef OME_LATENCY_PROBE
+	// Latency probe (OME_LATENCY_PROBE only): pipeline creation latency. Serialized decoder/encoder
+	// creation can back up the pipeline; this records how long each element took to build.
+	ov::LatencyProbeLog("CREATE", "kind=decoder ms=%lld decoder=%d codec=%s in_track=%u name=%s",
+						static_cast<long long>(creation_timer.Elapsed()), decoder_id,
+						cmn::GetCodecIdString(input_track->GetCodecId()), input_track->GetId(), input_stream->GetName().CStr());
+#endif	// OME_LATENCY_PROBE
 
 	return true;
 }
@@ -1385,6 +1402,11 @@ bool TranscoderStream::CreateEncoder(MediaTrackId encoder_id, std::shared_ptr<in
 		return false;
 	}
 
+#ifdef OME_LATENCY_PROBE
+	ov::StopWatch creation_timer;
+	creation_timer.Start();
+#endif	// OME_LATENCY_PROBE
+
 	// Create Encoder
 	auto encoder = TranscodeEncoder::Create(
 		encoder_id, output_stream, output_track, candidates,
@@ -1417,6 +1439,14 @@ bool TranscoderStream::CreateEncoder(MediaTrackId encoder_id, std::shared_ptr<in
 	}
 
 	SetEncoderWithFilter(encoder_id, post_filter, encoder);
+
+#ifdef OME_LATENCY_PROBE
+	ov::LatencyProbeLog("CREATE", "kind=encoder ms=%lld encoder=%d codec=%s module=%s:%d out_track=%d name=%s",
+						static_cast<long long>(creation_timer.Elapsed()), encoder_id,
+						cmn::GetCodecIdString(output_track->GetCodecId()),
+						cmn::GetCodecModuleIdString(encoder->GetModuleID()), encoder->GetDeviceID(),
+						output_track->GetId(), output_stream->GetName().CStr());
+#endif	// OME_LATENCY_PROBE
 
 	ov::String description = ov::String::FormatString("Id(%d)<Codec:%s,Module:%s:%d>, OutputTrack(%d)",
 													  encoder_id, cmn::GetCodecIdString(output_track->GetCodecId()),
@@ -1544,6 +1574,11 @@ bool TranscoderStream::CreateFilter(MediaTrackId filter_id, std::shared_ptr<info
 		return true;
 	}
 
+#ifdef OME_LATENCY_PROBE
+	ov::StopWatch creation_timer;
+	creation_timer.Start();
+#endif	// OME_LATENCY_PROBE
+
 	auto filter = TranscodeFilter::Create(filter_id, input_stream, input_track, output_stream, output_track, bind(&TranscoderStream::OnFilteredFrame, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 	if (filter == nullptr)
 	{
@@ -1553,6 +1588,11 @@ bool TranscoderStream::CreateFilter(MediaTrackId filter_id, std::shared_ptr<info
 	SetFilter(filter_id, filter);
 
 	logtd("%s Filter has been created. Id(%d), %s", _log_prefix.CStr(), filter_id, filter->GetDescription().CStr());
+
+#ifdef OME_LATENCY_PROBE
+	ov::LatencyProbeLog("CREATE", "kind=filter ms=%lld filter=%d name=%s",
+						static_cast<long long>(creation_timer.Elapsed()), filter_id, input_stream->GetName().CStr());
+#endif	// OME_LATENCY_PROBE
 
 	return true;
 }
@@ -1587,6 +1627,11 @@ void TranscoderStream::ChangeOutputFormat(std::shared_ptr<MediaFrame> buffer)
 		return;
 	}
 
+#ifdef OME_LATENCY_PROBE
+	ov::StopWatch creation_timer;
+	creation_timer.Start();
+#endif	// OME_LATENCY_PROBE
+
 	// Update Track of Input Stream
 	UpdateInputTrack(buffer);
 
@@ -1608,6 +1653,11 @@ void TranscoderStream::ChangeOutputFormat(std::shared_ptr<MediaFrame> buffer)
 
 		return;
 	}
+
+#ifdef OME_LATENCY_PROBE
+	ov::LatencyProbeLog("CREATE", "kind=format ms=%lld in_track=%u",
+						static_cast<long long>(creation_timer.Elapsed()), buffer->GetTrackId());
+#endif	// OME_LATENCY_PROBE
 }
 
 // Information of the input track is updated by the decoded frame


### PR DESCRIPTION
## Problem

Diagnosing where request-serving time goes, or where epoll worker threads stall, currently means hand-patching temporary instrumentation into hot paths and rebuilding. There is no built-in, low-overhead way to trace when a request arrived in the kernel versus when OME actually served it, or to observe worker-loop and pipeline-creation stalls.

## Solution

This adds an opt-in build option `OME_LATENCY_PROBE`, OFF by default so no probe code is compiled and normal builds carry zero runtime cost. When enabled, the serving path and socket workers append time-ordered records to a single `latency_probe.log`: per-request kernel-arrival to serve latency (`LLHLS`, `HTTP`), epoll-wait and worker-iteration stalls (`EPOLL`, `SPW`), receive lateness and send backpressure (`RECV_LATE`, `SEND_STALL`), segment and chunk creation (`SEG`), and transcoder element creation time (`CREATE`). The output directory is selected at runtime with the `OME_LATENCY_PROBE_DIR` environment variable and defaults to `/dev/shm`.

## Test

Built with the option OFF (default): the binary contains no probe symbols and behavior is unchanged. Built with `-DOME_LATENCY_PROBE=ON`: ran the server, issued HTTP requests, and confirmed the one-time startup banner on stderr plus `latency_probe.log` populated with time-ordered records at the directory given by `OME_LATENCY_PROBE_DIR`.

Pass conditions: the OFF build links with zero probe symbols; the ON build writes serving-path and worker-stall records to the single file at the configured location.
