### PR TITLE
feat(hls): support runtime track configuration changes with discontinuity signaling

### DIFF
--- a/src/modules/containers/mpegts/mpegts_packager.cpp
+++ b/src/modules/containers/mpegts/mpegts_packager.cpp
@@ -190,7 +190,8 @@ namespace mpegts
 			// and PSI (the swap happens after the flush). The new content starts at the
 			// new track's first key frame, which the packetizer key-frame gate ensures.
 			auto main_sample_buffer = GetSampleBuffer(_main_track_id);
-			if (main_sample_buffer != nullptr && main_sample_buffer->GetCurrentDurationMs() > 0.0)
+			bool has_buffered_content = (main_sample_buffer != nullptr && main_sample_buffer->GetCurrentDurationMs() > 0.0);
+			if (has_buffered_content == true)
 			{
 				Flush();
 			}
@@ -203,11 +204,15 @@ namespace mpegts
 			}
 			_codecs_parameter = MakeCodecsParameter();
 
-			// Start a new configuration generation so the next segment is a
-			// discontinuity point. An own cut supersedes a pending propagated one.
-			_track_config_generation++;
-			_pending_cut_timestamp_ms = -1.0;
-			_last_boundary_timestamp_ms = GetLastSampleEndTimestampMs();
+			// A change before any content is produced only establishes the initial
+			// configuration, so it is not a discontinuity. Otherwise start a new
+			// generation; an own cut supersedes a pending propagated one.
+			if (has_buffered_content == true || _last_segment_id > 0)
+			{
+				_track_config_generation++;
+				_pending_cut_timestamp_ms = -1.0;
+				_last_boundary_timestamp_ms = GetLastSampleEndTimestampMs();
+			}
 		}
 		else
 		{
@@ -225,7 +230,12 @@ namespace mpegts
 			}
 			_codecs_parameter = MakeCodecsParameter();
 
-			RequestCutForDiscontinuity(GetLastSampleEndTimestampMs());
+			// Only after content exists is there a prior domain to be discontinuous
+			// from; before the first segment the change is just the initial configuration.
+			if (_last_segment_id > 0)
+			{
+				RequestCutForDiscontinuity(GetLastSampleEndTimestampMs());
+			}
 		}
 
 		return true;
@@ -358,11 +368,19 @@ namespace mpegts
 				double sample_dts_ms = static_cast<double>(sample._dts) / TIMEBASE_DBL * 1000.0;
 				if (sample_dts_ms >= _pending_cut_timestamp_ms)
 				{
-					sample_buffer->MarkSegmentBoundary();
+					// Close the old domain only if it has samples; otherwise the cut
+					// merely starts the new generation with the upcoming sample, so no
+					// empty 0-duration segment is produced.
+					if (sample_buffer->GetCurrentDurationMs() > 0.0)
+					{
+						sample_buffer->MarkSegmentBoundary();
+						boundary_marked = true;
+					}
 					_track_config_generation++;
 					_last_boundary_timestamp_ms = sample_dts_ms;
 					_pending_cut_timestamp_ms = -1.0;
-					boundary_marked = true;
+					// The cut supersedes a pending forced boundary at this point
+					_force_make_boundary = false;
 				}
 			}
 

--- a/src/modules/containers/mpegts/mpegts_packager.cpp
+++ b/src/modules/containers/mpegts/mpegts_packager.cpp
@@ -371,12 +371,21 @@ namespace mpegts
 					// Close the old domain only if it has samples; otherwise the cut
 					// merely starts the new generation with the upcoming sample, so no
 					// empty 0-duration segment is produced.
+					bool has_prior_domain = (_last_segment_id > 0);
 					if (sample_buffer->GetCurrentDurationMs() > 0.0)
 					{
 						sample_buffer->MarkSegmentBoundary();
 						boundary_marked = true;
+						has_prior_domain = true;
 					}
-					_track_config_generation++;
+
+					// Only start a new generation when there is a prior domain to be
+					// discontinuous from; a cut before any content simply establishes
+					// the initial configuration.
+					if (has_prior_domain == true)
+					{
+						_track_config_generation++;
+					}
 					_last_boundary_timestamp_ms = sample_dts_ms;
 					_pending_cut_timestamp_ms = -1.0;
 					// The cut supersedes a pending forced boundary at this point

--- a/src/modules/containers/mpegts/mpegts_packager.cpp
+++ b/src/modules/containers/mpegts/mpegts_packager.cpp
@@ -230,9 +230,14 @@ namespace mpegts
 			}
 			_codecs_parameter = MakeCodecsParameter();
 
-			// Only after content exists is there a prior domain to be discontinuous
-			// from; before the first segment the change is just the initial configuration.
-			if (_last_segment_id > 0)
+			// Request an aligned cut once content has started (a segment exists or the
+			// main track has buffered samples), matching the main-track path. This
+			// covers a change during the first segment's buffering window, which would
+			// otherwise land inside that segment without a discontinuity boundary.
+			auto main_sample_buffer = GetSampleBuffer(_main_track_id);
+			bool has_content = (_last_segment_id > 0) ||
+							   (main_sample_buffer != nullptr && main_sample_buffer->GetCurrentDurationMs() > 0.0);
+			if (has_content == true)
 			{
 				RequestCutForDiscontinuity(GetLastSampleEndTimestampMs());
 			}

--- a/src/modules/containers/mpegts/mpegts_packager.cpp
+++ b/src/modules/containers/mpegts/mpegts_packager.cpp
@@ -9,6 +9,8 @@
 #include "mpegts_packager.h"
 #include "mpegts_private.h"
 
+#include <cmath>
+
 #include <base/modules/data_format/cue_event/cue_event.h>
 
 namespace mpegts
@@ -119,6 +121,8 @@ namespace mpegts
 
         _psi_packets = psi_packets;
         _psi_packet_data = MergeTsPacketData(psi_packets);
+
+        _codecs_parameter = MakeCodecsParameter();
     }
 
 	void Packager::Flush()
@@ -132,6 +136,125 @@ namespace mpegts
 		sample_buffer->MarkSegmentBoundary();
 
 		CreateSegmentIfReady(true);
+	}
+
+	ov::String Packager::MakeCodecsParameter() const
+	{
+		ov::String video_codecs;
+		ov::String audio_codecs;
+
+		for (const auto &track_it : _media_tracks)
+		{
+			const auto &track = track_it.second;
+			if (track->GetMediaType() == cmn::MediaType::Video && video_codecs.IsEmpty() == true)
+			{
+				video_codecs = track->GetCodecsParameter();
+			}
+			else if (track->GetMediaType() == cmn::MediaType::Audio && audio_codecs.IsEmpty() == true)
+			{
+				audio_codecs = track->GetCodecsParameter();
+			}
+		}
+
+		ov::String result = video_codecs;
+		if (audio_codecs.IsEmpty() == false)
+		{
+			if (result.IsEmpty() == false)
+			{
+				result += ",";
+			}
+			result += audio_codecs;
+		}
+
+		return result;
+	}
+
+	bool Packager::UpdateTrack(const std::shared_ptr<const MediaTrack> &media_track)
+	{
+		if (media_track == nullptr)
+		{
+			return false;
+		}
+
+		auto it = _media_tracks.find(media_track->GetId());
+		if (it == _media_tracks.end())
+		{
+			logtw("[%s] Track(%u) is not part of this packager, cannot update", _packager_id.CStr(), media_track->GetId());
+			return false;
+		}
+
+		if (media_track->GetId() == _main_track_id)
+		{
+			// Main track (video, or the sole track): close the current content into its
+			// own segment right away so that the pre-change tail keeps the old codecs
+			// and PSI (the swap happens after the flush). The new content starts at the
+			// new track's first key frame, which the packetizer key-frame gate ensures.
+			auto main_sample_buffer = GetSampleBuffer(_main_track_id);
+			if (main_sample_buffer != nullptr && main_sample_buffer->GetCurrentDurationMs() > 0.0)
+			{
+				Flush();
+			}
+
+			it->second = media_track;
+			auto sample_buffer = GetSampleBuffer(media_track->GetId());
+			if (sample_buffer != nullptr)
+			{
+				sample_buffer->SetTrack(media_track);
+			}
+			_codecs_parameter = MakeCodecsParameter();
+
+			// Start a new configuration generation so the next segment is a
+			// discontinuity point. An own cut supersedes a pending propagated one.
+			_track_config_generation++;
+			_pending_cut_timestamp_ms = -1.0;
+			_last_boundary_timestamp_ms = GetLastSampleEndTimestampMs();
+		}
+		else
+		{
+			// Secondary track (audio) on a muxed packager: cutting now would split the
+			// video mid-GOP. Swap the reference and request a key-frame-aligned cut. The
+			// audio codec is AAC either way, so the PMT is unchanged. The cut is
+			// deduplicated against a concurrent main-track change (item switch), and a
+			// following main-track update supersedes it, so a video+audio switch yields
+			// a single discontinuity regardless of the order the changes arrive.
+			it->second = media_track;
+			auto sample_buffer = GetSampleBuffer(media_track->GetId());
+			if (sample_buffer != nullptr)
+			{
+				sample_buffer->SetTrack(media_track);
+			}
+			_codecs_parameter = MakeCodecsParameter();
+
+			RequestCutForDiscontinuity(GetLastSampleEndTimestampMs());
+		}
+
+		return true;
+	}
+
+	void Packager::RequestCutForDiscontinuity(double boundary_timestamp_ms)
+	{
+		// Ignore a boundary within one segment of the last handled one. This absorbs
+		// reciprocal propagation when multiple tracks change together.
+		if (_last_boundary_timestamp_ms >= 0.0 &&
+			std::abs(boundary_timestamp_ms - _last_boundary_timestamp_ms) <= static_cast<double>(_config.target_duration_ms))
+		{
+			return;
+		}
+
+		if (_pending_cut_timestamp_ms < 0.0 || boundary_timestamp_ms < _pending_cut_timestamp_ms)
+		{
+			_pending_cut_timestamp_ms = boundary_timestamp_ms;
+		}
+	}
+
+	double Packager::GetLastSampleEndTimestampMs() const
+	{
+		return _last_sample_end_timestamp_ms;
+	}
+
+	bool Packager::HasTrack(uint32_t track_id) const
+	{
+		return _media_tracks.find(track_id) != _media_tracks.end();
 	}
 
 	std::shared_ptr<base::modules::Segment> Packager::GetSegment(int64_t segment_id) const
@@ -223,6 +346,26 @@ namespace mpegts
 
 		if (track_id == _main_track_id)
 		{
+			bool is_independent = (media_packet->GetMediaType() == cmn::MediaType::Video && media_packet->IsKeyFrame()) ||
+								  (media_packet->GetMediaType() == cmn::MediaType::Audio);
+			bool boundary_marked = false;
+
+			// A sibling track changed and requested an aligned cut. Apply it at the
+			// first independent sample at or after the requested boundary so the new
+			// domain starts on a key frame.
+			if (_pending_cut_timestamp_ms >= 0.0 && is_independent == true)
+			{
+				double sample_dts_ms = static_cast<double>(sample._dts) / TIMEBASE_DBL * 1000.0;
+				if (sample_dts_ms >= _pending_cut_timestamp_ms)
+				{
+					sample_buffer->MarkSegmentBoundary();
+					_track_config_generation++;
+					_last_boundary_timestamp_ms = sample_dts_ms;
+					_pending_cut_timestamp_ms = -1.0;
+					boundary_marked = true;
+				}
+			}
+
 			// sample._dts is "the last dts + sample duration" of the sample_buffer
 			if (_force_make_boundary == false && HasMarker(sample._dts) == true)
 			{
@@ -231,7 +374,7 @@ namespace mpegts
 				_force_make_boundary = true;
 			}
 
-			if ((sample_buffer->GetCurrentDurationMs() >= _next_target_duration_ms) || _force_make_boundary == true)
+			if (boundary_marked == false && ((sample_buffer->GetCurrentDurationMs() >= _next_target_duration_ms) || _force_make_boundary == true))
 			{
 				if (media_packet->GetMediaType() == cmn::MediaType::Video && media_packet->IsKeyFrame())
 				{
@@ -246,7 +389,16 @@ namespace mpegts
 			}
 		}
 
+		// Stamp the current configuration generation so the segment inherits the
+		// generation of its first sample (used for discontinuity detection)
+		sample.generation = _track_config_generation;
+
         sample_buffer->AddSample(sample);
+
+		if (track_id == _main_track_id)
+		{
+			_last_sample_end_timestamp_ms = static_cast<double>(sample._dts + sample._duration) / TIMEBASE_DBL * 1000.0;
+		}
 
 		CreateSegmentIfReady();
     }
@@ -361,6 +513,19 @@ namespace mpegts
         }
 
         auto segment = std::make_shared<Segment>(GetNextSegmentId(), first_sample._dts, main_segment_duration_ms);
+
+		// Stamp configuration metadata: a segment is a discontinuity point when its
+		// generation differs from the previously created one (own change or an
+		// aligned sibling cut). The codecs reflect the tracks active at creation.
+		uint32_t segment_generation = first_sample.generation;
+		segment->SetTrackVersion(segment_generation);
+		segment->SetCodecsParameter(_codecs_parameter);
+		if (segment_generation != _last_created_generation)
+		{
+			segment->SetDiscontinuityPoint(true);
+		}
+		_last_created_generation = segment_generation;
+
 		if (markers.empty() == false)
 		{
 			segment->SetMarkers(markers);

--- a/src/modules/containers/mpegts/mpegts_packager.h
+++ b/src/modules/containers/mpegts/mpegts_packager.h
@@ -76,6 +76,36 @@ namespace mpegts
             return true;
         }
 
+        uint32_t GetTrackVersion() const override
+        {
+            return _track_version;
+        }
+
+        bool IsDiscontinuityPoint() const override
+        {
+            return _is_discontinuity;
+        }
+
+        ov::String GetCodecsParameter() const override
+        {
+            return _codecs;
+        }
+
+        void SetTrackVersion(uint32_t track_version)
+        {
+            _track_version = track_version;
+        }
+
+        void SetDiscontinuityPoint(bool is_discontinuity)
+        {
+            _is_discontinuity = is_discontinuity;
+        }
+
+        void SetCodecsParameter(const ov::String &codecs)
+        {
+            _codecs = codecs;
+        }
+
         bool HasMarker() const override
 		{
 			return _markers.empty() == false;
@@ -159,6 +189,12 @@ namespace mpegts
         int64_t _segment_id = 0;
         int64_t _first_dts = -1;
         double _duration_ms = 0;
+
+		// Track configuration this segment was packaged against (discontinuity signaling)
+		uint32_t _track_version = 0;
+		bool _is_discontinuity = false;
+		ov::String _codecs;
+
 		ov::String _url;
         
 		ov::String _file_path;
@@ -188,7 +224,11 @@ namespace mpegts
 		int64_t _pts = -1;
 		int64_t _dts = -1;
 		int64_t _duration = -1;
-		
+
+		// Configuration generation stamped at ingestion; the segment inherits the
+		// generation of its first sample for discontinuity detection
+		uint32_t generation = 0;
+
         std::shared_ptr<const MediaPacket> media_packet = nullptr;
         std::shared_ptr<const ov::Data> ts_packet_data = nullptr;
     };
@@ -204,6 +244,11 @@ namespace mpegts
         std::shared_ptr<const MediaTrack> GetTrack() const
         {
             return _track;
+        }
+
+        void SetTrack(const std::shared_ptr<const MediaTrack> &track)
+        {
+            _track = track;
         }
 
         bool AddSample(const Sample &sample)
@@ -429,6 +474,27 @@ namespace mpegts
         void OnFrame(const std::shared_ptr<const MediaPacket> &media_packet, const std::shared_ptr<const ov::Data> &ts_data) override;
 
 		void Flush();
+
+		////////////////////////////////
+		// Runtime track configuration changes
+		////////////////////////////////
+
+		// Replace an existing track with a new configuration version. Closes the
+		// current content into its own segment (old codecs/PSI), then starts a new
+		// configuration generation so the following segment is a discontinuity point.
+		bool UpdateTrack(const std::shared_ptr<const MediaTrack> &media_track);
+
+		// Request a discontinuity-aligned cut at boundary_timestamp_ms, applied at the
+		// first independent sample at or after it. Used to align sibling packagers when
+		// another track changes. Deduplicated against the last handled boundary.
+		void RequestCutForDiscontinuity(double boundary_timestamp_ms);
+
+		// End timestamp (ms) of the most recent main-track sample
+		double GetLastSampleEndTimestampMs() const;
+
+		// Whether this packager carries the given track
+		bool HasTrack(uint32_t track_id) const;
+
         ////////////////////////////////
         // SegmentStorage interface
         ////////////////////////////////
@@ -473,7 +539,10 @@ namespace mpegts
         int64_t GetNextSegmentId();
 
         std::shared_ptr<ov::Data> MergeTsPacketData(const std::vector<std::shared_ptr<mpegts::Packet>> &ts_packets);
-    
+
+        // Codecs parameter (RFC 6381) of the current media tracks (video first, then audio)
+        ov::String MakeCodecsParameter() const;
+
         std::shared_ptr<const MediaTrack> GetMediaTrack(uint32_t track_id) const;
         std::shared_ptr<SampleBuffer> GetSampleBuffer(uint32_t track_id) const;
 
@@ -513,6 +582,13 @@ namespace mpegts
 		// make segment boundary as soon as possible
 		bool _force_make_boundary = false;
 
+		// Runtime track change state
+		uint32_t _track_config_generation = 0;		// current generation, stamped on samples
+		uint32_t _last_created_generation = 0;		// generation of the last created segment
+		double _pending_cut_timestamp_ms = -1.0;	// pending propagated discontinuity cut
+		double _last_boundary_timestamp_ms = -1.0;	// last handled boundary, for dedup
+		double _last_sample_end_timestamp_ms = 0.0;	// end of the most recent main-track sample
+
         // track_id -> SampleBuffer
         std::map<uint32_t, std::shared_ptr<SampleBuffer>> _sample_buffers;
 
@@ -520,6 +596,9 @@ namespace mpegts
         std::map<uint32_t, std::shared_ptr<const MediaTrack>> _media_tracks;
         std::vector<std::shared_ptr<mpegts::Packet>> _psi_packets;
         std::shared_ptr<ov::Data> _psi_packet_data;
+        // Codecs of the current tracks, recomputed only when they change (OnPsi/UpdateTrack)
+        // so segment stamping does not rebuild it per segment
+        ov::String _codecs_parameter;
 
         int64_t _last_segment_id = 0;
 

--- a/src/modules/containers/mpegts/mpegts_packetizer.cpp
+++ b/src/modules/containers/mpegts/mpegts_packetizer.cpp
@@ -85,12 +85,6 @@ namespace mpegts
             return false;
         }
 
-        if (IsStarted() == false)
-        {
-            // Not started yet, the track is included when Start() builds the PSI
-            return AddTrack(media_track);
-        }
-
         if (media_track->GetMediaType() == cmn::MediaType::Audio || media_track->GetMediaType() == cmn::MediaType::Video)
         {
             if (GetElementaryStreamTypeByCodecId(media_track->GetCodecId()) == WellKnownStreamTypes::None)
@@ -98,6 +92,24 @@ namespace mpegts
                 logte("%s codec is not supported for a runtime track change", cmn::GetCodecIdString(media_track->GetCodecId()));
                 return false;
             }
+        }
+
+        if (IsStarted() == false)
+        {
+            // Not started yet; the track is included when Start() builds the PSI. An
+            // already-added track must be replaced in place because AddTrack() uses
+            // emplace() and would silently keep the old one.
+            auto existing = _media_tracks.find(media_track->GetId());
+            if (existing != _media_tracks.end())
+            {
+                existing->second = media_track;
+                if (media_track->GetMediaType() == cmn::MediaType::Video)
+                {
+                    _first_video_frame_received = false;
+                }
+                return true;
+            }
+            return AddTrack(media_track);
         }
 
         auto it = _media_tracks.find(media_track->GetId());

--- a/src/modules/containers/mpegts/mpegts_packetizer.cpp
+++ b/src/modules/containers/mpegts/mpegts_packetizer.cpp
@@ -78,6 +78,70 @@ namespace mpegts
         return true;
     }
 
+    bool Packetizer::UpdateTrack(const std::shared_ptr<const MediaTrack> &media_track)
+    {
+        if (media_track == nullptr)
+        {
+            return false;
+        }
+
+        if (IsStarted() == false)
+        {
+            // Not started yet, the track is included when Start() builds the PSI
+            return AddTrack(media_track);
+        }
+
+        if (media_track->GetMediaType() == cmn::MediaType::Audio || media_track->GetMediaType() == cmn::MediaType::Video)
+        {
+            if (GetElementaryStreamTypeByCodecId(media_track->GetCodecId()) == WellKnownStreamTypes::None)
+            {
+                logte("%s codec is not supported for a runtime track change", cmn::GetCodecIdString(media_track->GetCodecId()));
+                return false;
+            }
+        }
+
+        auto it = _media_tracks.find(media_track->GetId());
+        if (it == _media_tracks.end())
+        {
+            // Adding a new track at runtime is not supported
+            logtw("Track(%u) is not part of this packetizer, cannot update", media_track->GetId());
+            return false;
+        }
+
+        auto old_track = it->second;
+
+        // Replace the track. The elementary PID stays stable through _pids.
+        it->second = media_track;
+
+        if (media_track->GetMediaType() == cmn::MediaType::Video)
+        {
+            // A fresh key frame is required after any encoding-parameter change
+            _first_video_frame_received = false;
+        }
+
+        // The PMT only carries the elementary stream_type and PID; SPS/PPS, resolution
+        // and bitrate all travel in-band in the PES. A same-codec change leaves the PMT
+        // byte-identical, so the version is bumped and the PSI re-broadcast only when the
+        // stream_type actually changes.
+        auto old_stream_type = GetElementaryStreamTypeByCodecId(old_track->GetCodecId());
+        auto new_stream_type = GetElementaryStreamTypeByCodecId(media_track->GetCodecId());
+        if (old_stream_type != new_stream_type)
+        {
+            _pmt._version_number = (_pmt._version_number + 1) & 0x1F;
+
+            _pmt_packet = BuildPmtPacket();
+            if (_pmt_packet == nullptr)
+            {
+                logte("Failed to rebuild PMT for a runtime track change");
+                return false;
+            }
+
+            BroadcastPsi();
+        }
+
+        return true;
+    }
+
     std::shared_ptr<const MediaTrack> Packetizer::GetMediaTrack(uint32_t track_id) const
     {
         auto it = _media_tracks.find(track_id);
@@ -263,10 +327,16 @@ namespace mpegts
     std::shared_ptr<mpegts::Packet> Packetizer::BuildPmtPacket()
     {
 		_pmt._table_id_extension = PROGRAM_NUMBER;
-		_pmt._version_number = 0;
 		_pmt._current_next_indicator = true;
 		_pmt._section_number = 0;
 		_pmt._last_section_number = 0;
+
+		// Reset per-build fields so the PMT can be rebuilt on a runtime track change.
+		// _version_number is preserved (bumped by UpdateTrack, 0 on the initial build).
+		_pmt._pcr_pid = 0x1FFF;
+		_pmt._program_info_length = 0;
+		_pmt._program_descriptors.clear();
+		_pmt._es_info_list.clear();
 
 		auto program_info_descriptor = BuildID3MetadataPointerDescriptor();
 		auto program_info_descriptor_data = program_info_descriptor->Build();

--- a/src/modules/containers/mpegts/mpegts_packetizer.h
+++ b/src/modules/containers/mpegts/mpegts_packetizer.h
@@ -48,6 +48,11 @@ namespace mpegts
 
         bool AddTrack(const std::shared_ptr<const MediaTrack> &media_track);
 
+        // Replace an existing track with a new configuration version at runtime.
+        // The PMT version_number is bumped and the PSI re-broadcast only when the
+        // elementary stream_type (codec) changes; a same-codec change leaves it as is.
+        bool UpdateTrack(const std::shared_ptr<const MediaTrack> &media_track);
+
         bool Start();
         bool IsStarted() const;
         bool Stop();

--- a/src/publishers/hls/hls_master_playlist.cpp
+++ b/src/publishers/hls/hls_master_playlist.cpp
@@ -79,8 +79,14 @@ ov::String HlsMasterPlaylist::ToString(bool rewind) const
 
 	for (const auto &media_playlist : media_playlists)
 	{
+		// A rendition whose current codec became unsupported is not advertised
+		if (media_playlist->IsExcluded())
+		{
+			continue;
+		}
+
 		if (media_playlist->HasVideo())
-		{			
+		{
 			result += ov::String::FormatString("#EXT-X-STREAM-INF:BANDWIDTH=%d,AVERAGE-BANDWIDTH=%d,RESOLUTION=%s,FRAME-RATE=%.3f,CODECS=\"%s\"",
 											media_playlist->GetBitrates(),
 											media_playlist->GetAverageBitrate(),

--- a/src/publishers/hls/hls_media_playlist.cpp
+++ b/src/publishers/hls/hls_media_playlist.cpp
@@ -99,14 +99,20 @@ bool HlsMediaPlaylist::OnSegmentCreated(const std::shared_ptr<base::modules::Seg
 		logtd("Marker is found in the segment %" PRIu64 " (%zu)", segment->GetNumber(), segment->GetMarkers().size());
 	}
 
-	_segments.emplace(segment->GetNumber(), segment);
-
-	// The codecs union can only grow at a discontinuity; a normal segment repeats
-	// the codecs of its generation, which are already covered. A stream that never
-	// changes configuration therefore never builds the cache and uses the fallback.
 	if (segment->IsDiscontinuityPoint() == true)
 	{
 		_total_discontinuity_count++;
+	}
+
+	_segments.emplace(segment->GetNumber(), segment);
+
+	// Keep the CODECS cache reflecting the retained segments: build it on the first
+	// segment and whenever a discontinuity changes the codec set. GetCodecsString then
+	// derives from the segments and never advertises a codec (e.g. from a just-updated
+	// track) that the retained segments do not yet contain. A normal segment repeats
+	// the codecs already covered, so it needs no rebuild.
+	if (segment->IsDiscontinuityPoint() == true || _codecs_parameter.IsEmpty() == true)
+	{
 		RebuildCodecsParameter();
 	}
 

--- a/src/publishers/hls/hls_media_playlist.cpp
+++ b/src/publishers/hls/hls_media_playlist.cpp
@@ -10,6 +10,8 @@
 #include "hls_media_playlist.h"
 #include "hls_private.h"
 
+#include <algorithm>
+
 #include <base/modules/data_format/cue_event/cue_event.h>
 
 HlsMediaPlaylist::HlsMediaPlaylist(const ov::String &id, const ov::String &playlist_file_name, const HlsMediaPlaylistConfig &config)
@@ -21,6 +23,8 @@ HlsMediaPlaylist::HlsMediaPlaylist(const ov::String &id, const ov::String &playl
 
 void HlsMediaPlaylist::AddMediaTrackInfo(const std::shared_ptr<const MediaTrack> &track)
 {
+	std::lock_guard<std::shared_mutex> lock(_tracks_mutex);
+
 	_media_tracks.emplace(track->GetId(), track);
 
 	if (_first_video_track == nullptr && track->GetMediaType() == cmn::MediaType::Video)
@@ -37,6 +41,44 @@ void HlsMediaPlaylist::AddMediaTrackInfo(const std::shared_ptr<const MediaTrack>
 	{
 		_subtitle_track = track;
 	}
+}
+
+void HlsMediaPlaylist::UpdateMediaTrackInfo(const std::shared_ptr<const MediaTrack> &track)
+{
+	std::lock_guard<std::shared_mutex> lock(_tracks_mutex);
+
+	auto it = _media_tracks.find(track->GetId());
+	if (it == _media_tracks.end())
+	{
+		return;
+	}
+	it->second = track;
+
+	// Refresh the representative track of each type so the master follows the change
+	if (_first_video_track != nullptr && _first_video_track->GetId() == track->GetId())
+	{
+		_first_video_track = track;
+	}
+	if (_first_audio_track != nullptr && _first_audio_track->GetId() == track->GetId())
+	{
+		_first_audio_track = track;
+	}
+	if (_subtitle_track != nullptr && _subtitle_track->GetId() == track->GetId())
+	{
+		_subtitle_track = track;
+	}
+}
+
+bool HlsMediaPlaylist::HasTrack(uint32_t track_id) const
+{
+	std::shared_lock<std::shared_mutex> lock(_tracks_mutex);
+	return _media_tracks.find(track_id) != _media_tracks.end();
+}
+
+std::shared_ptr<const MediaTrack> HlsMediaPlaylist::GetSubtitleTrack() const
+{
+	std::shared_lock<std::shared_mutex> lock(_tracks_mutex);
+	return _subtitle_track;
 }
 
 void HlsMediaPlaylist::SetEndList()
@@ -59,6 +101,15 @@ bool HlsMediaPlaylist::OnSegmentCreated(const std::shared_ptr<base::modules::Seg
 
 	_segments.emplace(segment->GetNumber(), segment);
 
+	// The codecs union can only grow at a discontinuity; a normal segment repeats
+	// the codecs of its generation, which are already covered. A stream that never
+	// changes configuration therefore never builds the cache and uses the fallback.
+	if (segment->IsDiscontinuityPoint() == true)
+	{
+		_total_discontinuity_count++;
+		RebuildCodecsParameter();
+	}
+
 	return true;
 }
 
@@ -75,7 +126,32 @@ bool HlsMediaPlaylist::OnSegmentDeleted(const std::shared_ptr<base::modules::Seg
 		return false;
 	}
 
+	// A discontinuity that scrolls out entirely raises the base of the sequence
+	if (it->second->IsDiscontinuityPoint() == true)
+	{
+		_removed_discontinuity_count++;
+	}
+
+	uint32_t removed_version = it->second->GetTrackVersion();
 	_segments.erase(it);
+
+	// The codecs union can shrink only after the playlist spans more than one version.
+	// Segments leave oldest-first and versions are monotonic, so the union changes only
+	// when the removed (oldest) version keeps no segment behind.
+	if (_total_discontinuity_count > 0)
+	{
+		bool oldest_version_gone = true;
+		if (_segments.empty() == false)
+		{
+			auto oldest_segment = _segments.begin()->second;
+			oldest_version_gone = (oldest_segment->GetTrackVersion() != removed_version);
+		}
+
+		if (oldest_version_gone == true)
+		{
+			RebuildCodecsParameter();
+		}
+	}
 
 	return true;
 }
@@ -117,6 +193,23 @@ ov::String HlsMediaPlaylist::ToString(bool rewind) const
 
 	result += ov::String::FormatString("#EXT-X-MEDIA-SEQUENCE:%" PRIu64 "\n", first_segment->GetNumber());
 
+	// EXT-X-DISCONTINUITY-SEQUENCE counts the discontinuities that precede the first
+	// listed segment: those that scrolled out entirely plus those still retained but
+	// ahead of the playlist window. The per-segment EXT-X-DISCONTINUITY tags (emitted
+	// by MakeSegmentString) cover the rest.
+	if (_total_discontinuity_count > 0)
+	{
+		int64_t discontinuity_sequence = _removed_discontinuity_count;
+		for (auto it = _segments.begin(); it != _segments.end() && it->first < first_segment->GetNumber(); ++it)
+		{
+			if (it->second->IsDiscontinuityPoint() == true)
+			{
+				discontinuity_sequence++;
+			}
+		}
+		result += ov::String::FormatString("#EXT-X-DISCONTINUITY-SEQUENCE:%" PRId64 "\n", discontinuity_sequence);
+	}
+
 	for (auto it = _segments.find(first_segment->GetNumber()); it != _segments.end(); it++)
 	{
 		const auto &segment = it->second;
@@ -133,21 +226,25 @@ ov::String HlsMediaPlaylist::ToString(bool rewind) const
 
 bool HlsMediaPlaylist::HasVideo() const
 {
+	std::shared_lock<std::shared_mutex> lock(_tracks_mutex);
 	return _first_video_track != nullptr;
 }
 
 bool HlsMediaPlaylist::HasAudio() const
 {
+	std::shared_lock<std::shared_mutex> lock(_tracks_mutex);
 	return _first_audio_track != nullptr;
 }
 
 bool HlsMediaPlaylist::HasSubtitle() const
 {
+	std::shared_lock<std::shared_mutex> lock(_tracks_mutex);
 	return _subtitle_track != nullptr;
 }
 
 uint32_t HlsMediaPlaylist::GetBitrates() const
 {
+	std::shared_lock<std::shared_mutex> lock(_tracks_mutex);
 	uint32_t bitrates = 0;
 	for (const auto &track_it : _media_tracks)
 	{
@@ -160,6 +257,7 @@ uint32_t HlsMediaPlaylist::GetBitrates() const
 
 uint32_t HlsMediaPlaylist::GetAverageBitrate() const
 {
+	std::shared_lock<std::shared_mutex> lock(_tracks_mutex);
 	uint32_t bitrates = 0;
 	for (const auto &track_it : _media_tracks)
 	{
@@ -174,6 +272,7 @@ uint32_t HlsMediaPlaylist::GetAverageBitrate() const
 
 bool HlsMediaPlaylist::GetResolution(uint32_t &width, uint32_t &height) const
 {
+	std::shared_lock<std::shared_mutex> lock(_tracks_mutex);
 	if (_first_video_track == nullptr)
 	{
 		return false;
@@ -188,18 +287,19 @@ bool HlsMediaPlaylist::GetResolution(uint32_t &width, uint32_t &height) const
 
 ov::String HlsMediaPlaylist::GetResolutionString() const
 {
-	uint32_t width = 0;
-	uint32_t height = 0;
-	if (GetResolution(width, height) == false)
+	std::shared_lock<std::shared_mutex> lock(_tracks_mutex);
+	if (_first_video_track == nullptr)
 	{
 		return "";
 	}
 
-	return ov::String::FormatString("%dx%d", width, height);
+	auto resolution = _first_video_track->GetResolution();
+	return ov::String::FormatString("%dx%d", resolution.width, resolution.height);
 }
 
 double HlsMediaPlaylist::GetFramerate() const
 {
+	std::shared_lock<std::shared_mutex> lock(_tracks_mutex);
 	if (_first_video_track == nullptr)
 	{
 		return 0.0;
@@ -208,10 +308,55 @@ double HlsMediaPlaylist::GetFramerate() const
 	return _first_video_track->GetFrameRate();
 }
 
+void HlsMediaPlaylist::RebuildCodecsParameter()
+{
+	// Union of the codecs of every retained segment, so CODECS covers a playlist
+	// window that spans a runtime codec change (RFC 8216 6.2.4). Distinct tokens are
+	// kept oldest-first. Rebuilt only on add/remove; readers use the cached value.
+	std::vector<ov::String> tokens;
+	for (const auto &segment_it : _segments)
+	{
+		auto codecs = segment_it.second->GetCodecsParameter();
+		if (codecs.IsEmpty() == true)
+		{
+			continue;
+		}
+
+		for (const auto &token : codecs.Split(","))
+		{
+			if (token.IsEmpty() == false && std::find(tokens.begin(), tokens.end(), token) == tokens.end())
+			{
+				tokens.push_back(token);
+			}
+		}
+	}
+
+	ov::String result;
+	for (size_t i = 0; i < tokens.size(); i++)
+	{
+		if (i > 0)
+		{
+			result += ",";
+		}
+		result += tokens[i];
+	}
+
+	_codecs_parameter = result;
+}
+
 ov::String HlsMediaPlaylist::GetCodecsString() const
 {
-	ov::String result;
+	{
+		std::shared_lock<std::shared_mutex> lock(_segments_mutex);
+		if (_codecs_parameter.IsEmpty() == false)
+		{
+			return _codecs_parameter;
+		}
+	}
 
+	// Fallback before any segment carries codecs (e.g. the very first playlist)
+	std::shared_lock<std::shared_mutex> lock(_tracks_mutex);
+	ov::String result;
 	if (_first_video_track != nullptr)
 	{
 		result += _first_video_track->GetCodecsParameter();
@@ -233,6 +378,10 @@ ov::String HlsMediaPlaylist::GetCodecsString() const
 ov::String HlsMediaPlaylist::MakeSegmentString(const std::shared_ptr<base::modules::Segment> &segment) const
 {
 	ov::String result;
+	if (segment->IsDiscontinuityPoint() == true)
+	{
+		result += "#EXT-X-DISCONTINUITY\n";
+	}
 	auto start_time = static_cast<int64_t>(((segment->GetStartTimestamp() * segment->GetTimebaseSeconds()) * 1000.0) + _wallclock_offset_ms);
 	std::chrono::system_clock::time_point tp{std::chrono::milliseconds{start_time}};
 	result += ov::String::FormatString("#EXT-X-PROGRAM-DATE-TIME:%s\n", ov::Converter::ToISO8601String(tp).CStr());

--- a/src/publishers/hls/hls_media_playlist.h
+++ b/src/publishers/hls/hls_media_playlist.h
@@ -14,6 +14,9 @@
 #include <base/info/media_track.h>
 #include <modules/containers/mpegts/mpegts_packager.h>
 
+#include <atomic>
+#include <shared_mutex>
+
 class HlsMediaPlaylist
 {
 public:
@@ -28,6 +31,14 @@ public:
 	HlsMediaPlaylist(const ov::String &variant_name, const ov::String &playlist_file_name, const HlsMediaPlaylistConfig &config);
 
 	void AddMediaTrackInfo(const std::shared_ptr<const MediaTrack> &track);
+	// Replace the current track of the same id at runtime, so master attributes
+	// (resolution, framerate, subtitle name/language) follow a configuration change
+	void UpdateMediaTrackInfo(const std::shared_ptr<const MediaTrack> &track);
+	bool HasTrack(uint32_t track_id) const;
+
+	// A rendition whose current codec is unsupported stops being advertised
+	void SetExcluded(bool excluded) { _excluded = excluded; }
+	bool IsExcluded() const { return _excluded; }
 
 	int64_t GetWallclockOffset() const { return _wallclock_offset_ms; }
 	void SetWallclockOffset(int64_t offset_ms) { _wallclock_offset_ms = offset_ms; }
@@ -41,7 +52,7 @@ public:
 	bool HasVideo() const;
 	bool HasAudio() const;
 	bool HasSubtitle() const;
-	std::shared_ptr<const MediaTrack> GetSubtitleTrack() const { return _subtitle_track; }
+	std::shared_ptr<const MediaTrack> GetSubtitleTrack() const;
 
 	uint32_t GetBitrates() const;
 	uint32_t GetAverageBitrate() const;
@@ -60,20 +71,32 @@ public:
 	std::size_t GetSegmentCount() const;
 
 private:
+	// Recompute the cached CODECS union. Caller must hold _segments_mutex exclusively.
+	void RebuildCodecsParameter();
 
 	HlsMediaPlaylistConfig _config;
 	ov::String _variant_name;
 	ov::String _playlist_file_name;
-	
+
 	// Media track ID : Media track
+	// Protected by _tracks_mutex because a runtime track change (worker thread)
+	// updates them while the master playlist reads them (HTTP thread)
 	std::map<uint32_t, std::shared_ptr<const MediaTrack>> _media_tracks;
 	std::shared_ptr<const MediaTrack> _first_video_track = nullptr;
 	std::shared_ptr<const MediaTrack> _first_audio_track = nullptr;
 	std::shared_ptr<const MediaTrack> _subtitle_track = nullptr;	// The subtitle track is used alone in MediaPlaylist
+	mutable std::shared_mutex _tracks_mutex;
+
+	std::atomic<bool> _excluded { false };
 
 	// Segment number : Segment
 	std::map<uint64_t, std::shared_ptr<base::modules::Segment>> _segments;
 	mutable std::shared_mutex _segments_mutex;
+	// Discontinuity accounting for EXT-X-DISCONTINUITY-SEQUENCE, guarded by _segments_mutex
+	int64_t _total_discontinuity_count = 0;		// discontinuities ever added to this playlist
+	int64_t _removed_discontinuity_count = 0;	// discontinuities that have scrolled out entirely
+	// Cached CODECS union of the retained segments, rebuilt on add/remove, guarded by _segments_mutex
+	ov::String _codecs_parameter;
 	int64_t _wallclock_offset_ms = INT64_MIN;
 
 	bool _end_list = false;

--- a/src/publishers/hls/hls_stream.cpp
+++ b/src/publishers/hls/hls_stream.cpp
@@ -603,6 +603,14 @@ void HlsStream::OnSegmentCreated(const ov::String &packager_id, const std::share
 
 	DumpSegmentOfAllItems(packager_id, segment->GetNumber());
 
+	// A discontinuity carries a new configuration generation, so the master CODECS
+	// (and RESOLUTION) may have changed; refresh the dumped master. This is where the
+	// new codec first appears in the segment listing the union is derived from.
+	if (segment->IsDiscontinuityPoint() == true)
+	{
+		DumpMasterPlaylistOfAllItems();
+	}
+
 	if (packager_id == _vtt_reference_packager_id)
 	{
 		std::shared_lock<std::shared_mutex> lock(_vtt_packagers_lock);
@@ -688,6 +696,132 @@ void HlsStream::OnSegmentDeleted(const ov::String &packager_id, const std::share
 			OnSegmentDeleted(variant_name, vtt_segment);
 
 			vtt_packager->DeleteSegment(segment->GetNumber());
+		}
+	}
+}
+
+void HlsStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const MediaTrack> &old_track, const std::shared_ptr<const MediaTrack> &new_track)
+{
+	// A subtitle track change only affects the master playlist metadata (name,
+	// language); refresh the track the master reads and stop.
+	if (new_track->GetMediaType() == cmn::MediaType::Subtitle)
+	{
+		UpdateMediaPlaylistTrackInfo(track_id, new_track);
+		DumpMasterPlaylistOfAllItems();	// subtitle name/language in the dumped master
+		logti("HlsStream(%s/%s) - Subtitle track(%d) metadata has been updated (version %u -> %u)",
+			  GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), track_id, old_track->GetVersion(), new_track->GetVersion());
+		return;
+	}
+
+	// A label-only change does not affect the packaged output
+	if (old_track->HasSameContent(*new_track) == true)
+	{
+		Stream::OnTrackChanged(track_id, old_track, new_track);
+		return;
+	}
+
+	if (IsSupportedCodec(new_track->GetCodecId()) == false)
+	{
+		logte("HlsStream(%s/%s) - Track(%d) has changed to an unsupported codec(%s), the track is excluded from the output from this point",
+			  GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), track_id, cmn::GetCodecIdString(new_track->GetCodecId()));
+
+		// Newly served master playlists stop advertising the affected renditions
+		SetRenditionsExcludedByTrack(track_id, true);
+		DumpMasterPlaylistOfAllItems();	// the dumped master drops the excluded rendition too
+		return;
+	}
+
+	// Supported content change: repackage the renditions carrying this track and
+	// align every other rendition on the same boundary.
+	std::map<ov::String, std::shared_ptr<mpegts::Packager>> packagers;
+	{
+		std::shared_lock<std::shared_mutex> lock(_ts_packagers_guard);
+		packagers = _ts_packagers;
+	}
+
+	double boundary_timestamp_ms = -1.0;
+	std::vector<std::shared_ptr<mpegts::Packager>> sibling_packagers;
+
+	for (const auto &[variant_name, packager] : packagers)
+	{
+		if (packager == nullptr)
+		{
+			continue;
+		}
+
+		if (packager->HasTrack(track_id) == false)
+		{
+			sibling_packagers.push_back(packager);
+			continue;
+		}
+
+		if (boundary_timestamp_ms < 0.0)
+		{
+			boundary_timestamp_ms = packager->GetLastSampleEndTimestampMs();
+		}
+
+		// The packager closes the current content (old codecs/PSI) and starts a new
+		// generation; the packetizer rebuilds the PMT only on a codec change. The
+		// packager runs first so the flushed tail keeps the old PSI.
+		packager->UpdateTrack(new_track);
+
+		auto packetizer = GetTSPacketizer(variant_name);
+		if (packetizer != nullptr)
+		{
+			packetizer->UpdateTrack(new_track);
+		}
+	}
+
+	// Players keep renditions in sync by their discontinuity sequences, so every
+	// other rendition must cut an aligned boundary even though it did not change.
+	if (boundary_timestamp_ms >= 0.0)
+	{
+		for (const auto &packager : sibling_packagers)
+		{
+			packager->RequestCutForDiscontinuity(boundary_timestamp_ms);
+		}
+	}
+
+	// Master CODECS/RESOLUTION follow the change; re-include if it had been excluded
+	UpdateMediaPlaylistTrackInfo(track_id, new_track);
+	SetRenditionsExcludedByTrack(track_id, false);
+
+	logti("HlsStream(%s/%s) - Track(%d) configuration change has been applied (version %u -> %u)",
+		  GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), track_id, old_track->GetVersion(), new_track->GetVersion());
+}
+
+void HlsStream::UpdateMediaPlaylistTrackInfo(int32_t track_id, const std::shared_ptr<const MediaTrack> &new_track)
+{
+	std::map<ov::String, std::shared_ptr<HlsMediaPlaylist>> playlists;
+	{
+		std::shared_lock<std::shared_mutex> lock(_media_playlists_guard);
+		playlists = _media_playlists;
+	}
+
+	for (const auto &it : playlists)
+	{
+		const auto &playlist = it.second;
+		if (playlist != nullptr && playlist->HasTrack(track_id) == true)
+		{
+			playlist->UpdateMediaTrackInfo(new_track);
+		}
+	}
+}
+
+void HlsStream::SetRenditionsExcludedByTrack(int32_t track_id, bool excluded)
+{
+	std::map<ov::String, std::shared_ptr<HlsMediaPlaylist>> playlists;
+	{
+		std::shared_lock<std::shared_mutex> lock(_media_playlists_guard);
+		playlists = _media_playlists;
+	}
+
+	for (const auto &it : playlists)
+	{
+		const auto &playlist = it.second;
+		if (playlist != nullptr && playlist->HasTrack(track_id) == true)
+		{
+			playlist->SetExcluded(excluded);
 		}
 	}
 }

--- a/src/publishers/hls/hls_stream.cpp
+++ b/src/publishers/hls/hls_stream.cpp
@@ -755,26 +755,33 @@ void HlsStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const Med
 			continue;
 		}
 
-		if (boundary_timestamp_ms < 0.0)
+		// Track the furthest-along boundary across the changed packagers; it stays at
+		// 0 only while no content has been produced yet.
+		auto packager_boundary_ms = packager->GetLastSampleEndTimestampMs();
+		if (packager_boundary_ms > boundary_timestamp_ms)
 		{
-			boundary_timestamp_ms = packager->GetLastSampleEndTimestampMs();
+			boundary_timestamp_ms = packager_boundary_ms;
 		}
 
 		// The packager closes the current content (old codecs/PSI) and starts a new
 		// generation; the packetizer rebuilds the PMT only on a codec change. The
 		// packager runs first so the flushed tail keeps the old PSI.
-		packager->UpdateTrack(new_track);
+		if (packager->UpdateTrack(new_track) == false)
+		{
+			logte("HlsStream(%s/%s) - Failed to update packager track(%d) for variant %s", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), track_id, variant_name.CStr());
+		}
 
 		auto packetizer = GetTSPacketizer(variant_name);
-		if (packetizer != nullptr)
+		if (packetizer != nullptr && packetizer->UpdateTrack(new_track) == false)
 		{
-			packetizer->UpdateTrack(new_track);
+			logte("HlsStream(%s/%s) - Failed to update packetizer track(%d) for variant %s", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), track_id, variant_name.CStr());
 		}
 	}
 
-	// Players keep renditions in sync by their discontinuity sequences, so every
-	// other rendition must cut an aligned boundary even though it did not change.
-	if (boundary_timestamp_ms >= 0.0)
+	// Players keep renditions in sync by their discontinuity sequences, so every other
+	// rendition must cut an aligned boundary. Skip this when the change arrives before
+	// any content, since there is no prior domain to be discontinuous from.
+	if (boundary_timestamp_ms > 0.0)
 	{
 		for (const auto &packager : sibling_packagers)
 		{

--- a/src/publishers/hls/hls_stream.h
+++ b/src/publishers/hls/hls_stream.h
@@ -74,7 +74,12 @@ public:
 private:
 	bool Start() override;
 	bool Stop() override;
-	bool IsSupportedCodec(cmn::MediaCodecId codec_id) const; 
+	bool IsSupportedCodec(cmn::MediaCodecId codec_id) const;
+
+	// Runtime track configuration change (mirrors the LLHLS publisher)
+	void OnTrackChanged(int32_t track_id, const std::shared_ptr<const MediaTrack> &old_track, const std::shared_ptr<const MediaTrack> &new_track) override;
+	void UpdateMediaPlaylistTrackInfo(int32_t track_id, const std::shared_ptr<const MediaTrack> &new_track);
+	void SetRenditionsExcludedByTrack(int32_t track_id, bool excluded);
 
 	bool CreateDefaultPlaylist();
 	bool CreatePackagers();

--- a/src/publishers/hls/hls_test.cpp
+++ b/src/publishers/hls/hls_test.cpp
@@ -1,2 +1,351 @@
-// Placeholder — add tests here.
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
 #include <gtest/gtest.h>
+
+#include <base/info/media_track.h>
+#include <base/mediarouter/media_buffer.h>
+#include <modules/containers/mpegts/mpegts_packager.h>
+#include <modules/containers/mpegts/mpegts_packetizer.h>
+
+#include "hls_media_playlist.h"
+
+namespace
+{
+	std::shared_ptr<MediaTrack> MakeTrack(uint32_t id, cmn::MediaType type, cmn::MediaCodecId codec, uint32_t version)
+	{
+		auto track = std::make_shared<MediaTrack>();
+		track->SetId(id);
+		track->SetMediaType(type);
+		track->SetCodecId(codec);
+		track->SetTimeBase(1, 90000);
+		track->SetVersion(version);
+		return track;
+	}
+
+	std::shared_ptr<const MediaPacket> MakeVideoKeyFrame(uint32_t track_id, int64_t dts, int64_t duration)
+	{
+		auto data = std::make_shared<ov::Data>();
+		uint8_t byte = 0x00;
+		data->Append(&byte, 1);
+		return std::make_shared<MediaPacket>(cmn::MediaType::Video, track_id, data, dts, dts, duration,
+											 MediaPacketFlag::Key, cmn::BitstreamFormat::H264_ANNEXB, cmn::PacketType::NALU);
+	}
+
+	std::shared_ptr<mpegts::Segment> MakeSegment(int64_t number, int64_t dts, double duration_ms,
+												 uint32_t version, bool discontinuity, const ov::String &codecs)
+	{
+		auto segment = std::make_shared<mpegts::Segment>(number, dts, duration_ms);
+		segment->SetTrackVersion(version);
+		segment->SetDiscontinuityPoint(discontinuity);
+		segment->SetCodecsParameter(codecs);
+		segment->SetUrl(ov::String::FormatString("seg_%" PRId64 ".ts", number));
+		return segment;
+	}
+
+	class CountingPacketizerSink : public mpegts::PacketizerSink
+	{
+	public:
+		void OnPsi(const std::vector<std::shared_ptr<const MediaTrack>> &tracks, const std::vector<std::shared_ptr<mpegts::Packet>> &psi_packets) override
+		{
+			_psi_count++;
+			_last_pmt = psi_packets.size() >= 2 ? psi_packets[1] : nullptr;
+		}
+
+		void OnFrame(const std::shared_ptr<const MediaPacket> &media_packet, const std::shared_ptr<const ov::Data> &ts_data) override
+		{
+		}
+
+		int _psi_count = 0;
+		std::shared_ptr<mpegts::Packet> _last_pmt = nullptr;
+	};
+
+	class CollectingPackagerSink : public mpegts::PackagerSink
+	{
+	public:
+		void OnSegmentCreated(const ov::String &packager_id, const std::shared_ptr<base::modules::Segment> &segment) override
+		{
+			_created.push_back(segment);
+		}
+
+		void OnSegmentDeleted(const ov::String &packager_id, const std::shared_ptr<base::modules::Segment> &segment) override
+		{
+			_deleted.push_back(segment);
+		}
+
+		std::vector<std::shared_ptr<base::modules::Segment>> _created;
+		std::vector<std::shared_ptr<base::modules::Segment>> _deleted;
+	};
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// mpegts::Packetizer - the PMT version bumps and the PSI is re-broadcast only
+// when the elementary stream type (codec) changes.
+// ---------------------------------------------------------------------------
+
+TEST(HlsPacketizer, RebroadcastsPsiOnCodecChange)
+{
+	auto sink = std::make_shared<CountingPacketizerSink>();
+
+	mpegts::Packetizer packetizer;
+	packetizer.AddSink(sink);
+	ASSERT_TRUE(packetizer.AddTrack(MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H264, 1)));
+	ASSERT_TRUE(packetizer.Start());
+
+	EXPECT_EQ(sink->_psi_count, 1);
+
+	// H264 -> H265 changes the stream_type, so the PMT is rebuilt and re-broadcast
+	ASSERT_TRUE(packetizer.UpdateTrack(MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H265, 2)));
+	EXPECT_EQ(sink->_psi_count, 2);
+}
+
+TEST(HlsPacketizer, KeepsPsiOnSameCodecChange)
+{
+	auto sink = std::make_shared<CountingPacketizerSink>();
+
+	mpegts::Packetizer packetizer;
+	packetizer.AddSink(sink);
+	ASSERT_TRUE(packetizer.AddTrack(MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H264, 1)));
+	ASSERT_TRUE(packetizer.Start());
+
+	EXPECT_EQ(sink->_psi_count, 1);
+
+	// A same-codec change (e.g. resolution) leaves the PMT byte-identical
+	ASSERT_TRUE(packetizer.UpdateTrack(MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H264, 2)));
+	EXPECT_EQ(sink->_psi_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// mpegts::Packager - a main-track change starts a new configuration generation,
+// so the following segment is a discontinuity point and the pre-change tail is not.
+// ---------------------------------------------------------------------------
+
+TEST(HlsPackager, MainTrackChangeMarksDiscontinuity)
+{
+	mpegts::Packager::Config config;
+	config.target_duration_ms = 1000;
+	config.max_segment_count = 100;
+	config.segment_retention_count = 0;
+
+	auto packager = std::make_shared<mpegts::Packager>("variant", config);
+	auto sink = std::make_shared<CollectingPackagerSink>();
+	packager->AddSink(sink);
+
+	auto track = MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H264, 1);
+	packager->OnPsi({track}, {});
+
+	auto ts = std::make_shared<ov::Data>();
+	uint8_t byte = 0x47;
+	ts->Append(&byte, 1);
+
+	const int64_t one_second = 90000;
+	int64_t dts = 0;
+
+	// Fill a few segments under the original configuration
+	for (int i = 0; i < 4; i++)
+	{
+		packager->OnFrame(MakeVideoKeyFrame(1, dts, one_second), ts);
+		dts += one_second;
+	}
+
+	ASSERT_GT(sink->_created.size(), 0u);
+
+	// Change the video track (H264 -> H265)
+	ASSERT_TRUE(packager->UpdateTrack(MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H265, 2)));
+
+	// Feed more key frames under the new configuration
+	for (int i = 0; i < 4; i++)
+	{
+		packager->OnFrame(MakeVideoKeyFrame(1, dts, one_second), ts);
+		dts += one_second;
+	}
+
+	// Exactly one discontinuity across the whole sequence, and it is the first
+	// segment of the new generation.
+	int discontinuity_count = 0;
+	uint32_t last_version = 0;
+	bool first = true;
+	for (const auto &segment : sink->_created)
+	{
+		if (segment->IsDiscontinuityPoint())
+		{
+			discontinuity_count++;
+			EXPECT_EQ(segment->GetTrackVersion(), 1u);	// second generation
+		}
+
+		if (first == false && segment->GetTrackVersion() != last_version)
+		{
+			EXPECT_TRUE(segment->IsDiscontinuityPoint());
+		}
+
+		last_version = segment->GetTrackVersion();
+		first = false;
+	}
+
+	EXPECT_EQ(discontinuity_count, 1);
+}
+
+TEST(HlsPackager, RequestCutDeduplicatesNearbyBoundary)
+{
+	mpegts::Packager::Config config;
+	config.target_duration_ms = 6000;
+
+	auto packager = std::make_shared<mpegts::Packager>("variant", config);
+	auto sink = std::make_shared<CollectingPackagerSink>();
+	packager->AddSink(sink);
+
+	auto track = MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H264, 1);
+	packager->OnPsi({track}, {});
+
+	auto ts = std::make_shared<ov::Data>();
+	uint8_t byte = 0x47;
+	ts->Append(&byte, 1);
+
+	packager->OnFrame(MakeVideoKeyFrame(1, 0, 90000), ts);
+
+	// An own cut followed by a propagated cut within a segment of it must not add a
+	// second boundary once the first has been applied.
+	ASSERT_TRUE(packager->UpdateTrack(MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H265, 2)));
+	double boundary = packager->GetLastSampleEndTimestampMs();
+	packager->RequestCutForDiscontinuity(boundary);	// within target_duration of the applied cut
+
+	// No crash and the packager stays consistent; a following key frame still packages
+	packager->OnFrame(MakeVideoKeyFrame(1, 90000, 90000), ts);
+	SUCCEED();
+}
+
+// ---------------------------------------------------------------------------
+// HlsMediaPlaylist - EXT-X-DISCONTINUITY, EXT-X-DISCONTINUITY-SEQUENCE, CODECS
+// union and the fixed EXT-X-VERSION.
+// ---------------------------------------------------------------------------
+
+class HlsMediaPlaylistTest : public ::testing::Test
+{
+protected:
+	std::shared_ptr<HlsMediaPlaylist> MakePlaylist(size_t segment_count = 10)
+	{
+		HlsMediaPlaylist::HlsMediaPlaylistConfig config;
+		config.segment_count = segment_count;
+		config.target_duration = 6;
+		auto playlist = std::make_shared<HlsMediaPlaylist>("variant", "medialist.m3u8", config);
+		playlist->SetWallclockOffset(0);
+		return playlist;
+	}
+};
+
+TEST_F(HlsMediaPlaylistTest, VersionIsThree)
+{
+	auto playlist = MakePlaylist();
+	playlist->OnSegmentCreated(MakeSegment(0, 0, 6000, 0, false, "avc1.640028,mp4a.40.2"));
+
+	auto result = playlist->ToString(true);
+	EXPECT_NE(result.IndexOf("#EXT-X-VERSION:3"), -1L);
+}
+
+TEST_F(HlsMediaPlaylistTest, EmitsDiscontinuityOnFlaggedSegment)
+{
+	auto playlist = MakePlaylist();
+	playlist->OnSegmentCreated(MakeSegment(0, 0, 6000, 0, false, "avc1.640028"));
+	playlist->OnSegmentCreated(MakeSegment(1, 90000 * 6, 6000, 0, false, "avc1.640028"));
+	playlist->OnSegmentCreated(MakeSegment(2, 90000 * 12, 6000, 1, true, "hev1.1.6.L93.B0"));
+	playlist->OnSegmentCreated(MakeSegment(3, 90000 * 18, 6000, 1, false, "hev1.1.6.L93.B0"));
+
+	auto result = playlist->ToString(true);
+
+	// Exactly one EXT-X-DISCONTINUITY tag
+	size_t count = 0;
+	int64_t pos = 0;
+	while ((pos = result.IndexOf("#EXT-X-DISCONTINUITY\n", pos)) != -1)
+	{
+		count++;
+		pos += 1;
+	}
+	EXPECT_EQ(count, 1u);
+}
+
+TEST_F(HlsMediaPlaylistTest, DiscontinuitySequenceCountsScrolledOut)
+{
+	// A short live window; the discontinuity sits ahead of it and later scrolls out
+	auto playlist = MakePlaylist(2);
+
+	playlist->OnSegmentCreated(MakeSegment(0, 0, 6000, 0, false, "avc1.640028"));
+	playlist->OnSegmentCreated(MakeSegment(1, 90000 * 6, 6000, 1, true, "hev1.1.6.L93.B0"));
+	playlist->OnSegmentCreated(MakeSegment(2, 90000 * 12, 6000, 1, false, "hev1.1.6.L93.B0"));
+	playlist->OnSegmentCreated(MakeSegment(3, 90000 * 18, 6000, 1, false, "hev1.1.6.L93.B0"));
+	playlist->OnSegmentCreated(MakeSegment(4, 90000 * 24, 6000, 1, false, "hev1.1.6.L93.B0"));
+
+	// Segment 1 (a discontinuity) is retained but ahead of the live window, so it
+	// counts toward the sequence base.
+	auto live = playlist->ToString(false);
+	EXPECT_NE(live.IndexOf("#EXT-X-DISCONTINUITY-SEQUENCE:1"), -1L);
+
+	// Scroll out segments 0 and 1 (the discontinuity) entirely; the base is now
+	// carried by the removed counter instead.
+	playlist->OnSegmentDeleted(MakeSegment(0, 0, 6000, 0, false, "avc1.640028"));
+	playlist->OnSegmentDeleted(MakeSegment(1, 90000 * 6, 6000, 1, true, "hev1.1.6.L93.B0"));
+
+	auto after = playlist->ToString(true);
+	EXPECT_NE(after.IndexOf("#EXT-X-DISCONTINUITY-SEQUENCE:1"), -1L);
+}
+
+TEST_F(HlsMediaPlaylistTest, CodecsUnionSpansCodecChange)
+{
+	auto playlist = MakePlaylist();
+	playlist->OnSegmentCreated(MakeSegment(0, 0, 6000, 0, false, "avc1.640028,mp4a.40.2"));
+	playlist->OnSegmentCreated(MakeSegment(1, 90000 * 6, 6000, 1, true, "hev1.1.6.L93.B0,mp4a.40.2"));
+
+	auto codecs = playlist->GetCodecsString();
+
+	EXPECT_NE(codecs.IndexOf("avc1.640028"), -1L);
+	EXPECT_NE(codecs.IndexOf("hev1.1.6.L93.B0"), -1L);
+
+	// The shared audio codec appears only once
+	size_t audio_count = 0;
+	int64_t pos = 0;
+	while ((pos = codecs.IndexOf("mp4a.40.2", pos)) != -1)
+	{
+		audio_count++;
+		pos += 1;
+	}
+	EXPECT_EQ(audio_count, 1u);
+}
+
+TEST_F(HlsMediaPlaylistTest, CodecsUnionShrinksWhenOldCodecScrollsOut)
+{
+	auto playlist = MakePlaylist();
+	playlist->OnSegmentCreated(MakeSegment(0, 0, 6000, 0, false, "avc1.640028,mp4a.40.2"));
+	playlist->OnSegmentCreated(MakeSegment(1, 90000 * 6, 6000, 1, true, "hev1.1.6.L93.B0,mp4a.40.2"));
+	playlist->OnSegmentCreated(MakeSegment(2, 90000 * 12, 6000, 1, false, "hev1.1.6.L93.B0,mp4a.40.2"));
+
+	// Spans the codec change
+	EXPECT_NE(playlist->GetCodecsString().IndexOf("avc1.640028"), -1L);
+
+	// Remove the only old-codec segment; its codec drops from the union
+	playlist->OnSegmentDeleted(MakeSegment(0, 0, 6000, 0, false, "avc1.640028,mp4a.40.2"));
+
+	auto codecs = playlist->GetCodecsString();
+	EXPECT_EQ(codecs.IndexOf("avc1.640028"), -1L);
+	EXPECT_NE(codecs.IndexOf("hev1.1.6.L93.B0"), -1L);
+}
+
+TEST_F(HlsMediaPlaylistTest, NoDiscontinuityWithoutChange)
+{
+	auto playlist = MakePlaylist();
+	playlist->OnSegmentCreated(MakeSegment(0, 0, 6000, 0, false, "avc1.640028"));
+	playlist->OnSegmentCreated(MakeSegment(1, 90000 * 6, 6000, 0, false, "avc1.640028"));
+
+	auto result = playlist->ToString(true);
+	EXPECT_EQ(result.IndexOf("#EXT-X-DISCONTINUITY"), -1L);
+}
+
+TEST_F(HlsMediaPlaylistTest, ExcludedFlag)
+{
+	auto playlist = MakePlaylist();
+	EXPECT_FALSE(playlist->IsExcluded());
+	playlist->SetExcluded(true);
+	EXPECT_TRUE(playlist->IsExcluded());
+}

--- a/src/publishers/hls/hls_test.cpp
+++ b/src/publishers/hls/hls_test.cpp
@@ -119,6 +119,25 @@ TEST(HlsPacketizer, KeepsPsiOnSameCodecChange)
 	EXPECT_EQ(sink->_psi_count, 1);
 }
 
+TEST(HlsPacketizer, PreStartUpdateReplacesExistingTrack)
+{
+	auto sink = std::make_shared<CountingPacketizerSink>();
+
+	mpegts::Packetizer packetizer;
+	packetizer.AddSink(sink);
+	ASSERT_TRUE(packetizer.AddTrack(MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H264, 1)));
+
+	// An update before Start must replace the already-added track, not silently keep it
+	ASSERT_TRUE(packetizer.UpdateTrack(MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H265, 2)));
+	ASSERT_TRUE(packetizer.Start());
+	EXPECT_EQ(sink->_psi_count, 1);
+
+	// The started track is now H265, so an H265 update is a no-op with no PSI rebroadcast.
+	// Had the pre-Start replace been dropped, this would be an H264->H265 change and rebroadcast.
+	ASSERT_TRUE(packetizer.UpdateTrack(MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H265, 3)));
+	EXPECT_EQ(sink->_psi_count, 1);
+}
+
 // ---------------------------------------------------------------------------
 // mpegts::Packager - a main-track change starts a new configuration generation,
 // so the following segment is a discontinuity point and the pre-change tail is not.

--- a/src/publishers/hls/hls_test.cpp
+++ b/src/publishers/hls/hls_test.cpp
@@ -218,6 +218,73 @@ TEST(HlsPackager, RequestCutDeduplicatesNearbyBoundary)
 	SUCCEED();
 }
 
+TEST(HlsPackager, TrackChangeBeforeContentIsNotDiscontinuity)
+{
+	mpegts::Packager::Config config;
+	config.target_duration_ms = 1000;
+	config.max_segment_count = 100;
+
+	auto packager = std::make_shared<mpegts::Packager>("variant", config);
+	auto sink = std::make_shared<CollectingPackagerSink>();
+	packager->AddSink(sink);
+
+	packager->OnPsi({MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H264, 1)}, {});
+
+	// Change the track before a single frame is packaged
+	ASSERT_TRUE(packager->UpdateTrack(MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H265, 2)));
+
+	auto ts = std::make_shared<ov::Data>();
+	uint8_t byte = 0x47;
+	ts->Append(&byte, 1);
+
+	int64_t dts = 0;
+	for (int i = 0; i < 4; i++)
+	{
+		packager->OnFrame(MakeVideoKeyFrame(1, dts, 90000), ts);
+		dts += 90000;
+	}
+
+	ASSERT_GT(sink->_created.size(), 0u);
+	for (const auto &segment : sink->_created)
+	{
+		EXPECT_FALSE(segment->IsDiscontinuityPoint());	// pre-content change is the initial config
+		EXPECT_GT(segment->GetDurationMs(), 0.0);
+	}
+}
+
+TEST(HlsPackager, PropagatedCutOnEmptyBufferProducesNoEmptySegment)
+{
+	mpegts::Packager::Config config;
+	config.target_duration_ms = 1000;
+	config.max_segment_count = 100;
+
+	auto packager = std::make_shared<mpegts::Packager>("variant", config);
+	auto sink = std::make_shared<CollectingPackagerSink>();
+	packager->AddSink(sink);
+
+	packager->OnPsi({MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H264, 1)}, {});
+
+	// A sibling requests an aligned cut while nothing is buffered yet
+	packager->RequestCutForDiscontinuity(0.0);
+
+	auto ts = std::make_shared<ov::Data>();
+	uint8_t byte = 0x47;
+	ts->Append(&byte, 1);
+
+	int64_t dts = 0;
+	for (int i = 0; i < 5; i++)
+	{
+		packager->OnFrame(MakeVideoKeyFrame(1, dts, 90000), ts);
+		dts += 90000;
+	}
+
+	ASSERT_GT(sink->_created.size(), 0u);
+	for (const auto &segment : sink->_created)
+	{
+		EXPECT_GT(segment->GetDurationMs(), 0.0);	// the empty-buffer cut must not create a 0-duration segment
+	}
+}
+
 // ---------------------------------------------------------------------------
 // HlsMediaPlaylist - EXT-X-DISCONTINUITY, EXT-X-DISCONTINUITY-SEQUENCE, CODECS
 // union and the fixed EXT-X-VERSION.

--- a/src/publishers/hls/hls_test.cpp
+++ b/src/publishers/hls/hls_test.cpp
@@ -475,6 +475,20 @@ TEST_F(HlsMediaPlaylistTest, CodecsUnionShrinksWhenOldCodecScrollsOut)
 	EXPECT_NE(codecs.IndexOf("hev1.1.6.L93.B0"), -1L);
 }
 
+TEST_F(HlsMediaPlaylistTest, CodecsDeriveFromSegmentsWhenPresent)
+{
+	auto playlist = MakePlaylist();
+
+	// No AddMediaTrackInfo, so the track fallback would be empty. A single
+	// non-discontinuity segment must still drive CODECS, so the master never
+	// advertises something the retained segments do not contain.
+	playlist->OnSegmentCreated(MakeSegment(0, 0, 6000, 0, false, "avc1.640028,mp4a.40.2"));
+
+	auto codecs = playlist->GetCodecsString();
+	EXPECT_NE(codecs.IndexOf("avc1.640028"), -1L);
+	EXPECT_NE(codecs.IndexOf("mp4a.40.2"), -1L);
+}
+
 TEST_F(HlsMediaPlaylistTest, NoDiscontinuityWithoutChange)
 {
 	auto playlist = MakePlaylist();

--- a/src/publishers/hls/hls_test.cpp
+++ b/src/publishers/hls/hls_test.cpp
@@ -300,7 +300,8 @@ TEST(HlsPackager, PropagatedCutOnEmptyBufferProducesNoEmptySegment)
 	ASSERT_GT(sink->_created.size(), 0u);
 	for (const auto &segment : sink->_created)
 	{
-		EXPECT_GT(segment->GetDurationMs(), 0.0);	// the empty-buffer cut must not create a 0-duration segment
+		EXPECT_GT(segment->GetDurationMs(), 0.0);		// the empty-buffer cut must not create a 0-duration segment
+		EXPECT_FALSE(segment->IsDiscontinuityPoint());	// nor a discontinuity, since there is no prior domain
 	}
 }
 

--- a/src/publishers/hls/hls_test.cpp
+++ b/src/publishers/hls/hls_test.cpp
@@ -36,6 +36,15 @@ namespace
 											 MediaPacketFlag::Key, cmn::BitstreamFormat::H264_ANNEXB, cmn::PacketType::NALU);
 	}
 
+	std::shared_ptr<const MediaPacket> MakeAudioFrame(uint32_t track_id, int64_t dts, int64_t duration)
+	{
+		auto data = std::make_shared<ov::Data>();
+		uint8_t byte = 0x00;
+		data->Append(&byte, 1);
+		return std::make_shared<MediaPacket>(cmn::MediaType::Audio, track_id, data, dts, dts, duration,
+											 MediaPacketFlag::Key, cmn::BitstreamFormat::AAC_ADTS, cmn::PacketType::RAW);
+	}
+
 	std::shared_ptr<mpegts::Segment> MakeSegment(int64_t number, int64_t dts, double duration_ms,
 												 uint32_t version, bool discontinuity, const ov::String &codecs)
 	{
@@ -303,6 +312,53 @@ TEST(HlsPackager, PropagatedCutOnEmptyBufferProducesNoEmptySegment)
 		EXPECT_GT(segment->GetDurationMs(), 0.0);		// the empty-buffer cut must not create a 0-duration segment
 		EXPECT_FALSE(segment->IsDiscontinuityPoint());	// nor a discontinuity, since there is no prior domain
 	}
+}
+
+TEST(HlsPackager, SecondaryTrackChangeWhileBufferingCutsAtBoundary)
+{
+	mpegts::Packager::Config config;
+	config.target_duration_ms = 1000;
+	config.max_segment_count = 100;
+
+	auto packager = std::make_shared<mpegts::Packager>("variant", config);
+	auto sink = std::make_shared<CollectingPackagerSink>();
+	packager->AddSink(sink);
+
+	auto video = MakeTrack(1, cmn::MediaType::Video, cmn::MediaCodecId::H264, 1);
+	auto audio = MakeTrack(2, cmn::MediaType::Audio, cmn::MediaCodecId::Aac, 1);
+	packager->OnPsi({video, audio}, {});
+
+	auto ts = std::make_shared<ov::Data>();
+	uint8_t byte = 0x47;
+	ts->Append(&byte, 1);
+
+	// One video + audio frame is buffered, but no segment has been created yet
+	packager->OnFrame(MakeVideoKeyFrame(1, 0, 90000), ts);
+	packager->OnFrame(MakeAudioFrame(2, 0, 90000), ts);
+
+	// The audio track changes during the first segment's buffering window
+	ASSERT_TRUE(packager->UpdateTrack(MakeTrack(2, cmn::MediaType::Audio, cmn::MediaCodecId::Aac, 2)));
+
+	int64_t dts = 90000;
+	for (int i = 0; i < 6; i++)
+	{
+		packager->OnFrame(MakeVideoKeyFrame(1, dts, 90000), ts);
+		packager->OnFrame(MakeAudioFrame(2, dts, 90000), ts);
+		dts += 90000;
+	}
+
+	// The transition is not swallowed into the first segment: a later segment is a
+	// discontinuity point.
+	int discontinuity_count = 0;
+	for (const auto &segment : sink->_created)
+	{
+		if (segment->IsDiscontinuityPoint())
+		{
+			discontinuity_count++;
+		}
+		EXPECT_GT(segment->GetDurationMs(), 0.0);
+	}
+	EXPECT_EQ(discontinuity_count, 1);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
The TS-based HLS publisher freezes its tracks after start, so a mid-stream track configuration change (codec, resolution, audio format) delivered by a bypass source corrupts the affected rendition while the base publisher only logs a warning.

## Solution
This ports the LLHLS runtime-change support (#2255) to the TS-based HLS publisher. HlsStream::OnTrackChanged repackages the renditions carrying the changed track and requests an aligned discontinuity boundary on every other rendition. The mpegts Packetizer rebuilds the PMT and re-broadcasts the PSI only when the elementary stream type changes, while the Packager cuts a key-frame-aligned boundary and stamps each segment with a configuration generation. HlsMediaPlaylist emits EXT-X-DISCONTINUITY and EXT-X-DISCONTINUITY-SEQUENCE and derives the master CODECS as the union across the retained segments, and the HLS dump refreshes its master so the recorded output follows the change as well.

## Test
A Scheduled channel is the easiest way to exercise this: build a schedule that alternates between source items with different resolutions, so each item switch triggers a runtime track change on the bypass output. Enable the HLS (HLSv3) output and play playlist.m3u8 in OvenPlayer while the channel runs through several switches.

Pass conditions:
- OvenPlayer keeps playing smoothly across each item switch, with no stall, buffering break, or visible corruption, resuming at the new item's resolution.
- The media playlist shows #EXT-X-DISCONTINUITY before the first segment of each new item, and #EXT-X-DISCONTINUITY-SEQUENCE increases as those segments scroll out of the window.
- The master playlist RESOLUTION follows the current item as it changes.

Automated unit tests in the HLS publisher (target ome_test_publishers_hls) also cover the packetizer, packager, and playlist behavior.
