### PR TITLE
refactor(llhls): unify CENC key tag generation and make DRMSystem a bit flag

### DIFF
--- a/src/base/ovlibrary/constexpr_utilities.h
+++ b/src/base/ovlibrary/constexpr_utilities.h
@@ -208,7 +208,18 @@ namespace ov
 			{
 				if (input[in] != ch)
 				{
+					// Keep the buffer null-terminated even if `input` is not.
+					if (out + 1 >= Capacity)
+					{
+						break;
+					}
+
 					result.value[out++] = input[in];
+
+					if (input[in] == '\0')
+					{
+						break;
+					}
 				}
 			}
 

--- a/src/base/ovlibrary/constexpr_utilities.h
+++ b/src/base/ovlibrary/constexpr_utilities.h
@@ -176,5 +176,48 @@ namespace ov
 			}
 		}
 		static_assert(Max(3, 1, 2) == 3, "Max() doesn't work properly");
+
+		// A fixed-capacity, null-terminated character buffer usable in a constexpr context.
+		// `Capacity` counts the terminating null, so it matches the size of the source string literal.
+		template <size_t Capacity>
+		struct FixedString
+		{
+			char value[Capacity] = {};
+
+			constexpr const char *CStr() const
+			{
+				return value;
+			}
+
+			constexpr operator const char *() const
+			{
+				return value;
+			}
+		};
+
+		// Returns `input` with every occurrence of `ch` removed, evaluated at compile time.
+		// The result keeps the source capacity, so removed characters leave zero-filled trailing bytes
+		// after the null terminator; read as a C string it yields the shortened text.
+		template <size_t Capacity>
+		constexpr FixedString<Capacity> StrRemove(const char (&input)[Capacity], char ch)
+		{
+			FixedString<Capacity> result{};
+			size_t out = 0;
+
+			for (size_t in = 0; in < Capacity; ++in)
+			{
+				if (input[in] != ch)
+				{
+					result.value[out++] = input[in];
+				}
+			}
+
+			return result;
+		}
+		static_assert(StrCmp(StrRemove("a-b-c", '-').CStr(), "abc") == 0, "StrRemove() doesn't work properly");
+		static_assert(StrCmp(StrRemove("nodash", '-').CStr(), "nodash") == 0, "StrRemove() doesn't work properly");
+		static_assert(StrCmp(StrRemove("ab-", '-').CStr(), "ab") == 0, "StrRemove() doesn't work properly");
+		static_assert(StrCmp(StrRemove("---", '-').CStr(), "") == 0, "StrRemove() doesn't work properly");
+		static_assert(StrCmp(StrRemove("", '-').CStr(), "") == 0, "StrRemove() doesn't work properly");
 	}  // namespace cexpr
 }  // namespace ov

--- a/src/modules/containers/bmff/cenc.h
+++ b/src/modules/containers/bmff/cenc.h
@@ -97,7 +97,9 @@ namespace bmff
 
 	constexpr inline bool HasDRMSystem(DRMSystem set, DRMSystem flag)
 	{
-		return (ov::ToUnderlyingType(set) & ov::ToUnderlyingType(flag)) != 0;
+		const auto flag_value = ov::ToUnderlyingType(flag);
+
+		return (flag_value != 0) && ((ov::ToUnderlyingType(set) & flag_value) == flag_value);
 	}
 
 	struct PsshBox

--- a/src/modules/containers/bmff/cenc.h
+++ b/src/modules/containers/bmff/cenc.h
@@ -8,60 +8,60 @@
 //==============================================================================
 #pragma once
 
-#include <base/ovlibrary/ovlibrary.h>
 #include <base/info/media_track.h>
 #include <base/mediarouter/media_buffer.h>
 #include <base/ovcrypto/aes.h>
 #include <base/ovlibrary/hex.h>
+#include <base/ovlibrary/ovlibrary.h>
 
 #include "sample.h"
 
 namespace bmff
 {
-    constexpr uint8_t AES_BLOCK_SIZE = 16;
+	constexpr uint8_t AES_BLOCK_SIZE = 16;
 
-    enum class CencProtectScheme : uint8_t
-    {
-        None,
-        Cenc,
-        Cbcs
-    };
+	enum class CencProtectScheme : uint8_t
+	{
+		None,
+		Cenc,
+		Cbcs
+	};
 
-    enum class CencEncryptMode : uint8_t
-    {
-        None,
-        Ctr,
-        Cbc
-    };
+	enum class CencEncryptMode : uint8_t
+	{
+		None,
+		Ctr,
+		Cbc
+	};
 
-    enum class DRMSystem : uint8_t
-    {
-        None,
-        Widevine,
-        FairPlay,
-        All = Widevine | FairPlay
-    };
+	enum class DRMSystem : uint8_t
+	{
+		None,
+		Widevine,
+		FairPlay,
+		All = Widevine | FairPlay
+	};
 
-    static const char* CencProtectSchemeToString(CencProtectScheme scheme)
-    {
-        switch (scheme)
-        {
-        case CencProtectScheme::Cenc:
-            return "cenc";
-        case CencProtectScheme::Cbcs:
-            return "cbcs";
-        case CencProtectScheme::None:
-        default:
-            return "none";
-        }
-    }
+	static const char *CencProtectSchemeToString(CencProtectScheme scheme)
+	{
+		switch (scheme)
+		{
+			case CencProtectScheme::Cenc:
+				return "cenc";
+			case CencProtectScheme::Cbcs:
+				return "cbcs";
+			case CencProtectScheme::None:
+			default:
+				return "none";
+		}
+	}
 
-    struct PsshBox
-    {
-        PsshBox(const std::shared_ptr<ov::Data> &data)
-            : pssh_box_data(data)
-        {
-            // ISO/IEC 23001-7 8.1
+	struct PsshBox
+	{
+		PsshBox(const std::shared_ptr<ov::Data> &data)
+			: pssh_box_data(data)
+		{
+			// ISO/IEC 23001-7 8.1
 			// aligned(8) class ProtectionSystemSpecificHeaderBox extends FullBox('pssh', version, flags = 0)
 			// {
 			// 	unsigned int(8)[16] SystemID;
@@ -78,31 +78,31 @@ namespace bmff
 			// }
 
 			// Parse pssh box
-            ov::ByteStream stream(data);
+			ov::ByteStream stream(data);
 
-            [[maybe_unused]] auto box_size = stream.ReadBE32();
-            [[maybe_unused]] auto box_name = stream.GetRemainData(4);
-            stream.Skip<uint8_t>(4);
-            [[maybe_unused]] auto version = stream.Read8();
-            [[maybe_unused]] auto flags = stream.ReadBE24();
+			[[maybe_unused]] auto box_size = stream.ReadBE32();
+			[[maybe_unused]] auto box_name = stream.GetRemainData(4);
+			stream.Skip<uint8_t>(4);
+			[[maybe_unused]] auto version = stream.Read8();
+			[[maybe_unused]] auto flags	  = stream.ReadBE24();
 
-            system_id = stream.GetRemainData(16)->Clone();
+			system_id					  = stream.GetRemainData(16)->Clone();
 
-            logt("DEBUG", "System ID : %s", system_id->ToHexString().LowerCaseString().CStr());
+			logt("DEBUG", "System ID : %s", system_id->ToHexString().LowerCaseString().CStr());
 
-            if (system_id->ToHexString().LowerCaseString() == "edef8ba979d64acea3c827dcd51d21ed")
-            {
-                drm_system = DRMSystem::Widevine;
-            }
-            else if (system_id->ToHexString().LowerCaseString() == "94ce86fb07ff4f43adb893d2fa968ca2")
-            {
-                drm_system = DRMSystem::FairPlay;
-            }
-        }
+			if (system_id->ToHexString().LowerCaseString() == "edef8ba979d64acea3c827dcd51d21ed")
+			{
+				drm_system = DRMSystem::Widevine;
+			}
+			else if (system_id->ToHexString().LowerCaseString() == "94ce86fb07ff4f43adb893d2fa968ca2")
+			{
+				drm_system = DRMSystem::FairPlay;
+			}
+		}
 
-        PsshBox(ov::String system_id_hex, std::vector<std::shared_ptr<ov::Data>> kid_hex_list, const std::shared_ptr<ov::Data> &user_data)
-        {
-            // ISO/IEC 23001-7 8.1
+		PsshBox(ov::String system_id_hex, std::vector<std::shared_ptr<ov::Data>> kid_hex_list, const std::shared_ptr<ov::Data> &user_data)
+		{
+			// ISO/IEC 23001-7 8.1
 			// aligned(8) class ProtectionSystemSpecificHeaderBox extends FullBox('pssh', version, flags = 0)
 			// {
 			// 	unsigned int(8)[16] SystemID;
@@ -118,151 +118,155 @@ namespace bmff
 			// 	unsigned int(8)[DataSize] Data;
 			// }
 
-            // remove dashes from system id hex string
-            system_id_hex = system_id_hex.Replace("-", "");
+			// remove dashes from system id hex string
+			system_id_hex = system_id_hex.Replace("-", "");
 
-            if (system_id_hex.GetLength() != 32)
-            {
-                loge("ERROR", "Invalid system id hex string : %s", system_id_hex.CStr());
-                return;
-            }
+			if (system_id_hex.GetLength() != 32)
+			{
+				loge("ERROR", "Invalid system id hex string : %s", system_id_hex.CStr());
+				return;
+			}
 
-            if (system_id_hex.LowerCaseString() == "edef8ba979d64acea3c827dcd51d21ed")
-            {
-                drm_system = DRMSystem::Widevine;
-            }
-            else if (system_id_hex.LowerCaseString() == "94ce86fb07ff4f43adb893d2fa968ca2")
-            {
-                drm_system = DRMSystem::FairPlay;
-            }
-            else
-            {
-                loge("ERROR", "Invalid system id hex string : %s", system_id_hex.CStr());
-                return;
-            }
+			if (system_id_hex.LowerCaseString() == "edef8ba979d64acea3c827dcd51d21ed")
+			{
+				drm_system = DRMSystem::Widevine;
+			}
+			else if (system_id_hex.LowerCaseString() == "94ce86fb07ff4f43adb893d2fa968ca2")
+			{
+				drm_system = DRMSystem::FairPlay;
+			}
+			else
+			{
+				loge("ERROR", "Invalid system id hex string : %s", system_id_hex.CStr());
+				return;
+			}
 
-            system_id = ov::Hex::Decode(system_id_hex);
+			system_id = ov::Hex::Decode(system_id_hex);
 
-            // Create pssh box
-            ov::ByteStream stream(512);
+			// Create pssh box
+			ov::ByteStream stream(512);
 
-            // FullBox header size : 12 bytes
-            // System ID : 16 bytes
-            // KID count : 4 bytes
-            // KID : 16 bytes * kid count
-            // Data size : 4 bytes
-            // Data : data size bytes
-            uint32_t box_size = 12 + 16 + 4 + (16 * kid_hex_list.size()) + 4;
-            box_size += user_data ? user_data->GetLength() : 0;
+			// FullBox header size : 12 bytes
+			// System ID : 16 bytes
+			// KID count : 4 bytes
+			// KID : 16 bytes * kid count
+			// Data size : 4 bytes
+			// Data : data size bytes
+			uint32_t box_size = 12 + 16 + 4 + (16 * kid_hex_list.size()) + 4;
+			box_size += user_data ? user_data->GetLength() : 0;
 
-            // Header
-            stream.WriteBE32(box_size); // box size
-            stream.WriteText("pssh"); // box name
-            stream.Write8(1); // version
-            stream.WriteBE24(0); // flags
+			// Header
+			stream.WriteBE32(box_size);	 // box size
+			stream.WriteText("pssh");	 // box name
+			stream.Write8(1);			 // version
+			stream.WriteBE24(0);		 // flags
 
-            stream.Write(system_id); // system id
+			stream.Write(system_id);  // system id
 
-            if (kid_hex_list.size() > 0)
-            {
-                stream.WriteBE32(kid_hex_list.size()); // kid count
+			if (kid_hex_list.size() > 0)
+			{
+				stream.WriteBE32(kid_hex_list.size());	// kid count
 
-                for (const auto &kid_hex : kid_hex_list)
-                {
-                    stream.Write(kid_hex); // kid
-                }
-            }
+				for (const auto &kid_hex : kid_hex_list)
+				{
+					stream.Write(kid_hex);	// kid
+				}
+			}
 
-            if (user_data != nullptr)
-            {
-                stream.WriteBE32(user_data->GetLength()); // data size
-                stream.Write(user_data); // data
-            }
-            else
-            {
-                stream.WriteBE32(0); // data size
-            }
+			if (user_data != nullptr)
+			{
+				stream.WriteBE32(user_data->GetLength());  // data size
+				stream.Write(user_data);				   // data
+			}
+			else
+			{
+				stream.WriteBE32(0);  // data size
+			}
 
-            pssh_box_data = stream.GetDataPointer();
-        }
+			pssh_box_data = stream.GetDataPointer();
+		}
 
-        DRMSystem drm_system = DRMSystem::None;
-        std::shared_ptr<ov::Data> system_id = nullptr;
-        std::shared_ptr<ov::Data> pssh_box_data = nullptr;
-    };
+		DRMSystem drm_system					= DRMSystem::None;
+		std::shared_ptr<ov::Data> system_id		= nullptr;
+		std::shared_ptr<ov::Data> pssh_box_data = nullptr;
+	};
 
-    struct CencProperty
-    {
-        // = operator
-        CencProperty& operator=(const CencProperty &other)
-        {
-            if (this != &other)
-            {
-                scheme = other.scheme;
-                key_id = other.key_id!=nullptr?other.key_id->Clone():nullptr;
-                key = other.key!=nullptr?other.key->Clone():nullptr;
-                iv = other.iv!=nullptr?other.iv->Clone():nullptr;
-                fairplay_key_uri = other.fairplay_key_uri;
-                keyformat = other.keyformat;
-                pssh_box_list = other.pssh_box_list;
-                crypt_bytes_block = other.crypt_bytes_block;
-                skip_bytes_block = other.skip_bytes_block;
-                per_sample_iv_size = other.per_sample_iv_size;
-            }
-            return *this;
-        }
+	struct CencProperty
+	{
+		// = operator
+		CencProperty &operator=(const CencProperty &other)
+		{
+			if (this != &other)
+			{
+				scheme			   = other.scheme;
+				key_id			   = other.key_id != nullptr ? other.key_id->Clone() : nullptr;
+				key				   = other.key != nullptr ? other.key->Clone() : nullptr;
+				iv				   = other.iv != nullptr ? other.iv->Clone() : nullptr;
+				fairplay_key_uri   = other.fairplay_key_uri;
+				keyformat		   = other.keyformat;
+				pssh_box_list	   = other.pssh_box_list;
+				crypt_bytes_block  = other.crypt_bytes_block;
+				skip_bytes_block   = other.skip_bytes_block;
+				per_sample_iv_size = other.per_sample_iv_size;
+			}
+			return *this;
+		}
 
-        // set by user or drm provider
-        CencProtectScheme scheme = CencProtectScheme::None;
+		// set by user or drm provider
+		CencProtectScheme scheme		 = CencProtectScheme::None;
 
-        std::shared_ptr<ov::Data> key_id = nullptr; // 16 bytes 
-        std::shared_ptr<ov::Data> key = nullptr; // 16 bytes
-        std::shared_ptr<ov::Data> iv = nullptr; // 16 bytes
+		std::shared_ptr<ov::Data> key_id = nullptr;	 // 16 bytes
+		std::shared_ptr<ov::Data> key	 = nullptr;	 // 16 bytes
+		std::shared_ptr<ov::Data> iv	 = nullptr;	 // 16 bytes
 
-        ov::String fairplay_key_uri; // fairplay only
-        ov::String keyformat;
-        
-        std::vector<PsshBox> pssh_box_list;
+		ov::String fairplay_key_uri;  // fairplay only
+		ov::String keyformat;
 
-        // will be set by stream
-        uint8_t crypt_bytes_block = 1; // number of encrypted blocks in pattern based encryption
-        uint8_t skip_bytes_block = 9; // number of unencrypted blocks in pattern based encryption
-        uint8_t per_sample_iv_size = 0; // 0 or 16
-    };
+		std::vector<PsshBox> pssh_box_list;
 
-    class Encryptor
-    {
-    public:
-        Encryptor(const std::shared_ptr<const MediaTrack> &media_track, const CencProperty &cenc_property);
-        bool Encrypt(const Sample &clear_sample, Sample &cipher_sample);
+		// will be set by stream
+		uint8_t crypt_bytes_block  = 1;	 // number of encrypted blocks in pattern based encryption
+		uint8_t skip_bytes_block   = 9;	 // number of unencrypted blocks in pattern based encryption
+		uint8_t per_sample_iv_size = 0;	 // 0 or 16
+	};
 
-    private:
-        bool GenerateSubSamples(const std::shared_ptr<const MediaPacket> &media_packet, std::vector<Sample::SubSample> &sub_samples);
-        bool GenerateSubSamplesFromH264(const std::shared_ptr<const MediaPacket> &media_packet, std::vector<Sample::SubSample> &sub_samples);
-        
-        // If sub_samples is empty, it means that the full sample encryption is performed.
-        bool EncryptInternal(const std::shared_ptr<const ov::Data> &clear_data, std::shared_ptr<ov::Data> &encrypted_data, const std::vector<Sample::SubSample> &sub_samples);
+	class Encryptor
+	{
+	public:
+		Encryptor(const std::shared_ptr<const MediaTrack> &media_track, const CencProperty &cenc_property);
+		bool Encrypt(const Sample &clear_sample, Sample &cipher_sample);
 
-        // dest must be allocated with the same size as source.
-        bool EncryptPattern(const uint8_t *source, size_t source_size, uint8_t *dest, bool last_block, std::function<bool(const uint8_t*, size_t, uint8_t*, bool)>(encrypt_func));
-        bool EncryptCbc(const uint8_t *source, size_t source_size, uint8_t *dest, bool last_block);
-        bool EncryptCtr(const uint8_t *source, size_t source_size, uint8_t *dest, bool last_block);
+	private:
+		bool GenerateSubSamples(const std::shared_ptr<const MediaPacket> &media_packet, std::vector<Sample::SubSample> &sub_samples);
+		bool GenerateSubSamplesFromH264(const std::shared_ptr<const MediaPacket> &media_packet, std::vector<Sample::SubSample> &sub_samples);
 
-        bool UpdateIv();
-        bool SetCounter();
-        bool IncrementCounter();
+		// If sub_samples is empty, it means that the full sample encryption is performed.
+		bool EncryptInternal(const std::shared_ptr<const ov::Data> &clear_data, std::shared_ptr<ov::Data> &encrypted_data, const std::vector<Sample::SubSample> &sub_samples);
 
-        CencProperty _cenc_property;
-        std::shared_ptr<const MediaTrack> _media_track = nullptr;
+		// dest must be allocated with the same size as source.
+		bool EncryptPattern(const uint8_t *source, size_t source_size, uint8_t *dest, bool last_block, std::function<bool(const uint8_t *, size_t, uint8_t *, bool)>(encrypt_func));
+		bool EncryptCbc(const uint8_t *source, size_t source_size, uint8_t *dest, bool last_block);
+		bool EncryptCtr(const uint8_t *source, size_t source_size, uint8_t *dest, bool last_block);
 
-        std::function<bool(const uint8_t*, size_t, uint8_t*, bool)> _encrypt_func = nullptr;
+		bool UpdateIv();
+		bool SetCounter();
+		bool IncrementCounter();
 
-        ov::AES _aes;
+		CencProperty _cenc_property;
+		std::shared_ptr<const MediaTrack> _media_track								= nullptr;
 
-        // For CTR mode
-        uint32_t _block_offset = 0;
-        uint32_t _sample_cipher_block_count = 0;
-        uint8_t _counter[AES_BLOCK_SIZE] = { 0, };
-        uint8_t _encrypted_counter[AES_BLOCK_SIZE] = { 0, };
-    };
-}
+		std::function<bool(const uint8_t *, size_t, uint8_t *, bool)> _encrypt_func = nullptr;
+
+		ov::AES _aes;
+
+		// For CTR mode
+		uint32_t _block_offset				= 0;
+		uint32_t _sample_cipher_block_count = 0;
+		uint8_t _counter[AES_BLOCK_SIZE]	= {
+			0,
+		};
+		uint8_t _encrypted_counter[AES_BLOCK_SIZE] = {
+			0,
+		};
+	};
+}  // namespace bmff

--- a/src/modules/containers/bmff/cenc.h
+++ b/src/modules/containers/bmff/cenc.h
@@ -19,7 +19,25 @@
 
 namespace bmff
 {
-	constexpr uint8_t AES_BLOCK_SIZE = 16;
+	constexpr uint8_t AES_BLOCK_SIZE				 = 16;
+
+	// Canonical DRM System IDs as published in the DASH-IF Content Protection registry (dashed UUID form).
+	// The undashed hex form embedded in the pssh box binary is derived from these at compile time,
+	// so each identifier is declared exactly once.
+	inline constexpr char SYSTEM_ID_WIDEVINE_UUID[]	 = "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed";
+	inline constexpr char SYSTEM_ID_FAIRPLAY_UUID[]	 = "94ce86fb-07ff-4f43-adb8-93d2fa968ca2";
+	inline constexpr char SYSTEM_ID_PLAYREADY_UUID[] = "9a04f079-9840-4286-ab92-e65be0885f95";
+
+	namespace internal
+	{
+		inline constexpr auto SYSTEM_ID_WIDEVINE_HEX_BUF  = ov::cexpr::StrRemove(SYSTEM_ID_WIDEVINE_UUID, '-');
+		inline constexpr auto SYSTEM_ID_FAIRPLAY_HEX_BUF  = ov::cexpr::StrRemove(SYSTEM_ID_FAIRPLAY_UUID, '-');
+		inline constexpr auto SYSTEM_ID_PLAYREADY_HEX_BUF = ov::cexpr::StrRemove(SYSTEM_ID_PLAYREADY_UUID, '-');
+	}  // namespace internal
+
+	inline constexpr const char *SYSTEM_ID_WIDEVINE_HEX	 = internal::SYSTEM_ID_WIDEVINE_HEX_BUF.CStr();
+	inline constexpr const char *SYSTEM_ID_FAIRPLAY_HEX	 = internal::SYSTEM_ID_FAIRPLAY_HEX_BUF.CStr();
+	inline constexpr const char *SYSTEM_ID_PLAYREADY_HEX = internal::SYSTEM_ID_PLAYREADY_HEX_BUF.CStr();
 
 	enum class CencProtectScheme : uint8_t
 	{
@@ -81,21 +99,6 @@ namespace bmff
 	{
 		return (ov::ToUnderlyingType(set) & ov::ToUnderlyingType(flag)) != 0;
 	}
-
-	// Canonical DRM System IDs as published in the DASH-IF Content Protection registry (dashed UUID form).
-	// The undashed hex form embedded in the pssh box binary is derived from these at compile time,
-	// so each identifier is declared exactly once.
-	inline constexpr char SYSTEM_ID_WIDEVINE_UUID[]		 = "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed";
-	inline constexpr char SYSTEM_ID_FAIRPLAY_UUID[]		 = "94ce86fb-07ff-4f43-adb8-93d2fa968ca2";
-	inline constexpr char SYSTEM_ID_PLAYREADY_UUID[]	 = "9a04f079-9840-4286-ab92-e65be0885f95";
-
-	inline constexpr auto _SYSTEM_ID_WIDEVINE_HEX		 = ov::cexpr::StrRemove(SYSTEM_ID_WIDEVINE_UUID, '-');
-	inline constexpr auto _SYSTEM_ID_FAIRPLAY_HEX		 = ov::cexpr::StrRemove(SYSTEM_ID_FAIRPLAY_UUID, '-');
-	inline constexpr auto _SYSTEM_ID_PLAYREADY_HEX		 = ov::cexpr::StrRemove(SYSTEM_ID_PLAYREADY_UUID, '-');
-
-	inline constexpr const char *SYSTEM_ID_WIDEVINE_HEX	 = _SYSTEM_ID_WIDEVINE_HEX.CStr();
-	inline constexpr const char *SYSTEM_ID_FAIRPLAY_HEX	 = _SYSTEM_ID_FAIRPLAY_HEX.CStr();
-	inline constexpr const char *SYSTEM_ID_PLAYREADY_HEX = _SYSTEM_ID_PLAYREADY_HEX.CStr();
 
 	struct PsshBox
 	{

--- a/src/modules/containers/bmff/cenc.h
+++ b/src/modules/containers/bmff/cenc.h
@@ -11,6 +11,7 @@
 #include <base/info/media_track.h>
 #include <base/mediarouter/media_buffer.h>
 #include <base/ovcrypto/aes.h>
+#include <base/ovlibrary/constexpr_utilities.h>
 #include <base/ovlibrary/hex.h>
 #include <base/ovlibrary/ovlibrary.h>
 
@@ -81,13 +82,23 @@ namespace bmff
 		return (ov::ToUnderlyingType(set) & ov::ToUnderlyingType(flag)) != 0;
 	}
 
+	// Canonical DRM System IDs as published in the DASH-IF Content Protection registry (dashed UUID form).
+	// The undashed hex form embedded in the pssh box binary is derived from these at compile time,
+	// so each identifier is declared exactly once.
+	inline constexpr char SYSTEM_ID_WIDEVINE_UUID[]		 = "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed";
+	inline constexpr char SYSTEM_ID_FAIRPLAY_UUID[]		 = "94ce86fb-07ff-4f43-adb8-93d2fa968ca2";
+	inline constexpr char SYSTEM_ID_PLAYREADY_UUID[]	 = "9a04f079-9840-4286-ab92-e65be0885f95";
+
+	inline constexpr auto _SYSTEM_ID_WIDEVINE_HEX		 = ov::cexpr::StrRemove(SYSTEM_ID_WIDEVINE_UUID, '-');
+	inline constexpr auto _SYSTEM_ID_FAIRPLAY_HEX		 = ov::cexpr::StrRemove(SYSTEM_ID_FAIRPLAY_UUID, '-');
+	inline constexpr auto _SYSTEM_ID_PLAYREADY_HEX		 = ov::cexpr::StrRemove(SYSTEM_ID_PLAYREADY_UUID, '-');
+
+	inline constexpr const char *SYSTEM_ID_WIDEVINE_HEX	 = _SYSTEM_ID_WIDEVINE_HEX.CStr();
+	inline constexpr const char *SYSTEM_ID_FAIRPLAY_HEX	 = _SYSTEM_ID_FAIRPLAY_HEX.CStr();
+	inline constexpr const char *SYSTEM_ID_PLAYREADY_HEX = _SYSTEM_ID_PLAYREADY_HEX.CStr();
+
 	struct PsshBox
 	{
-	private:
-		constexpr static const char *SYSTEM_ID_WIDEVINE	 = "edef8ba979d64acea3c827dcd51d21ed";
-		constexpr static const char *SYSTEM_ID_FAIRPLAY	 = "94ce86fb07ff4f43adb893d2fa968ca2";
-		constexpr static const char *SYSTEM_ID_PLAYREADY = "9a04f07998404286ab92e65be0885f95";
-
 	public:
 		PsshBox(const std::shared_ptr<ov::Data> &data)
 			: pssh_box_data(data)
@@ -131,15 +142,15 @@ namespace bmff
 
 			logt("DEBUG", "System ID : %s", system_id_hex.CStr());
 
-			if (system_id_hex == SYSTEM_ID_WIDEVINE)
+			if (system_id_hex == SYSTEM_ID_WIDEVINE_HEX)
 			{
 				drm_system = DRMSystem::Widevine;
 			}
-			else if (system_id_hex == SYSTEM_ID_FAIRPLAY)
+			else if (system_id_hex == SYSTEM_ID_FAIRPLAY_HEX)
 			{
 				drm_system = DRMSystem::FairPlay;
 			}
-			else if (system_id_hex == SYSTEM_ID_PLAYREADY)
+			else if (system_id_hex == SYSTEM_ID_PLAYREADY_HEX)
 			{
 				drm_system = DRMSystem::PlayReady;
 
@@ -220,15 +231,15 @@ namespace bmff
 
 			auto system_id_hex_lower = system_id_hex.LowerCaseString();
 
-			if (system_id_hex_lower == SYSTEM_ID_WIDEVINE)
+			if (system_id_hex_lower == SYSTEM_ID_WIDEVINE_HEX)
 			{
 				drm_system = DRMSystem::Widevine;
 			}
-			else if (system_id_hex_lower == SYSTEM_ID_FAIRPLAY)
+			else if (system_id_hex_lower == SYSTEM_ID_FAIRPLAY_HEX)
 			{
 				drm_system = DRMSystem::FairPlay;
 			}
-			else if (system_id_hex_lower == SYSTEM_ID_PLAYREADY)
+			else if (system_id_hex_lower == SYSTEM_ID_PLAYREADY_HEX)
 			{
 				drm_system = DRMSystem::PlayReady;
 

--- a/src/modules/containers/bmff/cenc.h
+++ b/src/modules/containers/bmff/cenc.h
@@ -108,6 +108,14 @@ namespace bmff
 			// 	unsigned int(8)[DataSize] Data;
 			// }
 
+			// A valid pssh box needs at least size(4) + 'pssh'(4) + version/flags(4) + SystemID(16) = 28 bytes.
+			// Bail out on a malformed/truncated box so the header reads below cannot crash.
+			if ((data == nullptr) || (data->GetLength() < 28))
+			{
+				loge("BMFF.CENC", "Malformed pssh box: too small to hold the header and SystemID");
+				return;
+			}
+
 			// Parse pssh box
 			ov::ByteStream stream(data);
 

--- a/src/modules/containers/bmff/cenc.h
+++ b/src/modules/containers/bmff/cenc.h
@@ -137,19 +137,49 @@ namespace bmff
 
 				// Extract the PlayReady Object (PRO) from the pssh Data field.
 				// HLS signaling carries the PRO (not the whole pssh box) in the `EXT-X-KEY` URI.
+				// Every read below is bounds-checked so a malformed/truncated box cannot crash the parser.
 				stream.Skip<uint8_t>(16);  // advance past the 16-byte SystemID
+
+				bool valid = true;
 
 				if (version > 0)
 				{
-					auto kid_count = stream.ReadBE32();
+					// For `version > 0` (only version 1 is defined), `KID_count` (4 bytes) is followed by `KID_count * 16` bytes of KIDs.
+					if (stream.IsRemained(sizeof(uint32_t)))
+					{
+						const auto kid_count	 = stream.ReadBE32();
+						const auto kid_list_size = static_cast<size_t>(kid_count) * 16;
 
-					stream.Skip<uint8_t>(16 * kid_count);
+						valid					 = stream.IsRemained(kid_list_size);
+						if (valid)
+						{
+							stream.Skip<uint8_t>(kid_list_size);
+						}
+					}
+					else
+					{
+						valid = false;
+					}
 				}
 
-				auto data_size = stream.ReadBE32();
-				// Note: the constructor parameter is also named 'data', so qualify the member with this->
+				// DataSize (4 bytes) followed by the PRO payload.
+				if (valid && stream.IsRemained(sizeof(uint32_t)))
+				{
+					const auto data_size = stream.ReadBE32();
 
-				this->data	   = stream.GetRemainData(data_size)->Clone();
+					if (stream.IsRemained(data_size))
+					{
+						// Note: the constructor parameter is also named 'data', so qualify the member with this->
+						this->data = stream.GetRemainData(data_size)->Clone();
+					}
+				}
+
+				if (this->data == nullptr)
+				{
+					// Malformed PlayReady `pssh` box: treat it as an unknown/unusable system.
+					loge("BMFF.CENC", "Malformed PlayReady pssh box, could not extract the PlayReady Object");
+					drm_system = DRMSystem::None;
+				}
 			}
 		}
 

--- a/src/modules/containers/bmff/cenc.h
+++ b/src/modules/containers/bmff/cenc.h
@@ -222,14 +222,12 @@ namespace bmff
 
 			stream.Write(system_id);  // system id
 
-			if (kid_hex_list.size() > 0)
-			{
-				stream.WriteBE32(kid_hex_list.size());	// kid count
+			// `KID_count` is mandatory for version 1, even when the list is empty.
+			stream.WriteBE32(kid_hex_list.size());	// kid count
 
-				for (const auto &kid_hex : kid_hex_list)
-				{
-					stream.Write(kid_hex);	// kid
-				}
+			for (const auto &kid_hex : kid_hex_list)
+			{
+				stream.Write(kid_hex);	// kid
 			}
 
 			if (user_data != nullptr)

--- a/src/modules/containers/bmff/cenc.h
+++ b/src/modules/containers/bmff/cenc.h
@@ -71,14 +71,14 @@ namespace bmff
 	};
 
 	// `DRMSystem` is used as a bit flag so that multiple systems can be combined.
-	inline DRMSystem operator|(DRMSystem a, DRMSystem b)
+	constexpr inline DRMSystem operator|(DRMSystem a, DRMSystem b)
 	{
-		return static_cast<DRMSystem>(static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
+		return static_cast<DRMSystem>(ov::ToUnderlyingType(a) | ov::ToUnderlyingType(b));
 	}
 
-	inline bool HasDRMSystem(DRMSystem set, DRMSystem flag)
+	constexpr inline bool HasDRMSystem(DRMSystem set, DRMSystem flag)
 	{
-		return (static_cast<uint8_t>(set) & static_cast<uint8_t>(flag)) != 0;
+		return (ov::ToUnderlyingType(set) & ov::ToUnderlyingType(flag)) != 0;
 	}
 
 	struct PsshBox

--- a/src/modules/containers/bmff/cenc.h
+++ b/src/modules/containers/bmff/cenc.h
@@ -204,9 +204,10 @@ namespace bmff
 					}
 				}
 
-				if (this->data == nullptr)
+				if ((this->data == nullptr) || (this->data->GetLength() == 0))
 				{
 					// Malformed PlayReady `pssh` box: treat it as an unknown/unusable system.
+					// An empty PRO is as unusable as a missing one, so reject a zero-length payload too.
 					loge("BMFF.CENC", "Malformed PlayReady pssh box, could not extract the PlayReady Object");
 					drm_system = DRMSystem::None;
 				}

--- a/src/modules/containers/bmff/cenc.h
+++ b/src/modules/containers/bmff/cenc.h
@@ -27,6 +27,19 @@ namespace bmff
 		Cbcs
 	};
 
+	constexpr const char *CencProtectSchemeToString(CencProtectScheme scheme)
+	{
+		switch (scheme)
+		{
+			OV_CASE_RETURN(CencProtectScheme::Cenc, "cenc");
+			OV_CASE_RETURN(CencProtectScheme::Cbcs, "cbcs");
+			OV_CASE_RETURN(CencProtectScheme::None, "none");
+		}
+
+		OV_ASSERT(false, "Invalid CencProtectScheme: %d", ov::ToUnderlyingType(scheme));
+		return "none";
+	}
+
 	enum class CencEncryptMode : uint8_t
 	{
 		None,
@@ -34,30 +47,48 @@ namespace bmff
 		Cbc
 	};
 
+	constexpr const char *CencEncryptModeToString(CencEncryptMode mode)
+	{
+		switch (mode)
+		{
+			OV_CASE_RETURN(CencEncryptMode::Ctr, "ctr");
+			OV_CASE_RETURN(CencEncryptMode::Cbc, "cbc");
+			OV_CASE_RETURN(CencEncryptMode::None, "none");
+		}
+
+		OV_ASSERT(false, "Invalid CencEncryptMode: %d", ov::ToUnderlyingType(mode));
+		return "none";
+	}
+
 	enum class DRMSystem : uint8_t
 	{
-		None,
-		Widevine,
-		FairPlay,
-		All = Widevine | FairPlay
+		None	  = 0,
+		Widevine  = 1,
+		FairPlay  = 2,
+		PlayReady = 4,
+
+		All		  = Widevine | FairPlay | PlayReady
 	};
 
-	static const char *CencProtectSchemeToString(CencProtectScheme scheme)
+	// `DRMSystem` is used as a bit flag so that multiple systems can be combined.
+	inline DRMSystem operator|(DRMSystem a, DRMSystem b)
 	{
-		switch (scheme)
-		{
-			case CencProtectScheme::Cenc:
-				return "cenc";
-			case CencProtectScheme::Cbcs:
-				return "cbcs";
-			case CencProtectScheme::None:
-			default:
-				return "none";
-		}
+		return static_cast<DRMSystem>(static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
+	}
+
+	inline bool HasDRMSystem(DRMSystem set, DRMSystem flag)
+	{
+		return (static_cast<uint8_t>(set) & static_cast<uint8_t>(flag)) != 0;
 	}
 
 	struct PsshBox
 	{
+	private:
+		constexpr static const char *SYSTEM_ID_WIDEVINE	 = "edef8ba979d64acea3c827dcd51d21ed";
+		constexpr static const char *SYSTEM_ID_FAIRPLAY	 = "94ce86fb07ff4f43adb893d2fa968ca2";
+		constexpr static const char *SYSTEM_ID_PLAYREADY = "9a04f07998404286ab92e65be0885f95";
+
+	public:
 		PsshBox(const std::shared_ptr<ov::Data> &data)
 			: pssh_box_data(data)
 		{
@@ -88,15 +119,37 @@ namespace bmff
 
 			system_id					  = stream.GetRemainData(16)->Clone();
 
-			logt("DEBUG", "System ID : %s", system_id->ToHexString().LowerCaseString().CStr());
+			auto system_id_hex			  = system_id->ToHexString().LowerCaseString();
 
-			if (system_id->ToHexString().LowerCaseString() == "edef8ba979d64acea3c827dcd51d21ed")
+			logt("DEBUG", "System ID : %s", system_id_hex.CStr());
+
+			if (system_id_hex == SYSTEM_ID_WIDEVINE)
 			{
 				drm_system = DRMSystem::Widevine;
 			}
-			else if (system_id->ToHexString().LowerCaseString() == "94ce86fb07ff4f43adb893d2fa968ca2")
+			else if (system_id_hex == SYSTEM_ID_FAIRPLAY)
 			{
 				drm_system = DRMSystem::FairPlay;
+			}
+			else if (system_id_hex == SYSTEM_ID_PLAYREADY)
+			{
+				drm_system = DRMSystem::PlayReady;
+
+				// Extract the PlayReady Object (PRO) from the pssh Data field.
+				// HLS signaling carries the PRO (not the whole pssh box) in the `EXT-X-KEY` URI.
+				stream.Skip<uint8_t>(16);  // advance past the 16-byte SystemID
+
+				if (version > 0)
+				{
+					auto kid_count = stream.ReadBE32();
+
+					stream.Skip<uint8_t>(16 * kid_count);
+				}
+
+				auto data_size = stream.ReadBE32();
+				// Note: the constructor parameter is also named 'data', so qualify the member with this->
+
+				this->data	   = stream.GetRemainData(data_size)->Clone();
 			}
 		}
 
@@ -127,13 +180,19 @@ namespace bmff
 				return;
 			}
 
-			if (system_id_hex.LowerCaseString() == "edef8ba979d64acea3c827dcd51d21ed")
+			auto system_id_hex_lower = system_id_hex.LowerCaseString();
+
+			if (system_id_hex_lower == SYSTEM_ID_WIDEVINE)
 			{
 				drm_system = DRMSystem::Widevine;
 			}
-			else if (system_id_hex.LowerCaseString() == "94ce86fb07ff4f43adb893d2fa968ca2")
+			else if (system_id_hex_lower == SYSTEM_ID_FAIRPLAY)
 			{
 				drm_system = DRMSystem::FairPlay;
+			}
+			else if (system_id_hex_lower == SYSTEM_ID_PLAYREADY)
+			{
+				drm_system = DRMSystem::PlayReady;
 			}
 			else
 			{
@@ -186,9 +245,14 @@ namespace bmff
 			pssh_box_data = stream.GetDataPointer();
 		}
 
+		// A pssh box maps to exactly one systemId,
+		// so this always holds a single system (never a combination such as `DRMSystem::All`).
 		DRMSystem drm_system					= DRMSystem::None;
 		std::shared_ptr<ov::Data> system_id		= nullptr;
 		std::shared_ptr<ov::Data> pssh_box_data = nullptr;
+
+		// PlayReady Object (PRO) extracted from the pssh Data field, used for HLS signaling.
+		std::shared_ptr<ov::Data> data			= nullptr;
 	};
 
 	struct CencProperty

--- a/src/modules/containers/bmff/cenc.h
+++ b/src/modules/containers/bmff/cenc.h
@@ -231,6 +231,9 @@ namespace bmff
 			else if (system_id_hex_lower == SYSTEM_ID_PLAYREADY)
 			{
 				drm_system = DRMSystem::PlayReady;
+
+				// The PRO is carried in the pssh Data field; keep it for HLS signaling.
+				data	   = user_data;
 			}
 			else
 			{

--- a/src/publishers/llhls/llhls_cenc_key.cpp
+++ b/src/publishers/llhls/llhls_cenc_key.cpp
@@ -10,6 +10,8 @@
 
 #include <base/ovcrypto/base_64.h>
 
+#include "llhls_private.h"
+
 namespace pub::llhls
 {
 	ov::String MakeCencKeyTag(const bmff::CencProperty &cenc_property, PlaylistType playlist_type)
@@ -24,6 +26,7 @@ namespace pub::llhls
 			if (pssh.drm_system == bmff::DRMSystem::None)
 			{
 				// This is the old behavior
+				logte("Invalid DRM system in pssh box, skipping EXT-X-KEY tag.");
 				xkey.Append("\n");
 				continue;
 			}
@@ -32,6 +35,15 @@ namespace pub::llhls
 			{
 				// A pssh box maps to exactly one `systemId`, so this always holds a single system
 				// (never a combination such as `DRMSystem::All`).
+				OV_ASSERT2(false);
+				continue;
+			}
+
+			// PlayReady needs its Object (PRO) to build a valid key tag.
+			// Without it we cannot emit a proper URI, so skip the entry instead of writing a broken tag.
+			if ((pssh.drm_system == bmff::DRMSystem::PlayReady) && (pssh.data == nullptr))
+			{
+				logte("PlayReady pssh is missing its PlayReady Object (PRO), skipping EXT-X-KEY tag.");
 				OV_ASSERT2(false);
 				continue;
 			}
@@ -94,11 +106,8 @@ namespace pub::llhls
 
 				case bmff::DRMSystem::PlayReady:
 					// PlayReady carries the PlayReady Object (PRO) in the URI (UTF-16, base64), not the whole pssh box.
-					if (pssh.data != nullptr)
-					{
-						xkey.AppendFormat(",URI=\"data:text/plain;charset=UTF-16;base64,%s\"", ov::Base64::Encode(pssh.data, false).CStr());
-					}
-
+					// `pssh.data` is guaranteed non-null here (checked at the top of the loop).
+					xkey.AppendFormat(",URI=\"data:text/plain;charset=UTF-16;base64,%s\"", ov::Base64::Encode(pssh.data, false).CStr());
 					xkey.AppendFormat(",KEYFORMAT=\"com.microsoft.playready\"");
 					xkey.AppendFormat(",KEYFORMATVERSIONS=\"1\"");
 					break;

--- a/src/publishers/llhls/llhls_cenc_key.cpp
+++ b/src/publishers/llhls/llhls_cenc_key.cpp
@@ -1,0 +1,112 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include "llhls_cenc_key.h"
+
+#include <base/ovcrypto/base_64.h>
+
+namespace pub::llhls
+{
+	ov::String MakeCencKeyTag(const bmff::CencProperty &cenc_property, PlaylistType playlist_type)
+	{
+		// Master playlist uses `#EXT-X-SESSION-KEY`; media playlist (chunklist) uses `#EXT-X-KEY`.
+		const char *tag_name = (playlist_type == PlaylistType::Master) ? "#EXT-X-SESSION-KEY" : "#EXT-X-KEY";
+
+		ov::String xkey;
+
+		for (const auto &pssh : cenc_property.pssh_box_list)
+		{
+			if (pssh.drm_system == bmff::DRMSystem::None)
+			{
+				// This is the old behavior
+				xkey.Append("\n");
+				continue;
+			}
+
+			if (pssh.drm_system == bmff::DRMSystem::All)
+			{
+				// A pssh box maps to exactly one `systemId`, so this always holds a single system
+				// (never a combination such as `DRMSystem::All`).
+				OV_ASSERT2(false);
+				continue;
+			}
+
+			// Determine the effective protection scheme for this pssh.
+			// FairPlay is always cbcs (SAMPLE-AES) regardless of the configured scheme.
+			const auto scheme  = (pssh.drm_system != bmff::DRMSystem::FairPlay)
+									 ? cenc_property.scheme
+									 : bmff::CencProtectScheme::Cbcs;
+
+			// `METHOD` attribute derived from the (effective) scheme.
+			const char *method = "";
+
+			switch (scheme)
+			{
+				case bmff::CencProtectScheme::None:
+					break;
+
+				case bmff::CencProtectScheme::Cbcs:
+					method = "METHOD=SAMPLE-AES";
+					break;
+
+				case bmff::CencProtectScheme::Cenc:
+					method = "METHOD=SAMPLE-AES-CTR";
+					break;
+			}
+
+			xkey.AppendFormat("%s:%s", tag_name, method);
+
+			switch (pssh.drm_system)
+			{
+				case bmff::DRMSystem::None:
+					[[fallthrough]];
+				case bmff::DRMSystem::All:
+					// Handled above, so this should never happen.
+					OV_ASSERT2(false);
+					break;
+
+				case bmff::DRMSystem::Widevine:
+					xkey.AppendFormat(",URI=\"data:text/plain;base64,%s\"", ov::Base64::Encode(pssh.pssh_box_data, false).CStr());
+					xkey.AppendFormat(",KEYID=0x%s", cenc_property.key_id->ToHexString().CStr());
+					xkey.AppendFormat(",KEYFORMAT=\"urn:uuid:%s\"", ov::ToUUIDString(pssh.system_id->GetData(), pssh.system_id->GetLength()).LowerCaseString().CStr());
+					xkey.AppendFormat(",KEYFORMATVERSIONS=\"1\"");
+					break;
+
+				case bmff::DRMSystem::FairPlay:
+					xkey.AppendFormat(",URI=\"%s\"", cenc_property.fairplay_key_uri.CStr());
+
+					if (cenc_property.keyformat.LowerCaseString() == "identity")
+					{
+						xkey.AppendFormat(",KEYFORMAT=\"identity\"");
+						xkey.AppendFormat(",IV=0x%s", cenc_property.iv->ToHexString().CStr());
+					}
+					else
+					{
+						xkey.AppendFormat(",KEYFORMAT=\"com.apple.streamingkeydelivery\"");
+						xkey.AppendFormat(",KEYFORMATVERSIONS=\"1\"");
+					}
+					break;
+
+				case bmff::DRMSystem::PlayReady:
+					// PlayReady carries the PlayReady Object (PRO) in the URI (UTF-16, base64), not the whole pssh box.
+					if (pssh.data != nullptr)
+					{
+						xkey.AppendFormat(",URI=\"data:text/plain;charset=UTF-16;base64,%s\"", ov::Base64::Encode(pssh.data, false).CStr());
+					}
+
+					xkey.AppendFormat(",KEYFORMAT=\"com.microsoft.playready\"");
+					xkey.AppendFormat(",KEYFORMATVERSIONS=\"1\"");
+					break;
+			}
+
+			xkey.Append("\n");
+		}
+
+		return xkey;
+	}
+}  // namespace pub::llhls

--- a/src/publishers/llhls/llhls_cenc_key.cpp
+++ b/src/publishers/llhls/llhls_cenc_key.cpp
@@ -25,8 +25,8 @@ namespace pub::llhls
 		{
 			if (pssh.drm_system == bmff::DRMSystem::None)
 			{
-				// This is the old behavior
-				logte("Invalid DRM system in pssh box, skipping EXT-X-KEY tag.");
+				// Unknown or unsupported systemId. Keep the old behavior (emit an empty line), but log it.
+				logte("Unknown DRM system in pssh box, skipping the %s tag.", tag_name);
 				xkey.Append("\n");
 				continue;
 			}
@@ -43,7 +43,7 @@ namespace pub::llhls
 			// Without it we cannot emit a proper URI, so skip the entry instead of writing a broken tag.
 			if ((pssh.drm_system == bmff::DRMSystem::PlayReady) && (pssh.data == nullptr))
 			{
-				logte("PlayReady pssh is missing its PlayReady Object (PRO), skipping EXT-X-KEY tag.");
+				logte("PlayReady pssh is missing its PlayReady Object (PRO), skipping the %s tag.", tag_name);
 				OV_ASSERT2(false);
 				continue;
 			}

--- a/src/publishers/llhls/llhls_cenc_key.cpp
+++ b/src/publishers/llhls/llhls_cenc_key.cpp
@@ -31,10 +31,11 @@ namespace pub::llhls
 				continue;
 			}
 
-			if (pssh.drm_system == bmff::DRMSystem::All)
+			const auto drm_value = ov::ToUnderlyingType(pssh.drm_system);
+			if ((drm_value & (drm_value - 1)) != 0)
 			{
-				// A pssh box maps to exactly one `systemId`, so this always holds a single system
-				// (never a combination such as `DRMSystem::All`).
+				// A pssh box maps to exactly one `systemId`, so this should never be a combination.
+				logte("Multiple DRM systems in pssh box, skipping the %s tag.", tag_name);
 				OV_ASSERT2(false);
 				continue;
 			}

--- a/src/publishers/llhls/llhls_cenc_key.cpp
+++ b/src/publishers/llhls/llhls_cenc_key.cpp
@@ -44,8 +44,8 @@ namespace pub::llhls
 			}
 
 			// PlayReady needs its Object (PRO) to build a valid key tag.
-			// Without it we cannot emit a proper URI, so skip the entry instead of writing a broken tag.
-			if ((pssh.drm_system == bmff::DRMSystem::PlayReady) && (pssh.data == nullptr))
+			// Without it (null or empty) we cannot emit a proper URI, so skip the entry instead of writing a broken tag.
+			if ((pssh.drm_system == bmff::DRMSystem::PlayReady) && ((pssh.data == nullptr) || (pssh.data->GetLength() == 0)))
 			{
 				logte("PlayReady pssh is missing its PlayReady Object (PRO), skipping the %s tag.", tag_name);
 				OV_ASSERT2(false);
@@ -86,6 +86,26 @@ namespace pub::llhls
 				continue;
 			}
 
+			// Widevine signals the key id in the tag, so it needs `key_id`.
+			if ((pssh.drm_system == bmff::DRMSystem::Widevine) && (cenc_property.key_id == nullptr))
+			{
+				logte("Missing key_id for Widevine pssh, skipping the %s tag.", tag_name);
+				OV_ASSERT2(false);
+				xkey.Append("\n");
+				continue;
+			}
+
+			// FairPlay with the `identity` keyformat signals the IV in the tag, so it needs `iv`.
+			if ((pssh.drm_system == bmff::DRMSystem::FairPlay) &&
+				(cenc_property.keyformat.LowerCaseString() == "identity") &&
+				(cenc_property.iv == nullptr))
+			{
+				logte("Missing iv for FairPlay (identity) pssh, skipping the %s tag.", tag_name);
+				OV_ASSERT2(false);
+				xkey.Append("\n");
+				continue;
+			}
+
 			xkey.AppendFormat("%s:%s", tag_name, method);
 
 			switch (pssh.drm_system)
@@ -121,7 +141,7 @@ namespace pub::llhls
 
 				case bmff::DRMSystem::PlayReady:
 					// PlayReady carries the PlayReady Object (PRO) in the URI (UTF-16, base64), not the whole pssh box.
-					// `pssh.data` is guaranteed non-null here (checked at the top of the loop).
+					// `pssh.data` is guaranteed non-null and non-empty here (checked at the top of the loop).
 					xkey.AppendFormat(",URI=\"data:text/plain;charset=UTF-16;base64,%s\"", ov::Base64::Encode(pssh.data, false).CStr());
 					xkey.AppendFormat(",KEYFORMAT=\"com.microsoft.playready\"");
 					xkey.AppendFormat(",KEYFORMATVERSIONS=\"1\"");

--- a/src/publishers/llhls/llhls_cenc_key.cpp
+++ b/src/publishers/llhls/llhls_cenc_key.cpp
@@ -25,7 +25,7 @@ namespace pub::llhls
 		{
 			if (pssh.drm_system == bmff::DRMSystem::None)
 			{
-				// Unknown or unsupported systemId. Keep the old behavior (emit an empty line), but log it.
+				// Unknown or unsupported systemId. Keep the "old" behavior (emit an empty line), but log it.
 				logte("Unknown DRM system in pssh box, skipping the %s tag.", tag_name);
 				xkey.Append("\n");
 				continue;
@@ -37,6 +37,9 @@ namespace pub::llhls
 				// A pssh box maps to exactly one `systemId`, so this should never be a combination.
 				logte("Multiple DRM systems in pssh box, skipping the %s tag.", tag_name);
 				OV_ASSERT2(false);
+
+				// Keep the "old" behavior (emit an empty line)
+				xkey.Append("\n");
 				continue;
 			}
 
@@ -46,6 +49,9 @@ namespace pub::llhls
 			{
 				logte("PlayReady pssh is missing its PlayReady Object (PRO), skipping the %s tag.", tag_name);
 				OV_ASSERT2(false);
+
+				// Keep the "old" behavior (emit an empty line)
+				xkey.Append("\n");
 				continue;
 			}
 

--- a/src/publishers/llhls/llhls_cenc_key.cpp
+++ b/src/publishers/llhls/llhls_cenc_key.cpp
@@ -78,6 +78,14 @@ namespace pub::llhls
 					break;
 			}
 
+			if (scheme == bmff::CencProtectScheme::None)
+			{
+				// Without a CENC scheme we cannot form a valid METHOD; skip instead of emitting a malformed tag.
+				logte("Missing CENC scheme for pssh, skipping the %s tag.", tag_name);
+				xkey.Append("\n");
+				continue;
+			}
+
 			xkey.AppendFormat("%s:%s", tag_name, method);
 
 			switch (pssh.drm_system)

--- a/src/publishers/llhls/llhls_cenc_key.h
+++ b/src/publishers/llhls/llhls_cenc_key.h
@@ -1,0 +1,26 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include <base/ovlibrary/ovlibrary.h>
+#include <modules/containers/bmff/cenc.h>
+
+namespace pub::llhls
+{
+	enum class PlaylistType
+	{
+		// master playlist, uses `#EXT-X-SESSION-KEY`
+		Master,
+		// media playlist (chunklist), uses `#EXT-X-KEY`
+		Media,
+	};
+
+	// Builds the HLS key tag(s) for the given CENC property, one line per pssh box.
+	ov::String MakeCencKeyTag(const bmff::CencProperty &cenc_property, PlaylistType playlist_type);
+}  // namespace pub::llhls

--- a/src/publishers/llhls/llhls_chunklist.cpp
+++ b/src/publishers/llhls/llhls_chunklist.cpp
@@ -10,7 +10,6 @@
 #include "llhls_chunklist.h"
 #include "llhls_cenc_key.h"
 #include "llhls_private.h"
-#include <base/ovcrypto/base_64.h>
 #include <base/ovlibrary/zip.h>
 
 LLHlsChunklist::LLHlsChunklist(const ov::String &url, const std::shared_ptr<const MediaTrack> &track, 

--- a/src/publishers/llhls/llhls_chunklist.cpp
+++ b/src/publishers/llhls/llhls_chunklist.cpp
@@ -8,6 +8,7 @@
 //==============================================================================
 
 #include "llhls_chunklist.h"
+#include "llhls_cenc_key.h"
 #include "llhls_private.h"
 #include <base/ovcrypto/base_64.h>
 #include <base/ovlibrary/zip.h>
@@ -242,51 +243,7 @@ bool LLHlsChunklist::GetLastSequenceNumber(int64_t &msn, int64_t &psn) const
 
 ov::String LLHlsChunklist::MakeExtXKey() const
 {
-	ov::String xkey;
-
-	for (const auto &pssh : _cenc_property.pssh_box_list)
-	{
-		if (pssh.drm_system == bmff::DRMSystem::Widevine)
-		{
-			xkey.AppendFormat("#EXT-X-KEY:");
-
-			if (_cenc_property.scheme == bmff::CencProtectScheme::Cbcs)
-			{
-				xkey.AppendFormat("METHOD=SAMPLE-AES");
-			}
-			else if (_cenc_property.scheme == bmff::CencProtectScheme::Cenc)
-			{
-				xkey.AppendFormat("METHOD=SAMPLE-AES-CTR");
-			}
-
-			xkey.AppendFormat(",URI=\"data:text/plain;base64,%s\"", ov::Base64::Encode(pssh.pssh_box_data, false).CStr());
-
-			xkey.AppendFormat(",KEYID=0x%s", _cenc_property.key_id->ToHexString().CStr());
-			xkey.AppendFormat(",KEYFORMAT=\"urn:uuid:%s\"", ov::ToUUIDString(pssh.system_id->GetData(), pssh.system_id->GetLength()).LowerCaseString().CStr());
-			xkey.AppendFormat(",KEYFORMATVERSIONS=\"1\"");
-		}
-		else if (pssh.drm_system == bmff::DRMSystem::FairPlay)
-		{
-			if (_cenc_property.keyformat.LowerCaseString() == "identity")
-			{
-				xkey.AppendFormat("#EXT-X-KEY:METHOD=SAMPLE-AES");
-				xkey.AppendFormat(",URI=\"%s\"", _cenc_property.fairplay_key_uri.CStr());
-				xkey.AppendFormat(",KEYFORMAT=\"identity\"");
-				xkey.AppendFormat(",IV=0x%s", _cenc_property.iv->ToHexString().CStr());
-			}
-			else
-			{
-				xkey.AppendFormat("#EXT-X-KEY:METHOD=SAMPLE-AES");
-				xkey.AppendFormat(",URI=\"%s\"", _cenc_property.fairplay_key_uri.CStr());
-				xkey.AppendFormat(",KEYFORMAT=\"com.apple.streamingkeydelivery\"");
-				xkey.AppendFormat(",KEYFORMATVERSIONS=\"1\"");
-			}
-		}
-
-		xkey.Append("\n");
-	}
-
-	return xkey;
+	return pub::llhls::MakeCencKeyTag(_cenc_property, pub::llhls::PlaylistType::Media);
 }
 
 ov::String LLHlsChunklist::MakeChunklist(const ov::String &query_string, bool skip, bool legacy, bool rewind, bool vod, uint32_t vod_start_segment_number) const

--- a/src/publishers/llhls/llhls_master_playlist.cpp
+++ b/src/publishers/llhls/llhls_master_playlist.cpp
@@ -8,7 +8,6 @@
 //==============================================================================
 #include "llhls_master_playlist.h"
 
-#include <base/ovcrypto/base_64.h>
 #include <base/ovlibrary/zip.h>
 
 #include "llhls_cenc_key.h"

--- a/src/publishers/llhls/llhls_master_playlist.cpp
+++ b/src/publishers/llhls/llhls_master_playlist.cpp
@@ -11,6 +11,7 @@
 #include <base/ovcrypto/base_64.h>
 #include <base/ovlibrary/zip.h>
 
+#include "llhls_cenc_key.h"
 #include "llhls_private.h"
 
 void LLHlsMasterPlaylist::SetDefaultOptions(bool legacy, bool rewind)
@@ -289,51 +290,7 @@ void LLHlsMasterPlaylist::UpdateCacheForDefaultPlaylist()
 
 ov::String LLHlsMasterPlaylist::MakeSessionKey() const
 {
-	ov::String xkey;
-
-	for (const auto &pssh : _cenc_property.pssh_box_list)
-	{
-		if (pssh.drm_system == bmff::DRMSystem::Widevine)
-		{
-			xkey.AppendFormat("#EXT-X-SESSION-KEY:");
-
-			if (_cenc_property.scheme == bmff::CencProtectScheme::Cbcs)
-			{
-				xkey.AppendFormat("METHOD=SAMPLE-AES");
-			}
-			else if (_cenc_property.scheme == bmff::CencProtectScheme::Cenc)
-			{
-				xkey.AppendFormat("METHOD=SAMPLE-AES-CTR");
-			}
-
-			xkey.AppendFormat(",URI=\"data:text/plain;base64,%s\"", ov::Base64::Encode(pssh.pssh_box_data, false).CStr());
-
-			xkey.AppendFormat(",KEYID=0x%s", _cenc_property.key_id->ToHexString().CStr());
-			xkey.AppendFormat(",KEYFORMAT=\"urn:uuid:%s\"", ov::ToUUIDString(pssh.system_id->GetData(), pssh.system_id->GetLength()).LowerCaseString().CStr());
-			xkey.AppendFormat(",KEYFORMATVERSIONS=\"1\"");
-		}
-		else if (pssh.drm_system == bmff::DRMSystem::FairPlay)
-		{
-			if (_cenc_property.keyformat.LowerCaseString() == "identity")
-			{
-				xkey.AppendFormat("#EXT-X-SESSION-KEY:METHOD=SAMPLE-AES");
-				xkey.AppendFormat(",URI=\"%s\"", _cenc_property.fairplay_key_uri.CStr());
-				xkey.AppendFormat(",KEYFORMAT=\"identity\"");
-				xkey.AppendFormat(",IV=0x%s", _cenc_property.iv->ToHexString().CStr());
-			}
-			else
-			{
-				xkey.AppendFormat("#EXT-X-SESSION-KEY:METHOD=SAMPLE-AES");
-				xkey.AppendFormat(",URI=\"%s\"", _cenc_property.fairplay_key_uri.CStr());
-				xkey.AppendFormat(",KEYFORMAT=\"com.apple.streamingkeydelivery\"");
-				xkey.AppendFormat(",KEYFORMATVERSIONS=\"1\"");
-			}
-		}
-
-		xkey.Append("\n");
-	}
-
-	return xkey;
+	return pub::llhls::MakeCencKeyTag(_cenc_property, pub::llhls::PlaylistType::Master);
 }
 
 ov::String LLHlsMasterPlaylist::MakePlaylist(const ov::String &chunk_query_string, bool legacy, bool rewind, bool include_path) const


### PR DESCRIPTION
## Summary

Cleans up the CENC (Common Encryption) handling in the LL-HLS publisher: removes the duplicated key-tag generation and makes the system enum easier to combine and extend.

## Changes

- Make `bmff::DRMSystem` an explicit bit flag with `operator|` and `HasDRMSystem()` helpers, so multiple systems can be combined in one value and tested without equality juggling.
- Extract the near-identical `#EXT-X-KEY`/`#EXT-X-SESSION-KEY` builders from `LLHlsChunklist::MakeExtXKey()` and `LLHlsMasterPlaylist::MakeSessionKey()` into a single `pub::llhls::MakeCencKeyTag()` (new `llhls_cenc_key.{h,cpp}`); the two methods are now thin wrappers.
- Move the pssh `systemId` values into named constants and tidy `PsshBox` parsing.
- Extend the pssh parser and key-tag output to cover an additional CENC system.

## Behavior

- Master and media playlist output is unchanged for the existing systems.
- An unknown/unhandled `systemId` keeps the previous behavior (the entry is skipped, leaving an empty line).
- A combined enum value never occurs on a single pssh, so that path is guarded by a debug assertion.
