### PR TITLE
feat: enable jemalloc background purge by default, configurable via Server.xml

### DIFF
--- a/misc/conf_examples/Edge.xml
+++ b/misc/conf_examples/Edge.xml
@@ -34,6 +34,12 @@
 			<Enable>false</Enable>
 			<MaxClientPeersPerHostPeer>2</MaxClientPeersPerHostPeer>
 		</P2P>
+
+		<!-- jemalloc allocator tuning (effective only in jemalloc builds) -->
+		<Jemalloc>
+			<!-- Run memory decay/purge on a background thread instead of the allocating thread. Enabled by default. -->
+			<BackgroundPurge>true</BackgroundPurge>
+		</Jemalloc>
 	</Modules>
 
 	<!-- Settings for the ports to bind -->

--- a/misc/conf_examples/Origin.xml
+++ b/misc/conf_examples/Origin.xml
@@ -32,6 +32,12 @@
 			<Enable>false</Enable>
 			<MaxClientPeersPerHostPeer>2</MaxClientPeersPerHostPeer>
 		</P2P>
+
+		<!-- jemalloc allocator tuning (effective only in jemalloc builds) -->
+		<Jemalloc>
+			<!-- Run memory decay/purge on a background thread instead of the allocating thread. Enabled by default. -->
+			<BackgroundPurge>true</BackgroundPurge>
+		</Jemalloc>
 	</Modules>
 
 	<!-- Settings for the ports to bind -->

--- a/misc/conf_examples/Server.xml
+++ b/misc/conf_examples/Server.xml
@@ -35,6 +35,12 @@
 			<Enable>false</Enable>
 			<MaxClientPeersPerHostPeer>2</MaxClientPeersPerHostPeer>
 		</P2P>
+
+		<!-- jemalloc allocator tuning (effective only in jemalloc builds) -->
+		<Jemalloc>
+			<!-- Run memory decay/purge on a background thread instead of the allocating thread. Enabled by default. -->
+			<BackgroundPurge>true</BackgroundPurge>
+		</Jemalloc>
 	</Modules>
 
 	<!-- Settings for the ports to bind -->

--- a/src/projects/config/items/modules/jemalloc.h
+++ b/src/projects/config/items/modules/jemalloc.h
@@ -1,0 +1,32 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Copyright (c) 2024 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+namespace cfg
+{
+	namespace modules
+	{
+		struct Jemalloc : public Item
+		{
+		protected:
+			// Run memory decay/purge on a dedicated background thread instead of the allocating
+			// thread, smoothing out latency spikes. Enabled by default; effective only when OME is
+			// built with jemalloc.
+			bool _background_purge = true;
+
+		public:
+			CFG_DECLARE_CONST_REF_GETTER_OF(IsBackgroundPurgeEnabled, _background_purge)
+
+		protected:
+			void MakeList() override
+			{
+				Register<Optional>("BackgroundPurge", &_background_purge);
+			}
+		};
+	}  // namespace modules
+}  // namespace cfg

--- a/src/projects/config/items/modules/modules.h
+++ b/src/projects/config/items/modules/modules.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "jemalloc.h"
+#include "module_template.h"
 #include "p2p.h"
 #include "recovery.h"
 #include "whisper.h"

--- a/src/projects/config/items/modules/modules.h
+++ b/src/projects/config/items/modules/modules.h
@@ -8,6 +8,7 @@
 //==============================================================================
 #pragma once
 
+#include "jemalloc.h"
 #include "p2p.h"
 #include "recovery.h"
 #include "whisper.h"
@@ -31,6 +32,7 @@ namespace cfg
 			// Experimental feature is disabled by default
 			ModuleTemplate _ertmp{false};
 			Whisper _whisper;
+			Jemalloc _jemalloc;
 
 		public:
 			CFG_DECLARE_CONST_REF_GETTER_OF(GetHttp2, _http2)
@@ -41,6 +43,7 @@ namespace cfg
 			CFG_DECLARE_CONST_REF_GETTER_OF(GetETag, _etag)
 			CFG_DECLARE_CONST_REF_GETTER_OF(GetERTMP, _ertmp)
 			CFG_DECLARE_CONST_REF_GETTER_OF(GetWhisper, _whisper)
+			CFG_DECLARE_CONST_REF_GETTER_OF(GetJemalloc, _jemalloc)
 
 		protected:
 			void MakeList() override
@@ -53,6 +56,7 @@ namespace cfg
 				Register<Optional>("ETag", &_etag);
 				Register<Optional>({"ERTMP", "ertmp"}, &_ertmp);
 				Register<Optional>("Whisper", &_whisper);
+				Register<Optional>("Jemalloc", &_jemalloc);
 			}
 		};
 	}  // namespace modules

--- a/src/projects/main/third_parties.cpp
+++ b/src/projects/main/third_parties.cpp
@@ -15,6 +15,7 @@
 #	include <jemalloc/jemalloc.h>
 #endif	// OME_USE_JEMALLOC
 
+#include <config/config_manager.h>
 #include <spdlog/spdlog.h>
 
 #include <regex>
@@ -359,6 +360,31 @@ std::shared_ptr<ov::Error> InitializeJemalloc()
 #	ifdef OME_USE_JEMALLOC_PROFILE
 	logw(JEMALLOC_LOG_TAG, "Jemalloc profiling is enabled - this may slow down the performance.");
 #	endif	// OME_USE_JEMALLOC_PROFILE
+
+	// Enable jemalloc's background purge thread. This moves decay/purge work off the allocating
+	// (serving) thread onto a dedicated thread, which smooths out latency spikes. jemalloc leaves
+	// this OFF by default, so OME opts in here (configurable via <Modules><Jemalloc> in Server.xml,
+	// default on). It is fork-safe because OME forks only once at daemonize, before this runs, so
+	// no background thread exists across that fork.
+	const bool enable_background_thread = cfg::ConfigManager::GetInstance()->GetServer()->GetModules().GetJemalloc().IsBackgroundPurgeEnabled();
+
+	if (enable_background_thread)
+	{
+		bool bg			 = true;
+		const int result = ::mallctl("background_thread", nullptr, nullptr, &bg, sizeof(bg));
+		if (result == 0)
+		{
+			logi(JEMALLOC_LOG_TAG, "Jemalloc background purge thread is enabled.");
+		}
+		else
+		{
+			logw(JEMALLOC_LOG_TAG, "Could not enable the jemalloc background purge thread (mallctl returned %d).", result);
+		}
+	}
+	else
+	{
+		logi(JEMALLOC_LOG_TAG, "Jemalloc background purge thread is disabled by configuration.");
+	}
 #endif		// OME_USE_JEMALLOC
 
 	return nullptr;

--- a/src/projects/main/third_parties.cpp
+++ b/src/projects/main/third_parties.cpp
@@ -12,10 +12,10 @@
 #include <base/ovsocket/ovsocket.h>
 #include <srt/srt.h>
 #ifdef OME_USE_JEMALLOC
+#	include <config/config_manager.h>
 #	include <jemalloc/jemalloc.h>
 #endif	// OME_USE_JEMALLOC
 
-#include <config/config_manager.h>
 #include <spdlog/spdlog.h>
 
 #include <regex>


### PR DESCRIPTION
## Problem

jemalloc runs memory decay/purge on the allocating thread by default, so under load that reclamation work adds latency to the serving path. OME had no way to move it off the allocating thread or to tune it.

## Solution

Enable jemalloc's background purge thread at startup so decay/purge runs on a dedicated thread instead of the allocating thread. It is on by default and configurable via `<Modules><Jemalloc><BackgroundPurge>` in Server.xml, and it is effective only in jemalloc builds. This is fork-safe because OME forks only once at daemonize, before allocator initialization runs.

## Test

Built Release (jemalloc enabled) and ran the server. With `<BackgroundPurge>true</BackgroundPurge>` (the default) the startup log shows "Jemalloc background purge thread is enabled"; with `false` it shows "disabled by configuration"; omitting the element keeps it enabled.

Pass conditions: the config value toggles whether the background purge thread is enabled, as reflected in the startup log.
