### PR TITLE
fix(file): serialize file writer lifecycle to fix races during concurrent recording control (#2250)

### DIFF
--- a/src/base/ovlibrary/interval_gate.h
+++ b/src/base/ovlibrary/interval_gate.h
@@ -1,0 +1,66 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Keukhan
+//  Copyright (c) 2026 OvenMedia Labs. All rights reserved.
+//
+//==============================================================================
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+
+namespace ov
+{
+	// A thread-safe, self-repeating interval gate: TryConsume() returns true for at most one
+	// caller per `interval_ms` window, then closes until the interval elapses.
+	class IntervalGate
+	{
+	public:
+		explicit IntervalGate(int64_t interval_ms)
+			: _interval_ms(interval_ms)
+		{
+		}
+
+		// Returns true at most once per interval, then starts a new interval.
+		// Exactly one thread wins the CAS; all others get false until the next interval.
+		bool TryConsume()
+		{
+			const int64_t now = NowMs();
+			int64_t last	  = _last_fire_ms.load(std::memory_order_relaxed);
+
+			if ((now - last) < _interval_ms)
+			{
+				return false;
+			}
+
+			return _last_fire_ms.compare_exchange_strong(last, now, std::memory_order_relaxed);
+		}
+
+		// Returns true if a TryConsume() would currently fire, without consuming.
+		bool IsReady() const
+		{
+			return (NowMs() - _last_fire_ms.load(std::memory_order_relaxed)) >= _interval_ms;
+		}
+
+		// Close the gate at "now" so the next TryConsume() waits a full interval.
+		void Reset()
+		{
+			_last_fire_ms.store(NowMs(), std::memory_order_relaxed);
+		}
+
+	private:
+		static int64_t NowMs()
+		{
+			return std::chrono::duration_cast<std::chrono::milliseconds>(
+					   std::chrono::steady_clock::now().time_since_epoch())
+				.count();
+		}
+
+		const int64_t _interval_ms;
+		std::atomic<int64_t> _last_fire_ms{0};
+	};
+}  // namespace ov

--- a/src/base/ovlibrary/ovlibrary.h
+++ b/src/base/ovlibrary/ovlibrary.h
@@ -53,5 +53,6 @@
 #include "./sequencial_map.h"
 #include "./thread_checker.h"
 #include "./tsa/mutex.h"
+#include "./interval_gate.h"
 
 #include "./logger/logger.h"

--- a/src/modules/ffmpeg/CMakeLists.txt
+++ b/src/modules/ffmpeg/CMakeLists.txt
@@ -1,1 +1,8 @@
 ome_add_static_library(ffmpeg_wrapper)
+
+if(OME_BUILD_TESTS)
+    file(GLOB _srcs "${CMAKE_CURRENT_SOURCE_DIR}/*_test.cpp")
+    ome_add_tests(ome_test_modules
+        SRCS ${_srcs}
+    )
+endif()

--- a/src/modules/ffmpeg/writer.cpp
+++ b/src/modules/ffmpeg/writer.cpp
@@ -66,6 +66,8 @@ namespace ffmpeg
 		return _error_message;
 	}
 
+	// Interrupt callback for FFmpeg I/O operations
+	// 1 = interrupt, 0 = continue
 	int Writer::InterruptCallback(void *opaque)
 	{
 		Writer *writer = (Writer *)opaque;
@@ -101,7 +103,19 @@ namespace ffmpeg
 		}
 		else if(writer->GetState() == WriterStateClosing)
 		{
-			// In closing state, Ignore interrupt to finish flushing and closing properly.
+			// Nothing opened or written yet: nothing to finalize, so interrupt the pending I/O now.
+			if (writer->_need_to_flush.load() == false && writer->_need_to_close.load() == false)
+			{
+				return 1;
+			}
+
+			// Close timeout
+			int64_t elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+			if(elapsed_ms > writer->GetSendTimeout())
+			{
+				logae(writer, "Close timeout occurred. %" PRId64 " milliseconds. ", elapsed_ms);
+				return 1;
+			}
 		}
 
 		return 0;
@@ -113,6 +127,15 @@ namespace ffmpeg
 		{
 			logae(this, "Destination url is empty");
 			return false;
+		}
+
+		{
+			std::shared_lock<std::shared_mutex> mlock(_av_format_lock);
+			if (_av_format != nullptr)
+			{
+				logae(this, "URL is already set. Create a new Writer instead of reusing this one.");
+				return false;
+			}
 		}
 
 		_url = url;
@@ -149,14 +172,14 @@ namespace ffmpeg
 
 	std::shared_ptr<AVStream> Writer::CreateAVStream(const std::shared_ptr<const MediaTrack> &media_track)
 	{
-		auto av_format = GetAVFormatContext();
-		if (!av_format)
+		// Caller (AddTrack) must hold _av_format_lock
+		if (_av_format == nullptr)
 		{
 			logae(this, "Context is not available");
 			return nullptr;
 		}
 
-		AVStream *new_stream = avformat_new_stream(av_format.get(), nullptr);
+		AVStream *new_stream = avformat_new_stream(_av_format.get(), nullptr);
 		if (!new_stream)
 		{
 			logae(this, "Could not allocate stream");
@@ -224,6 +247,15 @@ namespace ffmpeg
 	{
 		// A missing Opus config is synthesized inside ToAVStream(); the track itself
 		// is a frozen snapshot here and must not be modified.
+
+		// Serialize with other context ops; concurrent AddTrack() corrupts the stream array.
+		std::lock_guard<std::shared_mutex> mlock(_av_format_lock);
+
+		if (_av_format == nullptr)
+		{
+			logae(this, "Context is not available");
+			return false;
+		}
 
 		// Video/Audio is mapped 1:1
 		if (media_track->GetMediaType() == cmn::MediaType::Video ||
@@ -309,18 +341,36 @@ namespace ffmpeg
 
 	bool Writer::Start()
 	{
+		// Only a fresh (None) or cleanly stopped (Closed) writer may start; any other state
+		// means a Start() is still in effect and restarting would corrupt the context.
+		const WriterState current_state = GetState();
+		if (current_state == WriterStateConnected ||
+			current_state == WriterStateConnecting ||
+			current_state == WriterStateClosing ||
+			current_state == WriterStateError)
+		{
+			logae(this, "Writer is already started. state:%s", WriterStateToString(current_state));
+			return false;
+		}
+
 		SetState(WriterStateConnecting);
 
 		_start_time = -1LL;
+
+		// Serialize open/write-header with SendPacket() and teardown.
+		std::lock_guard<std::shared_mutex> mlock(_av_format_lock);
+
 		_need_to_flush = false;
 		_need_to_close = false;
 
-		auto av_format = GetAVFormatContext();
-		if (av_format == nullptr)
+		if (_av_format == nullptr)
 		{
+			SetState(WriterStateError);
 			logae(this, "Context is not available");
 			return false;
 		}
+
+		auto *av_format = _av_format.get();
 
 		// Set service & provider metadata
 		av_dict_set(&av_format->metadata, "service_provider", "OvenMediaEngine", 0);
@@ -364,7 +414,9 @@ namespace ffmpeg
 		AVDictionary *format_options = nullptr;
 		av_dict_set_int(&format_options, "use_editlist", 0, 0);
 
-		if (avformat_write_header(av_format.get(), &format_options) < 0)
+		int error = avformat_write_header(av_format, &format_options);
+		av_dict_free(&format_options);
+		if (error < 0)
 		{
 			SetState(WriterStateError);
 			logae(this, "Could not create header");
@@ -375,7 +427,7 @@ namespace ffmpeg
 		_need_to_flush = true;
 
 		SetState(WriterStateConnected);
-		
+
 		return true;
 	}
 
@@ -427,6 +479,14 @@ namespace ffmpeg
 		if (!packet)
 		{
 			logaw("Invalid packet. packet is null. Dropping.");
+			return true;
+		}
+
+		// av_stream/context are owned by _av_format; hold the lock through the write so a
+		// concurrent Stop()/Split() can't free them mid-use (UAF). Drop if already torn down.
+		std::unique_lock<std::shared_mutex> mlock(_av_format_lock);
+		if (_av_format == nullptr || GetState() != WriterStateConnected)
+		{
 			return true;
 		}
 
@@ -614,19 +674,7 @@ namespace ffmpeg
 			}
 		}
 
-		auto av_format = GetAVFormatContext();
-		if (!av_format)
-		{
-			av_packet_unref(&av_packet);
-			SetState(WriterStateError);
-			logae(this, "Context is not available");
-
-			return false;
-		}
-
 		_last_packet_sent_time = std::chrono::steady_clock::now();
-
-		std::unique_lock<std::shared_mutex> mlock(_av_format_lock);
 
 		// Check DTS monotonicity. if not, drop the packet.
 		auto it = _track_last_dts_map.find(av_packet.stream_index);
@@ -643,7 +691,7 @@ namespace ffmpeg
 		}
 
 		// Write packet
-		int error = ::av_write_frame(av_format.get(), &av_packet);
+		int error = ::av_write_frame(_av_format.get(), &av_packet);
 		if (error != 0)
 		{
 			av_packet_unref(&av_packet);
@@ -677,32 +725,17 @@ namespace ffmpeg
 		return _last_packet_sent_time.load();
 	}
 
-	std::shared_ptr<AVFormatContext> Writer::GetAVFormatContext() const
-	{
-		std::shared_lock<std::shared_mutex> mlock(_av_format_lock);
-		return _av_format;
-	}
-
 	void Writer::SetAVFormatContext(AVFormatContext *av_format)
 	{
 		std::lock_guard<std::shared_mutex> mlock(_av_format_lock);
-		// forward _need_to_flush and _need_to_close to lambda
-		_av_format.reset(av_format, [&need_to_flush = _need_to_flush, &need_to_close = _need_to_close](AVFormatContext *av_format_ptr) {
+
+		// Deleter only frees. Finalization (trailer/close) is done in ReleaseAVFormatContext()
+		_av_format.reset(av_format, [](AVFormatContext *av_format_ptr) {
 			if (av_format_ptr == nullptr)
 			{
 				return;
 			}
 
-			if (need_to_flush)
-			{
-				av_write_trailer(av_format_ptr);
-			}
-
-			if (need_to_close && av_format_ptr->pb != nullptr)
-			{
-				avio_closep(&av_format_ptr->pb);
-			}
-			
 			avformat_free_context(av_format_ptr);
 		});
 
@@ -713,6 +746,26 @@ namespace ffmpeg
 	void Writer::ReleaseAVFormatContext()
 	{
 		std::lock_guard<std::shared_mutex> mlock(_av_format_lock);
+
+		// Finalize under the lock so trailer/close runs once, never racing a write.
+		if (_av_format != nullptr)
+		{
+			if (_need_to_flush)
+			{
+				// Time the flush itself (not prior idle) so a dead peer can't hang Stop().
+				_last_packet_sent_time = std::chrono::steady_clock::now();
+				av_write_trailer(_av_format.get());
+				_need_to_flush = false;
+			}
+
+			if (_need_to_close && _av_format->pb != nullptr)
+			{
+				_last_packet_sent_time = std::chrono::steady_clock::now();
+				avio_closep(&_av_format->pb);
+				_need_to_close = false;
+			}
+		}
+
 		_av_format = nullptr;
 		_need_to_flush = false;
 		_need_to_close = false;

--- a/src/modules/ffmpeg/writer.cpp
+++ b/src/modules/ffmpeg/writer.cpp
@@ -101,7 +101,8 @@ namespace ffmpeg
 				return 1;
 			}
 		}
-		else if(writer->GetState() == WriterStateClosing)
+		// Error: a racing SendPacket() flipped this after Stop() began closing; the trailer/close still runs, so bound it too.
+		else if(writer->GetState() == WriterStateClosing || writer->GetState() == WriterStateError)
 		{
 			// Nothing opened or written yet: nothing to finalize, so interrupt the pending I/O now.
 			if (writer->_need_to_flush.load() == false && writer->_need_to_close.load() == false)
@@ -109,9 +110,10 @@ namespace ffmpeg
 				return 1;
 			}
 
-			// Close timeout
+			// Close timeout: give the final flush enough time (temporarily 2x send timeout)
+			// TODO: add a dedicated CloseTimeout
 			int64_t elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
-			if(elapsed_ms > writer->GetSendTimeout())
+			if (elapsed_ms > (int64_t)writer->GetSendTimeout() * 2)
 			{
 				logae(writer, "Close timeout occurred. %" PRId64 " milliseconds. ", elapsed_ms);
 				return 1;

--- a/src/modules/ffmpeg/writer.cpp
+++ b/src/modules/ffmpeg/writer.cpp
@@ -757,6 +757,14 @@ namespace ffmpeg
 		_av_format = nullptr;
 		_need_to_flush = false;
 		_need_to_close = false;
+
+		_track_last_dts_map.clear();
+
+		{
+			std::lock_guard<std::shared_mutex> tlock(_track_map_lock);
+			_av_track_map.clear();
+			_event_track_map.clear();
+		}
 	}
 
 	std::pair<std::shared_ptr<AVStream>, std::shared_ptr<const MediaTrack>> Writer::GetTrack(int32_t track_id, cmn::BitstreamFormat format) const

--- a/src/modules/ffmpeg/writer.cpp
+++ b/src/modules/ffmpeg/writer.cpp
@@ -352,24 +352,19 @@ namespace ffmpeg
 
 	bool Writer::Start()
 	{
-		// Only a fresh (None) or cleanly stopped (Closed) writer may start; any other state
-		// means a Start() is still in effect and restarting would corrupt the context.
+		std::lock_guard<std::shared_mutex> mlock(_av_format_lock);
+
 		const WriterState current_state = GetState();
-		if (current_state == WriterStateConnected ||
-			current_state == WriterStateConnecting ||
-			current_state == WriterStateClosing ||
-			current_state == WriterStateError)
+		if (current_state != WriterStateNone &&
+			current_state != WriterStateClosed)
 		{
-			logae(this, "Writer is already started. state:%s", WriterStateToString(current_state));
+			logae(this, "Cannot start writer. state:%s", WriterStateToString(current_state));
 			return false;
 		}
 
 		SetState(WriterStateConnecting);
 
-		_start_time = -1LL;
-
-		// Serialize open/write-header with SendPacket() and teardown.
-		std::lock_guard<std::shared_mutex> mlock(_av_format_lock);
+		_start_time	   = -1LL;
 
 		_need_to_flush = false;
 		_need_to_close = false;

--- a/src/modules/ffmpeg/writer.cpp
+++ b/src/modules/ffmpeg/writer.cpp
@@ -131,13 +131,13 @@ namespace ffmpeg
 			return false;
 		}
 
+
+		std::lock_guard<std::shared_mutex> mlock(_av_format_lock);
+		
+		if (_av_format != nullptr)
 		{
-			std::shared_lock<std::shared_mutex> mlock(_av_format_lock);
-			if (_av_format != nullptr)
-			{
-				logae(this, "URL is already set. url(%s)", _url.CStr());
-				return false;
-			}
+			logae(this, "URL is already set. url(%s)", _url.CStr());
+			return false;
 		}
 
 		_url = url;
@@ -152,13 +152,22 @@ namespace ffmpeg
 			return false;
 		}
 
-		SetAVFormatContext(av_format);
+		_av_format.reset(av_format, [](AVFormatContext *av_format_ptr) {
+			if (av_format_ptr == nullptr)
+			{
+				return;
+			}
+
+			avformat_free_context(av_format_ptr);
+		});
+		_output_format_name = _av_format->oformat->name;
 
 		return true;
 	}
 
 	ov::String Writer::GetUrl()
 	{
+		std::shared_lock<std::shared_mutex> mlock(_av_format_lock);
 		return _url;
 	}
 
@@ -725,24 +734,6 @@ namespace ffmpeg
 	std::chrono::steady_clock::time_point Writer::GetLastPacketSentTime()
 	{
 		return _last_packet_sent_time.load();
-	}
-
-	void Writer::SetAVFormatContext(AVFormatContext *av_format)
-	{
-		std::lock_guard<std::shared_mutex> mlock(_av_format_lock);
-
-		// Deleter only frees. Finalization (trailer/close) is done in ReleaseAVFormatContext()
-		_av_format.reset(av_format, [](AVFormatContext *av_format_ptr) {
-			if (av_format_ptr == nullptr)
-			{
-				return;
-			}
-
-			avformat_free_context(av_format_ptr);
-		});
-
-		// Set output format name
-		_output_format_name = _av_format->oformat->name;
 	}
 
 	void Writer::ReleaseAVFormatContext()

--- a/src/modules/ffmpeg/writer.cpp
+++ b/src/modules/ffmpeg/writer.cpp
@@ -133,7 +133,7 @@ namespace ffmpeg
 			std::shared_lock<std::shared_mutex> mlock(_av_format_lock);
 			if (_av_format != nullptr)
 			{
-				logae(this, "URL is already set. Create a new Writer instead of reusing this one.");
+				logae(this, "URL is already set. url(%s)", _url.CStr());
 				return false;
 			}
 		}

--- a/src/modules/ffmpeg/writer.h
+++ b/src/modules/ffmpeg/writer.h
@@ -86,7 +86,6 @@ namespace ffmpeg
 		ov::String GetErrorMessage() const;
 
 	private:
-		void SetAVFormatContext(AVFormatContext* av_format);
 		void ReleaseAVFormatContext();
 		std::pair<std::shared_ptr<AVStream>, std::shared_ptr<const MediaTrack>> GetTrack(int32_t track_id, cmn::BitstreamFormat format) const;
 		bool ToAVPacket(AVPacket &av_packet, const std::shared_ptr<AVStream> av_stream, const std::shared_ptr<MediaPacket> &media_packet, const std::shared_ptr<const MediaTrack> &media_track, int64_t start_time);

--- a/src/modules/ffmpeg/writer.h
+++ b/src/modules/ffmpeg/writer.h
@@ -86,7 +86,6 @@ namespace ffmpeg
 		ov::String GetErrorMessage() const;
 
 	private:
-		std::shared_ptr<AVFormatContext> GetAVFormatContext() const;
 		void SetAVFormatContext(AVFormatContext* av_format);
 		void ReleaseAVFormatContext();
 		std::pair<std::shared_ptr<AVStream>, std::shared_ptr<const MediaTrack>> GetTrack(int32_t track_id, cmn::BitstreamFormat format) const;
@@ -101,8 +100,8 @@ namespace ffmpeg
 		int64_t _start_time = -1LL;
 		TimestampMode _timestamp_mode = TIMESTAMP_STARTZERO_MODE;
 
-		bool _need_to_flush = false;
-		bool _need_to_close = false;
+		std::atomic<bool> _need_to_flush = false;
+		std::atomic<bool> _need_to_close = false;
 
 		// MediaTrackId -> AVStream, MediaTrack
 		bool AddMediaTrack(const std::shared_ptr<const MediaTrack> &media_track, const std::shared_ptr<AVStream> &av_stream);

--- a/src/modules/ffmpeg/writer_test.cpp
+++ b/src/modules/ffmpeg/writer_test.cpp
@@ -1,0 +1,332 @@
+//==============================================================================
+//
+//  OvenMediaEngine - Unit Tests
+//
+//  modules/ffmpeg/writer_test.cpp
+//  Covers: ffmpeg::Writer
+//    - Public API contract (url/timeouts/timestamp mode/tracks/state)
+//    - Muxer lifecycle (Start/Stop/finalize) and the trailer-flush guarantee
+//    - Thread-safety of SendPacket vs. Stop (the concurrency the crash fix targets)
+//
+//==============================================================================
+// cmake -S src -B build -DOME_BUILD_TESTS=ON
+// cmake --build build --target ome_test_modules
+// ctest --test-dir build -L modules -R FfmpegWriter --output-on-failure
+
+#include <gtest/gtest.h>
+
+#include <modules/ffmpeg/writer.h>
+
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdio>
+#include <filesystem>
+#include <thread>
+#include <vector>
+
+namespace
+{
+	namespace fs = std::filesystem;
+
+	// Unique temp path for one test. Name only varies by suffix so the same test
+	// is reproducible; the file is removed by TempFile's destructor.
+	class TempFile
+	{
+	public:
+		explicit TempFile(const char *suffix)
+		{
+			static std::atomic<uint64_t> counter{0};
+			ov::String name = ov::String::FormatString(
+				"ome_writer_test_%d_%llu.%s",
+				static_cast<int>(::getpid()),
+				static_cast<unsigned long long>(counter.fetch_add(1)),
+				suffix);
+			_path = (fs::temp_directory_path() / name.CStr()).string().c_str();
+		}
+
+		~TempFile()
+		{
+			std::error_code ec;
+			fs::remove(fs::path(_path.CStr()), ec);
+		}
+
+		const ov::String &Path() const { return _path; }
+
+		bool Exists() const { return fs::exists(fs::path(_path.CStr())); }
+
+		int64_t Size() const
+		{
+			std::error_code ec;
+			auto size = fs::file_size(fs::path(_path.CStr()), ec);
+			return ec ? -1 : static_cast<int64_t>(size);
+		}
+
+	private:
+		ov::String _path;
+	};
+
+	std::shared_ptr<MediaTrack> MakeVideoTrack(uint32_t id)
+	{
+		auto track = std::make_shared<MediaTrack>();
+		track->SetId(id);
+		track->SetMediaType(cmn::MediaType::Video);
+		track->SetCodecId(cmn::MediaCodecId::H264);
+		track->SetOriginBitstream(cmn::BitstreamFormat::H264_ANNEXB);
+		track->SetTimeBase(1, 90000);
+		track->SetResolution(320, 240);
+		track->SetBitrateByConfig(500000);
+		return track;
+	}
+
+	std::shared_ptr<MediaTrack> MakeAudioTrack(uint32_t id)
+	{
+		auto track = std::make_shared<MediaTrack>();
+		track->SetId(id);
+		track->SetMediaType(cmn::MediaType::Audio);
+		track->SetCodecId(cmn::MediaCodecId::Aac);
+		track->SetOriginBitstream(cmn::BitstreamFormat::AAC_ADTS);
+		track->SetTimeBase(1, 48000);
+		track->SetChannelLayout(cmn::AudioChannel::Layout::LayoutStereo);
+		track->SetSampleRate(48000);
+		track->SetBitrateByConfig(128000);
+		return track;
+	}
+
+	std::shared_ptr<MediaPacket> MakeVideoPacket(uint32_t track_id, int64_t pts, int64_t dts, bool key)
+	{
+		// Minimal AnnexB-ish payload. Content correctness is not asserted; this only
+		// drives SendPacket()'s code path (bitstream branch selection + write/drop).
+		static const uint8_t kNal[] = {0x00, 0x00, 0x00, 0x01, 0x65, 0x11, 0x22, 0x33};
+		return std::make_shared<MediaPacket>(
+			cmn::MediaType::Video, track_id,
+			kNal, static_cast<int32_t>(sizeof(kNal)),
+			pts, dts, 3000,
+			key ? MediaPacketFlag::Key : MediaPacketFlag::NoFlag,
+			cmn::BitstreamFormat::H264_ANNEXB, cmn::PacketType::NALU);
+	}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Construction & basic contract
+// ---------------------------------------------------------------------------
+
+TEST(FfmpegWriter, CreateReturnsInstance)
+{
+	auto writer = ffmpeg::Writer::Create();
+	ASSERT_NE(writer, nullptr);
+	EXPECT_EQ(writer->GetState(), ffmpeg::Writer::WriterStateNone);
+}
+
+TEST(FfmpegWriter, SetUrlEmptyFails)
+{
+	auto writer = ffmpeg::Writer::Create();
+	EXPECT_FALSE(writer->SetUrl(""));
+	EXPECT_FALSE(writer->GetErrorMessage().IsEmpty());
+}
+
+TEST(FfmpegWriter, SetUrlStoresUrl)
+{
+	TempFile tmp("ts");
+	auto writer = ffmpeg::Writer::Create();
+	ASSERT_TRUE(writer->SetUrl(tmp.Path(), "mpegts"));
+	EXPECT_STREQ(writer->GetUrl().CStr(), tmp.Path().CStr());
+}
+
+// A Writer owns one context for its lifetime. A second SetUrl() on the same
+// instance must be rejected (not replace the live context), so the original
+// URL is preserved and reuse is forced through a new Writer.
+TEST(FfmpegWriter, SetUrlOnLiveContextIsRejected)
+{
+	TempFile first("ts");
+	TempFile second("ts");
+	auto writer = ffmpeg::Writer::Create();
+	ASSERT_TRUE(writer->SetUrl(first.Path(), "mpegts"));
+
+	EXPECT_FALSE(writer->SetUrl(second.Path(), "mpegts"));
+	EXPECT_FALSE(writer->GetErrorMessage().IsEmpty());
+	// The original URL must be untouched.
+	EXPECT_STREQ(writer->GetUrl().CStr(), first.Path().CStr());
+}
+
+// ---------------------------------------------------------------------------
+// Timeouts & timestamp mode round-trips
+// ---------------------------------------------------------------------------
+
+TEST(FfmpegWriter, ConnectionTimeoutRoundTrip)
+{
+	auto writer = ffmpeg::Writer::Create();
+	writer->SetConnectionTimeout(1234);
+	EXPECT_EQ(writer->GetConnectionTimeout(), 1234);
+}
+
+TEST(FfmpegWriter, SendTimeoutRoundTrip)
+{
+	auto writer = ffmpeg::Writer::Create();
+	writer->SetSendTimeout(4321);
+	EXPECT_EQ(writer->GetSendTimeout(), 4321);
+}
+
+TEST(FfmpegWriter, TimestampModeRoundTrip)
+{
+	auto writer = ffmpeg::Writer::Create();
+	writer->SetTimestampMode(ffmpeg::Writer::TIMESTAMP_PASSTHROUGH_MODE);
+	EXPECT_EQ(writer->GetTimestampMode(), ffmpeg::Writer::TIMESTAMP_PASSTHROUGH_MODE);
+
+	writer->SetTimestampMode(ffmpeg::Writer::TIMESTAMP_STARTZERO_MODE);
+	EXPECT_EQ(writer->GetTimestampMode(), ffmpeg::Writer::TIMESTAMP_STARTZERO_MODE);
+}
+
+// ---------------------------------------------------------------------------
+// Track registration & lookup
+// ---------------------------------------------------------------------------
+
+TEST(FfmpegWriter, AddTrackRegistersTrack)
+{
+	TempFile tmp("ts");
+	auto writer = ffmpeg::Writer::Create();
+	ASSERT_TRUE(writer->SetUrl(tmp.Path(), "mpegts"));
+
+	ASSERT_TRUE(writer->AddTrack(MakeVideoTrack(1)));
+	ASSERT_TRUE(writer->AddTrack(MakeAudioTrack(2)));
+
+	EXPECT_NE(writer->GetTrackByTrackId(1), nullptr);
+	EXPECT_NE(writer->GetTrackByTrackId(2), nullptr);
+	EXPECT_EQ(writer->GetTrackByTrackId(999), nullptr);
+
+	EXPECT_EQ(writer->GetTrackCountByType(cmn::MediaType::Video), 1);
+	EXPECT_EQ(writer->GetTrackCountByType(cmn::MediaType::Audio), 1);
+}
+
+TEST(FfmpegWriter, GetTrackCountEmptyWithoutTracks)
+{
+	TempFile tmp("ts");
+	auto writer = ffmpeg::Writer::Create();
+	ASSERT_TRUE(writer->SetUrl(tmp.Path(), "mpegts"));
+
+	EXPECT_EQ(writer->GetTrackCountByType(cmn::MediaType::Video), 0);
+	EXPECT_EQ(writer->GetTrackCountByType(cmn::MediaType::Audio), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST(FfmpegWriter, StopBeforeStartIsSafe)
+{
+	auto writer = ffmpeg::Writer::Create();
+	// No SetUrl / Start: Stop must be a safe no-op (no crash, no double-free).
+	EXPECT_TRUE(writer->Stop());
+	EXPECT_EQ(writer->GetState(), ffmpeg::Writer::WriterStateClosed);
+}
+
+TEST(FfmpegWriter, StartWithoutContextFails)
+{
+	auto writer = ffmpeg::Writer::Create();
+	// Start without SetUrl (no AVFormatContext) must fail cleanly.
+	EXPECT_FALSE(writer->Start());
+}
+
+TEST(FfmpegWriter, StartWithNoTracksFails)
+{
+	TempFile tmp("ts");
+	auto writer = ffmpeg::Writer::Create();
+	ASSERT_TRUE(writer->SetUrl(tmp.Path(), "mpegts"));
+
+	// avformat_write_header() fails with "No streams to mux were specified".
+	EXPECT_FALSE(writer->Start());
+	EXPECT_EQ(writer->GetState(), ffmpeg::Writer::WriterStateError);
+}
+
+// Full lifecycle: a successful Start followed by Stop must finalize the file
+// (write the trailer and flush it). This is the behavior the crash fix must not
+// regress: the final avio flush must complete, so the output is non-empty.
+TEST(FfmpegWriter, FullLifecycleFinalizesFile)
+{
+	TempFile tmp("ts");
+	auto writer = ffmpeg::Writer::Create();
+	ASSERT_TRUE(writer->SetUrl(tmp.Path(), "mpegts"));
+	ASSERT_TRUE(writer->AddTrack(MakeVideoTrack(1)));
+
+	if (writer->Start() == false)
+	{
+		// Depends on the ffmpeg build (muxer/codec availability). Don't fail the suite.
+		GTEST_SKIP() << "Writer::Start() failed in this ffmpeg build: "
+					 << writer->GetErrorMessage().CStr();
+	}
+
+	EXPECT_EQ(writer->GetState(), ffmpeg::Writer::WriterStateConnected);
+
+	for (int i = 0; i < 10; i++)
+	{
+		writer->SendPacket(MakeVideoPacket(1, i * 3000, i * 3000, i == 0));
+	}
+
+	EXPECT_TRUE(writer->Stop());
+	EXPECT_EQ(writer->GetState(), ffmpeg::Writer::WriterStateClosed);
+
+	// The trailer/flush must have produced a non-empty file.
+	EXPECT_TRUE(tmp.Exists());
+	EXPECT_GT(tmp.Size(), 0);
+}
+
+TEST(FfmpegWriter, SendPacketBeforeStartIsDropped)
+{
+	TempFile tmp("ts");
+	auto writer = ffmpeg::Writer::Create();
+	ASSERT_TRUE(writer->SetUrl(tmp.Path(), "mpegts"));
+	ASSERT_TRUE(writer->AddTrack(MakeVideoTrack(1)));
+
+	// Not started yet: SendPacket must not be treated as an error (returns true, drops).
+	EXPECT_TRUE(writer->SendPacket(MakeVideoPacket(1, 0, 0, true)));
+}
+
+// ---------------------------------------------------------------------------
+// Thread-safety: SendPacket racing with Stop must not crash or corrupt state.
+// This exercises the lock that serializes frame-write against muxer teardown.
+// Most valuable under ThreadSanitizer, but must at minimum not crash.
+// ---------------------------------------------------------------------------
+
+TEST(FfmpegWriter, ConcurrentSendPacketAndStopDoesNotCrash)
+{
+	TempFile tmp("ts");
+	auto writer = ffmpeg::Writer::Create();
+	ASSERT_TRUE(writer->SetUrl(tmp.Path(), "mpegts"));
+	ASSERT_TRUE(writer->AddTrack(MakeVideoTrack(1)));
+
+	if (writer->Start() == false)
+	{
+		GTEST_SKIP() << "Writer::Start() failed in this ffmpeg build: "
+					 << writer->GetErrorMessage().CStr();
+	}
+
+	std::atomic<bool> stop_flag{false};
+	std::atomic<int64_t> pts{0};
+
+	std::vector<std::thread> senders;
+	for (int t = 0; t < 4; t++)
+	{
+		senders.emplace_back([&]() {
+			while (stop_flag.load() == false)
+			{
+				auto ts = pts.fetch_add(3000);
+				// After Stop() finalizes the context, SendPacket must bail out
+				// safely (re-check under the lock), never write into a freed context.
+				writer->SendPacket(MakeVideoPacket(1, ts, ts, false));
+			}
+		});
+	}
+
+	// Let some frames flow, then tear down while senders are still active.
+	std::this_thread::sleep_for(std::chrono::milliseconds(20));
+	EXPECT_TRUE(writer->Stop());
+	stop_flag.store(true);
+
+	for (auto &s : senders)
+	{
+		s.join();
+	}
+
+	// Reaching here without a crash/hang is the assertion.
+	EXPECT_EQ(writer->GetState(), ffmpeg::Writer::WriterStateClosed);
+}

--- a/src/publishers/file/file_application.cpp
+++ b/src/publishers/file/file_application.cpp
@@ -103,12 +103,13 @@ namespace pub
 
 		switch (session_state)
 		{
-			// State of disconnected and ready to connect
 			case pub::Session::SessionState::Ready:
 				[[fallthrough]];
 			case pub::Session::SessionState::Stopped:
-				session->Start();
-				logti("Recording Started. %s", session->GetRecord()->GetInfoString().CStr());
+				if (session->Start() == true)
+				{
+					logti("Recording Started. %s", session->GetRecord()->GetInfoString().CStr());
+				}
 
 				break;
 			// State of Recording
@@ -154,18 +155,23 @@ namespace pub
 
 	void FileApplication::SessionControllInternal(std::shared_ptr<FileStream> stream, std::shared_ptr<info::Record> userdata)
 	{
-		// If there is no session, create a new file(record) session.
-		auto session = std::static_pointer_cast<FileSession>(stream->GetSession(userdata->GetSessionId()));
-		if (session == nullptr || userdata->GetSessionId() == 0)
+		std::shared_ptr<FileSession> session;
+
 		{
-			session = stream->CreateSession();
-			if (session == nullptr)
+			std::lock_guard<std::mutex> lock(_session_control_mutex);
+
+			session = std::static_pointer_cast<FileSession>(stream->GetSession(userdata->GetSessionId()));
+			if (session == nullptr || userdata->GetSessionId() == 0)
 			{
-				logte("Failed to create session");
-				return;
+				session = stream->CreateSession();
+				if (session == nullptr)
+				{
+					logte("Failed to create session");
+					return;
+				}
+				userdata->SetSessionId(session->GetId());
+				session->SetRecord(userdata);
 			}
-			userdata->SetSessionId(session->GetId());
-			session->SetRecord(userdata);
 		}
 
 		if (userdata->GetEnable() == true && userdata->GetRemove() == false)

--- a/src/publishers/file/file_application.h
+++ b/src/publishers/file/file_application.h
@@ -45,5 +45,6 @@ namespace pub
 
 	private:
 		FileUserdataSets _record_info_list;
+		std::mutex _session_control_mutex;
 	};
 }  // namespace pub

--- a/src/publishers/file/file_session.cpp
+++ b/src/publishers/file/file_session.cpp
@@ -49,7 +49,17 @@ namespace pub
 
 	bool FileSession::Start()
 	{
+		std::lock_guard<std::mutex> lock(_record_control_mutex);
+
+		// If the session is already started, return true to avoid restarting it.
+		if (GetState() == SessionState::Started)
+		{
+			return true;
+		}
+
 		_is_splitting.store(false);
+
+		_found_first_keyframe = false;
 
 		if (StartRecord() == false)
 		{
@@ -71,6 +81,8 @@ namespace pub
 
 	bool FileSession::Stop()
 	{
+		std::lock_guard<std::mutex> lock(_record_control_mutex);
+
 		if (StopRecord() == false)
 		{
 			logae("Failed to stop recording. id(%d)", GetId());
@@ -90,6 +102,8 @@ namespace pub
 
 	bool FileSession::Split()
 	{
+		std::lock_guard<std::mutex> lock(_record_control_mutex);
+
 		if (StopRecord() == false)
 		{
 			logae("Failed to stop recording. id(%d)", GetId());
@@ -238,6 +252,16 @@ namespace pub
 		}
 
 		logad("Create temporary file(%s) and default track id(%d)", writer->GetUrl().CStr(), _default_track);
+
+		// No tracks added: skip Start() to avoid a "No streams to mux" header failure.
+		if (writer->GetTrackCountByType(cmn::MediaType::Video) == 0 &&
+			writer->GetTrackCountByType(cmn::MediaType::Audio) == 0)
+		{
+			SetState(SessionState::Error);
+			record->SetState(info::Record::RecordState::Error);
+			logae("No tracks to record. check the variant/track selection. %s", record->GetInfoString().CStr());
+			return false;
+		}
 
 		if (writer->Start() == false)
 		{

--- a/src/publishers/file/file_session.cpp
+++ b/src/publishers/file/file_session.cpp
@@ -184,6 +184,7 @@ namespace pub
 			SetState(SessionState::Error);
 			record->SetState(info::Record::RecordState::Error);
 			logae("Failed to set URL. Reason(%s), %s", writer->GetErrorMessage().CStr(), record->GetInfoString().CStr());
+			DestroyWriter();
 			return false;
 		}
 
@@ -260,6 +261,7 @@ namespace pub
 			SetState(SessionState::Error);
 			record->SetState(info::Record::RecordState::Error);
 			logae("No tracks to record. check the variant/track selection. %s", record->GetInfoString().CStr());
+			DestroyWriter();
 			return false;
 		}
 
@@ -268,6 +270,7 @@ namespace pub
 			SetState(SessionState::Error);
 			record->SetState(info::Record::RecordState::Error);
 			logae("Failed to start writer. Reason(%s), %s", writer->GetErrorMessage().CStr(), record->GetInfoString().CStr());
+			DestroyWriter();
 			return false;
 		}
 

--- a/src/publishers/file/file_session.h
+++ b/src/publishers/file/file_session.h
@@ -47,6 +47,8 @@ namespace pub
 		void DestroyWriter();
 
 	private:
+		std::mutex _record_control_mutex;
+
 		std::shared_ptr<ffmpeg::Writer> _writer;
 		std::shared_mutex _writer_mutex;
 

--- a/src/publishers/file/file_session.h
+++ b/src/publishers/file/file_session.h
@@ -57,7 +57,8 @@ namespace pub
 
 		std::map<cmn::MediaType, MediaTrackId> _default_track_by_type;
 		MediaTrackId _default_track;
-		bool _found_first_keyframe = false;
+
+		std::atomic<bool> _found_first_keyframe = false;
 
 		std::atomic<bool> _is_splitting = false;
 	};

--- a/src/publishers/file/file_stream.cpp
+++ b/src/publishers/file/file_stream.cpp
@@ -42,11 +42,12 @@ namespace pub
 			return false;
 		}
 
+		_stream_interval_gate.Reset();
+
 		auto result = Stream::Start();
 		if (result == true)
 		{
 			std::static_pointer_cast<FileApplication>(GetApplication())->SessionUpdateByStream(std::static_pointer_cast<FileStream>(GetSharedPtr()), false);
-			_stop_watch.Start();
 		}
 
 		return result;
@@ -63,7 +64,6 @@ namespace pub
 		if (result == true)
 		{
 			std::static_pointer_cast<FileApplication>(GetApplication())->SessionUpdateByStream(std::static_pointer_cast<FileStream>(GetSharedPtr()), true);
-			_stop_watch.Stop();
 		}
 
 		return result;
@@ -76,10 +76,9 @@ namespace pub
 			return;
 		}
 
-		// Periodically check the session. Retry the session in which the error occurred.
-		if (_stop_watch.IsElapsed(5000) && _stop_watch.Update())
+		// Periodically update sessions that still need (re)starting
+		if (_stream_interval_gate.TryConsume())
 		{
-			// If the recording is failed, it is for retrying.
 			std::static_pointer_cast<FileApplication>(GetApplication())->SessionUpdateByStream(std::static_pointer_cast<FileStream>(GetSharedPtr()), false);
 		}
 

--- a/src/publishers/file/file_stream.h
+++ b/src/publishers/file/file_stream.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <base/common_types.h>
+#include <base/ovlibrary/interval_gate.h>
 #include <base/publisher/stream.h>
 #include <modules/ovt_packetizer/ovt_packetizer.h>
 
@@ -31,7 +32,8 @@ namespace pub
 		bool Start() override;
 		bool Stop() override;
 
-		ov::StopWatch _stop_watch;
+		// Rate-limits the periodic session-retry in SendFrame() to one thread per interval.
+		ov::IntervalGate _stream_interval_gate{5000};
 		std::shared_ptr<mon::StreamMetrics> _stream_metrics;
 	};
 }  // namespace pub


### PR DESCRIPTION
## Summary
Related Issue : #2250

Fixes a crash in the File publisher where writing packets could race with recording control (Stop / Split / re-Start), causing a use-after-free on the `AVFormatContext`. All context access is now serialized under a single lock, muxer finalization is explicit, and the session control paths are guarded.

## Changes

**ffmpeg::Writer**
- serialize `SendPacket`/`Start`/`AddTrack` under one lock to fix the use-after-free
- move trailer/close into  `ReleaseAVFormatContext()`; 
- fix an `AVDictionary` leak in `Start()`.

**File publisher**
- guard session create/start/stop/split with mutexes.
- skip recording when no tracks are selected

**ov::IntervalGate** (new)
- thread-safe interval gate. replaces `StopWatch`  for the periodic session update.

**Tests**
- add `writer_test.cpp` (15 tests) for the Writer lifecycle

## Testing


### 1. Unit tests

    cmake -S src -B build -DOME_BUILD_TESTS=ON
    cmake --build build --target ome_test_modules
    ctest --test-dir build -L modules -R FfmpegWriter --output-on-failure

→ 15/15 passed (incl. the SendPacket-vs-Stop concurrency and trailer-flush tests).

### 2. Integration race test (RTMP ingest + concurrent Record API)

Reproduces the real-world race the fix targets: the stream ingest thread.

1. Push a continuous RTMP source
2. While ingesting, start/stop record concurrently (several parallel loops to maximize contention):

       while true; do
         curl -s -X POST -H "Authorization: Basic <token>" \
           http://localhost:8081/v1/vhosts/default/apps/app:startRecord \
           -d '{"id":"rec-1","stream":{"name":"stream"}}'
         curl -s -X POST -H "Authorization: Basic <token>" \
           http://localhost:8081/v1/vhosts/default/apps/app:stopRecord \
           -d '{"id":"rec-1"}'
       done

   Alternatively, drive `startRecord` from an Admission Webhook handler and repeatedly connect/disconnect the RTMP publisher.

3. Also exercise segmentation (`interval`/`schedule`) so `Split()` overlaps with the API calls.

