### PR TITLE
feat(ovt): relay runtime track configuration changes to edges

### DIFF
--- a/src/base/publisher/stream.cpp
+++ b/src/base/publisher/stream.cpp
@@ -280,6 +280,27 @@ namespace pub
 			  GetApplication()->GetPublisherTypeName());
 	}
 
+	void Stream::LogInbandRecoverableTrackChange(int32_t track_id, const std::shared_ptr<const MediaTrack> &old_track, const std::shared_ptr<const MediaTrack> &new_track)
+	{
+		// A codec change requires renegotiating the running session, which these
+		// publishers cannot do, so the track's output stops working from here.
+		if (old_track->GetCodecId() != new_track->GetCodecId())
+		{
+			logtw("%s/%s(%u) Track(%d) codec has changed (%s -> %s), which the %s publisher cannot apply to a running session. The output of this track stops working from here",
+				  GetApplicationName(), GetName().CStr(), GetId(), track_id,
+				  cmn::GetCodecIdString(old_track->GetCodecId()), cmn::GetCodecIdString(new_track->GetCodecId()),
+				  GetApplication()->GetPublisherTypeName());
+			return;
+		}
+
+		// The codec is unchanged, so the new parameter sets are delivered in-band
+		// and playback continues without renegotiation.
+		logti("%s/%s(%u) Track(%d) configuration has changed (version %u -> %u); the %s publisher applies it in-band",
+			  GetApplicationName(), GetName().CStr(), GetId(), track_id,
+			  old_track->GetVersion(), new_track->GetVersion(),
+			  GetApplication()->GetPublisherTypeName());
+	}
+
 	std::shared_ptr<const info::Playlist> Stream::GetDefaultPlaylist() const
 	{
 		auto info = GetDefaultPlaylistInfo();

--- a/src/base/publisher/stream.cpp
+++ b/src/base/publisher/stream.cpp
@@ -282,6 +282,16 @@ namespace pub
 
 	void Stream::LogInbandRecoverableTrackChange(int32_t track_id, const std::shared_ptr<const MediaTrack> &old_track, const std::shared_ptr<const MediaTrack> &new_track)
 	{
+		// A label-only change (e.g. a detected subtitle language) does not affect the
+		// media, so report it as a metadata update like the base does, not a config change.
+		if (old_track->HasSameContent(*new_track))
+		{
+			logti("%s/%s(%u) Track(%d) metadata has been updated (version %u -> %u)",
+				  GetApplicationName(), GetName().CStr(), GetId(),
+				  track_id, old_track->GetVersion(), new_track->GetVersion());
+			return;
+		}
+
 		// A codec change requires renegotiating the running session, which these
 		// publishers cannot do, so the track's output stops working from here.
 		if (old_track->GetCodecId() != new_track->GetCodecId())

--- a/src/base/publisher/stream.h
+++ b/src/base/publisher/stream.h
@@ -184,6 +184,11 @@ namespace pub
 		// A publisher that supports mid-stream configuration changes must override this.
 		virtual void OnTrackChanged(int32_t track_id, const std::shared_ptr<const MediaTrack> &old_track, const std::shared_ptr<const MediaTrack> &new_track);
 
+		// Log helper for publishers that carry parameter sets in-band (e.g. WebRTC,
+		// SRT/MPEG-TS). A same-codec change is a benign in-band update; a codec
+		// change cannot be applied to an already running session.
+		void LogInbandRecoverableTrackChange(int32_t track_id, const std::shared_ptr<const MediaTrack> &old_track, const std::shared_ptr<const MediaTrack> &new_track);
+
 	private:
 		std::shared_ptr<StreamWorker> GetWorkerBySessionID(session_id_t session_id);
 		std::map<session_id_t, std::shared_ptr<Session>> _sessions;

--- a/src/modules/ovt_packetizer/ovt_depacketizer.cpp
+++ b/src/modules/ovt_packetizer/ovt_depacketizer.cpp
@@ -91,6 +91,16 @@ bool OvtDepacketizer::IsAvailableMediaPacket()
 	return !_media_packets.empty();
 }
 
+bool OvtDepacketizer::IsAvailable()
+{
+	return !_order.empty();
+}
+
+bool OvtDepacketizer::IsNextMessage()
+{
+	return !_order.empty() && _order.front() == ItemType::Message;
+}
+
 bool OvtDepacketizer::AppendMessagePacket(const std::shared_ptr<OvtPacket> &packet)
 {
 	//TODO(Getroot): Need to validate packet
@@ -108,7 +118,8 @@ bool OvtDepacketizer::AppendMessagePacket(const std::shared_ptr<OvtPacket> &pack
 
 		auto message = _message_buffer.Clone();
 		_messages.push(message);
-		
+		_order.push(ItemType::Message);
+
 		_message_buffer.Clear();
 	}
 
@@ -161,6 +172,7 @@ bool OvtDepacketizer::AppendMediaPacket(const std::shared_ptr<OvtPacket> &packet
 		media_packet->SetDuration(duration);
 
 		_media_packets.push(media_packet);
+		_order.push(ItemType::MediaPacket);
 
 		_media_packet_buffer.Clear();
 	}
@@ -177,6 +189,7 @@ const std::shared_ptr<ov::Data> OvtDepacketizer::PopMessage()
 
 	auto message = _messages.front();
 	_messages.pop();
+	_order.pop();
 
 	return message;
 }
@@ -190,6 +203,7 @@ const std::shared_ptr<MediaPacket> OvtDepacketizer::PopMediaPacket()
 
 	auto media_packet = _media_packets.front();
 	_media_packets.pop();
+	_order.pop();
 
 	return media_packet;
 }

--- a/src/modules/ovt_packetizer/ovt_depacketizer.cpp
+++ b/src/modules/ovt_packetizer/ovt_depacketizer.cpp
@@ -83,22 +83,22 @@ bool OvtDepacketizer::ParsePacket()
 
 bool OvtDepacketizer::IsAvailableMessage()
 {
-	return !_messages.empty();
+	return !_items.empty() && _items.front().type == ItemType::Message;
 }
 
 bool OvtDepacketizer::IsAvailableMediaPacket()
 {
-	return !_media_packets.empty();
+	return !_items.empty() && _items.front().type == ItemType::MediaPacket;
 }
 
 bool OvtDepacketizer::IsAvailable()
 {
-	return !_order.empty();
+	return !_items.empty();
 }
 
 bool OvtDepacketizer::IsNextMessage()
 {
-	return !_order.empty() && _order.front() == ItemType::Message;
+	return !_items.empty() && _items.front().type == ItemType::Message;
 }
 
 bool OvtDepacketizer::AppendMessagePacket(const std::shared_ptr<OvtPacket> &packet)
@@ -116,9 +116,7 @@ bool OvtDepacketizer::AppendMessagePacket(const std::shared_ptr<OvtPacket> &pack
 			return false;
 		}
 
-		auto message = _message_buffer.Clone();
-		_messages.push(message);
-		_order.push(ItemType::Message);
+		_items.push(Item{ItemType::Message, _message_buffer.Clone(), nullptr});
 
 		_message_buffer.Clear();
 	}
@@ -171,8 +169,7 @@ bool OvtDepacketizer::AppendMediaPacket(const std::shared_ptr<OvtPacket> &packet
 		media_packet->SetFlag(media_flag);
 		media_packet->SetDuration(duration);
 
-		_media_packets.push(media_packet);
-		_order.push(ItemType::MediaPacket);
+		_items.push(Item{ItemType::MediaPacket, nullptr, media_packet});
 
 		_media_packet_buffer.Clear();
 	}
@@ -187,9 +184,8 @@ const std::shared_ptr<ov::Data> OvtDepacketizer::PopMessage()
 		return nullptr;
 	}
 
-	auto message = _messages.front();
-	_messages.pop();
-	_order.pop();
+	auto message = _items.front().message;
+	_items.pop();
 
 	return message;
 }
@@ -201,9 +197,8 @@ const std::shared_ptr<MediaPacket> OvtDepacketizer::PopMediaPacket()
 		return nullptr;
 	}
 
-	auto media_packet = _media_packets.front();
-	_media_packets.pop();
-	_order.pop();
+	auto media_packet = _items.front().media_packet;
+	_items.pop();
 
 	return media_packet;
 }

--- a/src/modules/ovt_packetizer/ovt_depacketizer.cpp
+++ b/src/modules/ovt_packetizer/ovt_depacketizer.cpp
@@ -98,7 +98,9 @@ bool OvtDepacketizer::IsAvailable()
 
 bool OvtDepacketizer::IsNextMessage()
 {
-	return !_items.empty() && _items.front().type == ItemType::Message;
+	// Same question as IsAvailableMessage() now that items share one ordered queue;
+	// delegate so the type check has a single source of truth.
+	return IsAvailableMessage();
 }
 
 bool OvtDepacketizer::AppendMessagePacket(const std::shared_ptr<OvtPacket> &packet)

--- a/src/modules/ovt_packetizer/ovt_depacketizer.cpp
+++ b/src/modules/ovt_packetizer/ovt_depacketizer.cpp
@@ -169,7 +169,7 @@ bool OvtDepacketizer::AppendMediaPacket(const std::shared_ptr<OvtPacket> &packet
 		media_packet->SetFlag(media_flag);
 		media_packet->SetDuration(duration);
 
-		_items.push(Item{ItemType::MediaPacket, nullptr, media_packet});
+		_items.push(Item{ItemType::MediaPacket, nullptr, std::move(media_packet)});
 
 		_media_packet_buffer.Clear();
 	}

--- a/src/modules/ovt_packetizer/ovt_depacketizer.h
+++ b/src/modules/ovt_packetizer/ovt_depacketizer.h
@@ -24,10 +24,23 @@ public:
 	const std::shared_ptr<ov::Data> PopMessage();
 	const std::shared_ptr<MediaPacket> PopMediaPacket();
 
+	// Messages and media share a single on-wire parse order. A consumer that must
+	// preserve their relative order (e.g. a track-change signaling message that has
+	// to apply before the media that follows it) pops via IsAvailable()/IsNextMessage()
+	// instead of draining the two queues separately.
+	bool IsAvailable();
+	bool IsNextMessage();
+
 private:
 	bool ParsePacket();
 	bool AppendMessagePacket(const std::shared_ptr<OvtPacket> &packet);
 	bool AppendMediaPacket(const std::shared_ptr<OvtPacket> &packet);
+
+	enum class ItemType : uint8_t
+	{
+		Message,
+		MediaPacket
+	};
 
 	std::shared_ptr<ov::Data>					_packet_buffer;
 
@@ -36,4 +49,6 @@ private:
 
 	std::queue<std::shared_ptr<ov::Data>>		_messages;
 	std::queue<std::shared_ptr<MediaPacket>>	_media_packets;
+	// Type of each completed item in parse order; front is the next item on the wire.
+	std::queue<ItemType>						_order;
 };

--- a/src/modules/ovt_packetizer/ovt_depacketizer.h
+++ b/src/modules/ovt_packetizer/ovt_depacketizer.h
@@ -42,13 +42,21 @@ private:
 		MediaPacket
 	};
 
+	// One completed item. Messages and media share a single queue so their relative
+	// on-wire order is never lost, and popping the wrong type is a guarded no-op
+	// instead of a silent desynchronization.
+	struct Item
+	{
+		ItemType						type;
+		std::shared_ptr<ov::Data>		message;
+		std::shared_ptr<MediaPacket>	media_packet;
+	};
+
 	std::shared_ptr<ov::Data>					_packet_buffer;
 
 	ov::Data									_message_buffer;
 	ov::Data									_media_packet_buffer;
 
-	std::queue<std::shared_ptr<ov::Data>>		_messages;
-	std::queue<std::shared_ptr<MediaPacket>>	_media_packets;
-	// Type of each completed item in parse order; front is the next item on the wire.
-	std::queue<ItemType>						_order;
+	// Completed items in on-wire parse order; front is the next item on the wire.
+	std::queue<Item>							_items;
 };

--- a/src/providers/ovt/ovt_stream.cpp
+++ b/src/providers/ovt/ovt_stream.cpp
@@ -762,8 +762,18 @@ namespace pvd
 			}
 			else if (application.UpperCaseString() == "NOTIFY")
 			{
-				// Origin relayed a runtime track configuration change
-				ApplyTrackNotification(object.GetJsonValue()["contents"]);
+				// Only the track configuration relay is understood. Ignore any other
+				// NOTIFY kind (or a malformed payload) so it cannot be misapplied.
+				auto &json_notify = object.GetJsonValue()["message"];
+				if (json_notify.isString() && ov::String(json_notify.asString().c_str()) == "track_changed")
+				{
+					ApplyTrackNotification(object.GetJsonValue()["contents"]);
+				}
+				else
+				{
+					logtd("[%s/%s(%u)] Ignored unknown NOTIFY message",
+						  GetApplicationInfo().GetVHostAppName().CStr(), GetName().CStr(), GetId());
+				}
 			}
 			else
 			{

--- a/src/providers/ovt/ovt_stream.cpp
+++ b/src/providers/ovt/ovt_stream.cpp
@@ -462,7 +462,7 @@ namespace pvd
 			auto json_video_track = json_track["videoTrack"];
 			if (json_video_track.isNull())
 			{
-				logte("Invalid json videoTrack");
+				logtd("Invalid json videoTrack");
 				return nullptr;
 			}
 
@@ -476,7 +476,7 @@ namespace pvd
 			auto json_audio_track = json_track["audioTrack"];
 			if (json_audio_track.isNull())
 			{
-				logte("Invalid json audioTrack");
+				logtd("Invalid json audioTrack");
 				return nullptr;
 			}
 
@@ -737,55 +737,57 @@ namespace pvd
 			return ProcessMediaResult::PROCESS_MEDIA_FAILURE;
 		}
 
-		// Apply signaling that arrived in this batch before forwarding media, so an
-		// origin-pushed configuration change is active for the packets that follow
-		// it on the wire.
-		while (_depacketizer.IsAvailableMessage())
+		// Consume messages and media in on-wire parse order, so an origin-pushed
+		// configuration change applies to the packets that follow it and not to the
+		// tail of the previous configuration that preceded it on the wire.
+		bool processed = false;
+		while (_depacketizer.IsAvailable())
 		{
-			auto message = _depacketizer.PopMessage();
-
-			// Parsing Payload
-			ov::String payload(message->GetDataAs<char>(), message->GetLength());
-			ov::JsonObject object = ov::Json::Parse(payload);
-
-			if (object.IsNull())
+			if (_depacketizer.IsNextMessage())
 			{
-				logte("An invalid response : Json format");
-				return PullStream::ProcessMediaResult::PROCESS_MEDIA_FAILURE;
-			}
+				auto message = _depacketizer.PopMessage();
 
-			ov::String application = object.GetJsonValue()["application"].asString().c_str();
+				// Parsing Payload
+				ov::String payload(message->GetDataAs<char>(), message->GetLength());
+				ov::JsonObject object = ov::Json::Parse(payload);
 
-			if (application.UpperCaseString() == "STOP")
-			{
-				return PullStream::ProcessMediaResult::PROCESS_MEDIA_FINISH;
-			}
-			else if (application.UpperCaseString() == "NOTIFY")
-			{
-				// Only the track configuration relay is understood. Ignore any other
-				// NOTIFY kind (or a malformed payload) so it cannot be misapplied.
-				auto &json_notify = object.GetJsonValue()["message"];
-				if (json_notify.isString() && ov::String(json_notify.asString().c_str()) == "track_changed")
+				if (object.IsNull())
 				{
-					ApplyTrackNotification(object.GetJsonValue()["contents"]);
+					logte("An invalid response : Json format");
+					return PullStream::ProcessMediaResult::PROCESS_MEDIA_FAILURE;
+				}
+
+				ov::String application = object.GetJsonValue()["application"].asString().c_str();
+
+				if (application.UpperCaseString() == "STOP")
+				{
+					return PullStream::ProcessMediaResult::PROCESS_MEDIA_FINISH;
+				}
+				else if (application.UpperCaseString() == "NOTIFY")
+				{
+					// Only the track configuration relay is understood. Ignore any other
+					// NOTIFY kind (or a malformed payload) so it cannot be misapplied.
+					auto &json_notify = object.GetJsonValue()["message"];
+					if (json_notify.isString() && ov::String(json_notify.asString().c_str()) == "track_changed")
+					{
+						ApplyTrackNotification(object.GetJsonValue()["contents"]);
+					}
+					else
+					{
+						logtd("[%s/%s(%u)] Ignored unknown NOTIFY message",
+							  GetApplicationInfo().GetVHostAppName().CStr(), GetName().CStr(), GetId());
+					}
 				}
 				else
 				{
-					logtd("[%s/%s(%u)] Ignored unknown NOTIFY message",
+					logte("An error occurred while receive data: An unexpected packet was received. Terminate stream thread : %s/%s(%u)",
 						  GetApplicationInfo().GetVHostAppName().CStr(), GetName().CStr(), GetId());
+					return PullStream::ProcessMediaResult::PROCESS_MEDIA_FAILURE;
 				}
-			}
-			else
-			{
-				logte("An error occurred while receive data: An unexpected packet was received. Terminate stream thread : %s/%s(%u)",
-					  GetApplicationInfo().GetVHostAppName().CStr(), GetName().CStr(), GetId());
-				return PullStream::ProcessMediaResult::PROCESS_MEDIA_FAILURE;
-			}
-		}
 
-		bool processed = false;
-		while (_depacketizer.IsAvailableMediaPacket())
-		{
+				continue;
+			}
+
 			auto media_packet = _depacketizer.PopMediaPacket();
 			media_packet->SetPacketType(cmn::PacketType::OVT);
 

--- a/src/providers/ovt/ovt_stream.cpp
+++ b/src/providers/ovt/ovt_stream.cpp
@@ -404,73 +404,13 @@ namespace pvd
 		}
 
 		//SetName(json_stream["streamName"].asString().c_str());
-		std::shared_ptr<MediaTrack> new_track;
-
 		for (size_t i = 0; i < json_tracks.size(); i++)
 		{
-			auto json_track = json_tracks[static_cast<int>(i)];
-
-			new_track = std::make_shared<MediaTrack>();
-
-			// Validation
-			if (!json_track["id"].isUInt() || !json_track["name"].isString() || !json_track["codecId"].isUInt() || !json_track["mediaType"].isUInt() ||
-				!json_track["timebaseNum"].isUInt() || !json_track["timebaseDen"].isUInt() ||
-				!json_track["bitrate"].isUInt() ||
-				!json_track["startFrameTime"].isUInt64() || !json_track["lastFrameTime"].isUInt64())
+			auto new_track = ParseTrackFromJson(json_tracks[static_cast<int>(i)]);
+			if (new_track == nullptr)
 			{
 				logte("Invalid json track [%zu]", i);
 				return false;
-			}
-
-			new_track->SetId(json_track["id"].asUInt());
-			new_track->SetVariantName(json_track["name"].asString().c_str());
-			new_track->SetPublicName(json_track["publicName"].asString().c_str());
-			new_track->SetLanguage(json_track["language"].asString().c_str());
-			new_track->SetCharacteristics(json_track["characteristics"].asString().c_str());
-			new_track->SetCodecId(static_cast<cmn::MediaCodecId>(json_track["codecId"].asUInt()));
-			new_track->SetMediaType(static_cast<cmn::MediaType>(json_track["mediaType"].asUInt()));
-			new_track->SetTimeBase(json_track["timebaseNum"].asUInt(), json_track["timebaseDen"].asUInt());
-			new_track->SetBitrateByConfig(json_track["bitrate"].asUInt());
-
-			// video or audio
-			if (new_track->GetMediaType() == cmn::MediaType::Video)
-			{
-				auto json_video_track = json_track["videoTrack"];
-				if (json_video_track.isNull())
-				{
-					logte("Invalid json videoTrack");
-					return false;
-				}
-
-				new_track->SetFrameRateByConfig(json_video_track["framerate"].asDouble());
-				new_track->SetMaxFrameRate(json_video_track["maxFramerate"].asDouble());
-				new_track->SetResolution(json_video_track["width"].asUInt(), json_video_track["height"].asUInt());
-				new_track->SetMaxResolution(json_video_track["maxWidth"].asUInt(), json_video_track["maxHeight"].asUInt());
-			}
-			else if (new_track->GetMediaType() == cmn::MediaType::Audio)
-			{
-				auto json_audio_track = json_track["audioTrack"];
-				if (json_audio_track.isNull())
-				{
-					logte("Invalid json audioTrack");
-					return false;
-				}
-
-				new_track->SetSampleRate(json_audio_track["samplerate"].asUInt());
-				if (new_track->GetSampleRate() == 0)
-				{
-					logte("Audio track(%u) received from origin has samplerate=0. The origin may have sent an invalid AudioSpecificConfig.", new_track->GetId());
-				}
-				new_track->SetSampleFormat(static_cast<cmn::AudioSample::Format>(json_audio_track["sampleFormat"].asInt()));
-				new_track->SetChannelLayout(static_cast<cmn::AudioChannel::Layout>(json_audio_track["layout"].asUInt()));
-			}
-
-			auto decoder_config = json_track["decoderConfig"];
-			if (decoder_config.isString())
-			{
-				auto config_data = ov::Base64::Decode(decoder_config.asString().c_str());
-				auto decoder_config = DecoderConfigurationRecordParser::Parse(new_track->GetCodecId(), config_data);
-				new_track->SetDecoderConfigurationRecord(decoder_config);
 			}
 
 			// The initial describe registers the track; a re-describe replaces it
@@ -491,6 +431,111 @@ namespace pvd
 
 		SetState(State::DESCRIBED);
 		return true;
+	}
+
+	std::shared_ptr<MediaTrack> OvtStream::ParseTrackFromJson(const Json::Value &json_track)
+	{
+		// Validation
+		if (!json_track["id"].isUInt() || !json_track["name"].isString() || !json_track["codecId"].isUInt() || !json_track["mediaType"].isUInt() ||
+			!json_track["timebaseNum"].isUInt() || !json_track["timebaseDen"].isUInt() ||
+			!json_track["bitrate"].isUInt() ||
+			!json_track["startFrameTime"].isUInt64() || !json_track["lastFrameTime"].isUInt64())
+		{
+			return nullptr;
+		}
+
+		auto new_track = std::make_shared<MediaTrack>();
+
+		new_track->SetId(json_track["id"].asUInt());
+		new_track->SetVariantName(json_track["name"].asString().c_str());
+		new_track->SetPublicName(json_track["publicName"].asString().c_str());
+		new_track->SetLanguage(json_track["language"].asString().c_str());
+		new_track->SetCharacteristics(json_track["characteristics"].asString().c_str());
+		new_track->SetCodecId(static_cast<cmn::MediaCodecId>(json_track["codecId"].asUInt()));
+		new_track->SetMediaType(static_cast<cmn::MediaType>(json_track["mediaType"].asUInt()));
+		new_track->SetTimeBase(json_track["timebaseNum"].asUInt(), json_track["timebaseDen"].asUInt());
+		new_track->SetBitrateByConfig(json_track["bitrate"].asUInt());
+
+		// video or audio
+		if (new_track->GetMediaType() == cmn::MediaType::Video)
+		{
+			auto json_video_track = json_track["videoTrack"];
+			if (json_video_track.isNull())
+			{
+				logte("Invalid json videoTrack");
+				return nullptr;
+			}
+
+			new_track->SetFrameRateByConfig(json_video_track["framerate"].asDouble());
+			new_track->SetMaxFrameRate(json_video_track["maxFramerate"].asDouble());
+			new_track->SetResolution(json_video_track["width"].asUInt(), json_video_track["height"].asUInt());
+			new_track->SetMaxResolution(json_video_track["maxWidth"].asUInt(), json_video_track["maxHeight"].asUInt());
+		}
+		else if (new_track->GetMediaType() == cmn::MediaType::Audio)
+		{
+			auto json_audio_track = json_track["audioTrack"];
+			if (json_audio_track.isNull())
+			{
+				logte("Invalid json audioTrack");
+				return nullptr;
+			}
+
+			new_track->SetSampleRate(json_audio_track["samplerate"].asUInt());
+			if (new_track->GetSampleRate() == 0)
+			{
+				logte("Audio track(%u) received from origin has samplerate=0. The origin may have sent an invalid AudioSpecificConfig.", new_track->GetId());
+			}
+			new_track->SetSampleFormat(static_cast<cmn::AudioSample::Format>(json_audio_track["sampleFormat"].asInt()));
+			new_track->SetChannelLayout(static_cast<cmn::AudioChannel::Layout>(json_audio_track["layout"].asUInt()));
+		}
+
+		auto decoder_config = json_track["decoderConfig"];
+		if (decoder_config.isString())
+		{
+			auto config_data = ov::Base64::Decode(decoder_config.asString().c_str());
+			auto decoder_config_record = DecoderConfigurationRecordParser::Parse(new_track->GetCodecId(), config_data);
+			new_track->SetDecoderConfigurationRecord(decoder_config_record);
+		}
+
+		return new_track;
+	}
+
+	void OvtStream::ApplyTrackNotification(const Json::Value &contents)
+	{
+		auto json_tracks = contents["stream"]["tracks"];
+		if (json_tracks.isArray() == false)
+		{
+			logtw("[%s/%s(%u)] Received a track change notification without a valid tracks array",
+				  GetApplicationInfo().GetVHostAppName().CStr(), GetName().CStr(), GetId());
+			return;
+		}
+
+		for (size_t i = 0; i < json_tracks.size(); i++)
+		{
+			auto new_track = ParseTrackFromJson(json_tracks[static_cast<int>(i)]);
+			if (new_track == nullptr)
+			{
+				logtw("[%s/%s(%u)] Ignored an invalid track in a change notification",
+					  GetApplicationInfo().GetVHostAppName().CStr(), GetName().CStr(), GetId());
+				continue;
+			}
+
+			// Only replace tracks this stream actually subscribed to. A TrackSet
+			// edge legitimately omits tracks the origin still notifies about.
+			if (GetTrack(new_track->GetId()) == nullptr)
+			{
+				continue;
+			}
+
+			if (ChangeTrack(new_track) == false)
+			{
+				continue;
+			}
+
+			logti("[%s/%s(%u)] Applied origin track(%u) configuration change (version %u)",
+				  GetApplicationInfo().GetVHostAppName().CStr(), GetName().CStr(), GetId(),
+				  new_track->GetId(), new_track->GetVersion());
+		}
 	}
 
 	bool OvtStream::RequestPlay()
@@ -692,75 +737,69 @@ namespace pvd
 			return ProcessMediaResult::PROCESS_MEDIA_FAILURE;
 		}
 
-		while (true)
+		// Apply signaling that arrived in this batch before forwarding media, so an
+		// origin-pushed configuration change is active for the packets that follow
+		// it on the wire.
+		while (_depacketizer.IsAvailableMessage())
 		{
-			if (_depacketizer.IsAvailableMediaPacket()) 
+			auto message = _depacketizer.PopMessage();
+
+			// Parsing Payload
+			ov::String payload(message->GetDataAs<char>(), message->GetLength());
+			ov::JsonObject object = ov::Json::Parse(payload);
+
+			if (object.IsNull())
 			{
-				auto media_packet = _depacketizer.PopMediaPacket();
-				media_packet->SetPacketType(cmn::PacketType::OVT);
-
-				int64_t pts = media_packet->GetPts();
-				int64_t dts = media_packet->GetDts();
-				int64_t duration = media_packet->GetDuration();
-
-				AdjustTimestampByBase(media_packet->GetTrackId(), pts, dts, std::numeric_limits<int64_t>::max(), duration);
-				[[maybe_unused]] auto old_pts = media_packet->GetPts();
-				[[maybe_unused]] auto old_dts = media_packet->GetDts();
-
-				media_packet->SetPts(pts);
-				media_packet->SetDts(dts);
-				media_packet->SetDuration(-1); // Duration should be set by MediaRouter again due to the AdjustTimestampByBase
-
-				logtt("[%s/%s(%u)] ProcessMediaPacket : TrackId(%d) ORI_PTS(%" PRId64 ") PTS(%" PRId64 ") ORI_DTS(%" PRId64 ") DTS(%" PRId64 ") Size(%zu)",
-					  GetApplicationInfo().GetVHostAppName().CStr(), GetName().CStr(), GetId(),
-					  media_packet->GetTrackId(), old_pts, media_packet->GetPts(), old_dts, media_packet->GetDts(), media_packet->GetDataLength());
-
-				SendFrame(media_packet);
-
-				if (_depacketizer.IsAvailableMediaPacket() || _depacketizer.IsAvailableMessage())
-				{
-					continue;
-				}
-
-				return PullStream::ProcessMediaResult::PROCESS_MEDIA_SUCCESS;
+				logte("An invalid response : Json format");
+				return PullStream::ProcessMediaResult::PROCESS_MEDIA_FAILURE;
 			}
-			else if (_depacketizer.IsAvailableMessage())
+
+			ov::String application = object.GetJsonValue()["application"].asString().c_str();
+
+			if (application.UpperCaseString() == "STOP")
 			{
-				auto message = _depacketizer.PopMessage();
-
-				// Parsing Payload
-				ov::String payload(message->GetDataAs<char>(), message->GetLength());
-				ov::JsonObject object = ov::Json::Parse(payload);
-
-				if (object.IsNull())
-				{
-					logte("An invalid response : Json format");
-					return PullStream::ProcessMediaResult::PROCESS_MEDIA_FAILURE;
-				}
-
-				//Json::Value &json_id = object.GetJsonValue()["id"];
-				Json::Value &json_app = object.GetJsonValue()["application"];
-
-				ov::String application = json_app.asString().c_str();
-
-				if (application.UpperCaseString() == "STOP")
-				{
-					logte("An invalid response : application is wrong (%s).", application.CStr());
-					return PullStream::ProcessMediaResult::PROCESS_MEDIA_FINISH;
-				}
-				else
-				{
-					logte("An error occurred while receive data: An unexpected packet was received. Terminate stream thread : %s/%s(%u)",
-						  GetApplicationInfo().GetVHostAppName().CStr(), GetName().CStr(), GetId());
-					return PullStream::ProcessMediaResult::PROCESS_MEDIA_FAILURE;
-				}
+				return PullStream::ProcessMediaResult::PROCESS_MEDIA_FINISH;
+			}
+			else if (application.UpperCaseString() == "NOTIFY")
+			{
+				// Origin relayed a runtime track configuration change
+				ApplyTrackNotification(object.GetJsonValue()["contents"]);
 			}
 			else
 			{
-				return ProcessMediaResult::PROCESS_MEDIA_TRY_AGAIN;
+				logte("An error occurred while receive data: An unexpected packet was received. Terminate stream thread : %s/%s(%u)",
+					  GetApplicationInfo().GetVHostAppName().CStr(), GetName().CStr(), GetId());
+				return PullStream::ProcessMediaResult::PROCESS_MEDIA_FAILURE;
 			}
 		}
 
-		return PullStream::ProcessMediaResult::PROCESS_MEDIA_SUCCESS;
+		bool processed = false;
+		while (_depacketizer.IsAvailableMediaPacket())
+		{
+			auto media_packet = _depacketizer.PopMediaPacket();
+			media_packet->SetPacketType(cmn::PacketType::OVT);
+
+			int64_t pts = media_packet->GetPts();
+			int64_t dts = media_packet->GetDts();
+			int64_t duration = media_packet->GetDuration();
+
+			AdjustTimestampByBase(media_packet->GetTrackId(), pts, dts, std::numeric_limits<int64_t>::max(), duration);
+			[[maybe_unused]] auto old_pts = media_packet->GetPts();
+			[[maybe_unused]] auto old_dts = media_packet->GetDts();
+
+			media_packet->SetPts(pts);
+			media_packet->SetDts(dts);
+			media_packet->SetDuration(-1); // Duration should be set by MediaRouter again due to the AdjustTimestampByBase
+
+			logtt("[%s/%s(%u)] ProcessMediaPacket : TrackId(%d) ORI_PTS(%" PRId64 ") PTS(%" PRId64 ") ORI_DTS(%" PRId64 ") DTS(%" PRId64 ") Size(%zu)",
+				  GetApplicationInfo().GetVHostAppName().CStr(), GetName().CStr(), GetId(),
+				  media_packet->GetTrackId(), old_pts, media_packet->GetPts(), old_dts, media_packet->GetDts(), media_packet->GetDataLength());
+
+			SendFrame(media_packet);
+			processed = true;
+		}
+
+		return processed ? PullStream::ProcessMediaResult::PROCESS_MEDIA_SUCCESS
+						 : PullStream::ProcessMediaResult::PROCESS_MEDIA_TRY_AGAIN;
 	}
 }  // namespace pvd

--- a/src/providers/ovt/ovt_stream.h
+++ b/src/providers/ovt/ovt_stream.h
@@ -62,6 +62,12 @@ namespace pvd
 		bool ConnectOrigin();
 		bool RequestDescribe();
 		bool ReceiveDescribe(uint32_t request_id);
+		// Builds a MediaTrack from one track entry of a DESCRIBE/notify payload.
+		// Returns nullptr if the entry is invalid.
+		std::shared_ptr<MediaTrack> ParseTrackFromJson(const Json::Value &json_track);
+		// Applies an origin-pushed track configuration change (server "notify").
+		// Only tracks this stream already has are replaced; others are ignored.
+		void ApplyTrackNotification(const Json::Value &contents);
 		bool RequestPlay();
 		bool ReceivePlay(uint32_t request_id);
 		bool RequestStop();

--- a/src/publishers/ovt/ovt_stream.cpp
+++ b/src/publishers/ovt/ovt_stream.cpp
@@ -176,7 +176,7 @@ void OvtStream::GenerateTrackDescription(const std::shared_ptr<const MediaTrack>
 	out_json_track["publicName"] = track->GetPublicName().CStr();
 	out_json_track["language"] = track->GetLanguage().CStr();
 	out_json_track["characteristics"] = track->GetCharacteristics().CStr();
-	out_json_track["codecId"] = static_cast<int8_t>(track->GetCodecId());
+	out_json_track["codecId"] = static_cast<uint8_t>(track->GetCodecId());
 	out_json_track["mediaType"] = static_cast<int8_t>(track->GetMediaType());
 	out_json_track["timebaseNum"] = track->GetTimeBase().GetNum();
 	out_json_track["timebaseDen"] = track->GetTimeBase().GetDen();

--- a/src/publishers/ovt/ovt_stream.cpp
+++ b/src/publishers/ovt/ovt_stream.cpp
@@ -216,9 +216,11 @@ void OvtStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const Med
 	}
 
 	// A label-only change does not affect the media configuration, so there is
-	// nothing for the edge to re-apply; the base treats it as a metadata update.
+	// nothing for the edge to re-apply. Defer to the base metadata-update handling
+	// and skip the edge relay.
 	if (old_track->HasSameContent(*new_track))
 	{
+		Stream::OnTrackChanged(track_id, old_track, new_track);
 		return;
 	}
 

--- a/src/publishers/ovt/ovt_stream.cpp
+++ b/src/publishers/ovt/ovt_stream.cpp
@@ -249,7 +249,12 @@ void OvtStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const Med
 	}
 
 	// Routed through OnOvtPacketized() -> BroadcastPacket() to every session
-	_packetizer->PacketizeMessage(OVT_PAYLOAD_TYPE_MESSAGE_RESPONSE, ov::Clock::NowMSec(), payload);
+	if (_packetizer->PacketizeMessage(OVT_PAYLOAD_TYPE_MESSAGE_RESPONSE, ov::Clock::NowMSec(), payload) == false)
+	{
+		logtw("%s/%s(%u) Failed to relay Track(%d) configuration change to edges (version %u -> %u)",
+			  GetApplicationName(), GetName().CStr(), GetId(), track_id, old_track->GetVersion(), new_track->GetVersion());
+		return;
+	}
 
 	logti("%s/%s(%u) Relayed Track(%d) configuration change to edges (version %u -> %u)",
 		  GetApplicationName(), GetName().CStr(), GetId(), track_id, old_track->GetVersion(), new_track->GetVersion());

--- a/src/publishers/ovt/ovt_stream.cpp
+++ b/src/publishers/ovt/ovt_stream.cpp
@@ -8,6 +8,9 @@
 #include "base/publisher/application.h"
 #include "base/publisher/stream.h"
 
+#include <base/ovlibrary/clock.h>
+#include <base/ovlibrary/json.h>
+#include <modules/ovt_packetizer/ovt_packet.h>
 #include <modules/ovt_packetizer/ovt_signaling.h>
 #include <orchestrator/orchestrator.h>
 
@@ -147,50 +150,10 @@ bool OvtStream::GenerateDescription(Json::Value &out_description)
 		json_playlists.append(json_playlist);
 	}
 
-	for (auto &track_item : GetTracks())
+	for (const auto &item : GetTracks())
 	{
-		auto &track = track_item.second;
-
 		Json::Value json_track;
-		Json::Value json_video_track;
-		Json::Value json_audio_track;
-
-		json_track["id"] = track->GetId();
-		json_track["name"] = track->GetVariantName().CStr();
-		json_track["publicName"] = track->GetPublicName().CStr();
-		json_track["language"] = track->GetLanguage().CStr();
-		json_track["characteristics"] = track->GetCharacteristics().CStr();
-		json_track["codecId"] = static_cast<int8_t>(track->GetCodecId());
-		json_track["mediaType"] = static_cast<int8_t>(track->GetMediaType());
-		json_track["timebaseNum"] = track->GetTimeBase().GetNum();
-		json_track["timebaseDen"] = track->GetTimeBase().GetDen();
-		json_track["bitrate"] = track->GetBitrate();
-		// Kept for wire compatibility; the receiver measures its own frame times
-		json_track["startFrameTime"] = 0;
-		json_track["lastFrameTime"] = 0;
-
-		json_video_track["framerate"] = track->GetFrameRate();
-		json_video_track["maxFramerate"] = track->GetMaxFrameRate();
-		auto resolution = track->GetResolution();
-		json_video_track["width"] = resolution.width;
-		json_video_track["height"] = resolution.height;
-		auto max_resolution = track->GetMaxResolution();
-		json_video_track["maxWidth"] = max_resolution.width;
-		json_video_track["maxHeight"] = max_resolution.height;
-
-		json_audio_track["samplerate"] = track->GetSampleRate();
-		json_audio_track["sampleFormat"] = static_cast<int8_t>(track->GetSample().GetFormat());
-		json_audio_track["layout"] = static_cast<uint32_t>(track->GetChannel().GetLayout());
-
-		json_track["videoTrack"] = json_video_track;
-		json_track["audioTrack"] = json_audio_track;
-
-		auto decoder_config = track->GetDecoderConfigurationRecord();
-		if (decoder_config != nullptr)
-		{
-			json_track["decoderConfig"] = ov::Base64::Encode(decoder_config->GetData()).CStr();
-		}
-		
+		GenerateTrackDescription(item.second, json_track);
 		json_tracks.append(json_track);
 	}
 
@@ -201,6 +164,95 @@ bool OvtStream::GenerateDescription(Json::Value &out_description)
 	out_description = std::move(json_root);
 
 	return true;
+}
+
+void OvtStream::GenerateTrackDescription(const std::shared_ptr<const MediaTrack> &track, Json::Value &out_json_track)
+{
+	Json::Value json_video_track;
+	Json::Value json_audio_track;
+
+	out_json_track["id"] = track->GetId();
+	out_json_track["name"] = track->GetVariantName().CStr();
+	out_json_track["publicName"] = track->GetPublicName().CStr();
+	out_json_track["language"] = track->GetLanguage().CStr();
+	out_json_track["characteristics"] = track->GetCharacteristics().CStr();
+	out_json_track["codecId"] = static_cast<int8_t>(track->GetCodecId());
+	out_json_track["mediaType"] = static_cast<int8_t>(track->GetMediaType());
+	out_json_track["timebaseNum"] = track->GetTimeBase().GetNum();
+	out_json_track["timebaseDen"] = track->GetTimeBase().GetDen();
+	out_json_track["bitrate"] = track->GetBitrate();
+	// Kept for wire compatibility; the receiver measures its own frame times
+	out_json_track["startFrameTime"] = 0;
+	out_json_track["lastFrameTime"] = 0;
+
+	json_video_track["framerate"] = track->GetFrameRate();
+	json_video_track["maxFramerate"] = track->GetMaxFrameRate();
+	auto resolution = track->GetResolution();
+	json_video_track["width"] = resolution.width;
+	json_video_track["height"] = resolution.height;
+	auto max_resolution = track->GetMaxResolution();
+	json_video_track["maxWidth"] = max_resolution.width;
+	json_video_track["maxHeight"] = max_resolution.height;
+
+	json_audio_track["samplerate"] = track->GetSampleRate();
+	json_audio_track["sampleFormat"] = static_cast<int8_t>(track->GetSample().GetFormat());
+	json_audio_track["layout"] = static_cast<uint32_t>(track->GetChannel().GetLayout());
+
+	out_json_track["videoTrack"] = json_video_track;
+	out_json_track["audioTrack"] = json_audio_track;
+
+	auto decoder_config = track->GetDecoderConfigurationRecord();
+	if (decoder_config != nullptr)
+	{
+		out_json_track["decoderConfig"] = ov::Base64::Encode(decoder_config->GetData()).CStr();
+	}
+}
+
+void OvtStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const MediaTrack> &old_track, const std::shared_ptr<const MediaTrack> &new_track)
+{
+	if (GetState() != Stream::State::STARTED)
+	{
+		return;
+	}
+
+	// Relay the changed track's already-parsed configuration to connected edges.
+	// OnTrackChanged runs right before the first media packet of the new version
+	// is broadcast, so the message reaches the edge ahead of that packet on the
+	// same connection. Only the changed track is sent; the edge replaces its own
+	// copy and skips tracks it did not subscribe to.
+	Json::Value json_track;
+	GenerateTrackDescription(new_track, json_track);
+
+	Json::Value json_tracks(Json::arrayValue);
+	json_tracks.append(json_track);
+
+	Json::Value json_stream;
+	json_stream["tracks"] = json_tracks;
+
+	Json::Value contents;
+	contents["version"] = OVT_SIGNALING_VERSION;
+	contents["stream"] = json_stream;
+
+	Json::Value root;
+	root["id"] = 0;
+	root["application"] = "notify";
+	root["code"] = 200;
+	root["message"] = "track_changed";
+	root["contents"] = contents;
+
+	auto payload = ov::Json::Stringify(root).ToData(false);
+
+	std::shared_lock<std::shared_mutex> mlock(_packetizer_lock);
+	if (_packetizer == nullptr)
+	{
+		return;
+	}
+
+	// Routed through OnOvtPacketized() -> BroadcastPacket() to every session
+	_packetizer->PacketizeMessage(OVT_PAYLOAD_TYPE_MESSAGE_RESPONSE, ov::Clock::NowMSec(), payload);
+
+	logti("%s/%s(%u) Relayed Track(%d) configuration change to edges (version %u -> %u)",
+		  GetApplicationName(), GetName().CStr(), GetId(), track_id, old_track->GetVersion(), new_track->GetVersion());
 }
 
 void OvtStream::SendVideoFrame(const std::shared_ptr<MediaPacket> &media_packet)

--- a/src/publishers/ovt/ovt_stream.cpp
+++ b/src/publishers/ovt/ovt_stream.cpp
@@ -215,6 +215,13 @@ void OvtStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const Med
 		return;
 	}
 
+	// A label-only change does not affect the media configuration, so there is
+	// nothing for the edge to re-apply; the base treats it as a metadata update.
+	if (old_track->HasSameContent(*new_track))
+	{
+		return;
+	}
+
 	// Relay the changed track's already-parsed configuration to connected edges.
 	// OnTrackChanged runs right before the first media packet of the new version
 	// is broadcast, so the message reaches the edge ahead of that packet on the

--- a/src/publishers/ovt/ovt_stream.h
+++ b/src/publishers/ovt/ovt_stream.h
@@ -40,7 +40,12 @@ private:
 	bool Start() override;
 	bool Stop() override;
 
+	// Relays the origin's already-parsed track configuration to connected edges
+	// so a runtime change (codec, resolution, decoder config) is applied there.
+	void OnTrackChanged(int32_t track_id, const std::shared_ptr<const MediaTrack> &old_track, const std::shared_ptr<const MediaTrack> &new_track) override;
+
 	bool GenerateDescription(Json::Value &out_description);
+	void GenerateTrackDescription(const std::shared_ptr<const MediaTrack> &track, Json::Value &out_json_track);
 	void FilterDescriptionByTrackIds(Json::Value &description, const std::set<uint32_t> &allowed_track_ids);
 
 	uint32_t							_worker_count = 0;

--- a/src/publishers/srt/srt_stream.cpp
+++ b/src/publishers/srt/srt_stream.cpp
@@ -109,6 +109,14 @@ namespace pub
 		return new_playlist;
 	}
 
+	void SrtStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const MediaTrack> &old_track, const std::shared_ptr<const MediaTrack> &new_track)
+	{
+		// A same-codec change (resolution, bitrate, parameter sets) is carried
+		// in-band in the MPEG-TS elementary stream, so the output stays valid. A
+		// codec change would need a new PMT that a running SRT client cannot adopt.
+		LogInbandRecoverableTrackChange(track_id, old_track, new_track);
+	}
+
 	bool SrtStream::IsSupportedTrack(const std::shared_ptr<const MediaTrack> &track) const
 	{
 		auto media_type = track->GetMediaType();

--- a/src/publishers/srt/srt_stream.h
+++ b/src/publishers/srt/srt_stream.h
@@ -55,6 +55,8 @@ namespace pub
 		bool Start() override;
 		bool Stop() override;
 
+		void OnTrackChanged(int32_t track_id, const std::shared_ptr<const MediaTrack> &old_track, const std::shared_ptr<const MediaTrack> &new_track) override;
+
 		bool IsSupportedTrack(const std::shared_ptr<const MediaTrack> &track) const;
 
 		std::shared_ptr<SrtPlaylist> GetSrtPlaylistInternal(const ov::String &file_name) OV_REQUIRES_SHARED(_srt_playlist_map_mutex);

--- a/src/publishers/webrtc/rtc_stream.cpp
+++ b/src/publishers/webrtc/rtc_stream.cpp
@@ -314,6 +314,14 @@ bool RtcStream::Stop()
 	return Stream::Stop();
 }
 
+void RtcStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const MediaTrack> &old_track, const std::shared_ptr<const MediaTrack> &new_track)
+{
+	// A same-codec change (resolution, bitrate, parameter sets) is delivered
+	// in-band via RTP, so a running session keeps decoding. A codec change would
+	// require a new SDP offer, which cannot be applied to an active session.
+	LogInbandRecoverableTrackChange(track_id, old_track, new_track);
+}
+
 bool RtcStream::IsSupportedCodec(cmn::MediaCodecId codec_id)
 {
 	switch (codec_id)

--- a/src/publishers/webrtc/rtc_stream.h
+++ b/src/publishers/webrtc/rtc_stream.h
@@ -58,7 +58,8 @@ public:
 private:
 	bool Start() override;
 	bool Stop() override;
-	// TODO(Getroot): Re-create the SDP when OnTrackChanged fires (track configuration change)
+	// TODO(Getroot): Re-create the SDP when the codec changes so an active session can adopt it
+	void OnTrackChanged(int32_t track_id, const std::shared_ptr<const MediaTrack> &old_track, const std::shared_ptr<const MediaTrack> &new_track) override;
 
 	bool IsSupportedCodec(cmn::MediaCodecId codec_id);
 

--- a/src/publishers/webrtc/rtc_stream.h
+++ b/src/publishers/webrtc/rtc_stream.h
@@ -58,7 +58,7 @@ public:
 private:
 	bool Start() override;
 	bool Stop() override;
-	// TODO(Getroot): Re-create the SDP when the codec changes so an active session can adopt it
+	// TODO(Getroot): a running session cannot adopt a codec change today; renegotiating the SDP on a codec change would allow it
 	void OnTrackChanged(int32_t track_id, const std::shared_ptr<const MediaTrack> &old_track, const std::shared_ptr<const MediaTrack> &new_track) override;
 
 	bool IsSupportedCodec(cmn::MediaCodecId codec_id);


### PR DESCRIPTION
Problem

A source track can change its configuration at runtime (codec, resolution, decoder configuration). The OVT publisher had no way to tell a connected edge, so the edge kept serving the previous configuration, and for parameters not carried in the media bitstream such as AAC or Opus the edge could never recover. Separately, the WebRTC and SRT publishers logged every such change as a warning that reads like an error even when the change is harmless.

Solution

The OVT origin now relays the changed track's already parsed configuration to connected edges as a signaling message when the track version changes, and the edge applies it before forwarding the packets that follow. The WebRTC and SRT publishers now log a change that keeps the codec as an informational message, since the new parameter sets travel in the media itself, and keep a warning only for a codec change that a running session cannot adopt.

Test

Method: an OVT origin running a scheduled channel that alternates 640x360 AAC 44100 and 1920x1080 AAC 48000 every 10 seconds, an OVT edge pulling it and republishing LLHLS, plus the full_pipeline e2e that routes RTMP through an OVT pull into a transcoder and LLHLS.
Pass: the origin logs the relay on every change, the edge applies each change with zero protocol errors across repeated flips, the AAC sample rate change that is not carried in the bitstream is reflected on the edge, WebRTC and SRT emit the informational log instead of the warning, and the full_pipeline OVT integration stays healthy across ten streams.
