### PR TITLE
feat(llhls): support runtime track configuration changes with discontinuity signaling

### DIFF
--- a/src/base/modules/container/segment_storage.h
+++ b/src/base/modules/container/segment_storage.h
@@ -51,6 +51,13 @@ namespace base
 			{
 				return false;
 			}
+
+			// Codecs parameter (RFC 6381) of the track version this segment was
+			// packaged against, empty when the container does not track it
+			virtual ov::String GetCodecsParameter() const
+			{
+				return "";
+			}
 			virtual bool HasMarker() const = 0;
 			virtual const std::vector<std::shared_ptr<Marker>> &GetMarkers() const = 0;
 			virtual void SetMarkers(const std::vector<std::shared_ptr<Marker>> &markers) = 0;

--- a/src/base/modules/container/segment_storage.h
+++ b/src/base/modules/container/segment_storage.h
@@ -37,6 +37,20 @@ namespace base
 		public:
 			// All partial segments are included
 			virtual bool IsCompleted() const = 0;
+
+			// Version of the track configuration this segment was packaged against.
+			// 0 means the container does not track versions.
+			virtual uint32_t GetTrackVersion() const
+			{
+				return 0;
+			}
+
+			// This segment starts a new discontinuity domain (a boundary was cut right
+			// before it), independent of whether its own track configuration changed
+			virtual bool IsDiscontinuityPoint() const
+			{
+				return false;
+			}
 			virtual bool HasMarker() const = 0;
 			virtual const std::vector<std::shared_ptr<Marker>> &GetMarkers() const = 0;
 			virtual void SetMarkers(const std::vector<std::shared_ptr<Marker>> &markers) = 0;

--- a/src/modules/containers/bmff/bmff_packager.cpp
+++ b/src/modules/containers/bmff/bmff_packager.cpp
@@ -36,6 +36,33 @@ namespace bmff
 		return _data_track;
 	}
 
+	bool Packager::UpdateMediaTrack(const std::shared_ptr<const MediaTrack> &media_track)
+	{
+		if (media_track == nullptr || media_track->GetId() != _media_track->GetId())
+		{
+			return false;
+		}
+
+		_media_track = media_track;
+
+		if (_cenc_property.scheme != CencProtectScheme::None && IsCencSupportedCodec(media_track->GetCodecId()) == false)
+		{
+			logte("CENC is not supported for the changed codec(%s), track(%u) will be excluded from CENC protection", cmn::GetCodecIdString(media_track->GetCodecId()), media_track->GetId());
+			_cenc_property.scheme = CencProtectScheme::None;
+		}
+
+		if (_media_track->GetMediaType() == cmn::MediaType::Audio)
+		{
+			_cenc_property.crypt_bytes_block = 0;
+			_cenc_property.skip_bytes_block = 0;
+		}
+
+		// The buffer was flushed at the boundary; rebuild it on the new track
+		_sample_buffer = SampleBuffer(_media_track, _cenc_property);
+
+		return true;
+	}
+
 	bool Packager::WriteFtypBox(ov::ByteStream &container_stream)
 	{
 		// ISO/IEC 14496-12 4.3

--- a/src/modules/containers/bmff/bmff_packager.h
+++ b/src/modules/containers/bmff/bmff_packager.h
@@ -27,9 +27,13 @@ namespace bmff
 		Packager(const std::shared_ptr<const MediaTrack> &media_track, const std::shared_ptr<const MediaTrack> &data_track, const CencProperty &cenc_property);
 
 	protected:
-		// Get track 
+		// Get track
 		const std::shared_ptr<const MediaTrack> &GetMediaTrack() const;
 		const std::shared_ptr<const MediaTrack> &GetDataTrack() const;
+
+		// Switch to a new version of the same track at a runtime configuration change.
+		// Re-evaluates the CENC codec capability and rebuilds the sample buffer.
+		bool UpdateMediaTrack(const std::shared_ptr<const MediaTrack> &media_track);
 
 		// Fytp Box
 		virtual bool WriteFtypBox(ov::ByteStream &container_stream);

--- a/src/modules/containers/bmff/cenc.h
+++ b/src/modules/containers/bmff/cenc.h
@@ -20,6 +20,12 @@ namespace bmff
 {
     constexpr uint8_t AES_BLOCK_SIZE = 16;
 
+    // Codecs the CENC implementation can encrypt
+    inline bool IsCencSupportedCodec(cmn::MediaCodecId codec_id)
+    {
+        return codec_id == cmn::MediaCodecId::H264 || codec_id == cmn::MediaCodecId::Aac;
+    }
+
     enum class CencProtectScheme : uint8_t
     {
         None,

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_packager.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_packager.cpp
@@ -100,17 +100,17 @@ namespace bmff
 		}
 
 		// The same codecs CreateInitializationSegment supports; validate before mutating
-		if ((media_track->GetCodecId() == cmn::MediaCodecId::H264) ||
-			(media_track->GetCodecId() == cmn::MediaCodecId::H265) ||
-			(media_track->GetCodecId() == cmn::MediaCodecId::Av1) ||
-			(media_track->GetCodecId() == cmn::MediaCodecId::Aac))
+		switch (media_track->GetCodecId())
 		{
-			// Supported codecs
-		}
-		else
-		{
-			logtw("FMP4Packager::UpdateTrack() - Unsupported codec id(%s)", cmn::GetCodecIdString(media_track->GetCodecId()));
-			return false;
+			case cmn::MediaCodecId::H264:
+			case cmn::MediaCodecId::H265:
+			case cmn::MediaCodecId::Av1:
+			case cmn::MediaCodecId::Aac:
+				// Supported codecs
+				break;
+			default:
+				logtw("FMP4Packager::UpdateTrack() - Unsupported codec id(%s)", cmn::GetCodecIdString(media_track->GetCodecId()));
+				return false;
 		}
 
 		// Close the current content so that samples of different track versions never

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_packager.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_packager.cpp
@@ -7,6 +7,8 @@
 //
 //==============================================================================
 
+#include <cmath>
+
 #include "fmp4_packager.h"
 #include "fmp4_private.h"
 
@@ -90,6 +92,91 @@ namespace bmff
 		return StoreInitializationSection(stream.GetDataPointer());
 	}
 
+	bool FMP4Packager::UpdateTrack(const std::shared_ptr<const MediaTrack> &media_track)
+	{
+		if (media_track == nullptr)
+		{
+			return false;
+		}
+
+		// The same codecs CreateInitializationSegment supports; validate before mutating
+		if ((media_track->GetCodecId() == cmn::MediaCodecId::H264) ||
+			(media_track->GetCodecId() == cmn::MediaCodecId::H265) ||
+			(media_track->GetCodecId() == cmn::MediaCodecId::Av1) ||
+			(media_track->GetCodecId() == cmn::MediaCodecId::Aac))
+		{
+			// Supported codecs
+		}
+		else
+		{
+			logtw("FMP4Packager::UpdateTrack() - Unsupported codec id(%s)", cmn::GetCodecIdString(media_track->GetCodecId()));
+			return false;
+		}
+
+		// Close the current content so that samples of different track versions never
+		// share a segment
+		if (Flush() == false)
+		{
+			return false;
+		}
+
+		int64_t completed_segment_number = -1;
+		if (_storage == nullptr || _storage->UpdateTrack(media_track, completed_segment_number) == false)
+		{
+			return false;
+		}
+
+		if (UpdateMediaTrack(media_track) == false)
+		{
+			// Publish the completion even on failure so the playlist can close the segment
+			_storage->NotifySegmentCompleted(completed_segment_number);
+			return false;
+		}
+
+		if (media_track->GetMediaType() == cmn::MediaType::Video)
+		{
+			_segmentation_info.keyframe_interval = media_track->GetKeyFrameInterval();
+
+			// The new content must start with a keyframe
+			_waiting_for_keyframe = true;
+			_dropped_samples_while_waiting = 0;
+		}
+		_segmentation_info.framerate = media_track->GetFrameRate();
+
+		// This track's own boundary supersedes a cut propagated from another track
+		_pending_cut_timestamp_ms = -1.0;
+		_last_boundary_timestamp_ms = GetLastSampleEndTimestampMs();
+
+		bool init_section_created = CreateInitializationSegment();
+
+		// The completion is published only after the new initialization section is
+		// stored; the playlist hints the new map, so it must be servable immediately
+		_storage->NotifySegmentCompleted(completed_segment_number);
+
+		return init_section_created;
+	}
+
+	void FMP4Packager::RequestCutForDiscontinuity(double boundary_timestamp_ms)
+	{
+		// Tracks changing together propagate to each other; a boundary within a
+		// segment length of the last handled one is the same event
+		if (_last_boundary_timestamp_ms >= 0 &&
+			std::abs(boundary_timestamp_ms - _last_boundary_timestamp_ms) <= _config.segment_duration_ms)
+		{
+			return;
+		}
+
+		if (_pending_cut_timestamp_ms < 0 || boundary_timestamp_ms < _pending_cut_timestamp_ms)
+		{
+			_pending_cut_timestamp_ms = boundary_timestamp_ms;
+		}
+	}
+
+	double FMP4Packager::GetLastSampleEndTimestampMs() const
+	{
+		return _segmentation_info.last_sample_timestamp_ms + _segmentation_info.last_sample_duration_ms;
+	}
+
 	bool FMP4Packager::ReserveDataPacket(const std::shared_ptr<const MediaPacket> &media_packet)
 	{
 		if (GetDataTrack() == nullptr)
@@ -164,6 +251,46 @@ namespace bmff
 	bool FMP4Packager::AppendSample(const std::shared_ptr<const MediaPacket> &media_packet)
 	{
 		logtt("MediaPacket : track(%d) pts(%" PRId64 "), dts(%" PRId64 "), duration(%" PRId64 "), flag(%d), size(%zu)", media_packet->GetTrackId(), media_packet->GetPts(), media_packet->GetDts(), media_packet->GetDuration(), ov::ToUnderlyingType(media_packet->GetFlag()), media_packet->GetDataLength());
+
+		if (_waiting_for_keyframe == true)
+		{
+			if (media_packet->GetFlag() != MediaPacketFlag::Key)
+			{
+				_dropped_samples_while_waiting++;
+				return true;
+			}
+
+			_waiting_for_keyframe = false;
+			if (_dropped_samples_while_waiting > 0)
+			{
+				logtw("track(%u) - Dropped %u non-keyframe samples until the first keyframe of the new track configuration", GetMediaTrack()->GetId(), _dropped_samples_while_waiting);
+				_dropped_samples_while_waiting = 0;
+			}
+		}
+
+		// A discontinuity propagated from another track cuts a boundary here; this
+		// sample is the first of the new domain, so it must be independent
+		if (_pending_cut_timestamp_ms >= 0)
+		{
+			double sample_timestamp_ms = (static_cast<double>(media_packet->GetDts()) / GetMediaTrack()->GetTimeBase().GetTimescale()) * 1000.0;
+			bool independent = (media_packet->GetFlag() == MediaPacketFlag::Key) || (GetMediaTrack()->GetMediaType() == cmn::MediaType::Audio);
+
+			if (sample_timestamp_ms >= _pending_cut_timestamp_ms && independent == true)
+			{
+				if (Flush() == false)
+				{
+					return false;
+				}
+
+				if (_storage != nullptr)
+				{
+					_storage->CutSegmentForDiscontinuity();
+				}
+
+				_last_boundary_timestamp_ms = _pending_cut_timestamp_ms;
+				_pending_cut_timestamp_ms = -1.0;
+			}
+		}
 
 		// Convert bitstream format
 		auto next_frame = ConvertBitstreamFormat(media_packet);
@@ -485,9 +612,12 @@ namespace bmff
 
 			auto chunk = chunk_stream.GetDataPointer();
 
-			if (_storage != nullptr && _storage->AppendMediaChunk(chunk, 
-											samples->GetStartTimestamp(), 
-											samples->GetTotalDuration(), 
+			// Storage expects milliseconds, samples hold durations in timescale units
+			double total_sample_duration_ms = (static_cast<double>(samples->GetTotalDuration()) / GetMediaTrack()->GetTimeBase().GetTimescale()) * 1000.0;
+
+			if (_storage != nullptr && _storage->AppendMediaChunk(chunk,
+											samples->GetStartTimestamp(),
+											total_sample_duration_ms,
 											samples->IsIndependent(), true) == false)
 			{
 				logte("FMP4Packager::Flush() - Failed to store media chunk");

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_packager.h
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_packager.h
@@ -35,6 +35,23 @@ namespace bmff
 		// Generate Initialization FMP4Segment
 		bool CreateInitializationSegment();
 
+		// Switch to a new version of the track at a runtime configuration change.
+		// Flushes the buffered samples, completes the in-progress segment, regenerates
+		// the initialization segment, and waits for a keyframe to start the new content.
+		bool UpdateTrack(const std::shared_ptr<const MediaTrack> &media_track);
+
+		// Another track of the stream changes at the given timestamp; cut a segment
+		// boundary there so that every rendition carries an aligned discontinuity.
+		// Video cuts at the first keyframe from the boundary, audio at the next frame.
+		// If a sample beyond the boundary arrived before this track's own change
+		// event, the cut would fire first and add an extra discontinuity domain;
+		// current runtime-change sources cannot interleave that way.
+		void RequestCutForDiscontinuity(double boundary_timestamp_ms);
+
+		// End timestamp of the last appended sample, the boundary position for
+		// propagating a discontinuity to the other tracks
+		double GetLastSampleEndTimestampMs() const;
+
 		// Generate Media FMP4Segment
 		bool AppendSample(const std::shared_ptr<const MediaPacket> &media_packet);
 
@@ -63,6 +80,17 @@ namespace bmff
 		std::shared_ptr<FMP4Storage> _storage = nullptr;
 
 		double _target_chunk_duration_ms = 0.0;
+
+		// After a track change, video samples are dropped until the first keyframe so
+		// that the discontinuity segment always starts independent
+		bool _waiting_for_keyframe = false;
+		uint32_t _dropped_samples_while_waiting = 0;
+
+		// Negative when no cut is pending
+		double _pending_cut_timestamp_ms = -1.0;
+		// Timestamp of the last boundary this packager handled (own track change or
+		// an applied cut), to ignore re-propagation of the same boundary event
+		double _last_boundary_timestamp_ms = -1.0;
 
 		std::queue<std::shared_ptr<const MediaPacket>> _reserved_data_packets;
 	};

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_storage.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_storage.cpp
@@ -267,6 +267,7 @@ namespace bmff
 				{
 					auto new_segment = std::make_shared<FMP4Segment>(last_segment->GetNumber(), _config.segment_duration_ms, track->GetTimeBase().GetExpr());
 					new_segment->SetTrackVersion(track->GetVersion());
+					new_segment->SetCodecsParameter(track->GetCodecsParameter());
 					_segments[last_segment->GetNumber()] = new_segment;
 				}
 			}
@@ -294,11 +295,6 @@ namespace bmff
 		{
 			_observer->OnMediaSegmentCompleted(GetTrack()->GetId(), segment_number);
 		}
-	}
-
-	uint32_t FMP4Storage::GetMinRetainedTrackVersion() const
-	{
-		return _min_retained_track_version;
 	}
 
 	void FMP4Storage::MarkPendingSegmentDiscontinuity()
@@ -461,6 +457,7 @@ namespace bmff
 		// Create next segment
 		auto segment = std::make_shared<FMP4Segment>(GetLastSegmentNumber() + 1, _config.segment_duration_ms, track->GetTimeBase().GetExpr());
 		segment->SetTrackVersion(track->GetVersion());
+		segment->SetCodecsParameter(track->GetCodecsParameter());
 		{
 			std::lock_guard<std::shared_mutex> lock(_segments_lock);
 			_segments.emplace(segment->GetNumber(), segment);
@@ -477,7 +474,6 @@ namespace bmff
 				if (_segments.size() > _config.max_segments + 3)
 				{
 					_segments.erase(_segments.begin());
-					_min_retained_track_version = _segments.empty() ? 0 : _segments.begin()->second->GetTrackVersion();
 					DropUnreferencedInitializationSections();
 				}
 

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_storage.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_storage.cpp
@@ -50,9 +50,40 @@ namespace bmff
 		logtt("FMP4 Storage has been terminated successfully");
 	}
 
+	std::shared_ptr<const MediaTrack> FMP4Storage::GetTrack() const
+	{
+		return std::atomic_load(&_track);
+	}
+
 	std::shared_ptr<ov::Data> FMP4Storage::GetInitializationSection() const
 	{
-		return _initialization_section;
+		// The version-less legacy URL always means the first section of the stream
+		std::shared_lock<std::shared_mutex> lock(_initialization_sections_lock);
+		auto it = _initialization_sections.find(_initial_track_version);
+		if (it == _initialization_sections.end())
+		{
+			return nullptr;
+		}
+
+		return it->second;
+	}
+
+	std::shared_ptr<ov::Data> FMP4Storage::GetInitializationSection(uint32_t track_version) const
+	{
+		std::shared_lock<std::shared_mutex> lock(_initialization_sections_lock);
+		auto it = _initialization_sections.find(track_version);
+		if (it == _initialization_sections.end())
+		{
+			return nullptr;
+		}
+
+		return it->second;
+	}
+
+	std::map<uint32_t, std::shared_ptr<ov::Data>> FMP4Storage::GetInitializationSections() const
+	{
+		std::shared_lock<std::shared_mutex> lock(_initialization_sections_lock);
+		return _initialization_sections;
 	}
 
 	std::shared_ptr<base::modules::Segment> FMP4Storage::GetSegment(int64_t segment_number) const
@@ -114,12 +145,22 @@ namespace bmff
 		// last chunk number + 1 of completed segment is the first chunk of the next segment
 		if (segment->IsCompleted() && segment->GetLastPartialNumber() + 1 == partial_number)
 		{
-			segment = GetSegmentInternal(segment_number + 1);
-			if (segment == nullptr)
+			auto next_segment = GetSegmentInternal(segment_number + 1);
+			if (next_segment == nullptr)
 			{
 				return nullptr;
 			}
 
+			// Never roll over across a discontinuity; the hinted name belongs to the
+			// previous domain and its content would be appended without the new
+			// initialization segment. The player re-syncs from the playlist on 404.
+			if (next_segment->IsDiscontinuityPoint() == true ||
+				next_segment->GetTrackVersion() != segment->GetTrackVersion())
+			{
+				return nullptr;
+			}
+
+			segment = next_segment;
 			partial_number = 0;
 		}
 
@@ -173,12 +214,140 @@ namespace bmff
 
 	bool FMP4Storage::StoreInitializationSection(const std::shared_ptr<ov::Data> &section)
 	{
-		_initialization_section = section;
+		auto track = GetTrack();
+		auto track_version = track->GetVersion();
+
+		{
+			std::lock_guard<std::shared_mutex> lock(_initialization_sections_lock);
+
+			if (_initialization_sections.empty())
+			{
+				_initial_track_version = track_version;
+			}
+
+			_initialization_sections[track_version] = section;
+		}
+
 		if (_observer != nullptr)
 		{
-			_observer->OnFMp4StorageInitialized(_track->GetId());
+			_observer->OnFMp4StorageInitialized(track->GetId());
 		}
 		return true;
+	}
+
+	bool FMP4Storage::UpdateTrack(const std::shared_ptr<const MediaTrack> &track, int64_t &completed_segment_number)
+	{
+		completed_segment_number = -1;
+
+		auto old_track = GetTrack();
+		if (track == nullptr || track->GetId() != old_track->GetId())
+		{
+			return false;
+		}
+
+		// Close the old content (the buffered samples were already flushed). The
+		// completion is reported to the caller instead of the observer here, so that
+		// it can be published after the new initialization section is stored.
+		completed_segment_number = CompleteLastSegment();
+
+		RealignSegmentDurationPacing();
+
+		std::atomic_store(&_track, track);
+
+		{
+			std::lock_guard<std::shared_mutex> segments_lock(_segments_lock);
+
+			if (_segments.empty() == false)
+			{
+				auto last_segment = _segments.rbegin()->second;
+
+				// The empty segment pre-created at the last completion still carries the
+				// old track timebase and version, so rebuild it on the new track
+				if (last_segment->IsCompleted() == false && last_segment->GetPartialCount() == 0)
+				{
+					auto new_segment = std::make_shared<FMP4Segment>(last_segment->GetNumber(), _config.segment_duration_ms, track->GetTimeBase().GetExpr());
+					new_segment->SetTrackVersion(track->GetVersion());
+					_segments[last_segment->GetNumber()] = new_segment;
+				}
+			}
+		}
+
+		MarkPendingSegmentDiscontinuity();
+
+		return true;
+	}
+
+	void FMP4Storage::CutSegmentForDiscontinuity()
+	{
+		auto completed_segment_number = CompleteLastSegment();
+
+		RealignSegmentDurationPacing();
+
+		MarkPendingSegmentDiscontinuity();
+
+		NotifySegmentCompleted(completed_segment_number);
+	}
+
+	void FMP4Storage::NotifySegmentCompleted(int64_t segment_number)
+	{
+		if (segment_number >= 0 && _observer != nullptr)
+		{
+			_observer->OnMediaSegmentCompleted(GetTrack()->GetId(), segment_number);
+		}
+	}
+
+	uint32_t FMP4Storage::GetMinRetainedTrackVersion() const
+	{
+		return _min_retained_track_version;
+	}
+
+	void FMP4Storage::MarkPendingSegmentDiscontinuity()
+	{
+		std::lock_guard<std::shared_mutex> lock(_segments_lock);
+
+		// Nothing was published yet; the first segment is not a discontinuity
+		if (_segments.empty() == true)
+		{
+			return;
+		}
+
+		auto last_segment = _segments.rbegin()->second;
+		if (last_segment->IsCompleted() == false && last_segment->GetPartialCount() == 0)
+		{
+			last_segment->SetDiscontinuityPoint();
+		}
+	}
+
+	int64_t FMP4Storage::CompleteLastSegment()
+	{
+		auto segment = GetLastSegmentInternal();
+		if (segment == nullptr || segment->IsCompleted() == true || segment->GetPartialCount() == 0)
+		{
+			return -1;
+		}
+
+		segment->SetCompleted();
+
+		_total_segment_duration_ms += segment->GetDurationMs();
+
+		CreateNextSegment();
+
+		return segment->GetNumber();
+	}
+
+	void FMP4Storage::RealignSegmentDurationPacing()
+	{
+		// Server-time based numbering relies on the catch-up pacing to keep segment
+		// numbers aligned to the wall clock, so the drift must not be reset
+		if (_config.server_time_based_segment_numbering == true)
+		{
+			return;
+		}
+
+		// A boundary segment can be completed short of the target. Without this reset
+		// the pacing would stretch the next segment past EXT-X-TARGETDURATION to catch up.
+		_total_expected_duration_ms = _total_segment_duration_ms;
+		_target_segment_duration_ms = _config.segment_duration_ms;
 	}
 
 	double FMP4Storage::GetTargetSegmentDuration() const
@@ -188,7 +357,8 @@ namespace bmff
 
 	ov::String FMP4Storage::GetDVRDirectory() const
 	{
-		return ov::String::FormatString("%s/%s/%d", _config.dvr_storage_path.CStr(), _stream_tag.CStr(), _track->GetId());
+		// Read via GetTrack, this path also runs on HTTP request threads
+		return ov::String::FormatString("%s/%s/%d", _config.dvr_storage_path.CStr(), _stream_tag.CStr(), GetTrack()->GetId());
 	}
 
 	ov::String FMP4Storage::GetSegmentFilePath(uint32_t segment_number) const
@@ -286,8 +456,11 @@ namespace bmff
 
 	std::shared_ptr<FMP4Segment> FMP4Storage::CreateNextSegment()
 	{
+		auto track = GetTrack();
+
 		// Create next segment
-		auto segment = std::make_shared<FMP4Segment>(GetLastSegmentNumber() + 1, _config.segment_duration_ms, _track->GetTimeBase().GetExpr());
+		auto segment = std::make_shared<FMP4Segment>(GetLastSegmentNumber() + 1, _config.segment_duration_ms, track->GetTimeBase().GetExpr());
+		segment->SetTrackVersion(track->GetVersion());
 		{
 			std::lock_guard<std::shared_mutex> lock(_segments_lock);
 			_segments.emplace(segment->GetNumber(), segment);
@@ -304,6 +477,8 @@ namespace bmff
 				if (_segments.size() > _config.max_segments + 3)
 				{
 					_segments.erase(_segments.begin());
+					_min_retained_track_version = _segments.empty() ? 0 : _segments.begin()->second->GetTrackVersion();
+					DropUnreferencedInitializationSections();
 				}
 
 				// DVR
@@ -315,7 +490,7 @@ namespace bmff
 				{
 					if (_observer != nullptr)
 					{
-						_observer->OnMediaSegmentDeleted(_track->GetId(), old_segment->GetNumber());
+						_observer->OnMediaSegmentDeleted(track->GetId(), old_segment->GetNumber());
 					}
 				}
 			}
@@ -323,10 +498,39 @@ namespace bmff
 
 		if (_observer != nullptr)
 		{
-			_observer->OnMediaSegmentCreated(_track->GetId(), segment->GetNumber());
+			_observer->OnMediaSegmentCreated(track->GetId(), segment->GetNumber());
 		}
 
 		return segment;
+	}
+
+	// Called with _segments_lock held
+	void FMP4Storage::DropUnreferencedInitializationSections()
+	{
+		// DVR keeps old segments servable from files, so their sections must be kept too
+		if (_config.dvr_enabled == true || _segments.empty() == true)
+		{
+			return;
+		}
+
+		// Versions are non-decreasing along segment numbers, so anything below the
+		// oldest retained segment's version is unreferenced. The initial version is
+		// kept for the version-less legacy URL.
+		auto min_retained_version = _segments.begin()->second->GetTrackVersion();
+
+		std::lock_guard<std::shared_mutex> lock(_initialization_sections_lock);
+
+		for (auto it = _initialization_sections.begin(); it != _initialization_sections.end() && it->first < min_retained_version;)
+		{
+			if (it->first != _initial_track_version)
+			{
+				it = _initialization_sections.erase(it);
+			}
+			else
+			{
+				it++;
+			}
+		}
 	}
 
 	bool FMP4Storage::AppendMediaChunk(const std::shared_ptr<ov::Data> &chunk, int64_t start_timestamp, double duration_ms, bool independent, bool last_chunk, const std::vector<std::shared_ptr<Marker>> &markers)

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_storage.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_storage.cpp
@@ -414,7 +414,7 @@ namespace bmff
 
 			if (_observer != nullptr)
 			{
-				_observer->OnMediaSegmentDeleted(_track->GetId(), segment_to_delete.segment_number);
+				_observer->OnMediaSegmentDeleted(GetTrack()->GetId(), segment_to_delete.segment_number);
 			}
 		}
 
@@ -554,7 +554,7 @@ namespace bmff
 			last_chunk = true;
 			// Too long segment buffered
 			logte("LLHLS stream (%s) / track (%d) - the duration of the segment being created exceeded twice the target segment duration (%.1lf ms | expected: %" PRIu64 ") because there were no IDR frames for a long time. This segment is forcibly created and may not play normally.", 
-			_stream_tag.CStr(), _track->GetId(), segment->GetDurationMs(), _config.segment_duration_ms);
+			_stream_tag.CStr(), GetTrack()->GetId(), segment->GetDurationMs(), _config.segment_duration_ms);
 		}
 
 		// Complete Segment if segment duration is over and new chunk data is independent(new segment should be started with independent chunk)
@@ -563,7 +563,7 @@ namespace bmff
 			segment->SetCompleted();
 			CreateNextSegment();
 
-			logtt("Segment[%" PRId64 "] is created : track(%u), duration(%f) chunks(%lu)", segment->GetNumber(), _track->GetId(),segment->GetDurationMs(), segment->GetPartialCount());
+			logtt("Segment[%" PRId64 "] is created : track(%u), duration(%f) chunks(%lu)", segment->GetNumber(), GetTrack()->GetId(),segment->GetDurationMs(), segment->GetPartialCount());
 			
 			_total_expected_duration_ms += _config.segment_duration_ms;
 			_total_segment_duration_ms += segment->GetDurationMs();
@@ -574,7 +574,7 @@ namespace bmff
 			// Therefore, in this case, the algorithm is configured to come out smaller unconditionally.
 			if (segment->HasMarker() == true)
 			{
-				logtd("LLHLS stream (%s) / track (%u) - segment[%" PRId64 "] has markers %s", _stream_tag.CStr(), _track->GetId(), segment->GetNumber(), segment->GetMarkers().back()->GetTag().CStr());
+				logtd("LLHLS stream (%s) / track (%u) - segment[%" PRId64 "] has markers %s", _stream_tag.CStr(), GetTrack()->GetId(), segment->GetNumber(), segment->GetMarkers().back()->GetTag().CStr());
 
 				_total_expected_duration_ms -= _config.segment_duration_ms;
 				
@@ -594,7 +594,7 @@ namespace bmff
 			double next_target_duration = _total_expected_duration_ms - _total_segment_duration_ms + _config.segment_duration_ms;
 
 			logtt("LLHLS stream (%s) / track (%u) - segment_seq(%" PRId64 ") segment_duration_ms: %f total_expected_duration_ms: %f, total_segment_duration_ms: %f, next_target_duration: %f",
-				_stream_tag.CStr(), _track->GetId(), segment->GetNumber(), segment->GetDurationMs(), _total_expected_duration_ms, _total_segment_duration_ms, next_target_duration);
+				_stream_tag.CStr(), GetTrack()->GetId(), segment->GetNumber(), segment->GetDurationMs(), _total_expected_duration_ms, _total_segment_duration_ms, next_target_duration);
 			
 			if (next_target_duration >= static_cast<double>(_config.segment_duration_ms)/2.0)
 			{
@@ -645,7 +645,7 @@ namespace bmff
 			// }
 
 			logtt("LLHLS stream (%s) / track (%u) - segment_duration_ms: %f total_expected_duration_ms: %f, total_segment_duration_ms: %f, next_target_duration: %f, target_segment_duration: %f has_marker: %d",
-				_stream_tag.CStr(), _track->GetId(), segment->GetDurationMs(), _total_expected_duration_ms, _total_segment_duration_ms, next_target_duration, _target_segment_duration_ms, segment->HasMarker());
+				_stream_tag.CStr(), GetTrack()->GetId(), segment->GetDurationMs(), _total_expected_duration_ms, _total_segment_duration_ms, next_target_duration, _target_segment_duration_ms, segment->HasMarker());
 		}
 
 		_max_chunk_duration_ms = std::max(_max_chunk_duration_ms, duration_ms);
@@ -655,7 +655,7 @@ namespace bmff
 		if (_observer != nullptr)
 		{
 			bool last_chunk = segment->IsCompleted() == true;
-			_observer->OnMediaChunkUpdated(_track->GetId(), segment->GetNumber(), segment->GetLastPartialNumber(), last_chunk);
+			_observer->OnMediaChunkUpdated(GetTrack()->GetId(), segment->GetNumber(), segment->GetLastPartialNumber(), last_chunk);
 		}
 
 		return true;

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_storage.h
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_storage.h
@@ -68,10 +68,6 @@ namespace bmff
 		// Notify the observer of a segment completed without a new chunk
 		void NotifySegmentCompleted(int64_t segment_number);
 
-		// Track version of the oldest retained segment, 0 until a segment has been
-		// dropped. Lock-free, safe to call from observer callbacks.
-		uint32_t GetMinRetainedTrackVersion() const;
-
 		// Complete the in-progress segment and start a new discontinuity domain
 		// without a configuration change (another track of the stream changed)
 		void CutSegmentForDiscontinuity();
@@ -232,10 +228,6 @@ namespace bmff
 		// segment number : segment
 		std::map<int64_t, std::shared_ptr<FMP4Segment>> _segments;
 		mutable std::shared_mutex _segments_lock;
-
-		// Version of the oldest retained segment, updated when the oldest is dropped.
-		// Versions are non-decreasing along segment numbers.
-		std::atomic<uint32_t> _min_retained_track_version{0};
 
 		int64_t _initial_segment_number = 0;
 		[[maybe_unused]] int64_t _start_timestamp_delta = -1;

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_storage.h
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_storage.h
@@ -10,6 +10,7 @@
 
 #include "fmp4_structure.h"
 #include <base/common_types.h>
+#include <base/info/media_track.h>
 #include <base/modules/container/segment_storage.h>
 #include <base/modules/marker/marker_box.h>
 
@@ -22,6 +23,8 @@ namespace bmff
 		virtual void OnMediaSegmentCreated(const int32_t &track_id, const uint32_t &segment_number) = 0;
 		virtual void OnMediaChunkUpdated(const int32_t &track_id, const uint32_t &segment_number, const uint32_t &chunk_number, bool last_chunk) = 0;
 		virtual void OnMediaSegmentDeleted(const int32_t &track_id, const uint32_t &segment_number) = 0;
+		// A segment was force-completed without a new chunk (track change boundary)
+		virtual void OnMediaSegmentCompleted(const int32_t &track_id, const uint32_t &segment_number) = 0;
 	};
 
 	class FMP4Storage : public base::modules::SegmentStorage
@@ -42,6 +45,9 @@ namespace bmff
 		virtual ~FMP4Storage();
 
 		std::shared_ptr<ov::Data> GetInitializationSection() const override;
+		std::shared_ptr<ov::Data> GetInitializationSection(uint32_t track_version) const;
+		// Snapshot of all retained sections, keyed by track version
+		std::map<uint32_t, std::shared_ptr<ov::Data>> GetInitializationSections() const;
 		std::shared_ptr<base::modules::Segment> GetSegment(int64_t segment_number) const override;
 		std::shared_ptr<base::modules::Segment> GetLastSegment() const override;
 		std::shared_ptr<base::modules::PartialSegment> GetPartialSegment(int64_t segment_number, int64_t partial_number) const override;
@@ -51,6 +57,24 @@ namespace bmff
 		
 		bool StoreInitializationSection(const std::shared_ptr<ov::Data> &section);
 		bool AppendMediaChunk(const std::shared_ptr<ov::Data> &chunk, int64_t start_timestamp, double duration_ms, bool independent, bool last_chunk, const std::vector<std::shared_ptr<Marker>> &markers = {});
+
+		// Switch to a new version of the track at a runtime configuration change.
+		// Completes the in-progress segment and creates subsequent segments with the
+		// new track. The completed segment number (-1 if none) is handed back so the
+		// caller can publish it via NotifySegmentCompleted once the new
+		// initialization section exists.
+		bool UpdateTrack(const std::shared_ptr<const MediaTrack> &track, int64_t &completed_segment_number);
+
+		// Notify the observer of a segment completed without a new chunk
+		void NotifySegmentCompleted(int64_t segment_number);
+
+		// Track version of the oldest retained segment, 0 until a segment has been
+		// dropped. Lock-free, safe to call from observer callbacks.
+		uint32_t GetMinRetainedTrackVersion() const;
+
+		// Complete the in-progress segment and start a new discontinuity domain
+		// without a configuration change (another track of the stream changed)
+		void CutSegmentForDiscontinuity();
 
 		uint64_t GetMaxPartialDurationMs() const override;
 		uint64_t GetMinPartialDurationMs() const override;
@@ -62,6 +86,18 @@ namespace bmff
 	private:
 		std::shared_ptr<FMP4Segment> GetSegmentInternal(int64_t segment_number) const;
 		std::shared_ptr<FMP4Segment> GetLastSegmentInternal() const;
+
+		// Force the in-progress segment to complete at a track change boundary.
+		// Returns the completed segment number, or -1 if there was nothing to complete.
+		int64_t CompleteLastSegment();
+
+		// Reset the segment duration pacing after a boundary cut
+		void RealignSegmentDurationPacing();
+
+		// Flag the pre-created empty segment as the start of a new discontinuity domain
+		void MarkPendingSegmentDiscontinuity();
+
+		void DropUnreferencedInitializationSections();
 		
 
 		// For DVR
@@ -178,15 +214,28 @@ namespace bmff
 
 		std::shared_ptr<FMP4Segment> CreateNextSegment();
 
+		std::shared_ptr<const MediaTrack> GetTrack() const;
+
 		Config	_config;
 
+		// Swapped by UpdateTrack at a runtime configuration change, read via GetTrack
 		std::shared_ptr<const MediaTrack> _track;
 
-		std::shared_ptr<ov::Data> _initialization_section = nullptr;
-		
+		// Initialization sections keyed by the track version that produced them.
+		// A runtime track change stores a new entry so that segments of the old
+		// version remain playable with their own section.
+		std::map<uint32_t, std::shared_ptr<ov::Data>> _initialization_sections;
+		// The first stored version, served for the version-less legacy URL
+		uint32_t _initial_track_version = 0;
+		mutable std::shared_mutex _initialization_sections_lock;
+
 		// segment number : segment
 		std::map<int64_t, std::shared_ptr<FMP4Segment>> _segments;
 		mutable std::shared_mutex _segments_lock;
+
+		// Version of the oldest retained segment, updated when the oldest is dropped.
+		// Versions are non-decreasing along segment numbers.
+		std::atomic<uint32_t> _min_retained_track_version{0};
 
 		int64_t _initial_segment_number = 0;
 		[[maybe_unused]] int64_t _start_timestamp_delta = -1;

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_structure.h
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_structure.h
@@ -103,6 +103,26 @@ namespace bmff
 			return _is_completed;
 		}
 
+		void SetTrackVersion(uint32_t track_version)
+		{
+			_track_version = track_version;
+		}
+
+		uint32_t GetTrackVersion() const override
+		{
+			return _track_version;
+		}
+
+		void SetDiscontinuityPoint()
+		{
+			_discontinuity_point = true;
+		}
+
+		bool IsDiscontinuityPoint() const override
+		{
+			return _discontinuity_point;
+		}
+
 		bool AppendPartialData(const std::shared_ptr<ov::Data> &partial_data, int64_t start_timestamp, double duration_ms, bool independent)
 		{
 			if (_is_completed)
@@ -212,6 +232,9 @@ namespace bmff
 
 	private:
 		bool _is_completed = false;
+
+		uint32_t _track_version = 0;
+		bool _discontinuity_point = false;
 
 		int64_t _number = -1;
 

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_structure.h
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_structure.h
@@ -123,6 +123,16 @@ namespace bmff
 			return _discontinuity_point;
 		}
 
+		void SetCodecsParameter(const ov::String &codecs)
+		{
+			_codecs_parameter = codecs;
+		}
+
+		ov::String GetCodecsParameter() const override
+		{
+			return _codecs_parameter;
+		}
+
 		bool AppendPartialData(const std::shared_ptr<ov::Data> &partial_data, int64_t start_timestamp, double duration_ms, bool independent)
 		{
 			if (_is_completed)
@@ -235,6 +245,7 @@ namespace bmff
 
 		uint32_t _track_version = 0;
 		bool _discontinuity_point = false;
+		ov::String _codecs_parameter;
 
 		int64_t _number = -1;
 

--- a/src/publishers/llhls/llhls_chunklist.cpp
+++ b/src/publishers/llhls/llhls_chunklist.cpp
@@ -109,6 +109,45 @@ bool LLHlsChunklist::CreateSegmentInfo(const SegmentInfo &info)
 	return true;
 }
 
+bool LLHlsChunklist::CompleteSegmentInfo(uint32_t segment_sequence, const ov::String &next_partial_url, const ov::String &next_partial_map_uri)
+{
+	std::shared_ptr<SegmentInfo> segment = GetSegmentInfo(segment_sequence);
+	if (segment == nullptr)
+	{
+		logte("Could not find segment info to complete. segment(%u)", segment_sequence);
+		return false;
+	}
+
+	{
+		std::lock_guard<std::shared_mutex> lock(_segments_guard);
+		segment->SetCompleted();
+		_last_completed_segment_sequence = segment_sequence;
+		_first_segment = false;
+
+		auto &partial_segments = segment->GetPartialSegments();
+		if (partial_segments.empty() == false && next_partial_url.IsEmpty() == false)
+		{
+			partial_segments.back()->SetNextUrl(next_partial_url);
+		}
+
+		_upcoming_map_uri = next_partial_map_uri;
+	}
+
+	UpdateCacheForDefaultChunklist();
+
+	return true;
+}
+
+void LLHlsChunklist::SetUpcomingMapUri(const ov::String &map_uri)
+{
+	{
+		std::lock_guard<std::shared_mutex> lock(_segments_guard);
+		_upcoming_map_uri = map_uri;
+	}
+
+	UpdateCacheForDefaultChunklist();
+}
+
 bool LLHlsChunklist::AppendPartialSegmentInfo(uint32_t segment_sequence, const SegmentInfo &info)
 {
 	std::shared_ptr<SegmentInfo> segment = GetSegmentInfo(segment_sequence);
@@ -124,6 +163,28 @@ bool LLHlsChunklist::AppendPartialSegmentInfo(uint32_t segment_sequence, const S
 		if (_first_segment == true)
 		{
 			_max_part_duration = std::max(_max_part_duration, info.GetDuration());
+		}
+
+		// A starting segment is stamped with the configuration it was packaged
+		// against; a version different from the previous segment or an explicitly
+		// flagged boundary cut is a discontinuity
+		if (segment->GetPartialSegmentsCount() == 0)
+		{
+			segment->SetTrackVersion(info.GetTrackVersion());
+			segment->SetMapUri(info.GetMapUri());
+
+			if (info.IsDiscontinuity() == true ||
+				(_last_started_track_version.has_value() == true &&
+				 _last_started_track_version.value() != info.GetTrackVersion()))
+			{
+				segment->SetDiscontinuity();
+				_total_discontinuity_count++;
+
+				// The hinted map is inline from this partial on
+				_upcoming_map_uri.Clear();
+			}
+
+			_last_started_track_version = info.GetTrackVersion();
 		}
 
 		if (info.IsCompleted() == true)
@@ -160,6 +221,12 @@ bool LLHlsChunklist::RemoveSegmentInfo(uint32_t segment_sequence)
 	{
 		logtc("The sequence number of the segment to be deleted is not the first segment. segment(%u) first(%" PRId64 ")", segment_sequence, old_segment->GetSequence());
 		return false;
+	}
+
+	if (old_segment->IsDiscontinuity() == true)
+	{
+		// Its EXT-X-DISCONTINUITY tag leaves the playlist with it
+		_removed_discontinuity_count++;
 	}
 
 	SaveOldSegmentInfo(old_segment);
@@ -403,9 +470,62 @@ ov::String LLHlsChunklist::MakeChunklist(const ov::String &query_string, bool sk
 
 	playlist.AppendFormat("#EXT-X-MEDIA-SEQUENCE:%" PRId64 "\n", vod == false ? first_segment->GetSequence() : static_cast<int64_t>(0));
 
-	if (_map_uri.IsEmpty() == false)
+	if (_total_discontinuity_count > 0)
 	{
-		playlist.AppendFormat("#EXT-X-MAP:URI=\"%s", _map_uri.CStr());
+		int64_t discontinuity_sequence = _removed_discontinuity_count;
+
+		if (vod == true)
+		{
+			// Removed segments listed again in the VOD playlist reclaim their tags
+			for (const auto &[number, old_segment] : _old_segments)
+			{
+				if (number >= vod_start_segment_number && old_segment->IsDiscontinuity() == true)
+				{
+					discontinuity_sequence--;
+				}
+			}
+		}
+
+		// Retained segments ahead of the playlist window count as removed for this view
+		for (auto it = _segments.begin(); it != _segments.end() && it->first < first_segment->GetSequence(); it++)
+		{
+			if (it->second->IsDiscontinuity() == true)
+			{
+				discontinuity_sequence++;
+			}
+		}
+
+		playlist.AppendFormat("#EXT-X-DISCONTINUITY-SEQUENCE:%" PRId64 "\n", discontinuity_sequence);
+	}
+
+	// The map of the first listed segment leads the playlist, following segments
+	// declare a new EXT-X-MAP when theirs differs
+	ov::String current_map_uri = _map_uri;
+	{
+		std::shared_ptr<SegmentInfo> first_listed_segment = first_segment;
+		if (vod == true)
+		{
+			for (const auto &[number, old_segment] : _old_segments)
+			{
+				if (number < vod_start_segment_number)
+				{
+					continue;
+				}
+
+				first_listed_segment = old_segment;
+				break;
+			}
+		}
+
+		if (first_listed_segment != nullptr && first_listed_segment->GetMapUri().IsEmpty() == false)
+		{
+			current_map_uri = first_listed_segment->GetMapUri();
+		}
+	}
+
+	if (current_map_uri.IsEmpty() == false)
+	{
+		playlist.AppendFormat("#EXT-X-MAP:URI=\"%s", current_map_uri.CStr());
 		if (query_string.IsEmpty() == false)
 		{
 			playlist.AppendFormat("?%s", query_string.CStr());
@@ -426,6 +546,22 @@ ov::String LLHlsChunklist::MakeChunklist(const ov::String &query_string, bool sk
 			if (number < vod_start_segment_number)
 			{
 				continue;
+			}
+
+			if (segment->IsDiscontinuity() == true)
+			{
+				playlist.AppendFormat("#EXT-X-DISCONTINUITY\n");
+			}
+
+			if (segment->GetMapUri().IsEmpty() == false && segment->GetMapUri() != current_map_uri)
+			{
+				current_map_uri = segment->GetMapUri();
+				playlist.AppendFormat("#EXT-X-MAP:URI=\"%s", current_map_uri.CStr());
+				if (query_string.IsEmpty() == false)
+				{
+					playlist.AppendFormat("?%s", query_string.CStr());
+				}
+				playlist.AppendFormat("\"\n");
 			}
 
 			std::chrono::system_clock::time_point tp{std::chrono::milliseconds{segment->GetStartTime()}};
@@ -459,6 +595,22 @@ ov::String LLHlsChunklist::MakeChunklist(const ov::String &query_string, bool sk
 		if (legacy == true && (segment->IsCompleted() == false))
 		{
 			continue;
+		}
+
+		if (segment->IsDiscontinuity() == true)
+		{
+			playlist.AppendFormat("#EXT-X-DISCONTINUITY\n");
+		}
+
+		if (segment->GetMapUri().IsEmpty() == false && segment->GetMapUri() != current_map_uri)
+		{
+			current_map_uri = segment->GetMapUri();
+			playlist.AppendFormat("#EXT-X-MAP:URI=\"%s", current_map_uri.CStr());
+			if (query_string.IsEmpty() == false)
+			{
+				playlist.AppendFormat("?%s", query_string.CStr());
+			}
+			playlist.AppendFormat("\"\n");
 		}
 
 		std::chrono::system_clock::time_point tp{std::chrono::milliseconds{segment->GetStartTime()}};
@@ -512,6 +664,18 @@ ov::String LLHlsChunklist::MakeChunklist(const ov::String &query_string, bool sk
 			segment->GetSequence() == last_segment->GetSequence() &&
 			segment->GetPartialSegmentsCount() > 0)
 		{
+			// The hinted partial opens a new map after a boundary cut; hint the new
+			// initialization section too so clients can fetch it ahead
+			if (_upcoming_map_uri.IsEmpty() == false && _upcoming_map_uri != current_map_uri)
+			{
+				playlist.AppendFormat("#EXT-X-PRELOAD-HINT:TYPE=MAP,URI=\"%s", _upcoming_map_uri.CStr());
+				if (query_string.IsEmpty() == false)
+				{
+					playlist.AppendFormat("?%s", query_string.CStr());
+				}
+				playlist.AppendFormat("\"\n");
+			}
+
 			auto &last_partial = segment->GetPartialSegments().back();
 			playlist.AppendFormat("#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"%s", last_partial->GetNextUrl().CStr());
 			if (query_string.IsEmpty() == false)

--- a/src/publishers/llhls/llhls_chunklist.cpp
+++ b/src/publishers/llhls/llhls_chunklist.cpp
@@ -146,6 +146,9 @@ ov::String LLHlsChunklist::GetListedCodecsUnion() const
 		return "";
 	}
 
+	// Keyed off the oldest retained segment, which trails the listed window by a
+	// few segments; a codec lingers in the union a little after leaving the window,
+	// which is a harmless superset for the CODECS attribute
 	return MakeCodecsUnionInternal(_segments.begin()->second->GetTrackVersion());
 }
 

--- a/src/publishers/llhls/llhls_chunklist.cpp
+++ b/src/publishers/llhls/llhls_chunklist.cpp
@@ -138,6 +138,62 @@ bool LLHlsChunklist::CompleteSegmentInfo(uint32_t segment_sequence, const ov::St
 	return true;
 }
 
+ov::String LLHlsChunklist::GetListedCodecsUnion() const
+{
+	std::shared_lock<std::shared_mutex> lock(_segments_guard);
+	if (_segments.empty() == true)
+	{
+		return "";
+	}
+
+	return MakeCodecsUnionInternal(_segments.begin()->second->GetTrackVersion());
+}
+
+ov::String LLHlsChunklist::GetAllCodecsUnion() const
+{
+	std::shared_lock<std::shared_mutex> lock(_segments_guard);
+	return MakeCodecsUnionInternal(0);
+}
+
+ov::String LLHlsChunklist::MakeCodecsUnionInternal(uint32_t min_track_version) const
+{
+	// Versions can share the same parameter (e.g. a samplerate-only change)
+	ov::String codecs_union;
+	std::vector<ov::String> distinct_codecs;
+	for (auto it = _version_codecs.lower_bound(min_track_version); it != _version_codecs.end(); it++)
+	{
+		const auto &codecs = it->second;
+		if (codecs.IsEmpty() == true)
+		{
+			continue;
+		}
+
+		bool exists = false;
+		for (const auto &existing : distinct_codecs)
+		{
+			if (existing == codecs)
+			{
+				exists = true;
+				break;
+			}
+		}
+
+		if (exists == true)
+		{
+			continue;
+		}
+
+		distinct_codecs.push_back(codecs);
+		if (codecs_union.IsEmpty() == false)
+		{
+			codecs_union.Append(",");
+		}
+		codecs_union.Append(codecs);
+	}
+
+	return codecs_union;
+}
+
 void LLHlsChunklist::SetUpcomingMapUri(const ov::String &map_uri)
 {
 	{
@@ -172,6 +228,12 @@ bool LLHlsChunklist::AppendPartialSegmentInfo(uint32_t segment_sequence, const S
 		{
 			segment->SetTrackVersion(info.GetTrackVersion());
 			segment->SetMapUri(info.GetMapUri());
+
+			// The chunklist learns each version's codecs from its segments
+			if (info.GetCodecsParameter().IsEmpty() == false)
+			{
+				_version_codecs[info.GetTrackVersion()] = info.GetCodecsParameter();
+			}
 
 			if (info.IsDiscontinuity() == true ||
 				(_last_started_track_version.has_value() == true &&

--- a/src/publishers/llhls/llhls_chunklist.h
+++ b/src/publishers/llhls/llhls_chunklist.h
@@ -196,6 +196,17 @@ public:
 			return _track_version;
 		}
 
+		// Codecs parameter of the track version this segment was packaged against
+		void SetCodecsParameter(const ov::String &codecs)
+		{
+			_codecs_parameter = codecs;
+		}
+
+		const ov::String &GetCodecsParameter() const
+		{
+			return _codecs_parameter;
+		}
+
 		ov::String GetStartDate() const
 		{
 			ov::String start_date;
@@ -244,6 +255,7 @@ public:
 		bool _discontinuity = false;
 		ov::String _map_uri;
 		uint32_t _track_version = 0;
+		ov::String _codecs_parameter;
 
 		std::deque<std::shared_ptr<SegmentInfo>> _partial_segments;
 
@@ -289,6 +301,16 @@ public:
 	// listed map. Set it only once the initialization section is servable.
 	void SetUpcomingMapUri(const ov::String &map_uri);
 
+	// The chunklist describes which codecs its own listing contains, learned from
+	// the segments it was fed; the master playlist CODECS attribute is built from
+	// that description.
+	// Every distinct codecs parameter among the listed segments, oldest first
+	ov::String GetListedCodecsUnion() const;
+
+	// Every distinct codecs parameter ever listed; dumped output keeps segments
+	// of every version, so it needs them all
+	ov::String GetAllCodecsUnion() const;
+
 	ov::String ToString(const ov::String &query_string, bool skip, bool legacy, bool rewind, bool vod = false, uint32_t vod_start_segment_number = 0) const;
 	std::shared_ptr<const ov::Data> ToGzipData(const ov::String &query_string, bool skip, bool legacy, bool rewind) const;
 
@@ -330,6 +352,13 @@ private:
 	// Map of the hinted-but-not-yet-listed partial. Emitted as a TYPE=MAP preload
 	// hint while it differs from the last listed map. Guarded by _segments_guard.
 	ov::String _upcoming_map_uri;
+
+	// Called with _segments_guard held; versions are non-decreasing along segments
+	ov::String MakeCodecsUnionInternal(uint32_t min_track_version) const;
+
+	// Track version : codecs parameter, learned from the first partial of each
+	// version's segments. Guarded by _segments_guard.
+	std::map<uint32_t, ov::String> _version_codecs;
 
 	// Discontinuity-flagged segments that left the live window (EXT-X-DISCONTINUITY-SEQUENCE base)
 	std::atomic<int64_t> _removed_discontinuity_count = 0;

--- a/src/publishers/llhls/llhls_chunklist.h
+++ b/src/publishers/llhls/llhls_chunklist.h
@@ -301,14 +301,16 @@ public:
 	// listed map. Set it only once the initialization section is servable.
 	void SetUpcomingMapUri(const ov::String &map_uri);
 
-	// The chunklist describes which codecs its own listing contains, learned from
+	// The chunklist describes which codecs its own segments contain, learned from
 	// the segments it was fed; the master playlist CODECS attribute is built from
 	// that description.
-	// Every distinct codecs parameter among the listed segments, oldest first
+	// Every distinct codecs parameter among the retained segments, oldest first.
+	// Retention runs a few segments behind the listed window, so this is a safe
+	// superset of the strictly-listed codecs (over-inclusive, never missing one).
 	ov::String GetListedCodecsUnion() const;
 
-	// Every distinct codecs parameter ever listed; dumped output keeps segments
-	// of every version, so it needs them all
+	// Every distinct codecs parameter ever seen; dumped output keeps segments of
+	// every version, so it needs them all
 	ov::String GetAllCodecsUnion() const;
 
 	ov::String ToString(const ov::String &query_string, bool skip, bool legacy, bool rewind, bool vod = false, uint32_t vod_start_segment_number = 0) const;

--- a/src/publishers/llhls/llhls_chunklist.h
+++ b/src/publishers/llhls/llhls_chunklist.h
@@ -8,6 +8,8 @@
 //==============================================================================
 #pragma once
 
+#include <optional>
+
 #include <base/ovlibrary/ovlibrary.h>
 #include <base/info/media_track.h>
 #include <base/mediarouter/media_buffer.h>
@@ -96,6 +98,11 @@ public:
 			return _next_url;
 		}
 
+		void SetNextUrl(const ov::String &next_url)
+		{
+			_next_url = next_url;
+		}
+
 		bool IsIndependent() const
 		{
 			return _is_independent;
@@ -156,6 +163,39 @@ public:
 			return _completed;
 		}
 
+		// This segment starts a new track configuration, EXT-X-DISCONTINUITY precedes it
+		void SetDiscontinuity()
+		{
+			_discontinuity = true;
+		}
+
+		bool IsDiscontinuity() const
+		{
+			return _discontinuity;
+		}
+
+		// Initialization segment (EXT-X-MAP) this segment was packaged against
+		void SetMapUri(const ov::String &map_uri)
+		{
+			_map_uri = map_uri;
+		}
+
+		const ov::String &GetMapUri() const
+		{
+			return _map_uri;
+		}
+
+		// Version of the track configuration this segment was packaged against
+		void SetTrackVersion(uint32_t track_version)
+		{
+			_track_version = track_version;
+		}
+
+		uint32_t GetTrackVersion() const
+		{
+			return _track_version;
+		}
+
 		ov::String GetStartDate() const
 		{
 			ov::String start_date;
@@ -201,6 +241,9 @@ public:
 		ov::String _next_url;
 		bool _is_independent = false;
 		bool _completed = false;
+		bool _discontinuity = false;
+		ov::String _map_uri;
+		uint32_t _track_version = 0;
 
 		std::deque<std::shared_ptr<SegmentInfo>> _partial_segments;
 
@@ -235,6 +278,17 @@ public:
 	bool AppendPartialSegmentInfo(uint32_t segment_sequence, const SegmentInfo &info);
 	bool RemoveSegmentInfo(uint32_t segment_sequence);
 
+	// Mark a segment completed without a new partial (track change boundary cut).
+	// The last partial advertised a next part that will never exist, so its next url
+	// is redirected to the first part of the following segment. The map that part
+	// will be packaged against is hinted as TYPE=MAP until the part is listed.
+	bool CompleteSegmentInfo(uint32_t segment_sequence, const ov::String &next_partial_url, const ov::String &next_partial_map_uri);
+
+	// Map the first partial of the next discontinuity domain will be packaged
+	// against, emitted as a TYPE=MAP preload hint while it differs from the last
+	// listed map. Set it only once the initialization section is servable.
+	void SetUpcomingMapUri(const ov::String &map_uri);
+
 	ov::String ToString(const ov::String &query_string, bool skip, bool legacy, bool rewind, bool vod = false, uint32_t vod_start_segment_number = 0) const;
 	std::shared_ptr<const ov::Data> ToGzipData(const ov::String &query_string, bool skip, bool legacy, bool rewind) const;
 
@@ -268,6 +322,19 @@ private:
 	double _part_hold_back = 0;
 	ov::String _map_uri;
 	bool _preload_hint_enabled = true;
+
+	// Track version of the most recently started segment; a segment starting with a
+	// different version gets the discontinuity flag. Guarded by _segments_guard.
+	std::optional<uint32_t> _last_started_track_version;
+
+	// Map of the hinted-but-not-yet-listed partial. Emitted as a TYPE=MAP preload
+	// hint while it differs from the last listed map. Guarded by _segments_guard.
+	ov::String _upcoming_map_uri;
+
+	// Discontinuity-flagged segments that left the live window (EXT-X-DISCONTINUITY-SEQUENCE base)
+	std::atomic<int64_t> _removed_discontinuity_count = 0;
+	// Total flagged segments ever, to decide whether the tag set must be emitted
+	std::atomic<int64_t> _total_discontinuity_count = 0;
 
 	std::atomic<int64_t> _last_segment_sequence = -1;
 	std::atomic<int64_t> _last_completed_segment_sequence = -1;

--- a/src/publishers/llhls/llhls_master_playlist.cpp
+++ b/src/publishers/llhls/llhls_master_playlist.cpp
@@ -126,6 +126,22 @@ bool LLHlsMasterPlaylist::AddMediaCandidate(const LLHlsMasterPlaylist::MediaInfo
 	return true;
 }
 
+void LLHlsMasterPlaylist::SetTrackCodecs(int32_t track_id, const ov::String &codecs)
+{
+	_track_codecs[track_id] = codecs;
+}
+
+ov::String LLHlsMasterPlaylist::GetTrackCodecs(const std::shared_ptr<const MediaTrack> &track) const
+{
+	auto it = _track_codecs.find(track->GetId());
+	if (it != _track_codecs.end() && it->second.IsEmpty() == false)
+	{
+		return it->second;
+	}
+
+	return track->GetCodecsParameter();
+}
+
 bool LLHlsMasterPlaylist::AddStreamInfo(const ov::String &video_group_id, int video_index_hint, const ov::String &audio_group_id, const ov::String &subtitle_group_id)
 {
 	auto new_stream_info = std::make_shared<StreamInfo>();
@@ -154,7 +170,7 @@ bool LLHlsMasterPlaylist::AddStreamInfo(const ov::String &video_group_id, int vi
 		new_stream_info->_width = resolution.width;
 		new_stream_info->_height = resolution.height;
 		new_stream_info->_framerate = video_track->GetFrameRate();
-		new_stream_info->_codecs = video_track->GetCodecsParameter();
+		new_stream_info->_codecs = GetTrackCodecs(video_track);
 
 		// 25-01-27 : Video group is not used now
 		// Active media group if video group has more than 1 media info
@@ -184,7 +200,7 @@ bool LLHlsMasterPlaylist::AddStreamInfo(const ov::String &video_group_id, int vi
 			}
 
 			new_stream_info->_bandwidth += audio_track->GetBitrate();
-			new_stream_info->_codecs += ov::String::FormatString(",%s", audio_track->GetCodecsParameter().CStr());
+			new_stream_info->_codecs += ov::String::FormatString(",%s", GetTrackCodecs(audio_track).CStr());
 		}
 
 		if (subtitle_group_id.IsEmpty() == false)
@@ -220,7 +236,7 @@ bool LLHlsMasterPlaylist::AddStreamInfo(const ov::String &video_group_id, int vi
 		}
 
 		new_stream_info->_bandwidth += audio_track->GetBitrate();
-		new_stream_info->_codecs = audio_track->GetCodecsParameter();
+		new_stream_info->_codecs = GetTrackCodecs(audio_track);
 
 		if (audio_group->_media_infos.size() > 1)
 		{

--- a/src/publishers/llhls/llhls_master_playlist.h
+++ b/src/publishers/llhls/llhls_master_playlist.h
@@ -58,6 +58,11 @@ public:
 	bool AddMediaCandidate(const LLHlsMasterPlaylist::MediaInfo &media_info);
 	bool AddStreamInfo(const ov::String &video_group_id, int video_index_hint, const ov::String &audio_group_id, const ov::String &subtitle_group_id);
 
+	// Codecs the CODECS attribute advertises for a track. A runtime configuration
+	// change can leave segments of several codecs in the window, so this can list
+	// more than the track's current parameter. Set before AddStreamInfo.
+	void SetTrackCodecs(int32_t track_id, const ov::String &codecs);
+
 	void UpdateCacheForDefaultPlaylist();
 
 	ov::String ToString(const ov::String &chunk_query_string, bool legacy, bool rewind, bool include_path=true) const;
@@ -102,6 +107,12 @@ private:
 
 	// Get Media Group
 	std::shared_ptr<MediaGroup> GetMediaGroup(const ov::String &group_id) const;
+
+	// Codecs set via SetTrackCodecs, falling back to the track's current parameter
+	ov::String GetTrackCodecs(const std::shared_ptr<const MediaTrack> &track) const;
+
+	// Track ID : codecs for the CODECS attribute
+	std::map<int32_t, ov::String> _track_codecs;
 
 	// Group ID : MediaInfo
 	std::map<ov::String, std::shared_ptr<MediaGroup>> _media_groups;

--- a/src/publishers/llhls/llhls_session.cpp
+++ b/src/publishers/llhls/llhls_session.cpp
@@ -235,9 +235,10 @@ void LLHlsSession::OnMessageReceived(const std::any &message)
 	int32_t track_id;
 	int64_t segment_number;
 	int64_t partial_number;
+	int64_t init_version;
 	ov::String stream_key;
 
-	if (ParseFileName(file, file_type, track_id, segment_number, partial_number, stream_key) == false)
+	if (ParseFileName(file, file_type, track_id, segment_number, partial_number, init_version, stream_key) == false)
 	{
 		response->SetStatusCode(http::StatusCode::NotFound);
 		ResponseData(exchange);
@@ -365,7 +366,7 @@ void LLHlsSession::OnMessageReceived(const std::any &message)
 		break;
 	}
 	case RequestType::InitializationSegment:
-		ResponseInitializationSegment(exchange, file, track_id);
+		ResponseInitializationSegment(exchange, file, track_id, init_version);
 		break;
 	case RequestType::Segment:
 		ResponseSegment(exchange, file, track_id, segment_number);
@@ -378,8 +379,11 @@ void LLHlsSession::OnMessageReceived(const std::any &message)
 	}
 }
 
-bool LLHlsSession::ParseFileName(const ov::String &file_name, RequestType &type, int32_t &track_id, int64_t &segment_number, int64_t &partial_number, ov::String &stream_key) const
+bool LLHlsSession::ParseFileName(const ov::String &file_name, RequestType &type, int32_t &track_id, int64_t &segment_number, int64_t &partial_number, int64_t &init_version, ov::String &stream_key) const
 {
+	// Negative means the version-less initial initialization segment
+	init_version = -1;
+
 	// Split to filename.ext
 	auto name_ext_items = file_name.Split(".");
 	if (name_ext_items.size() < 2 || (name_ext_items[1] != "m4s" && name_ext_items[1] != "m3u8" && name_ext_items[1] != "vtt"))
@@ -409,6 +413,7 @@ bool LLHlsSession::ParseFileName(const ov::String &file_name, RequestType &type,
 	else if (name_items[0] == "init")
 	{
 		// init_<track id>_<media type>_<stream key>_llhls
+		// init_<track id>_<media type>_<stream key>_v<track version>_llhls (after a track change)
 		if (name_items.size() < 5 || name_ext_items[1] != "m4s")
 		{
 			logtw("Invalid file name requested: %s", file_name.CStr());
@@ -418,6 +423,11 @@ bool LLHlsSession::ParseFileName(const ov::String &file_name, RequestType &type,
 		type = RequestType::InitializationSegment;
 		track_id = ov::Converter::ToInt32(name_items[1].CStr());
 		stream_key = name_items[3];
+
+		if (name_items.size() >= 6 && name_items[4].HasPrefix('v') == true)
+		{
+			init_version = ov::Converter::ToInt64(name_items[4].Substring(1).CStr());
+		}
 	}
 	else if (name_items[0] == "seg" && (name_ext_items[1] == "m4s" || name_ext_items[1] == "vtt"))
 	{
@@ -644,7 +654,7 @@ void LLHlsSession::ResponseChunklist(const std::shared_ptr<http::svr::HttpExchan
 	ResponseData(exchange);
 }
 
-void LLHlsSession::ResponseInitializationSegment(const std::shared_ptr<http::svr::HttpExchange> &exchange, const ov::String &file_name, const int32_t &track_id)
+void LLHlsSession::ResponseInitializationSegment(const std::shared_ptr<http::svr::HttpExchange> &exchange, const ov::String &file_name, const int32_t &track_id, const int64_t &init_version)
 {
 	auto llhls_stream = std::static_pointer_cast<LLHlsStream>(GetStream());
 	if (llhls_stream == nullptr)
@@ -655,7 +665,8 @@ void LLHlsSession::ResponseInitializationSegment(const std::shared_ptr<http::svr
 	auto response = exchange->GetResponse();
 
 	// Get the initialization segment
-	auto [result, initialization_segment] = llhls_stream->GetInitializationSegment(track_id);
+	auto [result, initialization_segment] = (init_version >= 0) ? llhls_stream->GetInitializationSegment(track_id, static_cast<uint32_t>(init_version))
+																: llhls_stream->GetInitializationSegment(track_id);
 	if (result == LLHlsStream::RequestResult::Success)
 	{
 		// Send the initialization segment

--- a/src/publishers/llhls/llhls_session.cpp
+++ b/src/publishers/llhls/llhls_session.cpp
@@ -426,7 +426,19 @@ bool LLHlsSession::ParseFileName(const ov::String &file_name, RequestType &type,
 
 		if (name_items.size() >= 6 && name_items[4].HasPrefix('v') == true)
 		{
-			init_version = ov::Converter::ToInt64(name_items[4].Substring(1).CStr());
+			auto version_token = name_items[4].Substring(1);
+			if (version_token.IsEmpty() == true || version_token.IsNumeric() == false)
+			{
+				logtw("Invalid file name requested: %s", file_name.CStr());
+				return false;
+			}
+
+			init_version = ov::Converter::ToInt64(version_token.CStr());
+			if (init_version < 0 || init_version > static_cast<int64_t>(std::numeric_limits<uint32_t>::max()))
+			{
+				logtw("Invalid file name requested: %s", file_name.CStr());
+				return false;
+			}
 		}
 	}
 	else if (name_items[0] == "seg" && (name_ext_items[1] == "m4s" || name_ext_items[1] == "vtt"))

--- a/src/publishers/llhls/llhls_session.h
+++ b/src/publishers/llhls/llhls_session.h
@@ -71,11 +71,11 @@ private:
 		PartialSegment,
 	};
 
-	bool ParseFileName(const ov::String &file_name, RequestType &type, int32_t &track_id, int64_t &segment_number, int64_t &partial_number, ov::String &stream_key) const;
+	bool ParseFileName(const ov::String &file_name, RequestType &type, int32_t &track_id, int64_t &segment_number, int64_t &partial_number, int64_t &init_version, ov::String &stream_key) const;
 
 	void ResponsePlaylist(const std::shared_ptr<http::svr::HttpExchange> &exchange, const ov::String &file_name, bool legacy, bool rewind, bool holdIfAccepted = true);
 	void ResponseChunklist(const std::shared_ptr<http::svr::HttpExchange> &exchange, const ov::String &file_name, const int32_t &track_id, int64_t msn, int64_t part, bool skip, bool legacy, bool rewind, bool holdIfAccepted = true);
-	void ResponseInitializationSegment(const std::shared_ptr<http::svr::HttpExchange> &exchange, const ov::String &file_name, const int32_t &track_id);
+	void ResponseInitializationSegment(const std::shared_ptr<http::svr::HttpExchange> &exchange, const ov::String &file_name, const int32_t &track_id, const int64_t &init_version);
 	void ResponseSegment(const std::shared_ptr<http::svr::HttpExchange> &exchange, const ov::String &file_name, const int32_t &track_id, const int64_t &segment_number);
 	void ResponsePartialSegment(const std::shared_ptr<http::svr::HttpExchange> &exchange, const ov::String &file_name, const int32_t &track_id, const int64_t &segment_number, const int64_t &partial_number, bool holdIfAccepted = true);
 

--- a/src/publishers/llhls/llhls_stream.cpp
+++ b/src/publishers/llhls/llhls_stream.cpp
@@ -619,6 +619,16 @@ std::shared_ptr<LLHlsMasterPlaylist> LLHlsStream::CreateMasterPlaylist(const std
 			continue;
 		}
 
+		// The CODECS attribute must cover every version whose segments remain
+		if (video_track != nullptr)
+		{
+			master_playlist->SetTrackCodecs(video_track->GetId(), GetCodecsParameterUnion(video_track));
+		}
+		if (audio_track != nullptr)
+		{
+			master_playlist->SetTrackCodecs(audio_track->GetId(), GetCodecsParameterUnion(audio_track));
+		}
+
 		// If there is no media track, it is not added to the master playlist
 		ov::String video_variant_name = video_track != nullptr ? video_track->GetVariantName() : "";
 		ov::String audio_variant_name = audio_track != nullptr ? audio_track->GetVariantName() : "";
@@ -719,17 +729,31 @@ bool LLHlsStream::DumpInitSegment(const std::shared_ptr<mdl::Dump> &item, const 
 		return false;
 	}
 
-	// Get segment
-	auto [result, data] = GetInitializationSegment(track_id);
-	if (result != RequestResult::Success)
+	auto storage = GetFmp4Storage(track_id);
+	if (storage == nullptr)
 	{
 		logtw("Could not get init segment for dump");
 		return false;
 	}
 
-	auto init_segment_name = GetInitializationSegmentName(track_id);
+	// Dump every retained section under the name the chunklist references; a dump
+	// started right after a track change lists segments of the previous version too
+	auto sections = storage->GetInitializationSections();
+	if (sections.empty() == true)
+	{
+		logtw("Could not get init segment for dump");
+		return false;
+	}
 
-	return DumpData(item, init_segment_name, data);
+	for (const auto &[track_version, data] : sections)
+	{
+		if (DumpData(item, GetMapUriForTrackVersion(track_id, track_version), data) == false)
+		{
+			return false;
+		}
+	}
+
+	return true;
 }
 
 void LLHlsStream::DumpSegmentOfAllItems(const int32_t &track_id, const uint32_t &segment_number)
@@ -925,6 +949,25 @@ std::tuple<LLHlsStream::RequestResult, std::shared_ptr<ov::Data>> LLHlsStream::G
 	}
 
 	return {RequestResult::Success, storage->GetInitializationSection()};
+}
+
+std::tuple<LLHlsStream::RequestResult, std::shared_ptr<ov::Data>> LLHlsStream::GetInitializationSegment(const int32_t &track_id, uint32_t track_version) const
+{
+	auto storage = GetFmp4Storage(track_id);
+	if (storage == nullptr)
+	{
+		logtw("Could not find storage for track_id = %d", track_id);
+		return {RequestResult::NotFound, nullptr};
+	}
+
+	auto section = storage->GetInitializationSection(track_version);
+	if (section == nullptr)
+	{
+		logtw("Could not find initialization section for track_id = %d, track_version = %u", track_id, track_version);
+		return {RequestResult::NotFound, nullptr};
+	}
+
+	return {RequestResult::Success, section};
 }
 
 std::tuple<LLHlsStream::RequestResult, std::shared_ptr<ov::Data>> LLHlsStream::GetSegment(const int32_t &track_id, const int64_t &segment_number) const
@@ -1384,7 +1427,93 @@ void LLHlsStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const M
 		return;
 	}
 
-	Stream::OnTrackChanged(track_id, old_track, new_track);
+	// A label-only change does not affect the packaged output
+	if (old_track->HasSameContent(*new_track) == true)
+	{
+		Stream::OnTrackChanged(track_id, old_track, new_track);
+		return;
+	}
+
+	if (IsSupportedMediaCodec(new_track->GetCodecId()) == false)
+	{
+		logte("LLHlsStream(%s/%s) - Track(%d) has changed to an unsupported codec(%s), the track is excluded from the output from this point", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), track_id, cmn::GetCodecIdString(new_track->GetCodecId()));
+		return;
+	}
+
+	auto packager = GetPackager(track_id);
+	if (packager == nullptr)
+	{
+		// The track was not packaged at start (e.g. an unsupported codec then);
+		// adding a track to the output at runtime is not supported
+		Stream::OnTrackChanged(track_id, old_track, new_track);
+		return;
+	}
+
+	// Nothing published yet means the new configuration simply replaces the initial
+	// one; there is no boundary to propagate
+	auto storage = GetFmp4Storage(track_id);
+	bool has_published_content = (storage != nullptr && storage->GetLastSegment() != nullptr);
+	auto boundary_timestamp_ms = packager->GetLastSampleEndTimestampMs();
+
+	auto chunklist = GetChunklistWriter(track_id);
+
+	// The packager closes the current content and repackages against the new track;
+	// segments carry their track version, from which the chunklist derives the
+	// discontinuity and the map switch
+	if (packager->UpdateTrack(new_track) == false)
+	{
+		logte("LLHlsStream(%s/%s) - Failed to apply the changed track(%d), the output of this track may be broken", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), track_id);
+		return;
+	}
+
+	// The new initialization section is stored from here, safe to hint its map
+	if (has_published_content == true && chunklist != nullptr)
+	{
+		chunklist->SetUpcomingMapUri(GetMapUriForTrackVersion(track_id, new_track->GetVersion()));
+	}
+
+	// Players keep renditions in sync by their discontinuity sequences, so every
+	// other track must cut an aligned boundary even though its configuration did
+	// not change
+	if (has_published_content == true)
+	{
+		std::shared_lock<std::shared_mutex> lock(_packager_map_lock);
+		auto packager_map = _packager_map;
+		lock.unlock();
+
+		for (const auto &[other_track_id, other_packager] : packager_map)
+		{
+			if (other_track_id == track_id)
+			{
+				continue;
+			}
+
+			other_packager->RequestCutForDiscontinuity(boundary_timestamp_ms);
+		}
+	}
+
+	{
+		std::lock_guard<std::shared_mutex> lock(_track_version_codecs_lock);
+		auto &version_codecs = _track_version_codecs[track_id];
+
+		// No segment of the previous configuration was ever published
+		if (has_published_content == false)
+		{
+			version_codecs.clear();
+		}
+
+		version_codecs[new_track->GetVersion()] = new_track->GetCodecsParameter();
+	}
+
+	// CODECS/RESOLUTION attributes of the master playlist follow the change
+	{
+		std::unique_lock<std::mutex> guard(_master_playlists_lock);
+		_master_playlists.clear();
+	}
+
+	DumpInitSegmentOfAllItems(track_id);
+
+	logti("LLHlsStream(%s/%s) - Track(%d) configuration change has been applied (version %u -> %u)", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), track_id, old_track->GetVersion(), new_track->GetVersion());
 }
 
 bool LLHlsStream::AppendMediaPacket(const std::shared_ptr<MediaPacket> &media_packet)
@@ -1408,8 +1537,6 @@ bool LLHlsStream::AppendMediaPacket(const std::shared_ptr<MediaPacket> &media_pa
 		logtw("Could not find packager. track id: %d", track->GetId());
 		return false;
 	}
-
-	logtt("AppendSample : track(%u) length(%zu)", media_packet->GetTrackId(), media_packet->GetDataLength());
 
 	packager->AppendSample(media_packet);
 
@@ -1480,22 +1607,10 @@ bool LLHlsStream::AddPackager(const std::shared_ptr<const MediaTrack> &media_tra
 
 	auto tag = ov::String::FormatString("%s/%s", GetApplicationInfo().GetVHostAppName().CStr(), GetName().CStr());
 
-	if (cenc_property.scheme != bmff::CencProtectScheme::None)
+	if (cenc_property.scheme != bmff::CencProtectScheme::None && bmff::IsCencSupportedCodec(media_track->GetCodecId()) == false)
 	{
-		if (media_track->GetCodecId() == cmn::MediaCodecId::H264)
-		{
-			// Supported
-		}
-		else if (media_track->GetCodecId() == cmn::MediaCodecId::Aac)
-		{
-			// Supported
-		}
-		else
-		{
-			cenc_property.scheme = bmff::CencProtectScheme::None;
-			// Not yet support for other codec
-			logte("LLHlsStream::AddPackager() - CENC is not supported for this codec(%s), this track will be excluded from CENC protection", cmn::GetCodecIdString(media_track->GetCodecId()));
-		}
+		cenc_property.scheme = bmff::CencProtectScheme::None;
+		logte("LLHlsStream::AddPackager() - CENC is not supported for this codec(%s), this track will be excluded from CENC protection", cmn::GetCodecIdString(media_track->GetCodecId()));
 	}
 
 	// Create Storage
@@ -1553,6 +1668,16 @@ bool LLHlsStream::AddPackager(const std::shared_ptr<const MediaTrack> &media_tra
 	{
 		std::unique_lock<std::shared_mutex> lock(_chunklist_map_lock);
 		_chunklist_map.emplace(track_id, chunklist);
+	}
+
+	{
+		std::lock_guard<std::shared_mutex> lock(_initial_track_versions_lock);
+		_initial_track_versions[track_id] = media_track->GetVersion();
+	}
+
+	{
+		std::lock_guard<std::shared_mutex> lock(_track_version_codecs_lock);
+		_track_version_codecs[track_id][media_track->GetVersion()] = media_track->GetCodecsParameter();
 	}
 
 	return true;
@@ -1637,6 +1762,11 @@ std::shared_ptr<base::modules::SegmentStorage> LLHlsStream::GetStorage(const int
 	return it->second;
 }
 
+std::shared_ptr<bmff::FMP4Storage> LLHlsStream::GetFmp4Storage(const int32_t &track_id) const
+{
+	return std::dynamic_pointer_cast<bmff::FMP4Storage>(GetStorage(track_id));
+}
+
 // Get fMP4 packager with the track id
 std::shared_ptr<bmff::FMP4Packager> LLHlsStream::GetPackager(const int32_t &track_id) const
 {
@@ -1678,6 +1808,118 @@ ov::String LLHlsStream::GetInitializationSegmentName(const int32_t &track_id) co
 									track_id,
 									ov::String(cmn::GetMediaTypeString(GetTrack(track_id)->GetMediaType())).LowerCaseString().CStr(),
 									_stream_key.CStr());
+}
+
+ov::String LLHlsStream::GetInitializationSegmentName(const int32_t &track_id, uint32_t track_version) const
+{
+	// init_<track id>_<media type>_<random str>_v<track version>_llhls.m4s
+	return ov::String::FormatString("init_%d_%s_%s_v%u_llhls.m4s",
+									track_id,
+									ov::String(cmn::GetMediaTypeString(GetTrack(track_id)->GetMediaType())).LowerCaseString().CStr(),
+									_stream_key.CStr(),
+									track_version);
+}
+
+ov::String LLHlsStream::GetMapUriForTrackVersion(const int32_t &track_id, uint32_t track_version) const
+{
+	{
+		std::shared_lock<std::shared_mutex> lock(_initial_track_versions_lock);
+		auto it = _initial_track_versions.find(track_id);
+		if (it == _initial_track_versions.end())
+		{
+			// No fMP4 packager for this track (e.g. WebVTT), no map
+			return "";
+		}
+
+		if (it->second == track_version)
+		{
+			return GetInitializationSegmentName(track_id);
+		}
+	}
+
+	return GetInitializationSegmentName(track_id, track_version);
+}
+
+ov::String LLHlsStream::GetCodecsParameterUnion(const std::shared_ptr<const MediaTrack> &track) const
+{
+	std::shared_lock<std::shared_mutex> lock(_track_version_codecs_lock);
+
+	auto it = _track_version_codecs.find(track->GetId());
+	if (it == _track_version_codecs.end() || it->second.empty() == true)
+	{
+		return track->GetCodecsParameter();
+	}
+
+	// Versions can share the same parameter (e.g. a samplerate-only change)
+	ov::String codecs_union;
+	std::vector<ov::String> distinct_codecs;
+	for (const auto &[version, codecs] : it->second)
+	{
+		bool exists = false;
+		for (const auto &existing : distinct_codecs)
+		{
+			if (existing == codecs)
+			{
+				exists = true;
+				break;
+			}
+		}
+
+		if (exists == true)
+		{
+			continue;
+		}
+
+		distinct_codecs.push_back(codecs);
+		if (codecs_union.IsEmpty() == false)
+		{
+			codecs_union.Append(",");
+		}
+		codecs_union.Append(codecs);
+	}
+
+	return codecs_union;
+}
+
+void LLHlsStream::PruneTrackVersionCodecs(const int32_t &track_id)
+{
+	// DVR keeps old segments servable, so their codecs stay advertised
+	if (_storage_config.dvr_enabled == true)
+	{
+		return;
+	}
+
+	auto storage = GetFmp4Storage(track_id);
+	if (storage == nullptr)
+	{
+		return;
+	}
+
+	auto min_retained_version = storage->GetMinRetainedTrackVersion();
+
+	bool pruned = false;
+	{
+		std::lock_guard<std::shared_mutex> lock(_track_version_codecs_lock);
+		auto it = _track_version_codecs.find(track_id);
+		if (it == _track_version_codecs.end())
+		{
+			return;
+		}
+
+		auto &version_codecs = it->second;
+		for (auto version_it = version_codecs.begin(); version_it != version_codecs.end() && version_it->first < min_retained_version;)
+		{
+			version_it = version_codecs.erase(version_it);
+			pruned = true;
+		}
+	}
+
+	// The cached master playlists still advertise the dropped codecs
+	if (pruned == true)
+	{
+		std::unique_lock<std::mutex> guard(_master_playlists_lock);
+		_master_playlists.clear();
+	}
 }
 
 ov::String LLHlsStream::GetSegmentName(const int32_t &track_id, const int64_t &segment_number) const
@@ -1942,6 +2184,18 @@ void LLHlsStream::OnMediaChunkUpdated(const int32_t &track_id, const uint32_t &s
 			}
 			partial_info.SetMarkers(segment->GetMarkers());
 		}
+
+		// The configuration the segment was packaged against; the chunklist derives
+		// discontinuities and map switches from it
+		partial_info.SetTrackVersion(segment->GetTrackVersion());
+		partial_info.SetMapUri(GetMapUriForTrackVersion(track_id, segment->GetTrackVersion()));
+
+		// A boundary cut propagated from another track flags the segment even though
+		// this track's own configuration did not change
+		if (segment->IsDiscontinuityPoint() == true)
+		{
+			partial_info.SetDiscontinuity();
+		}
 	}
 
 	playlist->AppendPartialSegmentInfo(segment_number, partial_info);
@@ -2039,7 +2293,45 @@ void LLHlsStream::OnMediaSegmentDeleted(const int32_t &track_id, const uint32_t 
 
 	playlist->RemoveSegmentInfo(segment_number);
 
+	// Codecs of versions that just left the window leave the CODECS attribute
+	PruneTrackVersionCodecs(track_id);
+
 	logtt("Media segment deleted : track_id = %d, segment_number = %d", track_id, segment_number);
+}
+
+void LLHlsStream::OnMediaSegmentCompleted(const int32_t &track_id, const uint32_t &segment_number)
+{
+	auto playlist = GetChunklistWriter(track_id);
+	if (playlist == nullptr)
+	{
+		logte("Playlist is not found : track_id = %d", track_id);
+		return;
+	}
+
+	// The map the upcoming partial will be packaged against; at a track change
+	// boundary it differs from the completed segment's map and is hinted as TYPE=MAP
+	ov::String next_partial_map_uri;
+	auto storage = GetFmp4Storage(track_id);
+	if (storage != nullptr)
+	{
+		auto last_segment = storage->GetLastSegment();
+		if (last_segment != nullptr)
+		{
+			next_partial_map_uri = GetMapUriForTrackVersion(track_id, last_segment->GetTrackVersion());
+		}
+	}
+
+	// Subtitle chunklists are not mirrored here; a configuration change of the VTT
+	// reference track is not supported yet
+	playlist->CompleteSegmentInfo(segment_number, GetNextPartialSegmentName(track_id, segment_number, 0, true), next_partial_map_uri);
+
+	int64_t last_msn = -1, last_psn = -1;
+	playlist->GetLastSequenceNumber(last_msn, last_psn);
+	NotifyPlaylistUpdated(track_id, last_msn, last_psn);
+
+	DumpSegmentOfAllItems(track_id, segment_number);
+
+	logtt("Media segment completed : track_id = %d, segment_number = %d", track_id, segment_number);
 }
 
 void LLHlsStream::NotifyPlaylistUpdated(const int32_t &track_id, const int64_t &msn, const int64_t &part)

--- a/src/publishers/llhls/llhls_stream.cpp
+++ b/src/publishers/llhls/llhls_stream.cpp
@@ -546,7 +546,7 @@ const ov::String &LLHlsStream::GetStreamKey() const
 	return _stream_key;
 }
 
-std::shared_ptr<LLHlsMasterPlaylist> LLHlsStream::CreateMasterPlaylist(const std::shared_ptr<const info::Playlist> &playlist) const
+std::shared_ptr<LLHlsMasterPlaylist> LLHlsStream::CreateMasterPlaylist(const std::shared_ptr<const info::Playlist> &playlist, bool include_unlisted_codecs) const
 {
 	auto master_playlist = std::make_shared<LLHlsMasterPlaylist>();
 
@@ -622,11 +622,11 @@ std::shared_ptr<LLHlsMasterPlaylist> LLHlsStream::CreateMasterPlaylist(const std
 		// The CODECS attribute must cover every version whose segments remain
 		if (video_track != nullptr)
 		{
-			master_playlist->SetTrackCodecs(video_track->GetId(), GetCodecsParameterUnion(video_track));
+			master_playlist->SetTrackCodecs(video_track->GetId(), GetCodecsParameterUnion(video_track, include_unlisted_codecs));
 		}
 		if (audio_track != nullptr)
 		{
-			master_playlist->SetTrackCodecs(audio_track->GetId(), GetCodecsParameterUnion(audio_track));
+			master_playlist->SetTrackCodecs(audio_track->GetId(), GetCodecsParameterUnion(audio_track, include_unlisted_codecs));
 		}
 
 		// If there is no media track, it is not added to the master playlist
@@ -686,7 +686,7 @@ bool LLHlsStream::DumpMasterPlaylist(const std::shared_ptr<mdl::Dump> &item)
 
 	for (auto &playlist : item->GetPlaylists())
 	{
-		auto [result, data] = GetMasterPlaylist(playlist, "", false, false, true, false);
+		auto [result, data] = GetMasterPlaylistForDump(playlist);
 		if (result != RequestResult::Success)
 		{
 			logtw("Could not get master playlist(%s) for dump", playlist.CStr());
@@ -837,6 +837,25 @@ bool LLHlsStream::DumpSegment(const std::shared_ptr<mdl::Dump> &item, const int3
 bool LLHlsStream::DumpData(const std::shared_ptr<mdl::Dump> &item, const ov::String &file_name, const std::shared_ptr<const ov::Data> &data)
 {
 	return item->DumpData(file_name, data);
+}
+
+std::tuple<LLHlsStream::RequestResult, std::shared_ptr<const ov::Data>> LLHlsStream::GetMasterPlaylistForDump(const ov::String &file_name) const
+{
+	auto file_name_without_ext = file_name.Substring(0, file_name.IndexOfRev('.'));
+
+	auto playlist = GetPlaylist(file_name_without_ext);
+	if (playlist == nullptr)
+	{
+		return {RequestResult::NotFound, nullptr};
+	}
+
+	auto master_playlist = CreateMasterPlaylist(playlist, true);
+	if (master_playlist == nullptr)
+	{
+		return {RequestResult::NotFound, nullptr};
+	}
+
+	return {RequestResult::Success, master_playlist->ToString("", false, true, false).ToData(false)};
 }
 
 std::tuple<LLHlsStream::RequestResult, std::shared_ptr<const ov::Data>> LLHlsStream::GetMasterPlaylist(const ov::String &file_name, const ov::String &chunk_query_string, bool gzip, bool legacy, bool rewind, bool include_path)
@@ -1499,19 +1518,6 @@ void LLHlsStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const M
 		}
 	}
 
-	{
-		std::lock_guard<std::shared_mutex> lock(_track_version_codecs_lock);
-		auto &version_codecs = _track_version_codecs[track_id];
-
-		// No segment of the previous configuration was ever published
-		if (has_published_content == false)
-		{
-			version_codecs.clear();
-		}
-
-		version_codecs[new_track->GetVersion()] = new_track->GetCodecsParameter();
-	}
-
 	// CODECS/RESOLUTION attributes of the master playlist follow the change
 	{
 		std::unique_lock<std::mutex> guard(_master_playlists_lock);
@@ -1519,6 +1525,9 @@ void LLHlsStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const M
 	}
 
 	DumpInitSegmentOfAllItems(track_id);
+
+	// Dumped master playlists must advertise the new codec as well
+	DumpMasterPlaylistsOfAllItems();
 
 	logti("LLHlsStream(%s/%s) - Track(%d) configuration change has been applied (version %u -> %u)", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), track_id, old_track->GetVersion(), new_track->GetVersion());
 }
@@ -1682,11 +1691,6 @@ bool LLHlsStream::AddPackager(const std::shared_ptr<const MediaTrack> &media_tra
 		_initial_track_versions[track_id] = media_track->GetVersion();
 	}
 
-	{
-		std::lock_guard<std::shared_mutex> lock(_track_version_codecs_lock);
-		_track_version_codecs[track_id][media_track->GetVersion()] = media_track->GetCodecsParameter();
-	}
-
 	return true;
 }
 
@@ -1847,86 +1851,19 @@ ov::String LLHlsStream::GetMapUriForTrackVersion(const int32_t &track_id, uint32
 	return GetInitializationSegmentName(track_id, track_version);
 }
 
-ov::String LLHlsStream::GetCodecsParameterUnion(const std::shared_ptr<const MediaTrack> &track) const
+ov::String LLHlsStream::GetCodecsParameterUnion(const std::shared_ptr<const MediaTrack> &track, bool include_unlisted) const
 {
-	std::shared_lock<std::shared_mutex> lock(_track_version_codecs_lock);
-
-	auto it = _track_version_codecs.find(track->GetId());
-	if (it == _track_version_codecs.end() || it->second.empty() == true)
+	auto chunklist = GetChunklistWriter(track->GetId());
+	if (chunklist != nullptr)
 	{
-		return track->GetCodecsParameter();
-	}
-
-	// Versions can share the same parameter (e.g. a samplerate-only change)
-	ov::String codecs_union;
-	std::vector<ov::String> distinct_codecs;
-	for (const auto &[version, codecs] : it->second)
-	{
-		bool exists = false;
-		for (const auto &existing : distinct_codecs)
-		{
-			if (existing == codecs)
-			{
-				exists = true;
-				break;
-			}
-		}
-
-		if (exists == true)
-		{
-			continue;
-		}
-
-		distinct_codecs.push_back(codecs);
+		auto codecs_union = include_unlisted ? chunklist->GetAllCodecsUnion() : chunklist->GetListedCodecsUnion();
 		if (codecs_union.IsEmpty() == false)
 		{
-			codecs_union.Append(",");
-		}
-		codecs_union.Append(codecs);
-	}
-
-	return codecs_union;
-}
-
-void LLHlsStream::PruneTrackVersionCodecs(const int32_t &track_id)
-{
-	// DVR keeps old segments servable, so their codecs stay advertised
-	if (_storage_config.dvr_enabled == true)
-	{
-		return;
-	}
-
-	auto storage = GetFmp4Storage(track_id);
-	if (storage == nullptr)
-	{
-		return;
-	}
-
-	auto min_retained_version = storage->GetMinRetainedTrackVersion();
-
-	bool pruned = false;
-	{
-		std::lock_guard<std::shared_mutex> lock(_track_version_codecs_lock);
-		auto it = _track_version_codecs.find(track_id);
-		if (it == _track_version_codecs.end())
-		{
-			return;
-		}
-
-		auto &version_codecs = it->second;
-		for (auto version_it = version_codecs.begin(); version_it != version_codecs.end() && version_it->first < min_retained_version;)
-		{
-			version_it = version_codecs.erase(version_it);
-			pruned = true;
+			return codecs_union;
 		}
 	}
 
-	// The cached master playlists still advertise the dropped codecs
-	if (pruned == true)
-	{
-		std::unique_lock<std::mutex> guard(_master_playlists_lock);
-		_master_playlists.clear();
-	}
+	return track->GetCodecsParameter();
 }
 
 ov::String LLHlsStream::GetSegmentName(const int32_t &track_id, const int64_t &segment_number) const
@@ -2193,9 +2130,10 @@ void LLHlsStream::OnMediaChunkUpdated(const int32_t &track_id, const uint32_t &s
 		}
 
 		// The configuration the segment was packaged against; the chunklist derives
-		// discontinuities and map switches from it
+		// discontinuities, map switches, and its codecs description from it
 		partial_info.SetTrackVersion(segment->GetTrackVersion());
 		partial_info.SetMapUri(GetMapUriForTrackVersion(track_id, segment->GetTrackVersion()));
+		partial_info.SetCodecsParameter(segment->GetCodecsParameter());
 
 		// A boundary cut propagated from another track flags the segment even though
 		// this track's own configuration did not change
@@ -2205,7 +2143,17 @@ void LLHlsStream::OnMediaChunkUpdated(const int32_t &track_id, const uint32_t &s
 		}
 	}
 
+	// A segment's first chunk can bring a codec into the listing; the cached
+	// master playlists do not advertise it yet
+	auto codecs_union_before = (chunk_number == 0) ? playlist->GetListedCodecsUnion() : ov::String();
+
 	playlist->AppendPartialSegmentInfo(segment_number, partial_info);
+
+	if (chunk_number == 0 && playlist->GetListedCodecsUnion() != codecs_union_before)
+	{
+		std::unique_lock<std::mutex> guard(_master_playlists_lock);
+		_master_playlists.clear();
+	}
 
 	logtt("Media chunk updated : track_id = %u, segment_number = %u, chunk_number = %d, start_timestamp = %" PRId64 ", chunk_duration = %f", track_id, segment_number, chunk_number, partial_segment->GetStartTimestamp(), chunk_duration);
 
@@ -2298,10 +2246,16 @@ void LLHlsStream::OnMediaSegmentDeleted(const int32_t &track_id, const uint32_t 
 		}
 	}
 
+	auto codecs_union_before = playlist->GetListedCodecsUnion();
+
 	playlist->RemoveSegmentInfo(segment_number);
 
-	// Codecs of versions that just left the window leave the CODECS attribute
-	PruneTrackVersionCodecs(track_id);
+	// The cached master playlists still advertise codecs that just left the listing
+	if (playlist->GetListedCodecsUnion() != codecs_union_before)
+	{
+		std::unique_lock<std::mutex> guard(_master_playlists_lock);
+		_master_playlists.clear();
+	}
 
 	logtt("Media segment deleted : track_id = %d, segment_number = %d", track_id, segment_number);
 }

--- a/src/publishers/llhls/llhls_stream.cpp
+++ b/src/publishers/llhls/llhls_stream.cpp
@@ -1492,6 +1492,24 @@ void LLHlsStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const M
 		return;
 	}
 
+	// Keep the EXT-X-KEY signaling honest about the track's real encryption state.
+	// When the codec changes to one CENC cannot encrypt (e.g. H265, AV1), the
+	// current policy is that the track keeps being produced in the clear (same as
+	// AddPackager at startup), so the playlist must stop advertising EXT-X-KEY;
+	// a return to a supported codec restores it. Leaving a stale EXT-X-KEY on clear
+	// segments would confuse players into attempting decryption.
+	// TODO: when the DRM-failure policy is decided, this may change to blocking the
+	// track update instead of producing clear output.
+	if (_cenc_property.scheme != bmff::CencProtectScheme::None && chunklist != nullptr)
+	{
+		auto track_cenc_property = _cenc_property;
+		if (bmff::IsCencSupportedCodec(new_track->GetCodecId()) == false)
+		{
+			track_cenc_property.scheme = bmff::CencProtectScheme::None;
+		}
+		chunklist->EnableCenc(track_cenc_property);
+	}
+
 	// The new initialization section is stored from here, safe to hint its map
 	if (has_published_content == true && chunklist != nullptr)
 	{

--- a/src/publishers/llhls/llhls_stream.cpp
+++ b/src/publishers/llhls/llhls_stream.cpp
@@ -1437,6 +1437,13 @@ void LLHlsStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const M
 	if (IsSupportedMediaCodec(new_track->GetCodecId()) == false)
 	{
 		logte("LLHlsStream(%s/%s) - Track(%d) has changed to an unsupported codec(%s), the track is excluded from the output from this point", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), track_id, cmn::GetCodecIdString(new_track->GetCodecId()));
+
+		// Newly served master playlists stop advertising the excluded rendition
+		{
+			std::unique_lock<std::mutex> guard(_master_playlists_lock);
+			_master_playlists.clear();
+		}
+
 		return;
 	}
 

--- a/src/publishers/llhls/llhls_stream.h
+++ b/src/publishers/llhls/llhls_stream.h
@@ -129,13 +129,15 @@ private:
 	// Get Playlist with the track id
 	std::shared_ptr<LLHlsChunklist> GetChunklistWriter(const int32_t &track_id) const;
 
-	std::shared_ptr<LLHlsMasterPlaylist> CreateMasterPlaylist(const std::shared_ptr<const info::Playlist> &playlist) const;
+	std::shared_ptr<LLHlsMasterPlaylist> CreateMasterPlaylist(const std::shared_ptr<const info::Playlist> &playlist, bool include_unlisted_codecs = false) const;
 
-	// Every codec parameter whose segments remain in the window, oldest first.
-	// The CODECS attribute of the master playlist must cover all of them.
-	ov::String GetCodecsParameterUnion(const std::shared_ptr<const MediaTrack> &track) const;
-	// Drop codec parameters of versions whose segments all left the window
-	void PruneTrackVersionCodecs(const int32_t &track_id);
+	// Uncached master playlist for dumped output; its CODECS attribute covers
+	// unlisted versions too because the dump keeps segments of every version
+	std::tuple<RequestResult, std::shared_ptr<const ov::Data>> GetMasterPlaylistForDump(const ov::String &file_name) const;
+
+	// Codecs the CODECS attribute advertises for a track, answered by the track's
+	// chunklist from its own listing (or registration history for dumped output)
+	ov::String GetCodecsParameterUnion(const std::shared_ptr<const MediaTrack> &track, bool include_unlisted = false) const;
 
 	ov::String GetChunklistName(const int32_t &track_id) const;
 	ov::String GetInitializationSegmentName(const int32_t &track_id) const;
@@ -190,10 +192,6 @@ private:
 	std::map<int32_t, uint32_t> _initial_track_versions;
 	mutable std::shared_mutex _initial_track_versions_lock;
 
-	// Track ID : (track version : codecs parameter) of versions whose segments
-	// remain in the window, source of the master playlist CODECS attribute
-	std::map<int32_t, std::map<uint32_t, ov::String>> _track_version_codecs;
-	mutable std::shared_mutex _track_version_codecs_lock;
 
 	uint64_t _max_chunk_duration_ms = 0;
 	uint64_t _min_chunk_duration_ms = std::numeric_limits<uint64_t>::max();

--- a/src/publishers/llhls/llhls_stream.h
+++ b/src/publishers/llhls/llhls_stream.h
@@ -76,6 +76,7 @@ public:
 	std::tuple<RequestResult, std::shared_ptr<const ov::Data>> GetMasterPlaylist(const ov::String &file_name, const ov::String &chunk_query_string, bool gzip, bool legacy, bool rewind, bool include_path=true);
 	std::tuple<RequestResult, std::shared_ptr<const ov::Data>> GetChunklist(const ov::String &chunk_query_string, const int32_t &track_id, int64_t msn, int64_t psn, bool skip, bool gzip, bool legacy, bool rewind) const;
 	std::tuple<RequestResult, std::shared_ptr<ov::Data>> GetInitializationSegment(const int32_t &track_id) const;
+	std::tuple<RequestResult, std::shared_ptr<ov::Data>> GetInitializationSegment(const int32_t &track_id, uint32_t track_version) const;
 	std::tuple<RequestResult, std::shared_ptr<ov::Data>> GetSegment(const int32_t &track_id, const int64_t &segment_number) const;
 	std::tuple<RequestResult, std::shared_ptr<ov::Data>> GetPartial(const int32_t &track_id, const int64_t &segment_number, const int64_t &chunk_number) const;
 
@@ -114,6 +115,7 @@ private:
 	void OnMediaSegmentCreated(const int32_t &track_id, const uint32_t &segment_number) override;
 	void OnMediaChunkUpdated(const int32_t &track_id, const uint32_t &segment_number, const uint32_t &chunk_number, bool last_chunk) override;
 	void OnMediaSegmentDeleted(const int32_t &track_id, const uint32_t &segment_number) override;
+	void OnMediaSegmentCompleted(const int32_t &track_id, const uint32_t &segment_number) override;
 
 	// Create and Get fMP4 packager and storage with track info, storage and packager_config
 	bool AddPackager(const std::shared_ptr<const MediaTrack> &media_track, const std::shared_ptr<const MediaTrack> &data_track);
@@ -122,13 +124,25 @@ private:
 	std::shared_ptr<bmff::FMP4Packager> GetPackager(const int32_t &track_id) const;
 	// Get storage with the track id
 	std::shared_ptr<base::modules::SegmentStorage> GetStorage(const int32_t &track_id) const;
+	// Get storage of a fMP4 media track (VTT tracks use a different storage type)
+	std::shared_ptr<bmff::FMP4Storage> GetFmp4Storage(const int32_t &track_id) const;
 	// Get Playlist with the track id
 	std::shared_ptr<LLHlsChunklist> GetChunklistWriter(const int32_t &track_id) const;
 
 	std::shared_ptr<LLHlsMasterPlaylist> CreateMasterPlaylist(const std::shared_ptr<const info::Playlist> &playlist) const;
 
+	// Every codec parameter whose segments remain in the window, oldest first.
+	// The CODECS attribute of the master playlist must cover all of them.
+	ov::String GetCodecsParameterUnion(const std::shared_ptr<const MediaTrack> &track) const;
+	// Drop codec parameters of versions whose segments all left the window
+	void PruneTrackVersionCodecs(const int32_t &track_id);
+
 	ov::String GetChunklistName(const int32_t &track_id) const;
 	ov::String GetInitializationSegmentName(const int32_t &track_id) const;
+	ov::String GetInitializationSegmentName(const int32_t &track_id, uint32_t track_version) const;
+	// Map uri a segment of the given version references; the initial version keeps
+	// the version-less name, tracks without a fMP4 packager have none
+	ov::String GetMapUriForTrackVersion(const int32_t &track_id, uint32_t track_version) const;
 	ov::String GetSegmentName(const int32_t &track_id, const int64_t &segment_number) const;
 	ov::String GetPartialSegmentName(const int32_t &track_id, const int64_t &segment_number, const int64_t &partial_number) const;
 	ov::String GetNextPartialSegmentName(const int32_t &track_id, const int64_t &segment_number, const int64_t &partial_number, bool last_chunk) const;
@@ -170,6 +184,16 @@ private:
 	mutable std::shared_mutex _packager_map_lock;
 	std::map<int32_t, std::shared_ptr<LLHlsChunklist>> _chunklist_map;
 	mutable std::shared_mutex _chunklist_map_lock;
+
+	// Track ID : track version the stream started with (uses the version-less
+	// initialization segment name, later versions carry a version suffix)
+	std::map<int32_t, uint32_t> _initial_track_versions;
+	mutable std::shared_mutex _initial_track_versions_lock;
+
+	// Track ID : (track version : codecs parameter) of versions whose segments
+	// remain in the window, source of the master playlist CODECS attribute
+	std::map<int32_t, std::map<uint32_t, ov::String>> _track_version_codecs;
+	mutable std::shared_mutex _track_version_codecs_lock;
 
 	uint64_t _max_chunk_duration_ms = 0;
 	uint64_t _min_chunk_duration_ms = std::numeric_limits<uint64_t>::max();

--- a/src/publishers/llhls/llhls_test.cpp
+++ b/src/publishers/llhls/llhls_test.cpp
@@ -25,7 +25,7 @@ namespace
 
 	// Simulates a segment packaged against the given track version, the way
 	// LLHlsStream::OnMediaChunkUpdated stamps partial infos from the storage segment
-	void AppendSegment(const std::shared_ptr<LLHlsChunklist> &chunklist, uint32_t sequence, uint32_t track_version, const ov::String &map_uri, bool discontinuity_point = false)
+	void AppendSegment(const std::shared_ptr<LLHlsChunklist> &chunklist, uint32_t sequence, uint32_t track_version, const ov::String &map_uri, bool discontinuity_point = false, const ov::String &codecs = "")
 	{
 		auto url = ov::String::FormatString("seg_1_%u_video_key_llhls.m4s", sequence);
 		chunklist->CreateSegmentInfo(LLHlsChunklist::SegmentInfo(sequence, url));
@@ -35,6 +35,7 @@ namespace
 		auto partial_info = LLHlsChunklist::SegmentInfo(0, sequence * 6000, 6.0, 1000, partial_url, next_partial_url, true, true);
 		partial_info.SetTrackVersion(track_version);
 		partial_info.SetMapUri(map_uri);
+		partial_info.SetCodecsParameter(codecs);
 		if (discontinuity_point == true)
 		{
 			partial_info.SetDiscontinuity();
@@ -195,6 +196,23 @@ TEST(LLHlsChunklist, PropagatedBoundaryCutDoesNotHintMap)
 	// No map change, so no map hint; the redirected part hint stays
 	EXPECT_EQ(playlist.IndexOf("#EXT-X-PRELOAD-HINT:TYPE=MAP"), -1);
 	EXPECT_NE(playlist.IndexOf("#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"part_1_2_0_video_key_llhls.m4s\""), -1);
+}
+
+TEST(LLHlsChunklist, CodecsUnionFollowsListing)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri, false, "avc1.42c00d");
+	AppendSegment(chunklist, 1, 2, kSecondMapUri, false, "avc1.640029");
+
+	// Both versions are listed
+	EXPECT_STREQ(chunklist->GetListedCodecsUnion().CStr(), "avc1.42c00d,avc1.640029");
+
+	// The old version left the listing, its codecs leave the listed union but
+	// stay in the learned history for dumped output
+	chunklist->RemoveSegmentInfo(0);
+	EXPECT_STREQ(chunklist->GetListedCodecsUnion().CStr(), "avc1.640029");
+	EXPECT_STREQ(chunklist->GetAllCodecsUnion().CStr(), "avc1.42c00d,avc1.640029");
 }
 
 TEST(LLHlsChunklist, VersionChangeBeforeFirstSegmentHasNoTag)

--- a/src/publishers/llhls/llhls_test.cpp
+++ b/src/publishers/llhls/llhls_test.cpp
@@ -1,2 +1,214 @@
-// Placeholder — add tests here.
 #include <gtest/gtest.h>
+
+#include "llhls_chunklist.h"
+
+namespace
+{
+	std::shared_ptr<MediaTrack> CreateVideoTrack()
+	{
+		auto track = std::make_shared<MediaTrack>();
+		track->SetId(1);
+		track->SetMediaType(cmn::MediaType::Video);
+		track->SetPublicName("video");
+		track->SetVariantName("video");
+		return track;
+	}
+
+	std::shared_ptr<LLHlsChunklist> CreateChunklist(const std::shared_ptr<MediaTrack> &track)
+	{
+		return std::make_shared<LLHlsChunklist>("chunklist_1_video_key_llhls.m3u8", track,
+												10,	 // segment count
+												6,	 // target duration
+												0.5, // part target duration
+												"init_1_video_key_llhls.m4s", true);
+	}
+
+	// Simulates a segment packaged against the given track version, the way
+	// LLHlsStream::OnMediaChunkUpdated stamps partial infos from the storage segment
+	void AppendSegment(const std::shared_ptr<LLHlsChunklist> &chunklist, uint32_t sequence, uint32_t track_version, const ov::String &map_uri, bool discontinuity_point = false)
+	{
+		auto url = ov::String::FormatString("seg_1_%u_video_key_llhls.m4s", sequence);
+		chunklist->CreateSegmentInfo(LLHlsChunklist::SegmentInfo(sequence, url));
+
+		auto partial_url = ov::String::FormatString("part_1_%u_0_video_key_llhls.m4s", sequence);
+		auto next_partial_url = ov::String::FormatString("part_1_%u_1_video_key_llhls.m4s", sequence);
+		auto partial_info = LLHlsChunklist::SegmentInfo(0, sequence * 6000, 6.0, 1000, partial_url, next_partial_url, true, true);
+		partial_info.SetTrackVersion(track_version);
+		partial_info.SetMapUri(map_uri);
+		if (discontinuity_point == true)
+		{
+			partial_info.SetDiscontinuity();
+		}
+
+		chunklist->AppendPartialSegmentInfo(sequence, partial_info);
+	}
+
+	const ov::String kInitialMapUri = "init_1_video_key_llhls.m4s";
+	const ov::String kSecondMapUri = "init_1_video_key_v2_llhls.m4s";
+} // namespace
+
+TEST(LLHlsChunklist, NoDiscontinuityTagsByDefault)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri);
+	AppendSegment(chunklist, 1, 1, kInitialMapUri);
+
+	auto playlist = chunklist->ToString("", false, false, false);
+
+	EXPECT_EQ(playlist.IndexOf("#EXT-X-DISCONTINUITY"), -1);
+	EXPECT_NE(playlist.IndexOf("#EXT-X-MAP:URI=\"init_1_video_key_llhls.m4s\""), -1);
+}
+
+TEST(LLHlsChunklist, TrackVersionChangeInsertsTagAndNewMap)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri);
+	AppendSegment(chunklist, 1, 1, kInitialMapUri);
+
+	// The next segment was packaged against a new track configuration
+	AppendSegment(chunklist, 2, 2, kSecondMapUri);
+
+	auto playlist = chunklist->ToString("", false, false, false);
+
+	auto discontinuity_index = playlist.IndexOf("#EXT-X-DISCONTINUITY\n");
+	EXPECT_NE(discontinuity_index, -1);
+
+	// The initial map leads the playlist, the new map follows the discontinuity
+	auto initial_map_index = playlist.IndexOf("#EXT-X-MAP:URI=\"init_1_video_key_llhls.m4s\"");
+	auto new_map_index = playlist.IndexOf("#EXT-X-MAP:URI=\"init_1_video_key_v2_llhls.m4s\"");
+	EXPECT_NE(initial_map_index, -1);
+	EXPECT_NE(new_map_index, -1);
+	EXPECT_LT(initial_map_index, discontinuity_index);
+	EXPECT_LT(discontinuity_index, new_map_index);
+
+	// The new map precedes the segment it applies to
+	EXPECT_LT(new_map_index, playlist.IndexOf("seg_1_2_video_key_llhls.m4s"));
+
+	EXPECT_NE(playlist.IndexOf("#EXT-X-DISCONTINUITY-SEQUENCE:0\n"), -1);
+}
+
+TEST(LLHlsChunklist, DiscontinuitySequenceCountsRemovedTags)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri);
+	AppendSegment(chunklist, 1, 2, kSecondMapUri);
+	AppendSegment(chunklist, 2, 2, kSecondMapUri);
+	AppendSegment(chunklist, 3, 2, kSecondMapUri);
+
+	// Removing the unflagged first segment keeps the sequence number
+	chunklist->RemoveSegmentInfo(0);
+	auto playlist = chunklist->ToString("", false, false, false);
+	EXPECT_NE(playlist.IndexOf("#EXT-X-DISCONTINUITY-SEQUENCE:0\n"), -1);
+	// The tag stays while its segment is the first of the playlist
+	EXPECT_NE(playlist.IndexOf("#EXT-X-DISCONTINUITY\n"), -1);
+	EXPECT_NE(playlist.IndexOf("#EXT-X-MAP:URI=\"init_1_video_key_v2_llhls.m4s\""), -1);
+
+	// Removing the flagged segment removes its tag and increments the sequence
+	chunklist->RemoveSegmentInfo(1);
+	playlist = chunklist->ToString("", false, false, false);
+	EXPECT_NE(playlist.IndexOf("#EXT-X-DISCONTINUITY-SEQUENCE:1\n"), -1);
+	EXPECT_EQ(playlist.IndexOf("#EXT-X-DISCONTINUITY\n"), -1);
+}
+
+TEST(LLHlsChunklist, PropagatedBoundaryFlagsWithoutVersionChange)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri);
+
+	// Another track of the stream changed; this track was cut at the boundary but
+	// keeps its own configuration and map
+	AppendSegment(chunklist, 1, 1, kInitialMapUri, true);
+
+	auto playlist = chunklist->ToString("", false, false, false);
+
+	auto discontinuity_index = playlist.IndexOf("#EXT-X-DISCONTINUITY\n");
+	EXPECT_NE(discontinuity_index, -1);
+	EXPECT_LT(discontinuity_index, playlist.IndexOf("seg_1_1_video_key_llhls.m4s"));
+
+	// The map does not change, so only one EXT-X-MAP appears
+	auto first_map_index = playlist.IndexOf("#EXT-X-MAP:URI=\"init_1_video_key_llhls.m4s\"");
+	EXPECT_NE(first_map_index, -1);
+	EXPECT_EQ(playlist.IndexOf("#EXT-X-MAP", first_map_index + 1), -1);
+}
+
+TEST(LLHlsChunklist, BoundaryCutHintsUpcomingMap)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri);
+	AppendSegment(chunklist, 1, 1, kInitialMapUri);
+
+	// Boundary cut: segment 1 is completed and the next partial opens a new map
+	chunklist->CompleteSegmentInfo(1, "part_1_2_0_video_key_llhls.m4s", kSecondMapUri);
+
+	auto playlist = chunklist->ToString("", false, false, false);
+
+	// The upcoming map is hinted ahead of the part that will use it
+	auto map_hint_index = playlist.IndexOf("#EXT-X-PRELOAD-HINT:TYPE=MAP,URI=\"init_1_video_key_v2_llhls.m4s\"");
+	auto part_hint_index = playlist.IndexOf("#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"part_1_2_0_video_key_llhls.m4s\"");
+	EXPECT_NE(map_hint_index, -1);
+	EXPECT_NE(part_hint_index, -1);
+	EXPECT_LT(map_hint_index, part_hint_index);
+
+	// Once the first partial of the new domain is listed the map appears inline
+	AppendSegment(chunklist, 2, 2, kSecondMapUri);
+	playlist = chunklist->ToString("", false, false, false);
+	EXPECT_EQ(playlist.IndexOf("#EXT-X-PRELOAD-HINT:TYPE=MAP"), -1);
+	EXPECT_NE(playlist.IndexOf("#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"part_1_2_1_video_key_llhls.m4s\""), -1);
+}
+
+TEST(LLHlsChunklist, UpcomingMapHintSetDirectly)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri);
+	// The boundary flush completed segment 1 through the normal chunk path; the
+	// stream sets the upcoming map once the new initialization section is stored
+	AppendSegment(chunklist, 1, 1, kInitialMapUri);
+	chunklist->SetUpcomingMapUri(kSecondMapUri);
+
+	auto playlist = chunklist->ToString("", false, false, false);
+	EXPECT_NE(playlist.IndexOf("#EXT-X-PRELOAD-HINT:TYPE=MAP,URI=\"init_1_video_key_v2_llhls.m4s\""), -1);
+
+	// The first partial of the new domain retires the map hint
+	AppendSegment(chunklist, 2, 2, kSecondMapUri);
+	playlist = chunklist->ToString("", false, false, false);
+	EXPECT_EQ(playlist.IndexOf("#EXT-X-PRELOAD-HINT:TYPE=MAP"), -1);
+}
+
+TEST(LLHlsChunklist, PropagatedBoundaryCutDoesNotHintMap)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri);
+	AppendSegment(chunklist, 1, 1, kInitialMapUri);
+
+	// A cut propagated from another track keeps this track's map
+	chunklist->CompleteSegmentInfo(1, "part_1_2_0_video_key_llhls.m4s", kInitialMapUri);
+
+	auto playlist = chunklist->ToString("", false, false, false);
+
+	// No map change, so no map hint; the redirected part hint stays
+	EXPECT_EQ(playlist.IndexOf("#EXT-X-PRELOAD-HINT:TYPE=MAP"), -1);
+	EXPECT_NE(playlist.IndexOf("#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"part_1_2_0_video_key_llhls.m4s\""), -1);
+}
+
+TEST(LLHlsChunklist, VersionChangeBeforeFirstSegmentHasNoTag)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+
+	// The track changed before anything was published; the first segment simply
+	// starts with the new configuration
+	AppendSegment(chunklist, 0, 2, kSecondMapUri);
+	AppendSegment(chunklist, 1, 2, kSecondMapUri);
+
+	auto playlist = chunklist->ToString("", false, false, false);
+
+	EXPECT_EQ(playlist.IndexOf("#EXT-X-DISCONTINUITY"), -1);
+	EXPECT_NE(playlist.IndexOf("#EXT-X-MAP:URI=\"init_1_video_key_v2_llhls.m4s\""), -1);
+	EXPECT_EQ(playlist.IndexOf("#EXT-X-MAP:URI=\"init_1_video_key_llhls.m4s\""), -1);
+}


### PR DESCRIPTION
## Problem

When a track configuration changed mid-stream (Scheduled Channel item transitions in bypass, WebRTC ingest resolution changes), the LLHLS output kept packaging against the initial configuration without any signaling, so players broke at every change.

## Solution

The LLHLS publisher now cuts an aligned segment boundary on every rendition at each configuration change and signals it per the HLS specification: EXT-X-DISCONTINUITY and EXT-X-DISCONTINUITY-SEQUENCE tags, versioned initialization segments with per-segment EXT-X-MAP switching, a TYPE=MAP preload hint so clients can fetch the upcoming initialization segment ahead of the boundary, and a master playlist CODECS attribute that covers every codec whose segments remain in the playlist window.

## hls.js limitation

hls.js (verified on 1.6.16, still present in current master) fatally errors with "discontinuity sequence mismatch" whenever a discontinuity appears at the live edge of an LL-HLS playlist. Its parser synthesizes the upcoming fragment with the current discontinuity sequence, and its playlist merge treats the sequence bump as a fatal parsing error, although rfc8216bis §4.4.5.3 explicitly allows the next part to start a new discontinuity domain. Until hls.js is patched, hls.js-based players including OvenPlayer can play streams containing discontinuities only with `?_HLS_legacy=YES`. Apple native players (iOS/macOS Safari) and Dolby OptiView play the boundaries seamlessly in LL-HLS mode.

## Test

- Unit: playlist writer tests covering discontinuity tagging, discontinuity sequence accounting, map switching, and preload hints.
- Manual: a Scheduled Channel alternating two bypass items every 10 seconds (640x360 H.264 Baseline with 44.1kHz AAC, and 1920x1080 High with 48kHz AAC, 1s keyframe interval).
- Pass conditions: every item transition produces EXT-X-DISCONTINUITY, a new EXT-X-MAP, and an increasing EXT-X-DISCONTINUITY-SEQUENCE with aligned boundaries on video and audio; the master CODECS attribute lists both codecs while segments of both configurations coexist in the window and returns to a single codec afterwards; iOS Safari and Dolby OptiView play across boundaries without interruption while staying in LL-HLS mode; hls.js plays with `?_HLS_legacy=YES`.
