### PR TITLE
fix(thumbnail): llhls playback fails with 404 after a thumbnail request on the same http/2 connection

### DIFF
--- a/src/publishers/thumbnail/thumbnail_interceptor.h
+++ b/src/publishers/thumbnail/thumbnail_interceptor.h
@@ -26,4 +26,12 @@ protected:
 	// Implementation of HttpRequestInterceptorInterface
 	//--------------------------------------------------------------------
 	bool IsInterceptorForRequest(const std::shared_ptr<const http::svr::HttpExchange> &client) override;
+
+	// If cached, this interceptor is pinned to the connection and requests for
+	// other publishers sharing the port (e.g. LLHLS over HTTP/2) would be
+	// routed here and get 404. So the interceptor must be selected per request.
+	bool IsCacheable() const override
+	{
+		return false;
+	}
 };


### PR DESCRIPTION
## Why

When Thumbnail and LLHLS publishers share the same TLS port with HTTP/2 enabled, browsers (notably Chrome) multiplex all requests for the origin over a single HTTP/2 connection. `HttpConnection::FindInterceptor` caches the first matched interceptor on the connection when `IsCacheable()` returns true. `ThumbnailInterceptor` did not override `IsCacheable()`, so it inherited the default `true`. Once a `thumb.jpg` request was served on a connection, the connection was pinned to the thumbnail interceptor, and all subsequent LLHLS requests (`llhls.m3u8`, chunklists, `.m4s` segments) on that connection were routed to it and returned 404. The same class of bug was previously fixed for the LLHLS/HLS interceptors in 23ed99d4d, but the thumbnail interceptor was missed.

## What

Override `IsCacheable()` to return `false` in `ThumbnailInterceptor`, same as the LLHLS/HLS interceptors, so the interceptor is selected per request based on the URL.

## How to test

1. Configure Thumbnail and LLHLS publishers to share the same TLS port (e.g. 56667) with the HTTP2 module enabled, and publish a stream with an image encode profile.
2. In Chrome (fresh launch), play `https://<host>:<port>/app/stream/llhls.m3u8` — playback works.
3. Open `https://<host>:<port>/app/stream/thumb.jpg` in another tab of the same browser.
4. Play the same LLHLS URL again.

**Pass criteria:** step 4 plays back normally with no 404 responses on `llhls.m3u8`/chunklist/`.m4s` requests (before this fix, all LLHLS requests on the shared HTTP/2 connection returned 404). The thumbnail in step 3 still loads normally.