### PR TITLE
feat(tr): add generic data plane interface for media frame backends

### DIFF
--- a/src/projects/modules/ffmpeg/ffmpeg_filter_graph.cpp
+++ b/src/projects/modules/ffmpeg/ffmpeg_filter_graph.cpp
@@ -9,6 +9,11 @@
 
 #include "ffmpeg_filter_graph.h"
 
+extern "C"
+{
+#include <libavutil/imgutils.h>
+#include <libavutil/pixdesc.h>
+}
 namespace ffmpeg
 {
 	FFmpegFilterGraph::~FFmpegFilterGraph()
@@ -126,6 +131,19 @@ namespace ffmpeg
 			}
 			else
 			{
+				AVPixelFormat pix_fmt = compat::ToAVPixelFormat(host_holder->GetPixelFormat());
+				if (pix_fmt == AV_PIX_FMT_NONE)
+				{
+					return CodecResult::InvalidData;
+				}
+
+				// Validate before copying the host planes into the AVFrame.
+				int planes = ::av_pix_fmt_count_planes(pix_fmt);
+				if (planes <= 0 || host_holder->GetPlaneCount() != planes)
+				{
+					return CodecResult::InvalidData;
+				}
+
 				// Build a new AVFrame from the generic host planes.
 				// For future non-FFmpeg backends; such a backend must override
 				// GetPixelFormat()/GetPlaneCount()/GetPlaneData()/GetStride().
@@ -135,13 +153,7 @@ namespace ffmpeg
 					return CodecResult::NoMemory;
 				}
 
- 				AVPixelFormat pix_fmt = compat::ToAVPixelFormat(host_holder->GetPixelFormat());
- 				if (pix_fmt == AV_PIX_FMT_NONE)
- 				{
- 					::av_frame_free(&local_frame);
- 					return CodecResult::InvalidData;
- 				}
- 				local_frame->format = static_cast<int>(pix_fmt);
+				local_frame->format = static_cast<int>(pix_fmt);
 				local_frame->width	= media_frame->GetWidth();
 				local_frame->height = media_frame->GetHeight();
 
@@ -155,23 +167,15 @@ namespace ffmpeg
 					return (rc == AVERROR(ENOMEM)) ? CodecResult::NoMemory : CodecResult::InvalidData;
 				}
 
-				// Validate before copying the host planes into the AVFrame.
-				int planes = ::av_pix_fmt_count_planes(static_cast<AVPixelFormat>(local_frame->format));
-				if (planes <= 0 || host_holder->GetPlaneCount() != planes)
+				const uint8_t *src_data[AV_NUM_DATA_POINTERS] = { nullptr };
+				int src_linesize[AV_NUM_DATA_POINTERS]		  = { 0 };
+				int min_linesize[AV_NUM_DATA_POINTERS] = { 0 };
+
+				if (::av_image_fill_linesizes(min_linesize, static_cast<AVPixelFormat>(local_frame->format), local_frame->width) < 0)
 				{
 					::av_frame_free(&local_frame);
 					return CodecResult::InvalidData;
 				}
-
-				const uint8_t *src_data[AV_NUM_DATA_POINTERS] = { nullptr };
-				int src_linesize[AV_NUM_DATA_POINTERS]		  = { 0 };
- 				int min_linesize[AV_NUM_DATA_POINTERS] = { 0 };
-
-				if (::av_image_fill_linesizes(min_linesize, static_cast<AVPixelFormat>(local_frame->format), local_frame->width) < 0)
-				{
- 					::av_frame_free(&local_frame);
- 					return CodecResult::InvalidData;
- 				}
 
 				for (int i = 0; i < planes && i < AV_NUM_DATA_POINTERS; i++)
 				{
@@ -190,18 +194,16 @@ namespace ffmpeg
 								static_cast<AVPixelFormat>(local_frame->format),
 								local_frame->width, local_frame->height);
 
-				local_frame->pts = media_frame->GetPts();
-				src_frame		 = local_frame;
+				local_frame->pts	  = media_frame->GetPts();
+				local_frame->pkt_dts  = media_frame->GetPts();
+				local_frame->duration = media_frame->GetDuration();
+				src_frame			  = local_frame;
 			}
 		}
 
 		if (src_frame == nullptr)
 		{
-			if (local_frame != nullptr)
-			{
-				::av_frame_free(&local_frame);
-			}
-			return CodecResult::NoMemory;
+			return CodecResult::InvalidData;
 		}
 
 		CodecResult result = ToCodecResult(::av_buffersrc_write_frame(_buffersrc_ctx, src_frame));

--- a/src/projects/modules/ffmpeg/ffmpeg_filter_graph.cpp
+++ b/src/projects/modules/ffmpeg/ffmpeg_filter_graph.cpp
@@ -94,14 +94,22 @@ namespace ffmpeg
 		}
 
 		const auto &data = media_frame->GetData();
+		if(data == nullptr)
+		{
+			return CodecResult::InvalidData;
+		}
 
 		std::shared_ptr<MediaFrameData> host_holder;
-		AVFrame *src_frame	 = static_cast<AVFrame *>(media_frame->GetPrivData());
-
-		// GPU to CPU transfer
+		AVFrame *src_frame	 = nullptr;
 		AVFrame *local_frame = nullptr;	 // built from generic host planes; freed below
 
-		if (hwframe_transfer && data != nullptr && data->IsHardwareFrame())
+		// GPU to CPU transfer
+		if (hwframe_transfer == false && data->GetBackend() == MediaFrameData::Backend::FFmpeg)
+		{
+			// Software / already-host FFmpeg frame: use its AVFrame directly.
+			src_frame = static_cast<AVFrame *>(data->GetNativeHandle());
+		}
+		else if (hwframe_transfer == true && data->IsHardwareFrame())
 		{
 			// Download to host memory(CPU)
 			host_holder = data->DownloadToHost();
@@ -139,14 +147,27 @@ namespace ffmpeg
 					return CodecResult::NoMemory;
 				}
 
+				// Validate before copying the host planes into the AVFrame.
+				int planes = ::av_pix_fmt_count_planes(static_cast<AVPixelFormat>(local_frame->format));
+				if (planes <= 0 || host_holder->GetPlaneCount() != planes)
+				{
+					::av_frame_free(&local_frame);
+					return CodecResult::InvalidData;
+				}
+
 				const uint8_t *src_data[AV_NUM_DATA_POINTERS] = { nullptr };
 				int src_linesize[AV_NUM_DATA_POINTERS]		  = { 0 };
 
-				int planes = host_holder->GetPlaneCount();
 				for (int i = 0; i < planes && i < AV_NUM_DATA_POINTERS; i++)
 				{
 					src_data[i]		= host_holder->GetPlaneData(i);
 					src_linesize[i] = host_holder->GetStride(i);
+
+					if (src_data[i] == nullptr || src_linesize[i] <= 0)
+					{
+						::av_frame_free(&local_frame);
+						return CodecResult::InvalidData;
+					}
 				}
 
 				::av_image_copy(local_frame->data, local_frame->linesize,

--- a/src/projects/modules/ffmpeg/ffmpeg_filter_graph.cpp
+++ b/src/projects/modules/ffmpeg/ffmpeg_filter_graph.cpp
@@ -128,6 +128,12 @@ namespace ffmpeg
 			{
 				// Reuse the AVFrame
 				src_frame = static_cast<AVFrame *>(host_holder->GetNativeHandle());
+				if (src_frame != nullptr)
+				{
+					src_frame->pts		 = media_frame->GetPts();
+					src_frame->pkt_dts	 = media_frame->GetPts();
+					src_frame->duration = media_frame->GetDuration();
+				}
 			}
 			else
 			{

--- a/src/projects/modules/ffmpeg/ffmpeg_filter_graph.cpp
+++ b/src/projects/modules/ffmpeg/ffmpeg_filter_graph.cpp
@@ -104,7 +104,8 @@ namespace ffmpeg
 		AVFrame *local_frame = nullptr;	 // built from generic host planes; freed below
 
 		// GPU to CPU transfer
-		if (hwframe_transfer == false && data->GetBackend() == MediaFrameData::Backend::FFmpeg)
+		if (data->GetBackend() == MediaFrameData::Backend::FFmpeg &&
+			(hwframe_transfer == false || data->IsHardwareFrame() == false))
 		{
 			// Software / already-host FFmpeg frame: use its AVFrame directly.
 			src_frame = static_cast<AVFrame *>(data->GetNativeHandle());
@@ -134,17 +135,24 @@ namespace ffmpeg
 					return CodecResult::NoMemory;
 				}
 
-				local_frame->format = static_cast<int>(compat::ToAVPixelFormat(host_holder->GetPixelFormat()));
+ 				AVPixelFormat pix_fmt = compat::ToAVPixelFormat(host_holder->GetPixelFormat());
+ 				if (pix_fmt == AV_PIX_FMT_NONE)
+ 				{
+ 					::av_frame_free(&local_frame);
+ 					return CodecResult::InvalidData;
+ 				}
+ 				local_frame->format = static_cast<int>(pix_fmt);
 				local_frame->width	= media_frame->GetWidth();
 				local_frame->height = media_frame->GetHeight();
 
 				// Copy the host planes into an owned (reference-counted) buffer so the
 				// data stays valid after host_holder is released, and the filter graph
 				// can reference the frame without copying it again.
-				if (::av_frame_get_buffer(local_frame, 0) < 0)
+				int rc = ::av_frame_get_buffer(local_frame, 0);
+				if (rc < 0)
 				{
 					::av_frame_free(&local_frame);
-					return CodecResult::NoMemory;
+					return (rc == AVERROR(ENOMEM)) ? CodecResult::NoMemory : CodecResult::InvalidData;
 				}
 
 				// Validate before copying the host planes into the AVFrame.
@@ -157,13 +165,20 @@ namespace ffmpeg
 
 				const uint8_t *src_data[AV_NUM_DATA_POINTERS] = { nullptr };
 				int src_linesize[AV_NUM_DATA_POINTERS]		  = { 0 };
+ 				int min_linesize[AV_NUM_DATA_POINTERS] = { 0 };
+
+				if (::av_image_fill_linesizes(min_linesize, static_cast<AVPixelFormat>(local_frame->format), local_frame->width) < 0)
+				{
+ 					::av_frame_free(&local_frame);
+ 					return CodecResult::InvalidData;
+ 				}
 
 				for (int i = 0; i < planes && i < AV_NUM_DATA_POINTERS; i++)
 				{
 					src_data[i]		= host_holder->GetPlaneData(i);
 					src_linesize[i] = host_holder->GetStride(i);
 
-					if (src_data[i] == nullptr || src_linesize[i] <= 0)
+					if (src_data[i] == nullptr || src_linesize[i] < min_linesize[i])
 					{
 						::av_frame_free(&local_frame);
 						return CodecResult::InvalidData;

--- a/src/projects/modules/ffmpeg/ffmpeg_filter_graph.cpp
+++ b/src/projects/modules/ffmpeg/ffmpeg_filter_graph.cpp
@@ -144,6 +144,11 @@ namespace ffmpeg
 					return CodecResult::InvalidData;
 				}
 
+				if (media_frame->GetWidth() <= 0 || media_frame->GetHeight() <= 0)
+				{
+					return CodecResult::InvalidData;
+				}
+
 				// Build a new AVFrame from the generic host planes.
 				// For future non-FFmpeg backends; such a backend must override
 				// GetPixelFormat()/GetPlaneCount()/GetPlaneData()/GetStride().

--- a/src/projects/modules/ffmpeg/ffmpeg_filter_graph.cpp
+++ b/src/projects/modules/ffmpeg/ffmpeg_filter_graph.cpp
@@ -96,26 +96,86 @@ namespace ffmpeg
 		const auto &data = media_frame->GetData();
 
 		std::shared_ptr<MediaFrameData> host_holder;
-		AVFrame *src_frame = static_cast<AVFrame *>(media_frame->GetPrivData());
+		AVFrame *src_frame	 = static_cast<AVFrame *>(media_frame->GetPrivData());
 
-		// GPU to CPU transfer 
+		// GPU to CPU transfer
+		AVFrame *local_frame = nullptr;	 // built from generic host planes; freed below
+
 		if (hwframe_transfer && data != nullptr && data->IsHardwareFrame())
 		{
+			// Download to host memory(CPU)
 			host_holder = data->DownloadToHost();
 			if (host_holder == nullptr)
 			{
 				return CodecResult::NoMemory;
 			}
 
-			src_frame = static_cast<AVFrame *>(host_holder->GetNativeHandle());
+			if (host_holder->GetBackend() == MediaFrameData::Backend::FFmpeg)
+			{
+				// Reuse the AVFrame
+				src_frame = static_cast<AVFrame *>(host_holder->GetNativeHandle());
+			}
+			else
+			{
+				// Build a new AVFrame from the generic host planes.
+				// For future non-FFmpeg backends; such a backend must override
+				// GetPixelFormat()/GetPlaneCount()/GetPlaneData()/GetStride().
+				local_frame = ::av_frame_alloc();
+				if (local_frame == nullptr)
+				{
+					return CodecResult::NoMemory;
+				}
+
+				local_frame->format = static_cast<int>(compat::ToAVPixelFormat(host_holder->GetPixelFormat()));
+				local_frame->width	= media_frame->GetWidth();
+				local_frame->height = media_frame->GetHeight();
+
+				// Copy the host planes into an owned (reference-counted) buffer so the
+				// data stays valid after host_holder is released, and the filter graph
+				// can reference the frame without copying it again.
+				if (::av_frame_get_buffer(local_frame, 0) < 0)
+				{
+					::av_frame_free(&local_frame);
+					return CodecResult::NoMemory;
+				}
+
+				const uint8_t *src_data[AV_NUM_DATA_POINTERS] = { nullptr };
+				int src_linesize[AV_NUM_DATA_POINTERS]		  = { 0 };
+
+				int planes = host_holder->GetPlaneCount();
+				for (int i = 0; i < planes && i < AV_NUM_DATA_POINTERS; i++)
+				{
+					src_data[i]		= host_holder->GetPlaneData(i);
+					src_linesize[i] = host_holder->GetStride(i);
+				}
+
+				::av_image_copy(local_frame->data, local_frame->linesize,
+								src_data, src_linesize,
+								static_cast<AVPixelFormat>(local_frame->format),
+								local_frame->width, local_frame->height);
+
+				local_frame->pts = media_frame->GetPts();
+				src_frame		 = local_frame;
+			}
 		}
 
 		if (src_frame == nullptr)
 		{
+			if (local_frame != nullptr)
+			{
+				::av_frame_free(&local_frame);
+			}
 			return CodecResult::NoMemory;
 		}
 
-		return ToCodecResult(::av_buffersrc_write_frame(_buffersrc_ctx, src_frame));
+		CodecResult result = ToCodecResult(::av_buffersrc_write_frame(_buffersrc_ctx, src_frame));
+
+		if (local_frame != nullptr)
+		{
+			::av_frame_free(&local_frame);
+		}
+
+		return result;
 	}
 
 	ReceiveResult FFmpegFilterGraph::PullFrame()

--- a/src/projects/modules/ffmpeg/ffmpeg_filter_graph.h
+++ b/src/projects/modules/ffmpeg/ffmpeg_filter_graph.h
@@ -21,8 +21,6 @@ extern "C"
 #include <libavfilter/buffersink.h>
 #include <libavfilter/buffersrc.h>
 #include <libavutil/frame.h>
-#include <libavutil/imgutils.h>
-#include <libavutil/pixdesc.h>
 }
 
 namespace ffmpeg

--- a/src/projects/modules/ffmpeg/ffmpeg_filter_graph.h
+++ b/src/projects/modules/ffmpeg/ffmpeg_filter_graph.h
@@ -21,6 +21,7 @@ extern "C"
 #include <libavfilter/buffersink.h>
 #include <libavfilter/buffersrc.h>
 #include <libavutil/frame.h>
+#include <libavutil/imgutils.h>
 }
 
 namespace ffmpeg

--- a/src/projects/modules/ffmpeg/ffmpeg_filter_graph.h
+++ b/src/projects/modules/ffmpeg/ffmpeg_filter_graph.h
@@ -22,6 +22,7 @@ extern "C"
 #include <libavfilter/buffersrc.h>
 #include <libavutil/frame.h>
 #include <libavutil/imgutils.h>
+#include <libavutil/pixdesc.h>
 }
 
 namespace ffmpeg

--- a/src/projects/modules/ffmpeg/ffmpeg_media_frame.cpp
+++ b/src/projects/modules/ffmpeg/ffmpeg_media_frame.cpp
@@ -96,7 +96,7 @@ namespace ffmpeg
 	int FFmpegMediaFrameData::GetPlaneCount() const
 	{
 		// Host pixel planes only;
-		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr)
+		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr || _frame->width <= 0 || _frame->height <= 0)
 		{
 			return 0;
 		}
@@ -108,7 +108,8 @@ namespace ffmpeg
 	const uint8_t *FFmpegMediaFrameData::GetPlaneData(int plane) const
 	{
 		// Host pixel planes only; a hardware frame has no CPU-side data.
-		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr || plane < 0 || plane >= AV_NUM_DATA_POINTERS)
+		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr || _frame->width <= 0 || _frame->height <= 0 ||
+			plane < 0 || plane >= AV_NUM_DATA_POINTERS)
 		{
 			return nullptr;
 		}

--- a/src/projects/modules/ffmpeg/ffmpeg_media_frame.cpp
+++ b/src/projects/modules/ffmpeg/ffmpeg_media_frame.cpp
@@ -8,6 +8,7 @@
 //==============================================================================
 
 #include "ffmpeg_media_frame.h"
+#include "compat.h"
 
 namespace ffmpeg
 {
@@ -90,6 +91,50 @@ namespace ffmpeg
 		host->pts = _frame->pts;
 
 		return std::make_shared<FFmpegMediaFrameData>(host);
+	}
+
+	int FFmpegMediaFrameData::GetPlaneCount() const
+	{
+		// Host pixel planes only;
+		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr)
+		{
+			return 0;
+		}
+
+		int planes = ::av_pix_fmt_count_planes(static_cast<AVPixelFormat>(_frame->format));
+		return (planes < 0) ? 0 : planes;
+	}
+
+	const uint8_t *FFmpegMediaFrameData::GetPlaneData(int plane) const
+	{
+		// Host pixel planes only; a hardware frame has no CPU-side data.
+		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr || plane < 0 || plane >= AV_NUM_DATA_POINTERS)
+		{
+			return nullptr;
+		}
+
+		return _frame->data[plane];
+	}
+
+	int FFmpegMediaFrameData::GetStride(int plane) const
+	{
+		// Host pixel planes only; a hardware frame has no CPU-side data.
+		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr || plane < 0 || plane >= AV_NUM_DATA_POINTERS)
+		{
+			return 0;
+		}
+
+		return _frame->linesize[plane];
+	}
+
+	cmn::VideoPixelFormatId FFmpegMediaFrameData::GetPixelFormat() const
+	{
+		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr)
+		{
+			return cmn::VideoPixelFormatId::None;
+		}
+
+		return ffmpeg::compat::ToVideoPixelFormat(_frame->format);
 	}
 
 	void FFmpegMediaFrameData::FillZero()

--- a/src/projects/modules/ffmpeg/ffmpeg_media_frame.cpp
+++ b/src/projects/modules/ffmpeg/ffmpeg_media_frame.cpp
@@ -119,7 +119,8 @@ namespace ffmpeg
 	int FFmpegMediaFrameData::GetStride(int plane) const
 	{
 		// Host pixel planes only; a hardware frame has no CPU-side data.
-		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr || plane < 0 || plane >= AV_NUM_DATA_POINTERS)
+		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr || _frame->width <= 0 || _frame->height <= 0 ||
+			plane < 0 || plane >= AV_NUM_DATA_POINTERS)
 		{
 			return 0;
 		}
@@ -129,7 +130,7 @@ namespace ffmpeg
 
 	cmn::VideoPixelFormatId FFmpegMediaFrameData::GetPixelFormat() const
 	{
-		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr)
+		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr || _frame->width <= 0 || _frame->height <= 0)
 		{
 			return cmn::VideoPixelFormatId::None;
 		}

--- a/src/projects/modules/ffmpeg/ffmpeg_media_frame.h
+++ b/src/projects/modules/ffmpeg/ffmpeg_media_frame.h
@@ -38,6 +38,12 @@ namespace ffmpeg
 		bool IsHardwareFrame() const override;
 		std::shared_ptr<MediaFrameData> DownloadToHost() const override;
 		void FillZero() override;
+
+		int GetPlaneCount() const override;
+		const uint8_t *GetPlaneData(int plane) const override;
+		int GetStride(int plane) const override;
+		cmn::VideoPixelFormatId GetPixelFormat() const override;
+
 		void SetPts(int64_t pts) override;
 		void SetDuration(int64_t duration) override;
 		void SetNbSamples(int32_t nb_samples) override;

--- a/src/projects/transcoder/media_frame.h
+++ b/src/projects/transcoder/media_frame.h
@@ -41,6 +41,12 @@ public:
 	virtual bool IsHardwareFrame() const = 0;
 	virtual std::shared_ptr<MediaFrameData> DownloadToHost() const = 0;
 	virtual void FillZero() = 0;
+
+	virtual int GetPlaneCount() const { return 0; }
+	virtual const uint8_t *GetPlaneData(int plane) const { return nullptr; }
+	virtual int GetStride(int plane) const { return 0; }
+	virtual cmn::VideoPixelFormatId GetPixelFormat() const { return cmn::VideoPixelFormatId::None; }
+
 	virtual void SetPts(int64_t pts) = 0;
 	virtual void SetDuration(int64_t duration) = 0;
 	virtual void SetNbSamples(int32_t nb_samples) = 0;


### PR DESCRIPTION
## Summary

Adds a backend-agnostic data plane interface to MediaFrameData, letting the FFmpeg filter graph accept host frames from any backend. This is a groundwork change for upcoming non-FFmpeg backends (NVIDIA / Netint / Others SDK). The existing FFmpeg path is untouched, so there's no behavior change today.

## Changes

- Add host-plane accessors to the `MediaFrameData` interface:
  - `GetPlaneCount()`, `GetPlaneData()`, `GetStride()`, `GetPixelFormat()`
- Implement them in `FFmpegMediaFrameData` — host frames only
- In `FFmpegFilterGraph::PushFrame()`:
  - Reuse the existing `AVFrame` when the downloaded host frame is an FFmpeg backend (unchanged behavior)

## Test

-  There is nothing to test in this PR
