### PR TITLE
feat(hevc): add H.265 slice header parser and switch sample entry to hvc1

### DIFF
--- a/src/modules/bitstream/h265/h265_decoder_configuration_record.cpp
+++ b/src/modules/bitstream/h265/h265_decoder_configuration_record.cpp
@@ -579,7 +579,7 @@ bool HEVCDecoderConfigurationRecord::AddVPS(const std::shared_ptr<ov::Data> &nal
 		return false;
 	}
 
-	_vps_map.emplace(vps.GetId(), vps);
+	_vps_map.emplace(vps.GetId(), std::make_shared<H265VPS>(vps));
 	_vps_data_list.push_back(nalu);
 
 	//_num_temporal_layers = std::max<uint8_t>(_num_temporal_layers, vps.GetMaxSubLayersMinus1() + 1);
@@ -627,7 +627,7 @@ bool HEVCDecoderConfigurationRecord::AddSPS(const std::shared_ptr<ov::Data> &nal
 	_constant_frame_rate = 0;
 
 	_sps_data_list.push_back(nalu);
-	_sps_map.emplace(sps.GetId(), sps);
+	_sps_map.emplace(sps.GetId(), std::make_shared<H265SPS>(sps));
 
 	return true;
 }
@@ -647,7 +647,7 @@ bool HEVCDecoderConfigurationRecord::AddPPS(const std::shared_ptr<ov::Data> &nal
 		return false;
 	}
 
-	_pps_map.emplace(pps.GetId(), pps);
+	_pps_map.emplace(pps.GetId(), std::make_shared<H265PPS>(pps));
 	_pps_data_list.push_back(nalu);
 
 	// TODO(Getroot) : Implement PPS parser for getting following values
@@ -665,30 +665,38 @@ bool HEVCDecoderConfigurationRecord::AddPPS(const std::shared_ptr<ov::Data> &nal
 	return true;
 }
 
-bool HEVCDecoderConfigurationRecord::GetSPS(int sps_id, H265SPS &sps) const
+std::shared_ptr<H265SPS> HEVCDecoderConfigurationRecord::GetSPS(int sps_id) const
 {
-	auto it = _sps_map.find(sps_id);
+	// sps_seq_parameter_set_id is in the range [0, 15] (Rec. ITU-T H.265 7.4.3.2.1). 
+	if (sps_id < 0 || sps_id > 15)
+	{
+		return nullptr;
+	}
+
+	auto it = _sps_map.find(static_cast<uint8_t>(sps_id));
 	if (it == _sps_map.end())
 	{
-		return false;
+		return nullptr;
 	}
 
-	sps = it->second;
-
-	return true;
+	return it->second;
 }
 
-bool HEVCDecoderConfigurationRecord::GetPPS(int pps_id, H265PPS &pps) const
+std::shared_ptr<H265PPS> HEVCDecoderConfigurationRecord::GetPPS(int pps_id) const
 {
-	auto it = _pps_map.find(pps_id);
-	if (it == _pps_map.end())
+	// pps_pic_parameter_set_id is in the range [0, 63] (Rec. ITU-T H.265 7.4.3.3.1).
+	if (pps_id < 0 || pps_id > 63)
 	{
-		return false;
+		return nullptr;
 	}
 
-	pps = it->second;
+	auto it = _pps_map.find(static_cast<uint8_t>(pps_id));
+	if (it == _pps_map.end())
+	{
+		return nullptr;
+	}
 
-	return true;
+	return it->second;
 }
 
 std::tuple<std::shared_ptr<ov::Data>, FragmentationHeader> HEVCDecoderConfigurationRecord::GetVpsSpsPpsAsAnnexB()

--- a/src/modules/bitstream/h265/h265_decoder_configuration_record.cpp
+++ b/src/modules/bitstream/h265/h265_decoder_configuration_record.cpp
@@ -60,7 +60,9 @@ ov::String HEVCDecoderConfigurationRecord::GetCodecsParameter() const
 
 	ov::String codecs_parameter;
 
-	codecs_parameter += "hev1";
+	// Use 'hvc1' (parameter sets in the sample entry) rather than 'hev1' (in-band allowed).
+	// This parallels AVC's use of 'avc1' and is required for encrypted HEVC
+	codecs_parameter += "hvc1";
 
 	if (_general_profile_space == 0)
 	{
@@ -659,6 +661,32 @@ bool HEVCDecoderConfigurationRecord::AddPPS(const std::shared_ptr<ov::Data> &nal
 	// else 
 	// 		parallelism_type = 1 // slice-based parallel decoding
 	_parallelism_type = 0;
+
+	return true;
+}
+
+bool HEVCDecoderConfigurationRecord::GetSPS(int sps_id, H265SPS &sps) const
+{
+	auto it = _sps_map.find(sps_id);
+	if (it == _sps_map.end())
+	{
+		return false;
+	}
+
+	sps = it->second;
+
+	return true;
+}
+
+bool HEVCDecoderConfigurationRecord::GetPPS(int pps_id, H265PPS &pps) const
+{
+	auto it = _pps_map.find(pps_id);
+	if (it == _pps_map.end())
+	{
+		return false;
+	}
+
+	pps = it->second;
 
 	return true;
 }

--- a/src/modules/bitstream/h265/h265_decoder_configuration_record.cpp
+++ b/src/modules/bitstream/h265/h265_decoder_configuration_record.cpp
@@ -470,9 +470,11 @@ void HEVCDecoderConfigurationRecord::RebuildNalUnitArray(H265NALUnitType nal_typ
 		v.push_back(nalu);
 	}
 
-	// The Annex B form is built from these lists and cached, so it no longer matches.
+	// Both cached forms are built from these lists, so neither matches any more: the Annex B
+	// bitstream here and the serialized record behind GetData() in the base class.
 	_vps_sps_pps_annexb_data = nullptr;
 	_vps_sps_pps_annexb_frag_header = FragmentationHeader();
+	UpdateData();
 }
 
 void HEVCDecoderConfigurationRecord::AddNalUnit(H265NALUnitType nal_type, const std::shared_ptr<ov::Data> &nal_unit)

--- a/src/modules/bitstream/h265/h265_decoder_configuration_record.cpp
+++ b/src/modules/bitstream/h265/h265_decoder_configuration_record.cpp
@@ -460,24 +460,42 @@ std::shared_ptr<const ov::Data> HEVCDecoderConfigurationRecord::Serialize()
 	return bit.GetDataObject();
 }
 
-void HEVCDecoderConfigurationRecord::AddNalUnit(H265NALUnitType nal_type, const std::shared_ptr<ov::Data> &nal_unit)
+void HEVCDecoderConfigurationRecord::RebuildNalUnitArray(H265NALUnitType nal_type, const std::map<uint8_t, std::shared_ptr<ov::Data>> &data_list)
 {
 	auto &v = _nal_units[static_cast<uint8_t>(nal_type)];
-	v.push_back(nal_unit);
-	
+	v.clear();
+	v.reserve(data_list.size());
+	for (const auto &[id, nalu] : data_list)
+	{
+		v.push_back(nalu);
+	}
+
+	// The Annex B form is built from these lists and cached, so it no longer matches.
+	_vps_sps_pps_annexb_data = nullptr;
+	_vps_sps_pps_annexb_frag_header = FragmentationHeader();
+}
+
+void HEVCDecoderConfigurationRecord::AddNalUnit(H265NALUnitType nal_type, const std::shared_ptr<ov::Data> &nal_unit)
+{
+	// Parameter sets are keyed by id, so Add*() maintains _nal_units itself.
 	if (nal_type == H265NALUnitType::VPS)
 	{
 		AddVPS(nal_unit);
+		return;
 	}
-	else if (nal_type == H265NALUnitType::SPS)
+	if (nal_type == H265NALUnitType::SPS)
 	{
 		// Set Info from SPS
 		AddSPS(nal_unit);
+		return;
 	}
-	else if (nal_type == H265NALUnitType::PPS)
+	if (nal_type == H265NALUnitType::PPS)
 	{
 		AddPPS(nal_unit);
+		return;
 	}
+
+	_nal_units[static_cast<uint8_t>(nal_type)].push_back(nal_unit);
 }
 
 uint8_t HEVCDecoderConfigurationRecord::Version()
@@ -574,13 +592,9 @@ bool HEVCDecoderConfigurationRecord::AddVPS(const std::shared_ptr<ov::Data> &nal
 		return false;
 	}
 
-	if (_vps_map.find(vps.GetId()) != _vps_map.end())
-	{
-		return false;
-	}
-
-	_vps_map.emplace(vps.GetId(), std::make_shared<H265VPS>(vps));
-	_vps_data_list.push_back(nalu);
+	_vps_map[vps.GetId()] = std::make_shared<H265VPS>(vps);
+	_vps_data_list[vps.GetId()] = nalu;
+	RebuildNalUnitArray(H265NALUnitType::VPS, _vps_data_list);
 
 	//_num_temporal_layers = std::max<uint8_t>(_num_temporal_layers, vps.GetMaxSubLayersMinus1() + 1);
 
@@ -593,11 +607,6 @@ bool HEVCDecoderConfigurationRecord::AddSPS(const std::shared_ptr<ov::Data> &nal
 	if (H265Parser::ParseSPS(nalu->GetDataAs<uint8_t>(), nalu->GetLength(), sps) == false)
 	{
 		logte("Could not parse H265 SPS unit");
-		return false;
-	}
-
-	if (_sps_map.find(sps.GetId()) != _sps_map.end())
-	{
 		return false;
 	}
 
@@ -626,8 +635,9 @@ bool HEVCDecoderConfigurationRecord::AddSPS(const std::shared_ptr<ov::Data> &nal
 	_avg_frame_rate = 0;
 	_constant_frame_rate = 0;
 
-	_sps_data_list.push_back(nalu);
-	_sps_map.emplace(sps.GetId(), std::make_shared<H265SPS>(sps));
+	_sps_map[sps.GetId()] = std::make_shared<H265SPS>(sps);
+	_sps_data_list[sps.GetId()] = nalu;
+	RebuildNalUnitArray(H265NALUnitType::SPS, _sps_data_list);
 
 	return true;
 }
@@ -642,13 +652,9 @@ bool HEVCDecoderConfigurationRecord::AddPPS(const std::shared_ptr<ov::Data> &nal
 		return false;
 	}
 
-	if (_pps_map.find(pps.GetId()) != _pps_map.end())
-	{
-		return false;
-	}
-
-	_pps_map.emplace(pps.GetId(), std::make_shared<H265PPS>(pps));
-	_pps_data_list.push_back(nalu);
+	_pps_map[pps.GetId()] = std::make_shared<H265PPS>(pps);
+	_pps_data_list[pps.GetId()] = nalu;
+	RebuildNalUnitArray(H265NALUnitType::PPS, _pps_data_list);
 
 	// TODO(Getroot) : Implement PPS parser for getting following values
 	// _parallelism_type can be derived from the following PPS values:
@@ -665,10 +671,9 @@ bool HEVCDecoderConfigurationRecord::AddPPS(const std::shared_ptr<ov::Data> &nal
 	return true;
 }
 
-std::shared_ptr<H265SPS> HEVCDecoderConfigurationRecord::GetSPS(int sps_id) const
+std::shared_ptr<const H265SPS> HEVCDecoderConfigurationRecord::GetSPS(int sps_id) const
 {
-	// sps_seq_parameter_set_id is in the range [0, 15] (Rec. ITU-T H.265 7.4.3.2.1). 
-	if (sps_id < 0 || sps_id > 15)
+	if (sps_id < 0 || static_cast<uint32_t>(sps_id) > H265_MAX_SPS_ID)
 	{
 		return nullptr;
 	}
@@ -682,10 +687,9 @@ std::shared_ptr<H265SPS> HEVCDecoderConfigurationRecord::GetSPS(int sps_id) cons
 	return it->second;
 }
 
-std::shared_ptr<H265PPS> HEVCDecoderConfigurationRecord::GetPPS(int pps_id) const
+std::shared_ptr<const H265PPS> HEVCDecoderConfigurationRecord::GetPPS(int pps_id) const
 {
-	// pps_pic_parameter_set_id is in the range [0, 63] (Rec. ITU-T H.265 7.4.3.3.1).
-	if (pps_id < 0 || pps_id > 63)
+	if (pps_id < 0 || static_cast<uint32_t>(pps_id) > H265_MAX_PPS_ID)
 	{
 		return nullptr;
 	}
@@ -715,7 +719,7 @@ std::tuple<std::shared_ptr<ov::Data>, FragmentationHeader> HEVCDecoderConfigurat
 	FragmentationHeader frag_header;
 	size_t offset = 0;
 
-	for (auto &vps_data : _vps_data_list)
+	for (auto &[vps_id, vps_data] : _vps_data_list)
 	{
 		data->Append(H26X_START_CODE_PREFIX, H26X_START_CODE_PREFIX_LEN);
 		offset += H26X_START_CODE_PREFIX_LEN;
@@ -726,7 +730,7 @@ std::tuple<std::shared_ptr<ov::Data>, FragmentationHeader> HEVCDecoderConfigurat
 		offset += vps_data->GetLength();
 	}
 
-	for (auto &sps_data : _sps_data_list)
+	for (auto &[sps_id, sps_data] : _sps_data_list)
 	{
 		data->Append(H26X_START_CODE_PREFIX, H26X_START_CODE_PREFIX_LEN);
 		offset += H26X_START_CODE_PREFIX_LEN;
@@ -737,7 +741,7 @@ std::tuple<std::shared_ptr<ov::Data>, FragmentationHeader> HEVCDecoderConfigurat
 		offset += sps_data->GetLength();
 	}
 
-	for (auto &pps_data : _pps_data_list)
+	for (auto &[pps_id, pps_data] : _pps_data_list)
 	{
 		data->Append(H26X_START_CODE_PREFIX, H26X_START_CODE_PREFIX_LEN);
 		offset += H26X_START_CODE_PREFIX_LEN;

--- a/src/modules/bitstream/h265/h265_decoder_configuration_record.h
+++ b/src/modules/bitstream/h265/h265_decoder_configuration_record.h
@@ -90,6 +90,10 @@ public:
 	// Get NAL units by NAL unit type
 	std::vector<std::shared_ptr<ov::Data>> GetNalUnits(H265NALUnitType nal_type);
 
+	// Get parsed SPS/PPS by id (used e.g. by the slice header parser for CENC)
+	bool GetSPS(int sps_id, H265SPS &sps) const;
+	bool GetPPS(int pps_id, H265PPS &pps) const;
+
 	// Helpers
 	int32_t GetWidth();
 	int32_t GetHeight();

--- a/src/modules/bitstream/h265/h265_decoder_configuration_record.h
+++ b/src/modules/bitstream/h265/h265_decoder_configuration_record.h
@@ -91,8 +91,8 @@ public:
 	std::vector<std::shared_ptr<ov::Data>> GetNalUnits(H265NALUnitType nal_type);
 
 	// Get parsed SPS/PPS by id (used e.g. by the slice header parser for CENC)
-	bool GetSPS(int sps_id, H265SPS &sps) const;
-	bool GetPPS(int pps_id, H265PPS &pps) const;
+	std::shared_ptr<H265SPS> GetSPS(int sps_id) const;
+	std::shared_ptr<H265PPS> GetPPS(int pps_id) const;
 
 	// Helpers
 	int32_t GetWidth();
@@ -136,15 +136,15 @@ private:
 	// Extra data
 	std::vector<std::shared_ptr<ov::Data>>	_vps_data_list;
 	// vps_id, vps
-	std::map<uint8_t, H265VPS> _vps_map;
+	std::map<uint8_t, std::shared_ptr<H265VPS>> _vps_map;
 
 	std::vector<std::shared_ptr<ov::Data>>	_sps_data_list;
 	// sps_id, sps
-	std::map<uint8_t, H265SPS> _sps_map;
+	std::map<uint8_t, std::shared_ptr<H265SPS>> _sps_map;
 
 	std::vector<std::shared_ptr<ov::Data>>	_pps_data_list;
 	// pps_id, pps
-	std::map<uint8_t, H265PPS> _pps_map;
+	std::map<uint8_t, std::shared_ptr<H265PPS>> _pps_map;
 
 	H265SPS _h265_sps;
 	std::shared_ptr<ov::Data> _vps_sps_pps_annexb_data = nullptr;

--- a/src/modules/bitstream/h265/h265_decoder_configuration_record.h
+++ b/src/modules/bitstream/h265/h265_decoder_configuration_record.h
@@ -91,8 +91,8 @@ public:
 	std::vector<std::shared_ptr<ov::Data>> GetNalUnits(H265NALUnitType nal_type);
 
 	// Get parsed SPS/PPS by id (used e.g. by the slice header parser for CENC)
-	std::shared_ptr<H265SPS> GetSPS(int sps_id) const;
-	std::shared_ptr<H265PPS> GetPPS(int pps_id) const;
+	std::shared_ptr<const H265SPS> GetSPS(int sps_id) const;
+	std::shared_ptr<const H265PPS> GetPPS(int pps_id) const;
 
 	// Helpers
 	int32_t GetWidth();
@@ -133,18 +133,18 @@ private:
 	// NAL unit type -> NAL unit vector
 	std::map<uint8_t, std::vector<std::shared_ptr<ov::Data>>> _nal_units;
 
-	// Extra data
-	std::vector<std::shared_ptr<ov::Data>>	_vps_data_list;
-	// vps_id, vps
+	// Raw NAL units and their parsed form, keyed by parameter set id.
+	std::map<uint8_t, std::shared_ptr<ov::Data>> _vps_data_list;
 	std::map<uint8_t, std::shared_ptr<H265VPS>> _vps_map;
 
-	std::vector<std::shared_ptr<ov::Data>>	_sps_data_list;
-	// sps_id, sps
+	std::map<uint8_t, std::shared_ptr<ov::Data>> _sps_data_list;
 	std::map<uint8_t, std::shared_ptr<H265SPS>> _sps_map;
 
-	std::vector<std::shared_ptr<ov::Data>>	_pps_data_list;
-	// pps_id, pps
+	std::map<uint8_t, std::shared_ptr<ov::Data>> _pps_data_list;
 	std::map<uint8_t, std::shared_ptr<H265PPS>> _pps_map;
+
+	// Replaces _nal_units[nal_type] with the id-ordered contents of a keyed data list.
+	void RebuildNalUnitArray(H265NALUnitType nal_type, const std::map<uint8_t, std::shared_ptr<ov::Data>> &data_list);
 
 	H265SPS _h265_sps;
 	std::shared_ptr<ov::Data> _vps_sps_pps_annexb_data = nullptr;

--- a/src/modules/bitstream/h265/h265_parser.cpp
+++ b/src/modules/bitstream/h265/h265_parser.cpp
@@ -1428,14 +1428,14 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 	auto pps = hvcc->GetPPS(slice_pic_parameter_set_id);
 	if (pps == nullptr)
 	{
-		logte("H265 slice header: PPS(%u) not found", slice_pic_parameter_set_id);
+		logtd("H265 slice header: PPS(%u) not found", slice_pic_parameter_set_id);
 		return false;
 	}
 
 	auto sps = hvcc->GetSPS(pps->pps_seq_parameter_set_id);
 	if (sps == nullptr)
 	{
-		logte("H265 slice header: SPS(%u) not found", pps->pps_seq_parameter_set_id);
+		logtd("H265 slice header: SPS(%u) not found", pps->pps_seq_parameter_set_id);
 		return false;
 	}
 

--- a/src/modules/bitstream/h265/h265_parser.cpp
+++ b/src/modules/bitstream/h265/h265_parser.cpp
@@ -1801,8 +1801,8 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 	uint8_t H265_READ_BITS(alignment_bit_equal_to_one, 1);
 	(void)alignment_bit_equal_to_one;
 
-	// The remaining alignment_bit_equal_to_zero bits pad to the next byte boundary.
-	// GetHeaderSizeInBytes() rounds up, giving the raw byte length of [NAL header + slice header].
+	// The slice header size in bits is BitsConsumed - NAL unit header size in bits.
+	//the slice header size does not include the NAL unit header.
 	shd._header_size_in_bits = parser.BitsConsumed() - (H265_NAL_UNIT_HEADER_SIZE * 8);
 
 	return true;

--- a/src/modules/bitstream/h265/h265_parser.cpp
+++ b/src/modules/bitstream/h265/h265_parser.cpp
@@ -2473,11 +2473,15 @@ bool H265Parser::ProcessShortTermRefPicSet(uint32_t idx, uint32_t num_short_term
 			return false;
 		}
 
-		// An inter-predicted RPS must reference a strictly earlier, already-parsed set
-		// (Rec. ITU-T H.265 7.4.8). ref_rps_idx is computed with unsigned arithmetic, so a
-		// malformed delta_idx_minus1 (>= idx) would underflow and index out of bounds; reject it.
+		// RefRpsIdx = idx - (delta_idx_minus1 + 1) must reference an earlier set (Rec. ITU-T H.265 7.4.8).
+		// Reject delta_idx_minus1 >= idx to avoid unsigned underflow.
+		if (rpset.delta_idx_minus1 >= idx)
+		{
+			return false;
+		}
+
 		uint32_t ref_rps_idx = idx - (rpset.delta_idx_minus1 + 1);
-		if (rpset.delta_idx_minus1 + 1 > idx || ref_rps_idx >= rpset_list.size())
+		if (ref_rps_idx >= rpset_list.size())
 		{
 			return false;
 		}

--- a/src/modules/bitstream/h265/h265_parser.cpp
+++ b/src/modules/bitstream/h265/h265_parser.cpp
@@ -1425,41 +1425,41 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 
 	uint32_t H265_READ_UEV(slice_pic_parameter_set_id);
 
-	H265PPS pps;
-	if (hvcc->GetPPS(slice_pic_parameter_set_id, pps) == false)
+	auto pps = hvcc->GetPPS(slice_pic_parameter_set_id);
+	if (pps == nullptr)
 	{
 		logte("H265 slice header: PPS(%u) not found", slice_pic_parameter_set_id);
 		return false;
 	}
 
-	H265SPS sps;
-	if (hvcc->GetSPS(pps.pps_seq_parameter_set_id, sps) == false)
+	auto sps = hvcc->GetSPS(pps->pps_seq_parameter_set_id);
+	if (sps == nullptr)
 	{
-		logte("H265 slice header: SPS(%u) not found", pps.pps_seq_parameter_set_id);
+		logte("H265 slice header: SPS(%u) not found", pps->pps_seq_parameter_set_id);
 		return false;
 	}
 
 	// Fail-safe: range/SCC extension PPS may add conditional slice syntax that is not
 	// handled here. Refuse rather than risk miscomputing the header size.
-	if (pps.pps_range_extension_flag || pps.pps_scc_extension_flag)
+	if (pps->pps_range_extension_flag || pps->pps_scc_extension_flag)
 	{
 		logtw("H265 slice header: range/SCC extension is not supported for CENC subsample encryption");
 		return false;
 	}
 
-	const uint32_t chroma_array_type = sps.GetChromaArrayType();
+	const uint32_t chroma_array_type = sps->GetChromaArrayType();
 
 	uint8_t dependent_slice_segment_flag = 0;
 	if (first_slice_segment_in_pic_flag == 0)
 	{
-		if (pps.dependent_slice_segments_enabled_flag)
+		if (pps->dependent_slice_segments_enabled_flag)
 		{
 			(void)H265_READ_BITS(dependent_slice_segment_flag, 1);
 		}
 
 		// slice_segment_address is u(Ceil(Log2(PicSizeInCtbsY))). 
 		// PicSizeInCtbsY == 0 indicates an invalid SPS
-		const uint32_t pic_size_in_ctbs_y = sps.GetPicSizeInCtbsY();
+		const uint32_t pic_size_in_ctbs_y = sps->GetPicSizeInCtbsY();
 		if (pic_size_in_ctbs_y == 0)
 		{
 			logtw("H265 slice header: invalid PicSizeInCtbsY(%u)", pic_size_in_ctbs_y);
@@ -1476,7 +1476,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 
 	if (dependent_slice_segment_flag == 0)
 	{
-		for (uint8_t i = 0; i < pps.num_extra_slice_header_bits; i++)
+		for (uint8_t i = 0; i < pps->num_extra_slice_header_bits; i++)
 		{
 			uint8_t H265_READ_BITS(slice_reserved_flag, 1);
 			(void)slice_reserved_flag;
@@ -1495,13 +1495,13 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 		const bool is_p_or_b = (slice_type == 0 || slice_type == 1);
 		const bool is_b = (slice_type == 0);
 
-		if (pps.output_flag_present_flag)
+		if (pps->output_flag_present_flag)
 		{
 			uint8_t H265_READ_BITS(pic_output_flag, 1);
 			(void)pic_output_flag;
 		}
 
-		if (sps._separate_colour_plane_flag == 1)
+		if (sps->_separate_colour_plane_flag == 1)
 		{
 			uint8_t H265_READ_BITS(colour_plane_id, 2);
 			(void)colour_plane_id;
@@ -1512,7 +1512,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 
 		if (is_idr == false)
 		{
-			uint32_t H265_READ_BITS(slice_pic_order_cnt_lsb, sps._log2_max_pic_order_cnt_lsb_minus4 + 4);
+			uint32_t H265_READ_BITS(slice_pic_order_cnt_lsb, sps->_log2_max_pic_order_cnt_lsb_minus4 + 4);
 			(void)slice_pic_order_cnt_lsb;
 
 			uint8_t H265_READ_BITS(short_term_ref_pic_set_sps_flag, 1);
@@ -1523,29 +1523,29 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 			if (short_term_ref_pic_set_sps_flag == 0)
 			{
 				// st_ref_pic_set(num_short_term_ref_pic_sets)
-				std::vector<ShortTermRefPicSet> rpset_list = sps._short_term_ref_pic_sets;
-				rpset_list.resize(sps._num_short_term_ref_pic_sets + 1);
-				if (ProcessShortTermRefPicSet(sps._num_short_term_ref_pic_sets, sps._num_short_term_ref_pic_sets, rpset_list, parser, rpset_list[sps._num_short_term_ref_pic_sets]) == false)
+				std::vector<ShortTermRefPicSet> rpset_list = sps->_short_term_ref_pic_sets;
+				rpset_list.resize(sps->_num_short_term_ref_pic_sets + 1);
+				if (ProcessShortTermRefPicSet(sps->_num_short_term_ref_pic_sets, sps->_num_short_term_ref_pic_sets, rpset_list, parser, rpset_list[sps->_num_short_term_ref_pic_sets]) == false)
 				{
 					return false;
 				}
-				current_strps = rpset_list[sps._num_short_term_ref_pic_sets];
+				current_strps = rpset_list[sps->_num_short_term_ref_pic_sets];
 				current_strps_valid = true;
 			}
-			else if (sps._num_short_term_ref_pic_sets > 1)
+			else if (sps->_num_short_term_ref_pic_sets > 1)
 			{
-				uint32_t H265_READ_BITS(short_term_ref_pic_set_idx, CeilLog2(sps._num_short_term_ref_pic_sets));
+				uint32_t H265_READ_BITS(short_term_ref_pic_set_idx, CeilLog2(sps->_num_short_term_ref_pic_sets));
 
-				if (short_term_ref_pic_set_idx >= sps._short_term_ref_pic_sets.size())
+				if (short_term_ref_pic_set_idx >= sps->_short_term_ref_pic_sets.size())
 				{
 					return false;
 				}
-				current_strps = sps._short_term_ref_pic_sets[short_term_ref_pic_set_idx];
+				current_strps = sps->_short_term_ref_pic_sets[short_term_ref_pic_set_idx];
 				current_strps_valid = true;
 			}
-			else if (sps._num_short_term_ref_pic_sets == 1)
+			else if (sps->_num_short_term_ref_pic_sets == 1)
 			{
-				current_strps = sps._short_term_ref_pic_sets[0];
+				current_strps = sps->_short_term_ref_pic_sets[0];
 				current_strps_valid = true;
 			}
 
@@ -1555,7 +1555,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 				{
 					// NumPicTotalCurr derivation for an inter-predicted current RPS is not
 					// implemented; it is only required when list modification is present.
-					if (pps.lists_modification_present_flag)
+					if (pps->lists_modification_present_flag)
 					{
 						logtw("H265 slice header: inter-predicted RPS with list modification is not supported for CENC");
 						return false;
@@ -1580,16 +1580,16 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 				}
 			}
 
-			if (sps._long_term_ref_pics_present_flag)
+			if (sps->_long_term_ref_pics_present_flag)
 			{
 				uint32_t num_long_term_sps = 0;
-				if (sps._num_long_term_ref_pics_sps > 0)
+				if (sps->_num_long_term_ref_pics_sps > 0)
 				{
 					(void)H265_READ_UEV(num_long_term_sps);
 				}
 				uint32_t H265_READ_UEV(num_long_term_pics);
 				const uint32_t num_long_term = num_long_term_sps + num_long_term_pics;
-				const uint32_t lt_idx_sps_bits = CeilLog2(sps._num_long_term_ref_pics_sps);
+				const uint32_t lt_idx_sps_bits = CeilLog2(sps->_num_long_term_ref_pics_sps);
 
 				for (uint32_t i = 0; i < num_long_term; i++)
 				{
@@ -1597,18 +1597,18 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 					if (i < num_long_term_sps)
 					{
 						uint32_t lt_idx_sps = 0;
-						if (sps._num_long_term_ref_pics_sps > 1)
+						if (sps->_num_long_term_ref_pics_sps > 1)
 						{
 							(void)H265_READ_BITS(lt_idx_sps, lt_idx_sps_bits);
 						}
-						if (lt_idx_sps < sps._used_by_curr_pic_lt_sps_flag.size())
+						if (lt_idx_sps < sps->_used_by_curr_pic_lt_sps_flag.size())
 						{
-							used_by_curr_pic_lt_flag = sps._used_by_curr_pic_lt_sps_flag[lt_idx_sps];
+							used_by_curr_pic_lt_flag = sps->_used_by_curr_pic_lt_sps_flag[lt_idx_sps];
 						}
 					}
 					else
 					{
-						uint32_t H265_READ_BITS(poc_lsb_lt, sps._log2_max_pic_order_cnt_lsb_minus4 + 4);
+						uint32_t H265_READ_BITS(poc_lsb_lt, sps->_log2_max_pic_order_cnt_lsb_minus4 + 4);
 						(void)poc_lsb_lt;
 						(void)H265_READ_BITS(used_by_curr_pic_lt_flag, 1);
 					}
@@ -1627,7 +1627,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 				}
 			}
 
-			if (sps._sps_temporal_mvp_enabled_flag)
+			if (sps->_sps_temporal_mvp_enabled_flag)
 			{
 				(void)H265_READ_BITS(slice_temporal_mvp_enabled_flag, 1);
 			}
@@ -1635,7 +1635,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 
 		uint8_t slice_sao_luma_flag = 0;
 		uint8_t slice_sao_chroma_flag = 0;
-		if (sps._sample_adaptive_offset_enabled_flag)
+		if (sps->_sample_adaptive_offset_enabled_flag)
 		{
 			(void)H265_READ_BITS(slice_sao_luma_flag, 1);
 			if (chroma_array_type != 0)
@@ -1646,12 +1646,12 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 
 		// When not overridden below, slice_deblocking_filter_disabled_flag is inferred to be
 		// equal to pps_deblocking_filter_disabled_flag (Rec. ITU-T H.265 7.4.7.1).
-		uint8_t slice_deblocking_filter_disabled_flag = pps.pps_deblocking_filter_disabled_flag;
+		uint8_t slice_deblocking_filter_disabled_flag = pps->pps_deblocking_filter_disabled_flag;
 
 		if (is_p_or_b)
 		{
-			uint32_t num_ref_idx_l0_active_minus1 = pps.num_ref_idx_l0_default_active_minus1;
-			uint32_t num_ref_idx_l1_active_minus1 = pps.num_ref_idx_l1_default_active_minus1;
+			uint32_t num_ref_idx_l0_active_minus1 = pps->num_ref_idx_l0_default_active_minus1;
+			uint32_t num_ref_idx_l1_active_minus1 = pps->num_ref_idx_l1_default_active_minus1;
 
 			uint8_t H265_READ_BITS(num_ref_idx_active_override_flag, 1);
 			if (num_ref_idx_active_override_flag)
@@ -1664,7 +1664,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 			}
 
 			// ref_pic_lists_modification()
-			if (pps.lists_modification_present_flag && num_pic_total_curr > 1)
+			if (pps->lists_modification_present_flag && num_pic_total_curr > 1)
 			{
 				const uint32_t list_entry_bits = CeilLog2(num_pic_total_curr);
 
@@ -1698,7 +1698,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 				(void)mvd_l1_zero_flag;
 			}
 
-			if (pps.cabac_init_present_flag)
+			if (pps->cabac_init_present_flag)
 			{
 				uint8_t H265_READ_BITS(cabac_init_flag, 1);
 				(void)cabac_init_flag;
@@ -1720,8 +1720,8 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 				}
 			}
 
-			if ((pps.weighted_pred_flag && slice_type == 1 /* P */) ||
-				(pps.weighted_bipred_flag && is_b))
+			if ((pps->weighted_pred_flag && slice_type == 1 /* P */) ||
+				(pps->weighted_bipred_flag && is_b))
 			{
 				if (ProcessPredWeightTable(parser, chroma_array_type, num_ref_idx_l0_active_minus1, num_ref_idx_l1_active_minus1, is_b) == false)
 				{
@@ -1738,7 +1738,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 		int32_t H265_READ_SEV(slice_qp_delta);
 		(void)slice_qp_delta;
 
-		if (pps.pps_slice_chroma_qp_offsets_present_flag)
+		if (pps->pps_slice_chroma_qp_offsets_present_flag)
 		{
 			int32_t H265_READ_SEV(slice_cb_qp_offset);
 			(void)slice_cb_qp_offset;
@@ -1749,7 +1749,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 		// pps_slice_act_qp_offsets (SCC) and cu_chroma_qp_offset (range ext) omitted; fail-safed above.
 
 		uint8_t deblocking_filter_override_flag = 0;
-		if (pps.deblocking_filter_override_enabled_flag)
+		if (pps->deblocking_filter_override_enabled_flag)
 		{
 			(void)H265_READ_BITS(deblocking_filter_override_flag, 1);
 		}
@@ -1765,7 +1765,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 			}
 		}
 
-		if (pps.pps_loop_filter_across_slices_enabled_flag &&
+		if (pps->pps_loop_filter_across_slices_enabled_flag &&
 			(slice_sao_luma_flag || slice_sao_chroma_flag || slice_deblocking_filter_disabled_flag == 0))
 		{
 			uint8_t H265_READ_BITS(slice_loop_filter_across_slices_enabled_flag, 1);
@@ -1773,7 +1773,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 		}
 	}
 
-	if (pps.tiles_enabled_flag || pps.entropy_coding_sync_enabled_flag)
+	if (pps->tiles_enabled_flag || pps->entropy_coding_sync_enabled_flag)
 	{
 		uint32_t H265_READ_UEV(num_entry_point_offsets);
 		if (num_entry_point_offsets > 0)
@@ -1787,7 +1787,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 		}
 	}
 
-	if (pps.slice_segment_header_extension_present_flag)
+	if (pps->slice_segment_header_extension_present_flag)
 	{
 		uint32_t H265_READ_UEV(slice_segment_header_extension_length);
 		for (uint32_t i = 0; i < slice_segment_header_extension_length; i++)

--- a/src/modules/bitstream/h265/h265_parser.cpp
+++ b/src/modules/bitstream/h265/h265_parser.cpp
@@ -1474,9 +1474,15 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 		}
 
 		uint32_t H265_READ_UEV(slice_type);
+
+		// slice_type : 0 = B, 1 = P, 2 = I. Values > 2 are invalid
+		if (slice_type > 2)
+		{
+			logtw("H265 slice header: invalid slice_type(%u)", slice_type);
+			return false;
+		}
 		shd._slice_type = slice_type;
 
-		// slice_type : 0 = B, 1 = P, 2 = I
 		const bool is_p_or_b = (slice_type == 0 || slice_type == 1);
 		const bool is_b = (slice_type == 0);
 

--- a/src/modules/bitstream/h265/h265_parser.cpp
+++ b/src/modules/bitstream/h265/h265_parser.cpp
@@ -1520,11 +1520,13 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 			else if (sps._num_short_term_ref_pic_sets > 1)
 			{
 				uint32_t H265_READ_BITS(short_term_ref_pic_set_idx, CeilLog2(sps._num_short_term_ref_pic_sets));
-				if (short_term_ref_pic_set_idx < sps._short_term_ref_pic_sets.size())
+
+				if (short_term_ref_pic_set_idx >= sps._short_term_ref_pic_sets.size())
 				{
-					current_strps = sps._short_term_ref_pic_sets[short_term_ref_pic_set_idx];
-					current_strps_valid = true;
+					return false;
 				}
+				current_strps = sps._short_term_ref_pic_sets[short_term_ref_pic_set_idx];
+				current_strps_valid = true;
 			}
 			else if (sps._num_short_term_ref_pic_sets == 1)
 			{

--- a/src/modules/bitstream/h265/h265_parser.cpp
+++ b/src/modules/bitstream/h265/h265_parser.cpp
@@ -1457,7 +1457,16 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 			(void)H265_READ_BITS(dependent_slice_segment_flag, 1);
 		}
 
-		const uint32_t addr_bits = CeilLog2(sps.GetPicSizeInCtbsY());
+		// slice_segment_address is u(Ceil(Log2(PicSizeInCtbsY))). 
+		// PicSizeInCtbsY == 0 indicates an invalid SPS
+		const uint32_t pic_size_in_ctbs_y = sps.GetPicSizeInCtbsY();
+		if (pic_size_in_ctbs_y == 0)
+		{
+			logtw("H265 slice header: invalid PicSizeInCtbsY(%u)", pic_size_in_ctbs_y);
+			return false;
+		}
+
+		const uint32_t addr_bits = CeilLog2(pic_size_in_ctbs_y);
 		if (addr_bits > 0)
 		{
 			uint32_t H265_READ_BITS(slice_segment_address, addr_bits);

--- a/src/modules/bitstream/h265/h265_parser.cpp
+++ b/src/modules/bitstream/h265/h265_parser.cpp
@@ -2502,7 +2502,9 @@ bool H265Parser::ProcessShortTermRefPicSet(uint32_t idx, uint32_t num_short_term
 		rpset.used_by_curr_pic_flag.resize(num_delta_pocs + 1);
 		rpset.use_delta_flag.resize(num_delta_pocs + 1, 1);
 
-		for (uint32_t i = 0; i < num_delta_pocs; i++)
+		// Rec. ITU-T H.265 7.3.7: the loop is inclusive
+		// for( j = 0; j <= NumDeltaPocs[RefRpsIdx]; j++ )
+		for (uint32_t i = 0; i <= num_delta_pocs; i++)
 		{
 			if (parser.ReadBits(1, rpset.used_by_curr_pic_flag[i]) == false)
 			{

--- a/src/modules/bitstream/h265/h265_parser.cpp
+++ b/src/modules/bitstream/h265/h265_parser.cpp
@@ -1,9 +1,15 @@
 // I developed the code of this file by referring to the source code of virinext's hevcsbrowser (https://github.com/virinext/hevcesbrowser).
 // Thanks to virinext.
 // - Getroot
+//
+// Bitstream syntax and semantics follow Rec. ITU-T H.265 (HEVC) | ISO/IEC 23008-2.
+// Standard document (all versions): https://www.itu.int/rec/T-REC-H.265
+// The section numbers cited throughout this file (e.g. 7.3.2.1 VPS, 7.3.2.2 SPS,
+// 7.3.2.3 PPS, 7.3.6.1 slice_segment_header) refer to that specification.
 
 #include "h265_parser.h"
 
+#include "h265_decoder_configuration_record.h"
 #include "h265_types.h"
 
 #define OV_LOG_TAG "H265Parser"
@@ -357,17 +363,21 @@ bool H265Parser::ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps)
 		}
 	}
 
+	sps._separate_colour_plane_flag = separate_colour_plane_flag;
+
 	uint32_t pic_width_in_luma_samples;
 	if (parser.ReadUEV(pic_width_in_luma_samples) == false)
 	{
 		return false;
 	}
+	sps._pic_width_in_luma_samples = pic_width_in_luma_samples;
 
 	uint32_t pic_height_in_luma_samples;
 	if (parser.ReadUEV(pic_height_in_luma_samples) == false)
 	{
 		return false;
 	}
+	sps._pic_height_in_luma_samples = pic_height_in_luma_samples;
 
 	uint8_t conformance_window_flag;
 	if (parser.ReadBits(1, conformance_window_flag) == false)
@@ -469,6 +479,7 @@ bool H265Parser::ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps)
 	{
 		return false;
 	}
+	sps._log2_max_pic_order_cnt_lsb_minus4 = log2_max_pic_order_cnt_lsb_minus4;
 
 	uint8_t sps_sub_layer_ordering_info_present_flag;
 	if (parser.ReadBits(1, sps_sub_layer_ordering_info_present_flag) == false)
@@ -502,12 +513,14 @@ bool H265Parser::ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps)
 	{
 		return false;
 	}
+	sps._log2_min_luma_coding_block_size_minus3 = log2_min_luma_coding_block_size_minus3;
 
 	uint32_t log2_diff_max_min_luma_coding_block_size;
 	if (parser.ReadUEV(log2_diff_max_min_luma_coding_block_size) == false)
 	{
 		return false;
 	}
+	sps._log2_diff_max_min_luma_coding_block_size = log2_diff_max_min_luma_coding_block_size;
 
 	uint32_t log2_min_transform_block_size_minus2;
 	if (parser.ReadUEV(log2_min_transform_block_size_minus2) == false)
@@ -605,6 +618,7 @@ bool H265Parser::ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps)
 	{
 		return false;
 	}
+	sps._sample_adaptive_offset_enabled_flag = sample_adaptive_offset_enabled_flag;
 
 	uint8_t pcm_enabled_flag;
 	if (parser.ReadBits(1, pcm_enabled_flag) == false)
@@ -652,6 +666,7 @@ bool H265Parser::ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps)
 	{
 		return false;
 	}
+	sps._num_short_term_ref_pic_sets = num_short_term_ref_pic_sets;
 
 	std::vector<ShortTermRefPicSet> rpset_list(num_short_term_ref_pic_sets);
 	for (uint32_t i = 0; i < num_short_term_ref_pic_sets; i++)
@@ -661,12 +676,14 @@ bool H265Parser::ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps)
 			return false;
 		}
 	}
+	sps._short_term_ref_pic_sets = rpset_list;
 
 	uint8_t long_term_ref_pics_present_flag;
 	if (parser.ReadBits(1, long_term_ref_pics_present_flag) == false)
 	{
 		return false;
 	}
+	sps._long_term_ref_pics_present_flag = long_term_ref_pics_present_flag;
 
 	if (long_term_ref_pics_present_flag == 1)
 	{
@@ -675,7 +692,9 @@ bool H265Parser::ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps)
 		{
 			return false;
 		}
+		sps._num_long_term_ref_pics_sps = num_long_term_ref_pics_sps;
 
+		sps._used_by_curr_pic_lt_sps_flag.resize(num_long_term_ref_pics_sps);
 		for (uint32_t i = 0; i < num_long_term_ref_pics_sps; i++)
 		{
 			uint32_t lt_ref_pic_poc_lsb_sps;
@@ -689,6 +708,7 @@ bool H265Parser::ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps)
 			{
 				return false;
 			}
+			sps._used_by_curr_pic_lt_sps_flag[i] = used_by_curr_pic_lt_sps_flag;
 		}
 	}
 
@@ -697,6 +717,8 @@ bool H265Parser::ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps)
 	{
 		return false;
 	}
+	sps._sps_temporal_mvp_enabled_flag = sps_temporal_mvp_enabled_flag;
+
 	uint8_t strong_intra_smoothing_enabled_flag;
 	if (parser.ReadBits(1, strong_intra_smoothing_enabled_flag) == false)
 	{
@@ -1154,12 +1176,18 @@ bool H265Parser::ParsePPS(const uint8_t *nalu, size_t length, H265PPS &pps)
 	(void)H265_READ_UEV(pps.pps_pic_parameter_set_id);
 	(void)H265_READ_UEV(pps.pps_seq_parameter_set_id);
 	uint8_t H265_READ_BITS(dependent_slice_segments_enabled_flag, 1);
+	pps.dependent_slice_segments_enabled_flag = dependent_slice_segments_enabled_flag;
 	uint8_t H265_READ_BITS(output_flag_present_flag, 1);
+	pps.output_flag_present_flag = output_flag_present_flag;
 	uint8_t H265_READ_BITS(num_extra_slice_header_bits, 3);
+	pps.num_extra_slice_header_bits = num_extra_slice_header_bits;
 	uint8_t H265_READ_BITS(sign_data_hiding_enabled_flag, 1);
 	uint8_t H265_READ_BITS(cabac_init_present_flag, 1);
+	pps.cabac_init_present_flag = cabac_init_present_flag;
 	uint32_t H265_READ_UEV(num_ref_idx_l0_default_active_minus1);
+	pps.num_ref_idx_l0_default_active_minus1 = num_ref_idx_l0_default_active_minus1;
 	uint32_t H265_READ_UEV(num_ref_idx_l1_default_active_minus1);
+	pps.num_ref_idx_l1_default_active_minus1 = num_ref_idx_l1_default_active_minus1;
 	int32_t H265_READ_SEV(init_qp_minus26);
 	uint8_t H265_READ_BITS(constrained_intra_pred_flag, 1);
 	uint8_t H265_READ_BITS(transform_skip_enabled_flag, 1);
@@ -1171,11 +1199,16 @@ bool H265Parser::ParsePPS(const uint8_t *nalu, size_t length, H265PPS &pps)
 	int32_t H265_READ_SEV(pps_cb_qp_offset);
 	int32_t H265_READ_SEV(pps_cr_qp_offset);
 	uint8_t H265_READ_BITS(pps_slice_chroma_qp_offsets_present_flag, 1);
+	pps.pps_slice_chroma_qp_offsets_present_flag = pps_slice_chroma_qp_offsets_present_flag;
 	uint8_t H265_READ_BITS(weighted_pred_flag, 1);
+	pps.weighted_pred_flag = weighted_pred_flag;
 	uint8_t H265_READ_BITS(weighted_bipred_flag, 1);
+	pps.weighted_bipred_flag = weighted_bipred_flag;
 	uint8_t H265_READ_BITS(transquant_bypass_enabled_flag, 1);
 	uint8_t H265_READ_BITS(tiles_enabled_flag, 1);
+	pps.tiles_enabled_flag = tiles_enabled_flag;
 	uint8_t H265_READ_BITS(entropy_coding_sync_enabled_flag, 1);
+	pps.entropy_coding_sync_enabled_flag = entropy_coding_sync_enabled_flag;
 	if (tiles_enabled_flag)
 	{
 		uint32_t H265_READ_UEV(num_tile_columns_minus1);
@@ -1197,11 +1230,14 @@ bool H265Parser::ParsePPS(const uint8_t *nalu, size_t length, H265PPS &pps)
 		uint8_t H265_READ_BITS(loop_filter_across_tiles_enabled_flag, 1);
 	}
 	uint8_t H265_READ_BITS(pps_loop_filter_across_slices_enabled_flag, 1);
+	pps.pps_loop_filter_across_slices_enabled_flag = pps_loop_filter_across_slices_enabled_flag;
 	uint8_t H265_READ_BITS(deblocking_filter_control_present_flag, 1);
 	if (deblocking_filter_control_present_flag)
 	{
 		uint8_t H265_READ_BITS(deblocking_filter_override_enabled_flag, 1);
+		pps.deblocking_filter_override_enabled_flag = deblocking_filter_override_enabled_flag;
 		uint8_t H265_READ_BITS(pps_deblocking_filter_disabled_flag, 1);
+		pps.pps_deblocking_filter_disabled_flag = pps_deblocking_filter_disabled_flag;
 		if (pps_deblocking_filter_disabled_flag == 0)
 		{
 			int32_t H265_READ_SEV(pps_beta_offset_div2);
@@ -1217,8 +1253,10 @@ bool H265Parser::ParsePPS(const uint8_t *nalu, size_t length, H265PPS &pps)
 		}
 	}
 	uint8_t H265_READ_BITS(lists_modification_present_flag, 1);
+	pps.lists_modification_present_flag = lists_modification_present_flag;
 	uint32_t H265_READ_UEV(log2_parallel_merge_level_minus2);
 	uint8_t H265_READ_BITS(slice_segment_header_extension_present_flag, 1);
+	pps.slice_segment_header_extension_present_flag = slice_segment_header_extension_present_flag;
 	uint8_t H265_READ_BITS(pps_extension_present_flag, 1);
 	uint8_t pps_range_extension_flag = 0;
 	uint8_t pps_multilayer_extension_flag = 0;
@@ -1232,6 +1270,8 @@ bool H265Parser::ParsePPS(const uint8_t *nalu, size_t length, H265PPS &pps)
 		(void)H265_READ_BITS(pps_3d_extension_flag, 1);
 		(void)H265_READ_BITS(pps_scc_extension_flag, 1);
 		(void)H265_READ_BITS(pps_extension_4bits, 4);
+		pps.pps_range_extension_flag = pps_range_extension_flag;
+		pps.pps_scc_extension_flag = pps_scc_extension_flag;
 	}
 	if (pps_range_extension_flag)
 	{
@@ -1261,6 +1301,492 @@ bool H265Parser::ParsePPS(const uint8_t *nalu, size_t length, H265PPS &pps)
 		// }
 	}
 	// rbsp_trailing_bits()
+
+	return true;
+}
+
+// Rec. ITU-T H.265 (V10), 7.3.6.3 Weighted prediction parameters syntax
+bool H265Parser::ProcessPredWeightTable(NalUnitBitstreamParser &parser, uint32_t chroma_array_type, uint32_t num_ref_idx_l0_active_minus1, uint32_t num_ref_idx_l1_active_minus1, bool is_b_slice)
+{
+	uint32_t luma_log2_weight_denom;
+	if (parser.ReadUEV(luma_log2_weight_denom) == false)
+	{
+		return false;
+	}
+
+	if (chroma_array_type != 0)
+	{
+		int32_t delta_chroma_log2_weight_denom;
+		if (parser.ReadSEV(delta_chroma_log2_weight_denom) == false)
+		{
+			return false;
+		}
+	}
+
+	for (int list = 0; list < (is_b_slice ? 2 : 1); list++)
+	{
+		const uint32_t num_ref = (list == 0) ? num_ref_idx_l0_active_minus1 : num_ref_idx_l1_active_minus1;
+
+		std::vector<uint8_t> luma_weight_flag(num_ref + 1, 0);
+		for (uint32_t i = 0; i <= num_ref; i++)
+		{
+			if (parser.ReadBits(1, luma_weight_flag[i]) == false)
+			{
+				return false;
+			}
+		}
+
+		std::vector<uint8_t> chroma_weight_flag(num_ref + 1, 0);
+		if (chroma_array_type != 0)
+		{
+			for (uint32_t i = 0; i <= num_ref; i++)
+			{
+				if (parser.ReadBits(1, chroma_weight_flag[i]) == false)
+				{
+					return false;
+				}
+			}
+		}
+
+		for (uint32_t i = 0; i <= num_ref; i++)
+		{
+			if (luma_weight_flag[i])
+			{
+				int32_t delta_luma_weight, luma_offset;
+				if (parser.ReadSEV(delta_luma_weight) == false || parser.ReadSEV(luma_offset) == false)
+				{
+					return false;
+				}
+			}
+			if (chroma_weight_flag[i])
+			{
+				for (int j = 0; j < 2; j++)
+				{
+					int32_t delta_chroma_weight, delta_chroma_offset;
+					if (parser.ReadSEV(delta_chroma_weight) == false || parser.ReadSEV(delta_chroma_offset) == false)
+					{
+						return false;
+					}
+				}
+			}
+		}
+	}
+
+	return true;
+}
+
+// Ceil(Log2(n)) : minimum number of bits to represent values [0, n-1]
+static uint32_t CeilLog2(uint32_t n)
+{
+	uint32_t bits = 0;
+	while ((1u << bits) < n)
+	{
+		bits++;
+	}
+	return bits;
+}
+
+// Rec. ITU-T H.265 (V10), 7.3.6.1 General slice segment header syntax
+// Parses through byte_alignment() so that GetHeaderSizeInBytes() returns the exact
+// number of leading bytes (NAL header excluded) that must be left in the clear for
+// CENC subsample encryption.
+bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceHeader &shd, const std::shared_ptr<HEVCDecoderConfigurationRecord> &hvcc)
+{
+	if (hvcc == nullptr)
+	{
+		return false;
+	}
+
+	NalUnitBitstreamParser parser(nalu, length);
+
+	H265NalUnitHeader nal_header;
+	if (ParseNalUnitHeader(parser, nal_header) == false)
+	{
+		return false;
+	}
+
+	if (nal_header.IsVideoSlice() == false)
+	{
+		return false;
+	}
+
+	const auto nal_type = nal_header.GetNalUnitType();
+	const uint8_t nal_type_num = ov::ToUnderlyingType(nal_type);
+	const bool is_irap = (nal_type_num >= 16 && nal_type_num <= 23);
+	const bool is_idr = (nal_type == H265NALUnitType::IDR_W_RADL || nal_type == H265NALUnitType::IDR_N_LP);
+
+	uint8_t H265_READ_BITS(first_slice_segment_in_pic_flag, 1);
+
+	if (is_irap)
+	{
+		uint8_t H265_READ_BITS(no_output_of_prior_pics_flag, 1);
+		(void)no_output_of_prior_pics_flag;
+	}
+
+	uint32_t H265_READ_UEV(slice_pic_parameter_set_id);
+
+	H265PPS pps;
+	if (hvcc->GetPPS(slice_pic_parameter_set_id, pps) == false)
+	{
+		logte("H265 slice header: PPS(%u) not found", slice_pic_parameter_set_id);
+		return false;
+	}
+
+	H265SPS sps;
+	if (hvcc->GetSPS(pps.pps_seq_parameter_set_id, sps) == false)
+	{
+		logte("H265 slice header: SPS(%u) not found", pps.pps_seq_parameter_set_id);
+		return false;
+	}
+
+	// Fail-safe: range/SCC extension PPS may add conditional slice syntax that is not
+	// handled here. Refuse rather than risk miscomputing the header size.
+	if (pps.pps_range_extension_flag || pps.pps_scc_extension_flag)
+	{
+		logtw("H265 slice header: range/SCC extension is not supported for CENC subsample encryption");
+		return false;
+	}
+
+	const uint32_t chroma_array_type = sps.GetChromaArrayType();
+
+	uint8_t dependent_slice_segment_flag = 0;
+	if (first_slice_segment_in_pic_flag == 0)
+	{
+		if (pps.dependent_slice_segments_enabled_flag)
+		{
+			(void)H265_READ_BITS(dependent_slice_segment_flag, 1);
+		}
+
+		const uint32_t addr_bits = CeilLog2(sps.GetPicSizeInCtbsY());
+		if (addr_bits > 0)
+		{
+			uint32_t H265_READ_BITS(slice_segment_address, addr_bits);
+			(void)slice_segment_address;
+		}
+	}
+
+	if (dependent_slice_segment_flag == 0)
+	{
+		for (uint8_t i = 0; i < pps.num_extra_slice_header_bits; i++)
+		{
+			uint8_t H265_READ_BITS(slice_reserved_flag, 1);
+			(void)slice_reserved_flag;
+		}
+
+		uint32_t H265_READ_UEV(slice_type);
+		shd._slice_type = slice_type;
+
+		// slice_type : 0 = B, 1 = P, 2 = I
+		const bool is_p_or_b = (slice_type == 0 || slice_type == 1);
+		const bool is_b = (slice_type == 0);
+
+		if (pps.output_flag_present_flag)
+		{
+			uint8_t H265_READ_BITS(pic_output_flag, 1);
+			(void)pic_output_flag;
+		}
+
+		if (sps._separate_colour_plane_flag == 1)
+		{
+			uint8_t H265_READ_BITS(colour_plane_id, 2);
+			(void)colour_plane_id;
+		}
+
+		uint8_t slice_temporal_mvp_enabled_flag = 0;
+		uint32_t num_pic_total_curr = 0;
+
+		if (is_idr == false)
+		{
+			uint32_t H265_READ_BITS(slice_pic_order_cnt_lsb, sps._log2_max_pic_order_cnt_lsb_minus4 + 4);
+			(void)slice_pic_order_cnt_lsb;
+
+			uint8_t H265_READ_BITS(short_term_ref_pic_set_sps_flag, 1);
+
+			ShortTermRefPicSet current_strps;
+			bool current_strps_valid = false;
+
+			if (short_term_ref_pic_set_sps_flag == 0)
+			{
+				// st_ref_pic_set(num_short_term_ref_pic_sets)
+				std::vector<ShortTermRefPicSet> rpset_list = sps._short_term_ref_pic_sets;
+				rpset_list.resize(sps._num_short_term_ref_pic_sets + 1);
+				if (ProcessShortTermRefPicSet(sps._num_short_term_ref_pic_sets, sps._num_short_term_ref_pic_sets, rpset_list, parser, rpset_list[sps._num_short_term_ref_pic_sets]) == false)
+				{
+					return false;
+				}
+				current_strps = rpset_list[sps._num_short_term_ref_pic_sets];
+				current_strps_valid = true;
+			}
+			else if (sps._num_short_term_ref_pic_sets > 1)
+			{
+				uint32_t H265_READ_BITS(short_term_ref_pic_set_idx, CeilLog2(sps._num_short_term_ref_pic_sets));
+				if (short_term_ref_pic_set_idx < sps._short_term_ref_pic_sets.size())
+				{
+					current_strps = sps._short_term_ref_pic_sets[short_term_ref_pic_set_idx];
+					current_strps_valid = true;
+				}
+			}
+			else if (sps._num_short_term_ref_pic_sets == 1)
+			{
+				current_strps = sps._short_term_ref_pic_sets[0];
+				current_strps_valid = true;
+			}
+
+			if (current_strps_valid)
+			{
+				if (current_strps.inter_ref_pic_set_prediction_flag)
+				{
+					// NumPicTotalCurr derivation for an inter-predicted current RPS is not
+					// implemented; it is only required when list modification is present.
+					if (pps.lists_modification_present_flag)
+					{
+						logtw("H265 slice header: inter-predicted RPS with list modification is not supported for CENC");
+						return false;
+					}
+				}
+				else
+				{
+					for (auto f : current_strps.used_by_curr_pic_s0_flag)
+					{
+						if (f)
+						{
+							num_pic_total_curr++;
+						}
+					}
+					for (auto f : current_strps.used_by_curr_pic_s1_flag)
+					{
+						if (f)
+						{
+							num_pic_total_curr++;
+						}
+					}
+				}
+			}
+
+			if (sps._long_term_ref_pics_present_flag)
+			{
+				uint32_t num_long_term_sps = 0;
+				if (sps._num_long_term_ref_pics_sps > 0)
+				{
+					(void)H265_READ_UEV(num_long_term_sps);
+				}
+				uint32_t H265_READ_UEV(num_long_term_pics);
+				const uint32_t num_long_term = num_long_term_sps + num_long_term_pics;
+				const uint32_t lt_idx_sps_bits = CeilLog2(sps._num_long_term_ref_pics_sps);
+
+				for (uint32_t i = 0; i < num_long_term; i++)
+				{
+					uint8_t used_by_curr_pic_lt_flag = 0;
+					if (i < num_long_term_sps)
+					{
+						uint32_t lt_idx_sps = 0;
+						if (sps._num_long_term_ref_pics_sps > 1)
+						{
+							(void)H265_READ_BITS(lt_idx_sps, lt_idx_sps_bits);
+						}
+						if (lt_idx_sps < sps._used_by_curr_pic_lt_sps_flag.size())
+						{
+							used_by_curr_pic_lt_flag = sps._used_by_curr_pic_lt_sps_flag[lt_idx_sps];
+						}
+					}
+					else
+					{
+						uint32_t H265_READ_BITS(poc_lsb_lt, sps._log2_max_pic_order_cnt_lsb_minus4 + 4);
+						(void)poc_lsb_lt;
+						(void)H265_READ_BITS(used_by_curr_pic_lt_flag, 1);
+					}
+
+					if (used_by_curr_pic_lt_flag)
+					{
+						num_pic_total_curr++;
+					}
+
+					uint8_t H265_READ_BITS(delta_poc_msb_present_flag, 1);
+					if (delta_poc_msb_present_flag)
+					{
+						uint32_t H265_READ_UEV(delta_poc_msb_cycle_lt);
+						(void)delta_poc_msb_cycle_lt;
+					}
+				}
+			}
+
+			if (sps._sps_temporal_mvp_enabled_flag)
+			{
+				(void)H265_READ_BITS(slice_temporal_mvp_enabled_flag, 1);
+			}
+		}
+
+		uint8_t slice_sao_luma_flag = 0;
+		uint8_t slice_sao_chroma_flag = 0;
+		if (sps._sample_adaptive_offset_enabled_flag)
+		{
+			(void)H265_READ_BITS(slice_sao_luma_flag, 1);
+			if (chroma_array_type != 0)
+			{
+				(void)H265_READ_BITS(slice_sao_chroma_flag, 1);
+			}
+		}
+
+		// When not overridden below, slice_deblocking_filter_disabled_flag is inferred to be
+		// equal to pps_deblocking_filter_disabled_flag (Rec. ITU-T H.265 7.4.7.1).
+		uint8_t slice_deblocking_filter_disabled_flag = pps.pps_deblocking_filter_disabled_flag;
+
+		if (is_p_or_b)
+		{
+			uint32_t num_ref_idx_l0_active_minus1 = pps.num_ref_idx_l0_default_active_minus1;
+			uint32_t num_ref_idx_l1_active_minus1 = pps.num_ref_idx_l1_default_active_minus1;
+
+			uint8_t H265_READ_BITS(num_ref_idx_active_override_flag, 1);
+			if (num_ref_idx_active_override_flag)
+			{
+				(void)H265_READ_UEV(num_ref_idx_l0_active_minus1);
+				if (is_b)
+				{
+					(void)H265_READ_UEV(num_ref_idx_l1_active_minus1);
+				}
+			}
+
+			// ref_pic_lists_modification()
+			if (pps.lists_modification_present_flag && num_pic_total_curr > 1)
+			{
+				const uint32_t list_entry_bits = CeilLog2(num_pic_total_curr);
+
+				uint8_t H265_READ_BITS(ref_pic_list_modification_flag_l0, 1);
+				if (ref_pic_list_modification_flag_l0)
+				{
+					for (uint32_t i = 0; i <= num_ref_idx_l0_active_minus1; i++)
+					{
+						uint32_t H265_READ_BITS(list_entry_l0, list_entry_bits);
+						(void)list_entry_l0;
+					}
+				}
+
+				if (is_b)
+				{
+					uint8_t H265_READ_BITS(ref_pic_list_modification_flag_l1, 1);
+					if (ref_pic_list_modification_flag_l1)
+					{
+						for (uint32_t i = 0; i <= num_ref_idx_l1_active_minus1; i++)
+						{
+							uint32_t H265_READ_BITS(list_entry_l1, list_entry_bits);
+							(void)list_entry_l1;
+						}
+					}
+				}
+			}
+
+			if (is_b)
+			{
+				uint8_t H265_READ_BITS(mvd_l1_zero_flag, 1);
+				(void)mvd_l1_zero_flag;
+			}
+
+			if (pps.cabac_init_present_flag)
+			{
+				uint8_t H265_READ_BITS(cabac_init_flag, 1);
+				(void)cabac_init_flag;
+			}
+
+			if (slice_temporal_mvp_enabled_flag)
+			{
+				uint8_t collocated_from_l0_flag = 1;
+				if (is_b)
+				{
+					(void)H265_READ_BITS(collocated_from_l0_flag, 1);
+				}
+
+				const uint32_t collocated_list_ref = collocated_from_l0_flag ? num_ref_idx_l0_active_minus1 : num_ref_idx_l1_active_minus1;
+				if (collocated_list_ref > 0)
+				{
+					uint32_t H265_READ_UEV(collocated_ref_idx);
+					(void)collocated_ref_idx;
+				}
+			}
+
+			if ((pps.weighted_pred_flag && slice_type == 1 /* P */) ||
+				(pps.weighted_bipred_flag && is_b))
+			{
+				if (ProcessPredWeightTable(parser, chroma_array_type, num_ref_idx_l0_active_minus1, num_ref_idx_l1_active_minus1, is_b) == false)
+				{
+					return false;
+				}
+			}
+
+			uint32_t H265_READ_UEV(five_minus_max_num_merge_cand);
+			(void)five_minus_max_num_merge_cand;
+
+			// use_integer_mv_flag (SCC) is omitted; SCC PPS is fail-safed above.
+		}
+
+		int32_t H265_READ_SEV(slice_qp_delta);
+		(void)slice_qp_delta;
+
+		if (pps.pps_slice_chroma_qp_offsets_present_flag)
+		{
+			int32_t H265_READ_SEV(slice_cb_qp_offset);
+			(void)slice_cb_qp_offset;
+			int32_t H265_READ_SEV(slice_cr_qp_offset);
+			(void)slice_cr_qp_offset;
+		}
+
+		// pps_slice_act_qp_offsets (SCC) and cu_chroma_qp_offset (range ext) omitted; fail-safed above.
+
+		uint8_t deblocking_filter_override_flag = 0;
+		if (pps.deblocking_filter_override_enabled_flag)
+		{
+			(void)H265_READ_BITS(deblocking_filter_override_flag, 1);
+		}
+		if (deblocking_filter_override_flag)
+		{
+			(void)H265_READ_BITS(slice_deblocking_filter_disabled_flag, 1);
+			if (slice_deblocking_filter_disabled_flag == 0)
+			{
+				int32_t H265_READ_SEV(slice_beta_offset_div2);
+				(void)slice_beta_offset_div2;
+				int32_t H265_READ_SEV(slice_tc_offset_div2);
+				(void)slice_tc_offset_div2;
+			}
+		}
+
+		if (pps.pps_loop_filter_across_slices_enabled_flag &&
+			(slice_sao_luma_flag || slice_sao_chroma_flag || slice_deblocking_filter_disabled_flag == 0))
+		{
+			uint8_t H265_READ_BITS(slice_loop_filter_across_slices_enabled_flag, 1);
+			(void)slice_loop_filter_across_slices_enabled_flag;
+		}
+	}
+
+	if (pps.tiles_enabled_flag || pps.entropy_coding_sync_enabled_flag)
+	{
+		uint32_t H265_READ_UEV(num_entry_point_offsets);
+		if (num_entry_point_offsets > 0)
+		{
+			uint32_t H265_READ_UEV(offset_len_minus1);
+			for (uint32_t i = 0; i < num_entry_point_offsets; i++)
+			{
+				uint32_t H265_READ_BITS(entry_point_offset_minus1, offset_len_minus1 + 1);
+				(void)entry_point_offset_minus1;
+			}
+		}
+	}
+
+	if (pps.slice_segment_header_extension_present_flag)
+	{
+		uint32_t H265_READ_UEV(slice_segment_header_extension_length);
+		for (uint32_t i = 0; i < slice_segment_header_extension_length; i++)
+		{
+			uint8_t H265_READ_BITS(slice_segment_header_extension_data_byte, 8);
+			(void)slice_segment_header_extension_data_byte;
+		}
+	}
+
+	// byte_alignment()
+	uint8_t H265_READ_BITS(alignment_bit_equal_to_one, 1);
+	(void)alignment_bit_equal_to_one;
+
+	// The remaining alignment_bit_equal_to_zero bits pad to the next byte boundary.
+	// GetHeaderSizeInBytes() rounds up, giving the raw byte length of [NAL header + slice header].
+	shd._header_size_in_bits = parser.BitsConsumed() - (H265_NAL_UNIT_HEADER_SIZE * 8);
 
 	return true;
 }
@@ -1910,7 +2436,9 @@ bool H265Parser::ProcessShortTermRefPicSet(uint32_t idx, uint32_t num_short_term
 
 	if (rpset.inter_ref_pic_set_prediction_flag == 1)
 	{
-		if (idx == rpset.inter_ref_pic_set_prediction_flag)
+		// delta_idx_minus1 is present only for the slice-level inline set,
+		// i.e. when stRpsIdx == num_short_term_ref_pic_sets (Rec. ITU-T H.265 7.3.7).
+		if (idx == num_short_term_ref_pic_sets)
 		{
 			if (parser.ReadUEV(rpset.delta_idx_minus1) == false)
 			{
@@ -1928,7 +2456,15 @@ bool H265Parser::ProcessShortTermRefPicSet(uint32_t idx, uint32_t num_short_term
 			return false;
 		}
 
+		// An inter-predicted RPS must reference a strictly earlier, already-parsed set
+		// (Rec. ITU-T H.265 7.4.8). ref_rps_idx is computed with unsigned arithmetic, so a
+		// malformed delta_idx_minus1 (>= idx) would underflow and index out of bounds; reject it.
 		uint32_t ref_rps_idx = idx - (rpset.delta_idx_minus1 + 1);
+		if (rpset.delta_idx_minus1 + 1 > idx || ref_rps_idx >= rpset_list.size())
+		{
+			return false;
+		}
+
 		uint32_t num_delta_pocs = 0;
 
 		if (rpset_list[ref_rps_idx].inter_ref_pic_set_prediction_flag)

--- a/src/modules/bitstream/h265/h265_parser.cpp
+++ b/src/modules/bitstream/h265/h265_parser.cpp
@@ -1379,7 +1379,8 @@ bool H265Parser::ProcessPredWeightTable(NalUnitBitstreamParser &parser, uint32_t
 static uint32_t CeilLog2(uint32_t n)
 {
 	uint32_t bits = 0;
-	while ((1u << bits) < n)
+	// Guard bits < 32
+	while (bits < 32 && (1u << bits) < n)
 	{
 		bits++;
 	}

--- a/src/modules/bitstream/h265/h265_parser.cpp
+++ b/src/modules/bitstream/h265/h265_parser.cpp
@@ -336,6 +336,14 @@ bool H265Parser::ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps)
 		return false;
 	}
 
+	if (sps_seq_parameter_set_id > H265_MAX_SPS_ID)
+	{
+		logte("H265 SPS: invalid sps_seq_parameter_set_id(%u)", sps_seq_parameter_set_id);
+		return false;
+	}
+
+	sps._id = sps_seq_parameter_set_id;
+
 	uint32_t chroma_format_idc;
 	if (parser.ReadUEV(chroma_format_idc) == false)
 	{
@@ -378,6 +386,14 @@ bool H265Parser::ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps)
 		return false;
 	}
 	sps._pic_height_in_luma_samples = pic_height_in_luma_samples;
+
+	// Bounded so GetPicSizeInCtbsY() cannot overflow (A.4.1).
+	if (pic_width_in_luma_samples == 0 || pic_width_in_luma_samples > H265_MAX_PIC_DIMENSION_IN_LUMA_SAMPLES ||
+		pic_height_in_luma_samples == 0 || pic_height_in_luma_samples > H265_MAX_PIC_DIMENSION_IN_LUMA_SAMPLES)
+	{
+		logte("H265 SPS: invalid picture size (%ux%u)", pic_width_in_luma_samples, pic_height_in_luma_samples);
+		return false;
+	}
 
 	uint8_t conformance_window_flag;
 	if (parser.ReadBits(1, conformance_window_flag) == false)
@@ -479,6 +495,14 @@ bool H265Parser::ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps)
 	{
 		return false;
 	}
+
+	// Value + 4 is used as a ReadBits() count (7.4.3.2.1).
+	if (log2_max_pic_order_cnt_lsb_minus4 > H265_MAX_LOG2_MAX_PIC_ORDER_CNT_LSB_MINUS4)
+	{
+		logte("H265 SPS: invalid log2_max_pic_order_cnt_lsb_minus4(%u)", log2_max_pic_order_cnt_lsb_minus4);
+		return false;
+	}
+
 	sps._log2_max_pic_order_cnt_lsb_minus4 = log2_max_pic_order_cnt_lsb_minus4;
 
 	uint8_t sps_sub_layer_ordering_info_present_flag;
@@ -666,6 +690,14 @@ bool H265Parser::ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps)
 	{
 		return false;
 	}
+
+	// 7.4.3.2.1
+	if (num_short_term_ref_pic_sets > H265_MAX_NUM_SHORT_TERM_REF_PIC_SETS)
+	{
+		logte("H265 SPS: invalid num_short_term_ref_pic_sets(%u)", num_short_term_ref_pic_sets);
+		return false;
+	}
+
 	sps._num_short_term_ref_pic_sets = num_short_term_ref_pic_sets;
 
 	std::vector<ShortTermRefPicSet> rpset_list(num_short_term_ref_pic_sets);
@@ -692,6 +724,14 @@ bool H265Parser::ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps)
 		{
 			return false;
 		}
+
+		// 7.4.3.2.1
+		if (num_long_term_ref_pics_sps > H265_MAX_NUM_LONG_TERM_REF_PICS_SPS)
+		{
+			logte("H265 SPS: invalid num_long_term_ref_pics_sps(%u)", num_long_term_ref_pics_sps);
+			return false;
+		}
+
 		sps._num_long_term_ref_pics_sps = num_long_term_ref_pics_sps;
 
 		sps._used_by_curr_pic_lt_sps_flag.resize(num_long_term_ref_pics_sps);
@@ -1175,6 +1215,14 @@ bool H265Parser::ParsePPS(const uint8_t *nalu, size_t length, H265PPS &pps)
 
 	(void)H265_READ_UEV(pps.pps_pic_parameter_set_id);
 	(void)H265_READ_UEV(pps.pps_seq_parameter_set_id);
+
+	if (pps.pps_pic_parameter_set_id > H265_MAX_PPS_ID || pps.pps_seq_parameter_set_id > H265_MAX_SPS_ID)
+	{
+		logte("H265 PPS: invalid parameter set id (pps: %u, sps: %u)",
+			  pps.pps_pic_parameter_set_id, pps.pps_seq_parameter_set_id);
+		return false;
+	}
+
 	uint8_t H265_READ_BITS(dependent_slice_segments_enabled_flag, 1);
 	pps.dependent_slice_segments_enabled_flag = dependent_slice_segments_enabled_flag;
 	uint8_t H265_READ_BITS(output_flag_present_flag, 1);
@@ -1185,8 +1233,18 @@ bool H265Parser::ParsePPS(const uint8_t *nalu, size_t length, H265PPS &pps)
 	uint8_t H265_READ_BITS(cabac_init_present_flag, 1);
 	pps.cabac_init_present_flag = cabac_init_present_flag;
 	uint32_t H265_READ_UEV(num_ref_idx_l0_default_active_minus1);
-	pps.num_ref_idx_l0_default_active_minus1 = num_ref_idx_l0_default_active_minus1;
 	uint32_t H265_READ_UEV(num_ref_idx_l1_default_active_minus1);
+
+	// Become loop bounds and vector sizes in the slice header (7.4.7.1).
+	if (num_ref_idx_l0_default_active_minus1 > H265_MAX_NUM_REF_IDX_ACTIVE_MINUS1 ||
+		num_ref_idx_l1_default_active_minus1 > H265_MAX_NUM_REF_IDX_ACTIVE_MINUS1)
+	{
+		logte("H265 PPS: invalid num_ref_idx_default_active_minus1 (l0: %u, l1: %u)",
+			  num_ref_idx_l0_default_active_minus1, num_ref_idx_l1_default_active_minus1);
+		return false;
+	}
+
+	pps.num_ref_idx_l0_default_active_minus1 = num_ref_idx_l0_default_active_minus1;
 	pps.num_ref_idx_l1_default_active_minus1 = num_ref_idx_l1_default_active_minus1;
 	int32_t H265_READ_SEV(init_qp_minus26);
 	uint8_t H265_READ_BITS(constrained_intra_pred_flag, 1);
@@ -1308,6 +1366,13 @@ bool H265Parser::ParsePPS(const uint8_t *nalu, size_t length, H265PPS &pps)
 // Rec. ITU-T H.265 (V10), 7.3.6.3 Weighted prediction parameters syntax
 bool H265Parser::ProcessPredWeightTable(NalUnitBitstreamParser &parser, uint32_t chroma_array_type, uint32_t num_ref_idx_l0_active_minus1, uint32_t num_ref_idx_l1_active_minus1, bool is_b_slice)
 {
+	// Sizes the vectors below (7.4.7.1).
+	if (num_ref_idx_l0_active_minus1 > H265_MAX_NUM_REF_IDX_ACTIVE_MINUS1 ||
+		num_ref_idx_l1_active_minus1 > H265_MAX_NUM_REF_IDX_ACTIVE_MINUS1)
+	{
+		return false;
+	}
+
 	uint32_t luma_log2_weight_denom;
 	if (parser.ReadUEV(luma_log2_weight_denom) == false)
 	{
@@ -1393,6 +1458,8 @@ static uint32_t CeilLog2(uint32_t n)
 // CENC subsample encryption.
 bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceHeader &shd, const std::shared_ptr<HEVCDecoderConfigurationRecord> &hvcc)
 {
+	shd = H265SliceHeader();
+
 	if (hvcc == nullptr)
 	{
 		return false;
@@ -1444,7 +1511,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 	// handled here. Refuse rather than risk miscomputing the header size.
 	if (pps->pps_range_extension_flag || pps->pps_scc_extension_flag)
 	{
-		logtw("H265 slice header: range/SCC extension is not supported for CENC subsample encryption");
+		logtd("H265 slice header: range/SCC extension is not supported for CENC subsample encryption");
 		return false;
 	}
 
@@ -1463,7 +1530,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 		const uint32_t pic_size_in_ctbs_y = sps->GetPicSizeInCtbsY();
 		if (pic_size_in_ctbs_y == 0)
 		{
-			logtw("H265 slice header: invalid PicSizeInCtbsY(%u)", pic_size_in_ctbs_y);
+			logtd("H265 slice header: invalid PicSizeInCtbsY(%u)", pic_size_in_ctbs_y);
 			return false;
 		}
 
@@ -1488,7 +1555,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 		// slice_type : 0 = B, 1 = P, 2 = I. Values > 2 are invalid
 		if (slice_type > 2)
 		{
-			logtw("H265 slice header: invalid slice_type(%u)", slice_type);
+			logtd("H265 slice header: invalid slice_type(%u)", slice_type);
 			return false;
 		}
 		shd._slice_type = slice_type;
@@ -1558,7 +1625,7 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 					// implemented; it is only required when list modification is present.
 					if (pps->lists_modification_present_flag)
 					{
-						logtw("H265 slice header: inter-predicted RPS with list modification is not supported for CENC");
+						logtd("H265 slice header: inter-predicted RPS with list modification is not supported for CENC");
 						return false;
 					}
 				}
@@ -1589,6 +1656,16 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 					(void)H265_READ_UEV(num_long_term_sps);
 				}
 				uint32_t H265_READ_UEV(num_long_term_pics);
+				// Each is checked before the sum so the sum cannot wrap (7.4.7.1).
+				if (num_long_term_sps > sps->_num_long_term_ref_pics_sps ||
+					num_long_term_pics > H265_MAX_DPB_SIZE ||
+					(num_long_term_sps + num_long_term_pics) > H265_MAX_DPB_SIZE)
+				{
+					logtd("H265 slice header: invalid long-term ref count (sps: %u, pics: %u)",
+						  num_long_term_sps, num_long_term_pics);
+					return false;
+				}
+
 				const uint32_t num_long_term = num_long_term_sps + num_long_term_pics;
 				const uint32_t lt_idx_sps_bits = CeilLog2(sps->_num_long_term_ref_pics_sps);
 
@@ -1602,10 +1679,15 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 						{
 							(void)H265_READ_BITS(lt_idx_sps, lt_idx_sps_bits);
 						}
-						if (lt_idx_sps < sps->_used_by_curr_pic_lt_sps_flag.size())
+						// Read with Ceil(Log2(num_long_term_ref_pics_sps)) bits, so an
+						// out-of-range index is representable (7.4.7.1).
+						if (lt_idx_sps >= sps->_used_by_curr_pic_lt_sps_flag.size())
 						{
-							used_by_curr_pic_lt_flag = sps->_used_by_curr_pic_lt_sps_flag[lt_idx_sps];
+							logtd("H265 slice header: invalid lt_idx_sps(%u)", lt_idx_sps);
+							return false;
 						}
+
+						used_by_curr_pic_lt_flag = sps->_used_by_curr_pic_lt_sps_flag[lt_idx_sps];
 					}
 					else
 					{
@@ -1661,6 +1743,15 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 				if (is_b)
 				{
 					(void)H265_READ_UEV(num_ref_idx_l1_active_minus1);
+				}
+
+				// Drive the loops below and the pred_weight_table() vector sizes (7.4.7.1).
+				if (num_ref_idx_l0_active_minus1 > H265_MAX_NUM_REF_IDX_ACTIVE_MINUS1 ||
+					num_ref_idx_l1_active_minus1 > H265_MAX_NUM_REF_IDX_ACTIVE_MINUS1)
+				{
+					logtd("H265 slice header: invalid num_ref_idx_active_minus1 (l0: %u, l1: %u)",
+						  num_ref_idx_l0_active_minus1, num_ref_idx_l1_active_minus1);
+					return false;
 				}
 			}
 
@@ -1780,9 +1871,18 @@ bool H265Parser::ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceH
 		if (num_entry_point_offsets > 0)
 		{
 			uint32_t H265_READ_UEV(offset_len_minus1);
+
+			// Used as a ReadBits() count (7.4.7.1).
+			if (offset_len_minus1 > H265_MAX_OFFSET_LEN_MINUS1)
+			{
+				logtd("H265 slice header: invalid offset_len_minus1(%u)", offset_len_minus1);
+				return false;
+			}
+
+			const uint8_t offset_len = static_cast<uint8_t>(offset_len_minus1 + 1);
 			for (uint32_t i = 0; i < num_entry_point_offsets; i++)
 			{
-				uint32_t H265_READ_BITS(entry_point_offset_minus1, offset_len_minus1 + 1);
+				uint32_t H265_READ_BITS(entry_point_offset_minus1, offset_len);
 				(void)entry_point_offset_minus1;
 			}
 		}
@@ -2528,6 +2628,15 @@ bool H265Parser::ProcessShortTermRefPicSet(uint32_t idx, uint32_t num_short_term
 	{
 		if (parser.ReadUEV(rpset.num_negative_pics) == false || parser.ReadUEV(rpset.num_positive_pics) == false)
 		{
+			return false;
+		}
+
+		// The sum becomes NumDeltaPocs for a later set (7.4.8).
+		if (rpset.num_negative_pics > H265_MAX_DPB_SIZE || rpset.num_positive_pics > H265_MAX_DPB_SIZE ||
+			(rpset.num_negative_pics + rpset.num_positive_pics) > H265_MAX_DPB_SIZE)
+		{
+			logtd("H265 st_ref_pic_set: invalid ref pic count (negative: %u, positive: %u)",
+				  rpset.num_negative_pics, rpset.num_positive_pics);
 			return false;
 		}
 

--- a/src/modules/bitstream/h265/h265_parser.h
+++ b/src/modules/bitstream/h265/h265_parser.h
@@ -118,44 +118,8 @@ struct H265VPS
 	uint8_t vps_video_parameter_set_id;
 };
 
-// Sequence Parameter Set (Rec. ITU-T H.265, 7.3.2.2)
-// Sequence-level parameters shared by every picture that references this SPS.
-// Variable-length bitstream: u(n)=n bits, ue(v)=Exp-Golomb unsigned, se(v)=signed. '*' = stored by OME.
-//
-//   syntax element                                | desc  | present when
-//   ----------------------------------------------|-------|-------------------------------------
-//   sps_video_parameter_set_id                    | u(4)  |
-//   sps_max_sub_layers_minus1                     | u(3)  | *
-//   sps_temporal_id_nesting_flag                  | u(1)  | *
-//   profile_tier_level()                          |  ...  | *  (profile/tier/level, 7.3.3)
-//   sps_seq_parameter_set_id                      | ue(v) |
-//   chroma_format_idc                             | ue(v) | *
-//   separate_colour_plane_flag                    | u(1)  | *  chroma_format_idc == 3
-//   pic_width_in_luma_samples                     | ue(v) | *
-//   pic_height_in_luma_samples                    | ue(v) | *
-//   conformance_window_flag                       | u(1)  |
-//     conf_win_{left,right,top,bottom}_offset     | ue(v) |    if conformance_window_flag
-//   bit_depth_luma_minus8                         | ue(v) | *
-//   bit_depth_chroma_minus8                       | ue(v) | *
-//   log2_max_pic_order_cnt_lsb_minus4             | ue(v) | *
-//   sps_sub_layer_ordering_info_present_flag      | u(1)  |
-//     max_dec_pic_buffering/reorder/latency[i]    | ue(v) |    per sub-layer
-//   log2_min_luma_coding_block_size_minus3        | ue(v) | *  -.
-//   log2_diff_max_min_luma_coding_block_size      | ue(v) | *  -'-> CtbSizeY / PicSizeInCtbsY
-//   log2_min/diff_max_min transform block size    | ue(v) |
-//   max_transform_hierarchy_depth_inter/intra     | ue(v) |
-//   scaling_list_enabled_flag [+ scaling_list()]  | u(1)  |
-//   amp_enabled_flag                              | u(1)  |
-//   sample_adaptive_offset_enabled_flag           | u(1)  | *
-//   pcm_enabled_flag [+ pcm params]               | u(1)  |
-//   num_short_term_ref_pic_sets                   | ue(v) | *
-//     st_ref_pic_set(i)                           |  ...  | *  loop, 7.3.7
-//   long_term_ref_pics_present_flag               | u(1)  | *
-//     num_long_term_ref_pics_sps [+ lt entries]   | ue(v) | *  if long_term_ref_pics_present
-//   sps_temporal_mvp_enabled_flag                 | u(1)  | *
-//   strong_intra_smoothing_enabled_flag           | u(1)  |
-//   vui_parameters_present_flag [+ vui()]         | u(1)  | *  VUI -> frame rate, SAR
-//   sps_extension_flag                            | u(1)  |
+// Sequence Parameter Set (Rec. ITU-T H.265 7.3.2.2)
+// Only the fields needed to parse the slice segment header (7.3.6.1) are retained.
 class H265SPS
 {
 public:
@@ -288,45 +252,8 @@ private:
     friend class H265Parser;
 };
 
-// Picture Parameter Set (Rec. ITU-T H.265, 7.3.2.3)
-// Picture-level parameters. u(n)=n bits, ue(v)=Exp-Golomb unsigned, se(v)=signed. '*' = stored by OME
-// (the stored flags are exactly those needed to know which slice_segment_header elements are present).
-//
-//   syntax element                                | desc  | present when
-//   ----------------------------------------------|-------|-------------------------------------
-//   pps_pic_parameter_set_id                      | ue(v) | *
-//   pps_seq_parameter_set_id                      | ue(v) | *  -> SPS
-//   dependent_slice_segments_enabled_flag         | u(1)  | *
-//   output_flag_present_flag                      | u(1)  | *
-//   num_extra_slice_header_bits                   | u(3)  | *
-//   sign_data_hiding_enabled_flag                 | u(1)  |
-//   cabac_init_present_flag                       | u(1)  | *
-//   num_ref_idx_l0_default_active_minus1          | ue(v) | *
-//   num_ref_idx_l1_default_active_minus1          | ue(v) | *
-//   init_qp_minus26                               | se(v) |
-//   constrained_intra_pred_flag                   | u(1)  |
-//   transform_skip_enabled_flag                   | u(1)  |
-//   cu_qp_delta_enabled_flag [+ diff_cu_qp_depth] | u(1)  |
-//   pps_cb_qp_offset / pps_cr_qp_offset           | se(v) |
-//   pps_slice_chroma_qp_offsets_present_flag      | u(1)  | *
-//   weighted_pred_flag                            | u(1)  | *
-//   weighted_bipred_flag                          | u(1)  | *
-//   transquant_bypass_enabled_flag                | u(1)  |
-//   tiles_enabled_flag                            | u(1)  | *
-//   entropy_coding_sync_enabled_flag              | u(1)  | *
-//     tile columns/rows params                    | ue(v) |    if tiles_enabled_flag
-//   pps_loop_filter_across_slices_enabled_flag    | u(1)  | *
-//   deblocking_filter_control_present_flag        | u(1)  |
-//     deblocking_filter_override_enabled_flag     | u(1)  | *
-//     pps_deblocking_filter_disabled_flag         | u(1)  | *
-//     pps_beta_offset_div2 / pps_tc_offset_div2   | se(v) |    if !pps_deblocking_filter_disabled
-//   pps_scaling_list_data_present_flag [+ data]   | u(1)  |
-//   lists_modification_present_flag               | u(1)  | *
-//   log2_parallel_merge_level_minus2              | ue(v) |
-//   slice_segment_header_extension_present_flag   | u(1)  | *
-//   pps_extension_present_flag                    | u(1)  |
-//     pps_range_extension_flag                    | u(1)  | *  fail-safed (not parsed)
-//     pps_scc_extension_flag                      | u(1)  | *  fail-safed (not parsed)
+// Picture Parameter Set (Rec. ITU-T H.265 7.3.2.3)
+// Only the flags needed to know which slice_segment_header elements are present are retained.
 struct H265PPS
 {
 public:
@@ -367,23 +294,8 @@ public:
 	uint8_t pps_scc_extension_flag = 0;
 };
 
-// Slice segment header (Rec. ITU-T H.265, 7.3.6.1)
-// H265Parser::ParseSliceHeader walks the header (in the order below) through byte_alignment() to
-// measure its size; only slice_type and the header size are retained ('*'). u(v) lengths shown inline.
-//
-//   syntax element                                | desc  | present when
-//   ----------------------------------------------|-------|-------------------------------------
-//   first_slice_segment_in_pic_flag               | u(1)  |
-//   no_output_of_prior_pics_flag                  | u(1)  | IRAP NAL (type 16..23)
-//   slice_pic_parameter_set_id                    | ue(v) |    -> PPS/SPS
-//   dependent_slice_segment_flag                  | u(1)  | !first && dependent_slices_enabled
-//   slice_segment_address                         | u(v)  | !first; v=Ceil(Log2(PicSizeInCtbsY))
-//   --- following present only if !dependent_slice_segment_flag ---
-//   slice_reserved_flag[i]                        | u(1)  | i < num_extra_slice_header_bits
-//   slice_type                                    | ue(v) | *  0=B, 1=P, 2=I
-//   pic_output_flag                               | u(1)  | output_flag_present
-//   colour_plane_id                               | u(2)  | separate_colour_plane
-// ....(omitted)....
+// Slice segment header (Rec. ITU-T H.265 7.3.6.1)
+// ParseSliceHeader walks it through byte_alignment() to measure the header size in bytes.
 class H265SliceHeader
 {
 public:

--- a/src/modules/bitstream/h265/h265_parser.h
+++ b/src/modules/bitstream/h265/h265_parser.h
@@ -241,11 +241,14 @@ public:
 	{
 		const uint32_t min_cb_log2_size_y = _log2_min_luma_coding_block_size_minus3 + 3;
 		const uint32_t ctb_log2_size_y = min_cb_log2_size_y + _log2_diff_max_min_luma_coding_block_size;
-		const uint32_t ctb_size_y = 1u << ctb_log2_size_y;
-		if (ctb_size_y == 0)
+
+		// CtbLog2SizeY is 4..6 for conformant streams (Rec. ITU-T H.265 7.4.3.2.1; CtbSizeY in {16,32,64}).
+		if (ctb_log2_size_y < 4 || ctb_log2_size_y > 6)
 		{
 			return 0;
 		}
+
+		const uint32_t ctb_size_y = 1u << ctb_log2_size_y;
 		const uint32_t pic_width_in_ctbs_y = (_pic_width_in_luma_samples + ctb_size_y - 1) / ctb_size_y;
 		const uint32_t pic_height_in_ctbs_y = (_pic_height_in_luma_samples + ctb_size_y - 1) / ctb_size_y;
 		return pic_width_in_ctbs_y * pic_height_in_ctbs_y;

--- a/src/modules/bitstream/h265/h265_parser.h
+++ b/src/modules/bitstream/h265/h265_parser.h
@@ -1,6 +1,11 @@
-// I developed the code of this file by referring to the source code of virinext's hevcsbrowser (https://github.com/virinext/hevcesbrowser). 
+// I developed the code of this file by referring to the source code of virinext's hevcsbrowser (https://github.com/virinext/hevcesbrowser).
 // Thanks to virinext.
 // - Getroot
+//
+// Bitstream syntax and semantics follow Rec. ITU-T H.265 (HEVC) | ISO/IEC 23008-2.
+// Standard document (all versions): https://www.itu.int/rec/T-REC-H.265
+// The section numbers cited throughout this file (e.g. 7.3.2.2 SPS, 7.3.2.3 PPS,
+// 7.3.6.1 slice_segment_header) refer to that specification.
 
 #pragma once
 
@@ -79,6 +84,13 @@ public:
         return _type;
     }
 
+	// VCL NAL units (coded slice segments) have NAL unit type in the range [0, 31].
+	// Rec. ITU-T H.265 Table 7-1.
+	bool IsVideoSlice() const
+	{
+		return ov::ToUnderlyingType(_type) <= 31;
+	}
+
     uint8_t GetLayerId()
     {
         return _layer_id;
@@ -106,6 +118,44 @@ struct H265VPS
 	uint8_t vps_video_parameter_set_id;
 };
 
+// Sequence Parameter Set (Rec. ITU-T H.265, 7.3.2.2)
+// Sequence-level parameters shared by every picture that references this SPS.
+// Variable-length bitstream: u(n)=n bits, ue(v)=Exp-Golomb unsigned, se(v)=signed. '*' = stored by OME.
+//
+//   syntax element                                | desc  | present when
+//   ----------------------------------------------|-------|-------------------------------------
+//   sps_video_parameter_set_id                    | u(4)  |
+//   sps_max_sub_layers_minus1                     | u(3)  | *
+//   sps_temporal_id_nesting_flag                  | u(1)  | *
+//   profile_tier_level()                          |  ...  | *  (profile/tier/level, 7.3.3)
+//   sps_seq_parameter_set_id                      | ue(v) |
+//   chroma_format_idc                             | ue(v) | *
+//   separate_colour_plane_flag                    | u(1)  | *  chroma_format_idc == 3
+//   pic_width_in_luma_samples                     | ue(v) | *
+//   pic_height_in_luma_samples                    | ue(v) | *
+//   conformance_window_flag                       | u(1)  |
+//     conf_win_{left,right,top,bottom}_offset     | ue(v) |    if conformance_window_flag
+//   bit_depth_luma_minus8                         | ue(v) | *
+//   bit_depth_chroma_minus8                       | ue(v) | *
+//   log2_max_pic_order_cnt_lsb_minus4             | ue(v) | *
+//   sps_sub_layer_ordering_info_present_flag      | u(1)  |
+//     max_dec_pic_buffering/reorder/latency[i]    | ue(v) |    per sub-layer
+//   log2_min_luma_coding_block_size_minus3        | ue(v) | *  -.
+//   log2_diff_max_min_luma_coding_block_size      | ue(v) | *  -'-> CtbSizeY / PicSizeInCtbsY
+//   log2_min/diff_max_min transform block size    | ue(v) |
+//   max_transform_hierarchy_depth_inter/intra     | ue(v) |
+//   scaling_list_enabled_flag [+ scaling_list()]  | u(1)  |
+//   amp_enabled_flag                              | u(1)  |
+//   sample_adaptive_offset_enabled_flag           | u(1)  | *
+//   pcm_enabled_flag [+ pcm params]               | u(1)  |
+//   num_short_term_ref_pic_sets                   | ue(v) | *
+//     st_ref_pic_set(i)                           |  ...  | *  loop, 7.3.7
+//   long_term_ref_pics_present_flag               | u(1)  | *
+//     num_long_term_ref_pics_sps [+ lt entries]   | ue(v) | *  if long_term_ref_pics_present
+//   sps_temporal_mvp_enabled_flag                 | u(1)  | *
+//   strong_intra_smoothing_enabled_flag           | u(1)  |
+//   vui_parameters_present_flag [+ vui()]         | u(1)  | *  VUI -> frame rate, SAR
+//   sps_extension_flag                            | u(1)  |
 class H265SPS
 {
 public:
@@ -180,6 +230,27 @@ public:
         return out_str;
     }
 
+	// ChromaArrayType (Rec. ITU-T H.265 eq. 7-10)
+	uint32_t GetChromaArrayType() const
+	{
+		return (_separate_colour_plane_flag == 1) ? 0 : _chroma_format_idc;
+	}
+
+	// PicSizeInCtbsY (Rec. ITU-T H.265 eq. 7-15..7-20) - used to size slice_segment_address.
+	uint32_t GetPicSizeInCtbsY() const
+	{
+		const uint32_t min_cb_log2_size_y = _log2_min_luma_coding_block_size_minus3 + 3;
+		const uint32_t ctb_log2_size_y = min_cb_log2_size_y + _log2_diff_max_min_luma_coding_block_size;
+		const uint32_t ctb_size_y = 1u << ctb_log2_size_y;
+		if (ctb_size_y == 0)
+		{
+			return 0;
+		}
+		const uint32_t pic_width_in_ctbs_y = (_pic_width_in_luma_samples + ctb_size_y - 1) / ctb_size_y;
+		const uint32_t pic_height_in_ctbs_y = (_pic_height_in_luma_samples + ctb_size_y - 1) / ctb_size_y;
+		return pic_width_in_ctbs_y * pic_height_in_ctbs_y;
+	}
+
 private:
     unsigned int _width = 0;
     unsigned int _height = 0;
@@ -196,9 +267,63 @@ private:
 	uint32_t _bit_depth_luma_minus8 = 0;
 	uint32_t _bit_depth_chroma_minus8 = 0;
 
+	// Fields required to parse the slice_segment_header (Rec. ITU-T H.265 7.3.6.1)
+	uint8_t _separate_colour_plane_flag = 0;
+	uint32_t _pic_width_in_luma_samples = 0;
+	uint32_t _pic_height_in_luma_samples = 0;
+	uint32_t _log2_min_luma_coding_block_size_minus3 = 0;
+	uint32_t _log2_diff_max_min_luma_coding_block_size = 0;
+	uint32_t _log2_max_pic_order_cnt_lsb_minus4 = 0;
+	uint8_t _sample_adaptive_offset_enabled_flag = 0;
+	uint8_t _sps_temporal_mvp_enabled_flag = 0;
+	uint8_t _long_term_ref_pics_present_flag = 0;
+	uint32_t _num_long_term_ref_pics_sps = 0;
+	std::vector<uint8_t> _used_by_curr_pic_lt_sps_flag;
+	uint32_t _num_short_term_ref_pic_sets = 0;
+	std::vector<ShortTermRefPicSet> _short_term_ref_pic_sets;
+
     friend class H265Parser;
 };
 
+// Picture Parameter Set (Rec. ITU-T H.265, 7.3.2.3)
+// Picture-level parameters. u(n)=n bits, ue(v)=Exp-Golomb unsigned, se(v)=signed. '*' = stored by OME
+// (the stored flags are exactly those needed to know which slice_segment_header elements are present).
+//
+//   syntax element                                | desc  | present when
+//   ----------------------------------------------|-------|-------------------------------------
+//   pps_pic_parameter_set_id                      | ue(v) | *
+//   pps_seq_parameter_set_id                      | ue(v) | *  -> SPS
+//   dependent_slice_segments_enabled_flag         | u(1)  | *
+//   output_flag_present_flag                      | u(1)  | *
+//   num_extra_slice_header_bits                   | u(3)  | *
+//   sign_data_hiding_enabled_flag                 | u(1)  |
+//   cabac_init_present_flag                       | u(1)  | *
+//   num_ref_idx_l0_default_active_minus1          | ue(v) | *
+//   num_ref_idx_l1_default_active_minus1          | ue(v) | *
+//   init_qp_minus26                               | se(v) |
+//   constrained_intra_pred_flag                   | u(1)  |
+//   transform_skip_enabled_flag                   | u(1)  |
+//   cu_qp_delta_enabled_flag [+ diff_cu_qp_depth] | u(1)  |
+//   pps_cb_qp_offset / pps_cr_qp_offset           | se(v) |
+//   pps_slice_chroma_qp_offsets_present_flag      | u(1)  | *
+//   weighted_pred_flag                            | u(1)  | *
+//   weighted_bipred_flag                          | u(1)  | *
+//   transquant_bypass_enabled_flag                | u(1)  |
+//   tiles_enabled_flag                            | u(1)  | *
+//   entropy_coding_sync_enabled_flag              | u(1)  | *
+//     tile columns/rows params                    | ue(v) |    if tiles_enabled_flag
+//   pps_loop_filter_across_slices_enabled_flag    | u(1)  | *
+//   deblocking_filter_control_present_flag        | u(1)  |
+//     deblocking_filter_override_enabled_flag     | u(1)  | *
+//     pps_deblocking_filter_disabled_flag         | u(1)  | *
+//     pps_beta_offset_div2 / pps_tc_offset_div2   | se(v) |    if !pps_deblocking_filter_disabled
+//   pps_scaling_list_data_present_flag [+ data]   | u(1)  |
+//   lists_modification_present_flag               | u(1)  | *
+//   log2_parallel_merge_level_minus2              | ue(v) |
+//   slice_segment_header_extension_present_flag   | u(1)  | *
+//   pps_extension_present_flag                    | u(1)  |
+//     pps_range_extension_flag                    | u(1)  | *  fail-safed (not parsed)
+//     pps_scc_extension_flag                      | u(1)  | *  fail-safed (not parsed)
 struct H265PPS
 {
 public:
@@ -212,9 +337,83 @@ public:
 		return pps_seq_parameter_set_id;
 	}
 
-	uint32_t pps_pic_parameter_set_id;
-	uint32_t pps_seq_parameter_set_id;
+	uint32_t pps_pic_parameter_set_id = 0;
+	uint32_t pps_seq_parameter_set_id = 0;
+
+	// Fields required to parse the slice_segment_header (Rec. ITU-T H.265 7.3.6.1)
+	uint8_t dependent_slice_segments_enabled_flag = 0;
+	uint8_t output_flag_present_flag = 0;
+	uint8_t num_extra_slice_header_bits = 0;
+	uint8_t cabac_init_present_flag = 0;
+	uint32_t num_ref_idx_l0_default_active_minus1 = 0;
+	uint32_t num_ref_idx_l1_default_active_minus1 = 0;
+	uint8_t weighted_pred_flag = 0;
+	uint8_t weighted_bipred_flag = 0;
+	uint8_t pps_slice_chroma_qp_offsets_present_flag = 0;
+	uint8_t deblocking_filter_override_enabled_flag = 0;
+	uint8_t pps_deblocking_filter_disabled_flag = 0;
+	uint8_t pps_loop_filter_across_slices_enabled_flag = 0;
+	uint8_t lists_modification_present_flag = 0;
+	uint8_t tiles_enabled_flag = 0;
+	uint8_t entropy_coding_sync_enabled_flag = 0;
+	uint8_t slice_segment_header_extension_present_flag = 0;
+
+	// Extension flags. When set, the slice_segment_header may contain additional
+	// conditional syntax that this parser does not handle; treated as fail-safe.
+	uint8_t pps_range_extension_flag = 0;
+	uint8_t pps_scc_extension_flag = 0;
 };
+
+// Slice segment header (Rec. ITU-T H.265, 7.3.6.1)
+// H265Parser::ParseSliceHeader walks the header (in the order below) through byte_alignment() to
+// measure its size; only slice_type and the header size are retained ('*'). u(v) lengths shown inline.
+//
+//   syntax element                                | desc  | present when
+//   ----------------------------------------------|-------|-------------------------------------
+//   first_slice_segment_in_pic_flag               | u(1)  |
+//   no_output_of_prior_pics_flag                  | u(1)  | IRAP NAL (type 16..23)
+//   slice_pic_parameter_set_id                    | ue(v) |    -> PPS/SPS
+//   dependent_slice_segment_flag                  | u(1)  | !first && dependent_slices_enabled
+//   slice_segment_address                         | u(v)  | !first; v=Ceil(Log2(PicSizeInCtbsY))
+//   --- following present only if !dependent_slice_segment_flag ---
+//   slice_reserved_flag[i]                        | u(1)  | i < num_extra_slice_header_bits
+//   slice_type                                    | ue(v) | *  0=B, 1=P, 2=I
+//   pic_output_flag                               | u(1)  | output_flag_present
+//   colour_plane_id                               | u(2)  | separate_colour_plane
+// ....(omitted)....
+class H265SliceHeader
+{
+public:
+	enum class SliceType : uint8_t
+	{
+		BSlice = 0,
+		PSlice = 1,
+		ISlice = 2
+	};
+
+	SliceType GetSliceType() const
+	{
+		return static_cast<SliceType>(_slice_type);
+	}
+
+	size_t GetHeaderSizeInBits() const
+	{
+		return _header_size_in_bits;
+	}
+
+	size_t GetHeaderSizeInBytes() const
+	{
+		return ((_header_size_in_bits + 7) / 8);
+	}
+
+private:
+	uint32_t _slice_type = 2;
+	size_t _header_size_in_bits = 0;
+
+	friend class H265Parser;
+};
+
+class HEVCDecoderConfigurationRecord;
 
 class H265Parser
 {
@@ -229,6 +428,10 @@ public:
     static bool ParseSPS(const uint8_t *nalu, size_t length, H265SPS &sps);
 	static bool ParsePPS(const uint8_t *nalu, size_t length, H265PPS &pps);
 
+	// Parses the slice_segment_header up to (and including) byte_alignment() so that the
+	// header size in bytes can be used to split CENC clear/protected byte ranges.
+	static bool ParseSliceHeader(const uint8_t *nalu, size_t length, H265SliceHeader &header, const std::shared_ptr<HEVCDecoderConfigurationRecord> &hvcc);
+
 private:
     static bool ParseNalUnitHeader(NalUnitBitstreamParser &parser, H265NalUnitHeader &header);
     static bool ProcessProfileTierLevel(uint32_t max_sub_layers_minus1, NalUnitBitstreamParser &parser, ProfileTierLevel &profile);
@@ -236,4 +439,5 @@ private:
     static bool ProcessVuiParameters(uint32_t max_sub_layers_minus1, NalUnitBitstreamParser &parser, VuiParameters &params);
     static bool ProcessHrdParameters(uint8_t common_inf_present_flag, uint32_t max_sub_layers_minus1, NalUnitBitstreamParser &parser, HrdParameters &params);
     static bool ProcessSubLayerHrdParameters(uint8_t sub_pic_hrd_params_present_flag, uint32_t cpb_cnt, NalUnitBitstreamParser &parser, SubLayerHrdParameters &params);
+    static bool ProcessPredWeightTable(NalUnitBitstreamParser &parser, uint32_t chroma_array_type, uint32_t num_ref_idx_l0_active_minus1, uint32_t num_ref_idx_l1_active_minus1, bool is_b_slice);
 };

--- a/src/modules/bitstream/h265/h265_parser.h
+++ b/src/modules/bitstream/h265/h265_parser.h
@@ -17,6 +17,20 @@
 
 
 constexpr size_t H265_NAL_UNIT_HEADER_SIZE = 2;
+
+// Spec ranges for Exp-Golomb values used as allocation sizes, loop bounds or bit counts.
+constexpr uint32_t H265_MAX_NUM_SHORT_TERM_REF_PIC_SETS = 64;			// 7.4.3.2.1
+constexpr uint32_t H265_MAX_NUM_LONG_TERM_REF_PICS_SPS = 32;			// 7.4.3.2.1
+constexpr uint32_t H265_MAX_NUM_REF_IDX_ACTIVE_MINUS1 = 14;				// 7.4.7.1
+constexpr uint32_t H265_MAX_DPB_SIZE = 16;								// A.4.2 (bounds 7.4.8)
+constexpr uint32_t H265_MAX_LOG2_MAX_PIC_ORDER_CNT_LSB_MINUS4 = 12;		// 7.4.3.2.1
+constexpr uint32_t H265_MAX_OFFSET_LEN_MINUS1 = 31;						// 7.4.7.1
+constexpr uint32_t H265_MAX_PIC_DIMENSION_IN_LUMA_SAMPLES = 65536;		// A.4.1, with headroom
+
+// Parameter set ids. The maps in HEVCDecoderConfigurationRecord are keyed by uint8_t.
+constexpr uint32_t H265_MAX_SPS_ID = 15;								// 7.4.3.2.1
+constexpr uint32_t H265_MAX_PPS_ID = 63;								// 7.4.3.3.1
+
 struct ProfileTierLevel
 {
 	uint8_t _general_profile_space = 0;
@@ -201,13 +215,22 @@ public:
 	}
 
 	// PicSizeInCtbsY (Rec. ITU-T H.265 eq. 7-15..7-20) - used to size slice_segment_address.
+	// Returns 0 when the SPS is unusable; callers treat 0 as a parse failure.
 	uint32_t GetPicSizeInCtbsY() const
 	{
-		const uint32_t min_cb_log2_size_y = _log2_min_luma_coding_block_size_minus3 + 3;
-		const uint32_t ctb_log2_size_y = min_cb_log2_size_y + _log2_diff_max_min_luma_coding_block_size;
+		// Summed in 64 bits: both fields are unbounded ue(v).
+		const uint64_t min_cb_log2_size_y = static_cast<uint64_t>(_log2_min_luma_coding_block_size_minus3) + 3;
+		const uint64_t ctb_log2_size_y = min_cb_log2_size_y + _log2_diff_max_min_luma_coding_block_size;
 
 		// CtbLog2SizeY is 4..6 for conformant streams (Rec. ITU-T H.265 7.4.3.2.1; CtbSizeY in {16,32,64}).
 		if (ctb_log2_size_y < 4 || ctb_log2_size_y > 6)
+		{
+			return 0;
+		}
+
+		// Keeps the rounding and the product below from overflowing.
+		if (_pic_width_in_luma_samples == 0 || _pic_width_in_luma_samples > H265_MAX_PIC_DIMENSION_IN_LUMA_SAMPLES ||
+			_pic_height_in_luma_samples == 0 || _pic_height_in_luma_samples > H265_MAX_PIC_DIMENSION_IN_LUMA_SAMPLES)
 		{
 			return 0;
 		}

--- a/src/modules/bitstream/h265/h265_parser_test.cpp
+++ b/src/modules/bitstream/h265/h265_parser_test.cpp
@@ -1,0 +1,543 @@
+//==============================================================================
+//
+//  OvenMediaEngine - Unit Tests
+//
+//  Covers H265Parser (SPS/PPS parsing, slice-segment-header size accounting)
+//  and HEVCDecoderConfigurationRecord SPS/PPS lookup (id range validation).
+//
+//  Bitstreams are hand-built with a BitWriter so the expected values
+//  (GetHeaderSizeInBytes(), slice type, resolution, ...) are known by
+//  construction rather than captured from the parser under test.
+//  Syntax follows Rec. ITU-T H.265 (7.3.2.2 SPS, 7.3.2.3 PPS, 7.3.6.1 slice).
+//
+//==============================================================================
+
+// Unit tests
+// ----------
+// cmake build/debug && ninja -C build/debug ome_test_modules
+// ./build/debug/bin/ome_test_modules --gtest_filter='H265Parser.*:H265DecoderConfig.*'
+
+#include <gtest/gtest.h>
+
+#include <base/ovlibrary/bit_writer.h>
+#include <base/ovlibrary/data.h>
+#include <modules/bitstream/h265/h265_decoder_configuration_record.h>
+#include <modules/bitstream/h265/h265_parser.h>
+
+#include <memory>
+#include <vector>
+
+namespace
+{
+	// ---- Exp-Golomb writers (Rec. ITU-T H.265 9.2) ----
+	void WriteUE(ov::BitWriter &w, uint32_t v)
+	{
+		uint64_t n = static_cast<uint64_t>(v) + 1;
+		int numbits = 0;
+		while ((n >> (numbits + 1)) != 0)
+		{
+			numbits++;
+		}
+		if (numbits > 0)
+		{
+			w.WriteBits(numbits, 0);
+		}
+		w.WriteBits(numbits + 1, n);
+	}
+
+	void WriteSE(ov::BitWriter &w, int32_t v)
+	{
+		uint32_t code = (v <= 0) ? static_cast<uint32_t>(-2 * static_cast<int64_t>(v))
+								 : static_cast<uint32_t>(2 * static_cast<int64_t>(v) - 1);
+		WriteUE(w, code);
+	}
+
+	// rbsp_trailing_bits(): stop bit '1' then zero-pad to a byte boundary.
+	void WriteTrailing(ov::BitWriter &w)
+	{
+		w.WriteBits(1, 1);
+		while (w.GetBitCount() % 8 != 0)
+		{
+			w.WriteBits(1, 0);
+		}
+	}
+
+	std::vector<uint8_t> ToBytes(ov::BitWriter &w)
+	{
+		return std::vector<uint8_t>(w.GetData(), w.GetData() + w.GetDataSize());
+	}
+
+	// Insert emulation_prevention_three_byte into an RBSP payload to form an EBSP.
+	std::vector<uint8_t> ApplyEmulationPrevention(const std::vector<uint8_t> &rbsp)
+	{
+		std::vector<uint8_t> out;
+		out.reserve(rbsp.size() + 4);
+		size_t zeros = 0;
+		for (uint8_t b : rbsp)
+		{
+			if (zeros >= 2 && b <= 0x03)
+			{
+				out.push_back(0x03);
+				zeros = 0;
+			}
+			out.push_back(b);
+			zeros = (b == 0x00) ? zeros + 1 : 0;
+		}
+		return out;
+	}
+
+	// Build a NAL unit: 2-byte header (nal_type) + emulation-prevented RBSP.
+	std::vector<uint8_t> MakeNal(uint8_t nal_type, const std::vector<uint8_t> &rbsp)
+	{
+		std::vector<uint8_t> nal;
+		nal.push_back(static_cast<uint8_t>((nal_type << 1) & 0x7E));	 // forbidden=0, layerId hi=0
+		nal.push_back(0x01);										 // layerId lo=0, tid_plus1=1
+		auto ebsp = ApplyEmulationPrevention(rbsp);
+		nal.insert(nal.end(), ebsp.begin(), ebsp.end());
+		return nal;
+	}
+
+	std::shared_ptr<ov::Data> ToData(const std::vector<uint8_t> &bytes)
+	{
+		return std::make_shared<ov::Data>(bytes.data(), bytes.size());
+	}
+
+	// Ceil(Log2(n)) : bits needed to represent [0, n-1].
+	uint32_t CeilLog2(uint32_t n)
+	{
+		uint32_t bits = 0;
+		while ((1u << bits) < n)
+		{
+			bits++;
+		}
+		return bits;
+	}
+
+	// ---- Minimal SPS (4:2:0, 320x240, SAO configurable) ----
+	// num_strps short-term RPS are stored, each with num_negative_pics=1
+	// (delta_poc_s0_minus1=0, used_by_curr_pic_s0_flag=1), num_positive_pics=0
+	// -> NumDeltaPocs == 1. log2_diff selects CtbLog2SizeY (= 3 + log2_diff).
+	std::vector<uint8_t> BuildSps(bool sao_enabled, uint32_t num_strps = 0, uint32_t log2_diff = 3)
+	{
+		ov::BitWriter w(64);
+		w.WriteBits(4, 0);	// sps_video_parameter_set_id
+		w.WriteBits(3, 0);	// sps_max_sub_layers_minus1
+		w.WriteBits(1, 0);	// sps_temporal_id_nesting_flag
+
+		// profile_tier_level (max_sub_layers_minus1 == 0 -> 96 bits)
+		w.WriteBits(2, 0);			 // general_profile_space
+		w.WriteBits(1, 0);			 // general_tier_flag
+		w.WriteBits(5, 1);			 // general_profile_idc (Main)
+		w.WriteBits(32, 0x60000000); // general_profile_compatibility_flags
+		w.WriteBits(32, 0);			 // general_constraint_indicator_flags (hi 32)
+		w.WriteBits(16, 0);			 // general_constraint_indicator_flags (lo 16)
+		w.WriteBits(8, 93);			 // general_level_idc (3.1)
+
+		WriteUE(w, 0);	// sps_seq_parameter_set_id
+		WriteUE(w, 1);	// chroma_format_idc (4:2:0)
+		WriteUE(w, 320);  // pic_width_in_luma_samples
+		WriteUE(w, 240);  // pic_height_in_luma_samples
+		w.WriteBits(1, 0);	// conformance_window_flag
+		WriteUE(w, 0);	// bit_depth_luma_minus8
+		WriteUE(w, 0);	// bit_depth_chroma_minus8
+		WriteUE(w, 0);	// log2_max_pic_order_cnt_lsb_minus4
+
+		w.WriteBits(1, 0);	// sps_sub_layer_ordering_info_present_flag -> one iteration
+		WriteUE(w, 0);	// sps_max_dec_pic_buffering_minus1
+		WriteUE(w, 0);	// sps_max_num_reorder_pics
+		WriteUE(w, 0);	// sps_max_latency_increase_plus1
+
+		WriteUE(w, 0);	// log2_min_luma_coding_block_size_minus3 (MinCbLog2SizeY=3)
+		WriteUE(w, log2_diff);	// log2_diff_max_min_luma_coding_block_size (CtbLog2SizeY = 3 + log2_diff)
+		WriteUE(w, 0);	// log2_min_transform_block_size_minus2
+		WriteUE(w, 3);	// log2_diff_max_min_transform_block_size
+		WriteUE(w, 0);	// max_transform_hierarchy_depth_inter
+		WriteUE(w, 0);	// max_transform_hierarchy_depth_intra
+		w.WriteBits(1, 0);	// scaling_list_enabled_flag
+		w.WriteBits(1, 0);	// amp_enabled_flag
+		w.WriteBits(1, sao_enabled ? 1 : 0);  // sample_adaptive_offset_enabled_flag
+		w.WriteBits(1, 0);	// pcm_enabled_flag
+		WriteUE(w, num_strps);	// num_short_term_ref_pic_sets
+		for (uint32_t i = 0; i < num_strps; i++)
+		{
+			if (i > 0)
+			{
+				w.WriteBits(1, 0);	// inter_ref_pic_set_prediction_flag (idx > 0)
+			}
+			WriteUE(w, 1);	// num_negative_pics
+			WriteUE(w, 0);	// num_positive_pics
+			WriteUE(w, 0);	// delta_poc_s0_minus1[0]
+			w.WriteBits(1, 1);	// used_by_curr_pic_s0_flag[0]
+		}
+		w.WriteBits(1, 0);	// long_term_ref_pics_present_flag
+		w.WriteBits(1, 0);	// sps_temporal_mvp_enabled_flag
+		w.WriteBits(1, 0);	// strong_intra_smoothing_enabled_flag
+		w.WriteBits(1, 0);	// vui_parameters_present_flag
+		w.WriteBits(1, 0);	// sps_extension_flag
+
+		WriteTrailing(w);
+		return MakeNal(33, ToBytes(w));
+	}
+
+	// ---- Minimal PPS (all optional/flagged syntax disabled) ----
+	// range_extension sets pps_extension_present_flag + pps_range_extension_flag so the
+	// slice-header parser must fail-safe (transform_skip_enabled_flag is 0, so the range
+	// extension carries no extra payload).
+	std::vector<uint8_t> BuildPps(uint32_t num_extra_slice_header_bits = 0, bool range_extension = false)
+	{
+		ov::BitWriter w(32);
+		WriteUE(w, 0);	// pps_pic_parameter_set_id
+		WriteUE(w, 0);	// pps_seq_parameter_set_id
+		w.WriteBits(1, 0);	// dependent_slice_segments_enabled_flag
+		w.WriteBits(1, 0);	// output_flag_present_flag
+		w.WriteBits(3, num_extra_slice_header_bits);  // num_extra_slice_header_bits
+		w.WriteBits(1, 0);	// sign_data_hiding_enabled_flag
+		w.WriteBits(1, 0);	// cabac_init_present_flag
+		WriteUE(w, 0);	// num_ref_idx_l0_default_active_minus1
+		WriteUE(w, 0);	// num_ref_idx_l1_default_active_minus1
+		WriteSE(w, 0);	// init_qp_minus26
+		w.WriteBits(1, 0);	// constrained_intra_pred_flag
+		w.WriteBits(1, 0);	// transform_skip_enabled_flag
+		w.WriteBits(1, 0);	// cu_qp_delta_enabled_flag
+		WriteSE(w, 0);	// pps_cb_qp_offset
+		WriteSE(w, 0);	// pps_cr_qp_offset
+		w.WriteBits(1, 0);	// pps_slice_chroma_qp_offsets_present_flag
+		w.WriteBits(1, 0);	// weighted_pred_flag
+		w.WriteBits(1, 0);	// weighted_bipred_flag
+		w.WriteBits(1, 0);	// transquant_bypass_enabled_flag
+		w.WriteBits(1, 0);	// tiles_enabled_flag
+		w.WriteBits(1, 0);	// entropy_coding_sync_enabled_flag
+		w.WriteBits(1, 0);	// pps_loop_filter_across_slices_enabled_flag
+		w.WriteBits(1, 0);	// deblocking_filter_control_present_flag
+		w.WriteBits(1, 0);	// pps_scaling_list_data_present_flag
+		w.WriteBits(1, 0);	// lists_modification_present_flag
+		WriteUE(w, 0);	// log2_parallel_merge_level_minus2
+		w.WriteBits(1, 0);	// slice_segment_header_extension_present_flag
+		w.WriteBits(1, range_extension ? 1 : 0);  // pps_extension_present_flag
+		if (range_extension)
+		{
+			w.WriteBits(1, 1);	// pps_range_extension_flag
+			w.WriteBits(1, 0);	// pps_multilayer_extension_flag
+			w.WriteBits(1, 0);	// pps_3d_extension_flag
+			w.WriteBits(1, 0);	// pps_scc_extension_flag
+			w.WriteBits(4, 0);	// pps_extension_4bits
+			// pps_range_extension() is empty because transform_skip_enabled_flag == 0.
+		}
+
+		WriteTrailing(w);
+		return MakeNal(34, ToBytes(w));
+	}
+
+	// ---- IDR (I) slice segment header. SAO flags present iff sao_enabled. ----
+	// Header syntax bits (before byte_alignment):
+	//   first_slice(1) + no_output(1) + pps_id ue(0)=1 + slice_type ue(2)=3
+	//   [+ sao_luma(1) + sao_chroma(1) when sao] + slice_qp_delta se(0)=1
+	//   = 7 (sao off) or 9 (sao on) bits; byte_alignment rounds up to 1 / 2 bytes.
+	std::vector<uint8_t> BuildIdrSlice(bool sao_enabled, uint32_t slice_type = 2)
+	{
+		ov::BitWriter w(16);
+		w.WriteBits(1, 1);	// first_slice_segment_in_pic_flag
+		w.WriteBits(1, 0);	// no_output_of_prior_pics_flag (IRAP)
+		WriteUE(w, 0);	// slice_pic_parameter_set_id
+		WriteUE(w, slice_type);	// slice_type (default 2 = I)
+		if (sao_enabled)
+		{
+			w.WriteBits(1, 0);	// slice_sao_luma_flag
+			w.WriteBits(1, 0);	// slice_sao_chroma_flag (ChromaArrayType != 0)
+		}
+		WriteSE(w, 0);	// slice_qp_delta
+		// byte_alignment()
+		w.WriteBits(1, 1);	// alignment_bit_equal_to_one
+		while (w.GetBitCount() % 8 != 0)
+		{
+			w.WriteBits(1, 0);	// alignment_bit_equal_to_zero
+		}
+		auto rbsp = ToBytes(w);
+		// A couple of bytes of (dummy) slice data after the header.
+		rbsp.push_back(0xFF);
+		rbsp.push_back(0xFF);
+		return MakeNal(19, rbsp);  // IDR_W_RADL
+	}
+
+	std::shared_ptr<HEVCDecoderConfigurationRecord> BuildRecord(bool sao_enabled,
+															   uint32_t num_strps = 0,
+															   uint32_t num_extra_slice_header_bits = 0,
+															   uint32_t log2_diff = 3,
+															   bool range_extension = false)
+	{
+		auto record = std::make_shared<HEVCDecoderConfigurationRecord>();
+		record->AddNalUnit(H265NALUnitType::SPS, ToData(BuildSps(sao_enabled, num_strps, log2_diff)));
+		record->AddNalUnit(H265NALUnitType::PPS, ToData(BuildPps(num_extra_slice_header_bits, range_extension)));
+		return record;
+	}
+
+	// ---- Non-IDR (P) slice whose slice-level short-term RPS is inter-predicted
+	// (short_term_ref_pic_set_sps_flag == 0, inter_ref_pic_set_prediction_flag == 1).
+	// This is the case that exercises the ProcessShortTermRefPicSet flag loop; the
+	// spec loop is inclusive (j <= NumDeltaPocs[RefRpsIdx]), so with NumDeltaPocs==1
+	// the parser must read 2 used_by_curr_pic_flag bits. An off-by-one there shifts
+	// every following bit and changes the measured header size.
+	//
+	// Built to require an SPS with one short-term RPS and a PPS with
+	// num_extra_slice_header_bits == 5, so the total header (with the alignment bit)
+	// is 25 bits -> 4 bytes. A one-bit under-read would give 24 bits -> 3 bytes.
+	std::vector<uint8_t> BuildInterPredictedRpsPSlice(uint32_t delta_idx_minus1 = 0)
+	{
+		ov::BitWriter w(16);
+		w.WriteBits(1, 1);	// first_slice_segment_in_pic_flag
+		WriteUE(w, 0);	// slice_pic_parameter_set_id
+		w.WriteBits(5, 0);	// slice_reserved_flag[0..4] (num_extra_slice_header_bits == 5)
+		WriteUE(w, 1);	// slice_type (P)
+		w.WriteBits(4, 0);	// slice_pic_order_cnt_lsb (log2_max_pic_order_cnt_lsb_minus4 + 4 == 4)
+		w.WriteBits(1, 0);	// short_term_ref_pic_set_sps_flag -> inline st_ref_pic_set(1)
+
+		// st_ref_pic_set(stRpsIdx == num_short_term_ref_pic_sets == 1): inter-predicted.
+		w.WriteBits(1, 1);	// inter_ref_pic_set_prediction_flag
+		WriteUE(w, delta_idx_minus1);	// delta_idx_minus1 (RefRpsIdx = idx - (delta_idx_minus1 + 1))
+		w.WriteBits(1, 0);	// delta_rps_sign
+		WriteUE(w, 0);	// abs_delta_rps_minus1
+		// NumDeltaPocs[RefRpsIdx=0] == 1 -> loop j = 0..1 (inclusive): 2 flags.
+		w.WriteBits(1, 1);	// used_by_curr_pic_flag[0] (used -> no use_delta_flag)
+		w.WriteBits(1, 1);	// used_by_curr_pic_flag[1] (used -> no use_delta_flag)
+
+		w.WriteBits(1, 0);	// num_ref_idx_active_override_flag
+		WriteUE(w, 0);	// five_minus_max_num_merge_cand
+		WriteSE(w, 0);	// slice_qp_delta
+
+		// byte_alignment()
+		w.WriteBits(1, 1);
+		while (w.GetBitCount() % 8 != 0)
+		{
+			w.WriteBits(1, 0);
+		}
+		auto rbsp = ToBytes(w);
+		rbsp.push_back(0xFF);
+		rbsp.push_back(0xFF);
+		return MakeNal(1, rbsp);  // TRAIL_R (non-IDR, non-IRAP)
+	}
+
+	// Non-IDR P slice that selects a short-term RPS from the SPS by index
+	// (short_term_ref_pic_set_sps_flag == 1). short_term_ref_pic_set_idx is read as
+	// Ceil(Log2(num_strps)) bits; pass an out-of-range value to hit the range guard.
+	std::vector<uint8_t> BuildSpsRpsIdxPSlice(uint32_t num_strps, uint32_t idx)
+	{
+		ov::BitWriter w(16);
+		w.WriteBits(1, 1);	// first_slice_segment_in_pic_flag
+		WriteUE(w, 0);	// slice_pic_parameter_set_id
+		WriteUE(w, 1);	// slice_type (P)
+		w.WriteBits(4, 0);	// slice_pic_order_cnt_lsb (4 bits)
+		w.WriteBits(1, 1);	// short_term_ref_pic_set_sps_flag
+		if (num_strps > 1)
+		{
+			w.WriteBits(CeilLog2(num_strps), idx);	// short_term_ref_pic_set_idx
+		}
+		WriteTrailing(w);
+		auto rbsp = ToBytes(w);
+		rbsp.push_back(0xFF);
+		return MakeNal(1, rbsp);  // TRAIL_R
+	}
+
+	// Non-first slice segment (first_slice_segment_in_pic_flag == 0). The parser must
+	// read slice_segment_address = u(Ceil(Log2(PicSizeInCtbsY))); when PicSizeInCtbsY is
+	// invalid (0) it fails fast before the address.
+	std::vector<uint8_t> BuildNonFirstSlice()
+	{
+		ov::BitWriter w(16);
+		w.WriteBits(1, 0);	// first_slice_segment_in_pic_flag
+		WriteUE(w, 0);	// slice_pic_parameter_set_id
+		WriteTrailing(w);
+		auto rbsp = ToBytes(w);
+		rbsp.push_back(0xFF);
+		return MakeNal(1, rbsp);  // TRAIL_R
+	}
+}  // namespace
+
+// ============================================================================
+// SPS parsing
+// ============================================================================
+
+TEST(H265Parser, ParseCraftedSps)
+{
+	auto sps_nal = BuildSps(/*sao=*/false);
+
+	H265SPS sps;
+	ASSERT_TRUE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+
+	EXPECT_EQ(sps.GetWidth(), 320u);
+	EXPECT_EQ(sps.GetHeight(), 240u);
+	EXPECT_EQ(sps.GetChromaFormatIdc(), 1u);
+	EXPECT_EQ(sps.GetChromaArrayType(), 1u);
+	// CtbSizeY = 64 -> ceil(320/64)=5, ceil(240/64)=4 -> 20
+	EXPECT_EQ(sps.GetPicSizeInCtbsY(), 20u);
+}
+
+// ============================================================================
+// HEVCDecoderConfigurationRecord::GetSPS/GetPPS id range validation
+// ============================================================================
+
+TEST(H265DecoderConfig, GetSpsPpsLookupAndRange)
+{
+	auto record = BuildRecord(/*sao=*/false);
+
+	// Present ids resolve.
+	ASSERT_NE(record->GetSPS(0), nullptr);
+	ASSERT_NE(record->GetPPS(0), nullptr);
+	EXPECT_EQ(record->GetSPS(0)->GetWidth(), 320u);
+
+	// Absent-but-valid ids -> nullptr.
+	EXPECT_EQ(record->GetSPS(1), nullptr);
+	EXPECT_EQ(record->GetPPS(1), nullptr);
+
+	// Out-of-range ids must not wrap into the uint8_t map key.
+	EXPECT_EQ(record->GetSPS(16), nullptr);	  // sps id range is [0, 15]
+	EXPECT_EQ(record->GetSPS(256), nullptr);  // would wrap to 0
+	EXPECT_EQ(record->GetSPS(-1), nullptr);
+	EXPECT_EQ(record->GetPPS(64), nullptr);	  // pps id range is [0, 63]
+	EXPECT_EQ(record->GetPPS(256), nullptr);  // would wrap to 0
+	EXPECT_EQ(record->GetPPS(-1), nullptr);
+}
+
+TEST(H265DecoderConfig, CodecsParameterUsesHvc1)
+{
+	auto record = BuildRecord(/*sao=*/false);
+	EXPECT_TRUE(record->GetCodecsParameter().HasPrefix("hvc1"));
+}
+
+// ============================================================================
+// Slice header size accounting
+// ============================================================================
+
+TEST(H265Parser, IdrSliceHeaderSize_SaoOff)
+{
+	auto record = BuildRecord(/*sao=*/false);
+	auto slice = BuildIdrSlice(/*sao=*/false);
+
+	H265SliceHeader shd;
+	ASSERT_TRUE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+	EXPECT_EQ(shd.GetSliceType(), H265SliceHeader::SliceType::ISlice);
+	// 7 header bits + 1 alignment bit = 8 bits -> 1 byte (NAL header excluded).
+	EXPECT_EQ(shd.GetHeaderSizeInBytes(), 1u);
+}
+
+TEST(H265Parser, IdrSliceHeaderSize_SaoOn)
+{
+	auto record = BuildRecord(/*sao=*/true);
+	auto slice = BuildIdrSlice(/*sao=*/true);
+
+	H265SliceHeader shd;
+	ASSERT_TRUE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+	EXPECT_EQ(shd.GetSliceType(), H265SliceHeader::SliceType::ISlice);
+	// 9 header bits + 1 alignment bit = 10 bits -> 2 bytes.
+	EXPECT_EQ(shd.GetHeaderSizeInBytes(), 2u);
+}
+
+// ============================================================================
+// Slice header guard / failure paths
+// ============================================================================
+
+TEST(H265Parser, SliceHeaderRejectsNullRecord)
+{
+	auto slice = BuildIdrSlice(/*sao=*/false);
+	H265SliceHeader shd;
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, nullptr));
+}
+
+TEST(H265Parser, SliceHeaderRejectsNonVclNal)
+{
+	auto record = BuildRecord(/*sao=*/false);
+	auto sps_nal = BuildSps(/*sao=*/false);  // NAL type 33 is not a slice
+	H265SliceHeader shd;
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(sps_nal.data(), sps_nal.size(), shd, record));
+}
+
+TEST(H265Parser, SliceHeaderRejectsMissingPps)
+{
+	// Record with only an SPS: the slice references PPS id 0 which is absent.
+	auto record = std::make_shared<HEVCDecoderConfigurationRecord>();
+	record->AddNalUnit(H265NALUnitType::SPS, ToData(BuildSps(/*sao=*/false)));
+
+	auto slice = BuildIdrSlice(/*sao=*/false);
+	H265SliceHeader shd;
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+}
+
+// Regression guard for the ProcessShortTermRefPicSet inclusive-loop fix
+// (Rec. ITU-T H.265 7.3.7: for j = 0; j <= NumDeltaPocs[RefRpsIdx]; j++).
+// With the off-by-one (j < NumDeltaPocs) the parser under-reads one bit and
+// the measured header size becomes 3 bytes instead of 4.
+TEST(H265Parser, SliceHeaderSize_InlineInterPredictedRps)
+{
+	auto record = BuildRecord(/*sao=*/false, /*num_strps=*/1, /*num_extra=*/5);
+	auto slice = BuildInterPredictedRpsPSlice();
+
+	H265SliceHeader shd;
+	ASSERT_TRUE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+	EXPECT_EQ(shd.GetSliceType(), H265SliceHeader::SliceType::PSlice);
+	// 24 header bits + 1 alignment bit = 25 bits -> 4 bytes.
+	EXPECT_EQ(shd.GetHeaderSizeInBytes(), 4u);
+}
+
+// ============================================================================
+// Fail-safe / robustness guards (validate the review fixes)
+// ============================================================================
+
+// slice_type must be 0..2; a larger value is rejected instead of mis-parsed.
+TEST(H265Parser, SliceHeaderRejectsInvalidSliceType)
+{
+	auto record = BuildRecord(/*sao=*/false);
+	auto slice = BuildIdrSlice(/*sao=*/false, /*slice_type=*/3);
+
+	H265SliceHeader shd;
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+}
+
+// short_term_ref_pic_set_idx read with Ceil(Log2(num)) bits can exceed num-1 when
+// num is not a power of two (num=3 -> 2 bits -> value 3). It must be rejected.
+TEST(H265Parser, SliceHeaderRejectsOutOfRangeStrpsIdx)
+{
+	auto record = BuildRecord(/*sao=*/false, /*num_strps=*/3);
+	auto slice = BuildSpsRpsIdxPSlice(/*num_strps=*/3, /*idx=*/3);	 // valid range is 0..2
+
+	H265SliceHeader shd;
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+}
+
+// An inter-predicted inline RPS with delta_idx_minus1 >= stRpsIdx would underflow
+// RefRpsIdx; the guard must reject it.
+TEST(H265Parser, SliceHeaderRejectsInterRpsDeltaIdxUnderflow)
+{
+	auto record = BuildRecord(/*sao=*/false, /*num_strps=*/1, /*num_extra=*/5);
+	// stRpsIdx == 1, so delta_idx_minus1 == 1 makes RefRpsIdx underflow.
+	auto slice = BuildInterPredictedRpsPSlice(/*delta_idx_minus1=*/1);
+
+	H265SliceHeader shd;
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+}
+
+// CtbLog2SizeY out of the valid [4,6] range -> GetPicSizeInCtbsY() == 0, and a
+// non-first slice (which needs slice_segment_address) must fail fast.
+TEST(H265Parser, SliceHeaderRejectsInvalidCtbSize)
+{
+	H265SPS sps;
+	auto sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/0, /*log2_diff=*/4);  // CtbLog2SizeY = 7
+	ASSERT_TRUE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+	EXPECT_EQ(sps.GetPicSizeInCtbsY(), 0u);
+
+	auto record = BuildRecord(/*sao=*/false, /*num_strps=*/0, /*num_extra=*/0, /*log2_diff=*/4);
+	auto slice = BuildNonFirstSlice();
+
+	H265SliceHeader shd;
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+}
+
+// A PPS that enables the range extension is not supported by the slice-header
+// parser and must be rejected up front.
+TEST(H265Parser, SliceHeaderRejectsRangeExtensionPps)
+{
+	auto record = BuildRecord(/*sao=*/false, /*num_strps=*/0, /*num_extra=*/0,
+							  /*log2_diff=*/3, /*range_extension=*/true);
+	auto slice = BuildIdrSlice(/*sao=*/false);
+
+	H265SliceHeader shd;
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+}

--- a/src/modules/bitstream/h265/h265_parser_test.cpp
+++ b/src/modules/bitstream/h265/h265_parser_test.cpp
@@ -103,21 +103,71 @@ namespace
 	}
 
 	// Ceil(Log2(n)) : bits needed to represent [0, n-1].
+	// Mirrors the parser's helper, including its bits < 32 guard.
 	uint32_t CeilLog2(uint32_t n)
 	{
 		uint32_t bits = 0;
-		while ((1u << bits) < n)
+		while (bits < 32 && (1u << bits) < n)
 		{
 			bits++;
 		}
 		return bits;
 	}
 
+	// Out-of-range SPS values for the range guards; defaults are conformant.
+	struct SpsOverrides
+	{
+		uint32_t pic_width = 320;
+		uint32_t pic_height = 240;
+		uint32_t num_negative_pics = 1;
+		uint32_t num_positive_pics = 0;
+		bool long_term_ref_pics_present = false;
+		uint32_t num_long_term_ref_pics_sps = 0;
+	};
+
+	// ---- Minimal VPS (Rec. ITU-T H.265 7.3.2.1). Only needed so a record becomes valid. ----
+	std::vector<uint8_t> BuildVps()
+	{
+		ov::BitWriter w(32);
+		w.WriteBits(4, 0);		// vps_video_parameter_set_id
+		w.WriteBits(1, 1);		// vps_base_layer_internal_flag
+		w.WriteBits(1, 1);		// vps_base_layer_available_flag
+		w.WriteBits(6, 0);		// vps_max_layers_minus1
+		w.WriteBits(3, 0);		// vps_max_sub_layers_minus1
+		w.WriteBits(1, 0);		// vps_temporal_id_nesting_flag
+		w.WriteBits(16, 0xFFFF);  // vps_reserved_0xffff_16bits
+
+		// profile_tier_level (max_sub_layers_minus1 == 0 -> 96 bits)
+		w.WriteBits(2, 0);			  // general_profile_space
+		w.WriteBits(1, 0);			  // general_tier_flag
+		w.WriteBits(5, 1);			  // general_profile_idc (Main)
+		w.WriteBits(32, 0x60000000);  // general_profile_compatibility_flags
+		w.WriteBits(32, 0);			  // general_constraint_indicator_flags (hi 32)
+		w.WriteBits(16, 0);			  // general_constraint_indicator_flags (lo 16)
+		w.WriteBits(8, 93);			  // general_level_idc (3.1)
+
+		w.WriteBits(1, 0);	// vps_sub_layer_ordering_info_present_flag -> one iteration
+		WriteUE(w, 0);	// vps_max_dec_pic_buffering_minus1
+		WriteUE(w, 0);	// vps_max_num_reorder_pics
+		WriteUE(w, 0);	// vps_max_latency_increase_plus1
+
+		w.WriteBits(6, 0);	// vps_max_layer_id
+		WriteUE(w, 0);	// vps_num_layer_sets_minus1
+		w.WriteBits(1, 0);	// vps_timing_info_present_flag
+		w.WriteBits(1, 0);	// vps_extension_flag
+
+		WriteTrailing(w);
+		return MakeNal(32, ToBytes(w));	 // VPS
+	}
+
 	// ---- Minimal SPS (4:2:0, 320x240, SAO configurable) ----
 	// num_strps short-term RPS are stored, each with num_negative_pics=1
 	// (delta_poc_s0_minus1=0, used_by_curr_pic_s0_flag=1), num_positive_pics=0
 	// -> NumDeltaPocs == 1. log2_diff selects CtbLog2SizeY (= 3 + log2_diff).
-	std::vector<uint8_t> BuildSps(bool sao_enabled, uint32_t num_strps = 0, uint32_t log2_diff = 3)
+	std::vector<uint8_t> BuildSps(bool sao_enabled, uint32_t num_strps = 0, uint32_t log2_diff = 3,
+								  const SpsOverrides &overrides = {},
+								  uint32_t log2_max_pic_order_cnt_lsb_minus4 = 0,
+								  uint32_t sps_id = 0)
 	{
 		ov::BitWriter w(64);
 		w.WriteBits(4, 0);	// sps_video_parameter_set_id
@@ -133,14 +183,14 @@ namespace
 		w.WriteBits(16, 0);			 // general_constraint_indicator_flags (lo 16)
 		w.WriteBits(8, 93);			 // general_level_idc (3.1)
 
-		WriteUE(w, 0);	// sps_seq_parameter_set_id
+		WriteUE(w, sps_id);	// sps_seq_parameter_set_id
 		WriteUE(w, 1);	// chroma_format_idc (4:2:0)
-		WriteUE(w, 320);  // pic_width_in_luma_samples
-		WriteUE(w, 240);  // pic_height_in_luma_samples
+		WriteUE(w, overrides.pic_width);   // pic_width_in_luma_samples
+		WriteUE(w, overrides.pic_height);  // pic_height_in_luma_samples
 		w.WriteBits(1, 0);	// conformance_window_flag
 		WriteUE(w, 0);	// bit_depth_luma_minus8
 		WriteUE(w, 0);	// bit_depth_chroma_minus8
-		WriteUE(w, 0);	// log2_max_pic_order_cnt_lsb_minus4
+		WriteUE(w, log2_max_pic_order_cnt_lsb_minus4);	// log2_max_pic_order_cnt_lsb_minus4
 
 		w.WriteBits(1, 0);	// sps_sub_layer_ordering_info_present_flag -> one iteration
 		WriteUE(w, 0);	// sps_max_dec_pic_buffering_minus1
@@ -164,12 +214,31 @@ namespace
 			{
 				w.WriteBits(1, 0);	// inter_ref_pic_set_prediction_flag (idx > 0)
 			}
-			WriteUE(w, 1);	// num_negative_pics
-			WriteUE(w, 0);	// num_positive_pics
-			WriteUE(w, 0);	// delta_poc_s0_minus1[0]
-			w.WriteBits(1, 1);	// used_by_curr_pic_s0_flag[0]
+			WriteUE(w, overrides.num_negative_pics);	// num_negative_pics
+			WriteUE(w, overrides.num_positive_pics);	// num_positive_pics
+			for (uint32_t j = 0; j < overrides.num_negative_pics; j++)
+			{
+				WriteUE(w, 0);	// delta_poc_s0_minus1[j]
+				w.WriteBits(1, 1);	// used_by_curr_pic_s0_flag[j]
+			}
+			for (uint32_t j = 0; j < overrides.num_positive_pics; j++)
+			{
+				WriteUE(w, 0);	// delta_poc_s1_minus1[j]
+				w.WriteBits(1, 1);	// used_by_curr_pic_s1_flag[j]
+			}
 		}
-		w.WriteBits(1, 0);	// long_term_ref_pics_present_flag
+
+		w.WriteBits(1, overrides.long_term_ref_pics_present ? 1 : 0);  // long_term_ref_pics_present_flag
+		if (overrides.long_term_ref_pics_present)
+		{
+			WriteUE(w, overrides.num_long_term_ref_pics_sps);
+			for (uint32_t i = 0; i < overrides.num_long_term_ref_pics_sps; i++)
+			{
+				// lt_ref_pic_poc_lsb_sps[i] is u(log2_max_pic_order_cnt_lsb_minus4 + 4).
+				w.WriteBits(log2_max_pic_order_cnt_lsb_minus4 + 4, 0);
+				w.WriteBits(1, 0);	// used_by_curr_pic_lt_sps_flag[i]
+			}
+		}
 		w.WriteBits(1, 0);	// sps_temporal_mvp_enabled_flag
 		w.WriteBits(1, 0);	// strong_intra_smoothing_enabled_flag
 		w.WriteBits(1, 0);	// vui_parameters_present_flag
@@ -183,18 +252,23 @@ namespace
 	// range_extension sets pps_extension_present_flag + pps_range_extension_flag so the
 	// slice-header parser must fail-safe (transform_skip_enabled_flag is 0, so the range
 	// extension carries no extra payload).
-	std::vector<uint8_t> BuildPps(uint32_t num_extra_slice_header_bits = 0, bool range_extension = false)
+	// entropy_coding_sync selects WPP: the slice header gains num_entry_point_offsets
+	// and, unlike tiles_enabled_flag, the PPS gains no syntax of its own.
+	std::vector<uint8_t> BuildPps(uint32_t num_extra_slice_header_bits = 0, bool range_extension = false,
+								  uint32_t num_ref_idx_default_active_minus1 = 0,
+								  bool entropy_coding_sync = false,
+								  uint32_t pps_id = 0, uint32_t sps_id = 0)
 	{
 		ov::BitWriter w(32);
-		WriteUE(w, 0);	// pps_pic_parameter_set_id
-		WriteUE(w, 0);	// pps_seq_parameter_set_id
+		WriteUE(w, pps_id);	// pps_pic_parameter_set_id
+		WriteUE(w, sps_id);	// pps_seq_parameter_set_id
 		w.WriteBits(1, 0);	// dependent_slice_segments_enabled_flag
 		w.WriteBits(1, 0);	// output_flag_present_flag
 		w.WriteBits(3, num_extra_slice_header_bits);  // num_extra_slice_header_bits
 		w.WriteBits(1, 0);	// sign_data_hiding_enabled_flag
 		w.WriteBits(1, 0);	// cabac_init_present_flag
-		WriteUE(w, 0);	// num_ref_idx_l0_default_active_minus1
-		WriteUE(w, 0);	// num_ref_idx_l1_default_active_minus1
+		WriteUE(w, num_ref_idx_default_active_minus1);	// num_ref_idx_l0_default_active_minus1
+		WriteUE(w, num_ref_idx_default_active_minus1);	// num_ref_idx_l1_default_active_minus1
 		WriteSE(w, 0);	// init_qp_minus26
 		w.WriteBits(1, 0);	// constrained_intra_pred_flag
 		w.WriteBits(1, 0);	// transform_skip_enabled_flag
@@ -206,7 +280,7 @@ namespace
 		w.WriteBits(1, 0);	// weighted_bipred_flag
 		w.WriteBits(1, 0);	// transquant_bypass_enabled_flag
 		w.WriteBits(1, 0);	// tiles_enabled_flag
-		w.WriteBits(1, 0);	// entropy_coding_sync_enabled_flag
+		w.WriteBits(1, entropy_coding_sync ? 1 : 0);  // entropy_coding_sync_enabled_flag
 		w.WriteBits(1, 0);	// pps_loop_filter_across_slices_enabled_flag
 		w.WriteBits(1, 0);	// deblocking_filter_control_present_flag
 		w.WriteBits(1, 0);	// pps_scaling_list_data_present_flag
@@ -263,11 +337,14 @@ namespace
 															   uint32_t num_strps = 0,
 															   uint32_t num_extra_slice_header_bits = 0,
 															   uint32_t log2_diff = 3,
-															   bool range_extension = false)
+															   bool range_extension = false,
+															   bool entropy_coding_sync = false,
+															   const SpsOverrides &overrides = {})
 	{
 		auto record = std::make_shared<HEVCDecoderConfigurationRecord>();
-		record->AddNalUnit(H265NALUnitType::SPS, ToData(BuildSps(sao_enabled, num_strps, log2_diff)));
-		record->AddNalUnit(H265NALUnitType::PPS, ToData(BuildPps(num_extra_slice_header_bits, range_extension)));
+		record->AddNalUnit(H265NALUnitType::SPS, ToData(BuildSps(sao_enabled, num_strps, log2_diff, overrides)));
+		record->AddNalUnit(H265NALUnitType::PPS, ToData(BuildPps(num_extra_slice_header_bits, range_extension,
+																/*num_ref_idx_default_active_minus1=*/0, entropy_coding_sync)));
 		return record;
 	}
 
@@ -335,6 +412,155 @@ namespace
 		auto rbsp = ToBytes(w);
 		rbsp.push_back(0xFF);
 		return MakeNal(1, rbsp);  // TRAIL_R
+	}
+
+	// ---- Non-IDR B slice (7.3.6.1). Needs an SPS with exactly one short-term RPS.
+	// 1 + 1 + 1 + 4 + 1 + 1 + 1 + 1 + 1 = 12 bits, + 1 alignment bit -> 2 bytes.
+	std::vector<uint8_t> BuildBSlice()
+	{
+		ov::BitWriter w(16);
+		w.WriteBits(1, 1);	// first_slice_segment_in_pic_flag
+		WriteUE(w, 0);	// slice_pic_parameter_set_id
+		WriteUE(w, 0);	// slice_type (0 = B)
+		w.WriteBits(4, 0);	// slice_pic_order_cnt_lsb (log2_max_pic_order_cnt_lsb == 4)
+		w.WriteBits(1, 1);	// short_term_ref_pic_set_sps_flag (num_strps == 1 -> no index)
+		w.WriteBits(1, 0);	// num_ref_idx_active_override_flag
+		w.WriteBits(1, 0);	// mvd_l1_zero_flag (B only)
+		WriteUE(w, 0);	// five_minus_max_num_merge_cand
+		WriteSE(w, 0);	// slice_qp_delta
+
+		// byte_alignment()
+		w.WriteBits(1, 1);
+		while (w.GetBitCount() % 8 != 0)
+		{
+			w.WriteBits(1, 0);
+		}
+		auto rbsp = ToBytes(w);
+		rbsp.push_back(0xFF);
+		rbsp.push_back(0xFF);
+		return MakeNal(1, rbsp);  // TRAIL_R
+	}
+
+	// ---- IDR slice carrying entry point offsets (WPP). Walks the
+	// num_entry_point_offsets / offset_len_minus1 path (7.3.6.1).
+	std::vector<uint8_t> BuildWppIdrSlice(uint32_t num_entry_point_offsets, uint32_t offset_len_minus1)
+	{
+		ov::BitWriter w(32);
+		w.WriteBits(1, 1);	// first_slice_segment_in_pic_flag
+		w.WriteBits(1, 0);	// no_output_of_prior_pics_flag (IRAP)
+		WriteUE(w, 0);	// slice_pic_parameter_set_id
+		WriteUE(w, 2);	// slice_type (I)
+		WriteSE(w, 0);	// slice_qp_delta
+
+		WriteUE(w, num_entry_point_offsets);
+		if (num_entry_point_offsets > 0)
+		{
+			WriteUE(w, offset_len_minus1);
+			// Offsets are written only for a representable width.
+			if (offset_len_minus1 < 32)
+			{
+				for (uint32_t i = 0; i < num_entry_point_offsets; i++)
+				{
+					w.WriteBits(offset_len_minus1 + 1, 0);	// entry_point_offset_minus1[i]
+				}
+			}
+		}
+
+		// byte_alignment()
+		w.WriteBits(1, 1);
+		while (w.GetBitCount() % 8 != 0)
+		{
+			w.WriteBits(1, 0);
+		}
+		auto rbsp = ToBytes(w);
+		rbsp.push_back(0xFF);
+		rbsp.push_back(0xFF);
+		return MakeNal(19, rbsp);  // IDR_W_RADL
+	}
+
+	// ---- Non-IDR P slice with long-term refs (7.3.6.1). Needs an SPS with
+	// num_long_term_ref_pics_sps == 2, so lt_idx_sps is 1 bit. One entry comes from the
+	// SPS and one is coded explicitly, walking both branches of the long-term loop.
+	// 1 + 1 + 3 + 4 + 1 + 3 + 3 + (1+1) + (4+1+1) + 1 + 1 + 1 = 27 bits,
+	// + 1 alignment bit -> 4 bytes.
+	// num_long_term_ref_pics_sps selects the lt_idx_sps width, so it must match the SPS.
+	std::vector<uint8_t> BuildLongTermRefPSlice(uint32_t num_long_term_sps = 1, uint32_t num_long_term_pics = 1,
+											   uint32_t lt_idx_sps = 0, uint32_t num_long_term_ref_pics_sps = 2)
+	{
+		ov::BitWriter w(16);
+		w.WriteBits(1, 1);	// first_slice_segment_in_pic_flag
+		WriteUE(w, 0);	// slice_pic_parameter_set_id
+		WriteUE(w, 1);	// slice_type (P)
+		w.WriteBits(4, 0);	// slice_pic_order_cnt_lsb
+		w.WriteBits(1, 1);	// short_term_ref_pic_set_sps_flag (num_strps == 1 -> no index)
+
+		WriteUE(w, num_long_term_sps);	// num_long_term_sps (num_long_term_ref_pics_sps > 0 -> present)
+		WriteUE(w, num_long_term_pics);	// num_long_term_pics
+
+		// Entries are only written for counts small enough to be walked.
+		const bool write_entries = (num_long_term_sps <= H265_MAX_DPB_SIZE && num_long_term_pics <= H265_MAX_DPB_SIZE);
+		for (uint32_t i = 0; write_entries && i < num_long_term_sps + num_long_term_pics; i++)
+		{
+			if (i < num_long_term_sps)
+			{
+				// Taken from the SPS list; lt_idx_sps is present when the list has > 1 entry.
+				if (num_long_term_ref_pics_sps > 1)
+				{
+					w.WriteBits(CeilLog2(num_long_term_ref_pics_sps), lt_idx_sps);
+				}
+			}
+			else
+			{
+				// Coded explicitly.
+				w.WriteBits(4, 0);	// poc_lsb_lt[i]
+				w.WriteBits(1, 0);	// used_by_curr_pic_lt_flag[i]
+			}
+			w.WriteBits(1, 0);	// delta_poc_msb_present_flag[i]
+		}
+
+		w.WriteBits(1, 0);	// num_ref_idx_active_override_flag
+		WriteUE(w, 0);	// five_minus_max_num_merge_cand
+		WriteSE(w, 0);	// slice_qp_delta
+
+		// byte_alignment()
+		w.WriteBits(1, 1);
+		while (w.GetBitCount() % 8 != 0)
+		{
+			w.WriteBits(1, 0);
+		}
+		auto rbsp = ToBytes(w);
+		rbsp.push_back(0xFF);
+		rbsp.push_back(0xFF);
+		return MakeNal(1, rbsp);  // TRAIL_R
+	}
+
+	// ---- Non-first IDR slice segment that parses successfully (7.3.6.1).
+	// slice_segment_address is u(Ceil(Log2(PicSizeInCtbsY))), so address_bits must match the
+	// SPS; num_extra shifts the total off the byte boundary.
+	std::vector<uint8_t> BuildNonFirstIdrSlice(uint32_t address_bits, uint32_t num_extra = 0)
+	{
+		ov::BitWriter w(16);
+		w.WriteBits(1, 0);	// first_slice_segment_in_pic_flag
+		w.WriteBits(1, 0);	// no_output_of_prior_pics_flag (IRAP)
+		WriteUE(w, 0);	// slice_pic_parameter_set_id
+		w.WriteBits(address_bits, 1);	// slice_segment_address
+		for (uint32_t i = 0; i < num_extra; i++)
+		{
+			w.WriteBits(1, 0);	// slice_reserved_flag[i]
+		}
+		WriteUE(w, 2);	// slice_type (I)
+		WriteSE(w, 0);	// slice_qp_delta
+
+		// byte_alignment()
+		w.WriteBits(1, 1);
+		while (w.GetBitCount() % 8 != 0)
+		{
+			w.WriteBits(1, 0);
+		}
+		auto rbsp = ToBytes(w);
+		rbsp.push_back(0xFF);
+		rbsp.push_back(0xFF);
+		return MakeNal(19, rbsp);  // IDR_W_RADL
 	}
 
 	// Non-first slice segment (first_slice_segment_in_pic_flag == 0). The parser must
@@ -477,6 +703,49 @@ TEST(H265Parser, SliceHeaderSize_InlineInterPredictedRps)
 	EXPECT_EQ(shd.GetHeaderSizeInBytes(), 4u);
 }
 
+TEST(H265Parser, BSliceHeaderSize)
+{
+	auto record = BuildRecord(/*sao=*/false, /*num_strps=*/1);
+	auto slice = BuildBSlice();
+
+	H265SliceHeader shd;
+	ASSERT_TRUE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+	EXPECT_EQ(shd.GetSliceType(), H265SliceHeader::SliceType::BSlice);
+	// 12 header bits + 1 alignment bit = 13 bits -> 2 bytes.
+	EXPECT_EQ(shd.GetHeaderSizeInBytes(), 2u);
+}
+
+// Two entry point offsets 8 bits wide:
+// 1 + 1 + 1 + 3 + 1 + 3 + 7 + 2*8 = 33 bits, + 1 alignment bit -> 5 bytes.
+TEST(H265Parser, WppSliceHeaderSize_EntryPointOffsets)
+{
+	auto record = BuildRecord(/*sao=*/false, /*num_strps=*/0, /*num_extra=*/0,
+							  /*log2_diff=*/3, /*range_extension=*/false, /*entropy_coding_sync=*/true);
+	auto slice = BuildWppIdrSlice(/*num_entry_point_offsets=*/2, /*offset_len_minus1=*/7);
+
+	H265SliceHeader shd;
+	ASSERT_TRUE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+	EXPECT_EQ(shd.GetSliceType(), H265SliceHeader::SliceType::ISlice);
+	EXPECT_EQ(shd.GetHeaderSizeInBytes(), 5u);
+}
+
+TEST(H265Parser, LongTermRefSliceHeaderSize)
+{
+	SpsOverrides overrides;
+	overrides.long_term_ref_pics_present = true;
+	overrides.num_long_term_ref_pics_sps = 2;
+
+	auto record = BuildRecord(/*sao=*/false, /*num_strps=*/1, /*num_extra=*/0, /*log2_diff=*/3,
+							  /*range_extension=*/false, /*entropy_coding_sync=*/false, overrides);
+	auto slice = BuildLongTermRefPSlice();
+
+	H265SliceHeader shd;
+	ASSERT_TRUE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+	EXPECT_EQ(shd.GetSliceType(), H265SliceHeader::SliceType::PSlice);
+	// 27 header bits + 1 alignment bit = 28 bits -> 4 bytes.
+	EXPECT_EQ(shd.GetHeaderSizeInBytes(), 4u);
+}
+
 // ============================================================================
 // Fail-safe / robustness guards (validate the review fixes)
 // ============================================================================
@@ -539,5 +808,351 @@ TEST(H265Parser, SliceHeaderRejectsRangeExtensionPps)
 	auto slice = BuildIdrSlice(/*sao=*/false);
 
 	H265SliceHeader shd;
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+}
+
+// ============================================================================
+// Range guards on Exp-Golomb values used as allocation sizes or loop bounds
+// ============================================================================
+
+TEST(H265Parser, SpsRejectsOversizedPictureDimensions)
+{
+	SpsOverrides overrides;
+	overrides.pic_width = H265_MAX_PIC_DIMENSION_IN_LUMA_SAMPLES + 1;
+
+	H265SPS sps;
+	auto sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/0, /*log2_diff=*/3, overrides);
+	EXPECT_FALSE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+
+	// Rejected before the rounding and the product in GetPicSizeInCtbsY() can overflow.
+	overrides.pic_width = 320;
+	overrides.pic_height = 1u << 20;
+	sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/0, /*log2_diff=*/3, overrides);
+	EXPECT_FALSE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+}
+
+TEST(H265Parser, SpsRejectsZeroPictureDimensions)
+{
+	SpsOverrides overrides;
+	overrides.pic_width = 0;
+
+	H265SPS sps;
+	auto sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/0, /*log2_diff=*/3, overrides);
+	EXPECT_FALSE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+
+	overrides.pic_width = 320;
+	overrides.pic_height = 0;
+	sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/0, /*log2_diff=*/3, overrides);
+	EXPECT_FALSE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+}
+
+// num_short_term_ref_pic_sets is 0..64 (7.4.3.2.1); the slice header also does resize(n + 1).
+TEST(H265Parser, SpsRejectsExcessiveShortTermRefPicSets)
+{
+	H265SPS sps;
+	auto sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/H265_MAX_NUM_SHORT_TERM_REF_PIC_SETS + 1);
+	EXPECT_FALSE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+
+	// The boundary value is still accepted.
+	sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/H265_MAX_NUM_SHORT_TERM_REF_PIC_SETS);
+	EXPECT_TRUE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+}
+
+// num_negative_pics / num_positive_pics size four vectors in st_ref_pic_set() (7.4.8).
+TEST(H265Parser, SpsRejectsExcessiveRefPicCounts)
+{
+	SpsOverrides overrides;
+	overrides.num_negative_pics = H265_MAX_DPB_SIZE + 1;
+
+	H265SPS sps;
+	auto sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/1, /*log2_diff=*/3, overrides);
+	EXPECT_FALSE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+
+	// Each count is in range but their sum is not.
+	overrides.num_negative_pics = 10;
+	overrides.num_positive_pics = 10;
+	sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/1, /*log2_diff=*/3, overrides);
+	EXPECT_FALSE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+
+	// The boundary sum is still accepted.
+	overrides.num_negative_pics = H265_MAX_DPB_SIZE - 1;
+	overrides.num_positive_pics = 1;
+	sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/1, /*log2_diff=*/3, overrides);
+	EXPECT_TRUE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+}
+
+// num_long_term_ref_pics_sps is 0..32 (7.4.3.2.1); resizes _used_by_curr_pic_lt_sps_flag.
+TEST(H265Parser, SpsRejectsExcessiveLongTermRefPics)
+{
+	SpsOverrides overrides;
+	overrides.long_term_ref_pics_present = true;
+	overrides.num_long_term_ref_pics_sps = H265_MAX_NUM_LONG_TERM_REF_PICS_SPS + 1;
+
+	H265SPS sps;
+	auto sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/0, /*log2_diff=*/3, overrides);
+	EXPECT_FALSE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+
+	// The boundary value is still accepted.
+	overrides.num_long_term_ref_pics_sps = H265_MAX_NUM_LONG_TERM_REF_PICS_SPS;
+	sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/0, /*log2_diff=*/3, overrides);
+	EXPECT_TRUE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+}
+
+// num_ref_idx_lX_default_active_minus1 is 0..14 (7.4.7.1); becomes the slice header default.
+TEST(H265Parser, PpsRejectsExcessiveNumRefIdxDefaultActive)
+{
+	H265PPS pps;
+	auto pps_nal = BuildPps(/*num_extra=*/0, /*range_extension=*/false,
+							/*num_ref_idx_default_active_minus1=*/H265_MAX_NUM_REF_IDX_ACTIVE_MINUS1 + 1);
+	EXPECT_FALSE(H265Parser::ParsePPS(pps_nal.data(), pps_nal.size(), pps));
+
+	// The boundary value is still accepted.
+	pps_nal = BuildPps(/*num_extra=*/0, /*range_extension=*/false,
+					   /*num_ref_idx_default_active_minus1=*/H265_MAX_NUM_REF_IDX_ACTIVE_MINUS1);
+	EXPECT_TRUE(H265Parser::ParsePPS(pps_nal.data(), pps_nal.size(), pps));
+}
+
+// slice_segment_address is u(Ceil(Log2(PicSizeInCtbsY))) and sizes the clear range of every
+// non-first slice segment. 1920x1080 with CtbSizeY 64 gives 30*17 = 510 CTBs -> 9 bits.
+// The two cases bracket the byte boundary so a one-bit error either way is caught.
+TEST(H265Parser, NonFirstSliceSegmentHeaderSize)
+{
+	SpsOverrides overrides;
+	overrides.pic_width = 1920;
+	overrides.pic_height = 1080;
+
+	{
+		// 1 + 1 + 1 + 9 + 3 + 1 = 16 bits, + 1 alignment bit = 17 -> 3 bytes.
+		// An 8-bit address would give 16 bits -> 2 bytes.
+		auto record = BuildRecord(/*sao=*/false, /*num_strps=*/0, /*num_extra=*/0, /*log2_diff=*/3,
+								  /*range_extension=*/false, /*entropy_coding_sync=*/false, overrides);
+		ASSERT_EQ(record->GetSPS(0)->GetPicSizeInCtbsY(), 510u);
+
+		auto slice = BuildNonFirstIdrSlice(/*address_bits=*/9);
+		H265SliceHeader shd;
+		ASSERT_TRUE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+		EXPECT_EQ(shd.GetHeaderSizeInBytes(), 3u);
+	}
+
+	{
+		// With 7 extra slice header bits: 16 + 7 = 23 bits, + 1 = 24 -> 3 bytes.
+		// A 10-bit address would give 25 bits -> 4 bytes.
+		auto record = BuildRecord(/*sao=*/false, /*num_strps=*/0, /*num_extra=*/7, /*log2_diff=*/3,
+								  /*range_extension=*/false, /*entropy_coding_sync=*/false, overrides);
+
+		auto slice = BuildNonFirstIdrSlice(/*address_bits=*/9, /*num_extra=*/7);
+		H265SliceHeader shd;
+		ASSERT_TRUE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+		EXPECT_EQ(shd.GetHeaderSizeInBytes(), 3u);
+	}
+}
+
+// A failed parse leaves the output struct cleared, not holding the previous slice's values.
+TEST(H265Parser, SliceHeaderIsResetOnFailure)
+{
+	auto record = BuildRecord(/*sao=*/false);
+
+	H265SliceHeader shd;
+	auto good = BuildIdrSlice(/*sao=*/false);
+	ASSERT_TRUE(H265Parser::ParseSliceHeader(good.data(), good.size(), shd, record));
+	ASSERT_EQ(shd.GetHeaderSizeInBytes(), 1u);
+
+	// Reusing the same struct for a NAL that fails must clear it.
+	auto bad = BuildIdrSlice(/*sao=*/false, /*slice_type=*/3);
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(bad.data(), bad.size(), shd, record));
+	EXPECT_EQ(shd.GetHeaderSizeInBytes(), 0u);
+}
+
+// ============================================================================
+// Long-term reference picture counts and indices (7.4.7.1)
+// ============================================================================
+
+// num_long_term_sps + num_long_term_pics is summed in uint32 and drives the long-term loop.
+TEST(H265Parser, SliceHeaderRejectsWrappingLongTermCount)
+{
+	SpsOverrides overrides;
+	overrides.long_term_ref_pics_present = true;
+	overrides.num_long_term_ref_pics_sps = 2;
+
+	auto record = BuildRecord(/*sao=*/false, /*num_strps=*/1, /*num_extra=*/0, /*log2_diff=*/3,
+							  /*range_extension=*/false, /*entropy_coding_sync=*/false, overrides);
+
+	H265SliceHeader shd;
+	// 0x80000000 + 0x80000000 wraps to 0.
+	auto slice = BuildLongTermRefPSlice(/*num_long_term_sps=*/0x80000000, /*num_long_term_pics=*/0x80000000);
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+
+	// num_long_term_sps must not exceed the SPS list size.
+	slice = BuildLongTermRefPSlice(/*num_long_term_sps=*/3, /*num_long_term_pics=*/0);
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+
+	// The sum must fit the DPB.
+	slice = BuildLongTermRefPSlice(/*num_long_term_sps=*/2, /*num_long_term_pics=*/H265_MAX_DPB_SIZE);
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+}
+
+// lt_idx_sps is read with Ceil(Log2(num_long_term_ref_pics_sps)) bits, so for a list of 3
+// the value 3 is representable but out of range.
+TEST(H265Parser, SliceHeaderRejectsOutOfRangeLtIdxSps)
+{
+	SpsOverrides overrides;
+	overrides.long_term_ref_pics_present = true;
+	overrides.num_long_term_ref_pics_sps = 3;	 // Ceil(Log2(3)) == 2 bits -> 0..3 representable
+
+	auto record = BuildRecord(/*sao=*/false, /*num_strps=*/1, /*num_extra=*/0, /*log2_diff=*/3,
+							  /*range_extension=*/false, /*entropy_coding_sync=*/false, overrides);
+
+	H265SliceHeader shd;
+	auto slice = BuildLongTermRefPSlice(/*num_long_term_sps=*/1, /*num_long_term_pics=*/0,
+										/*lt_idx_sps=*/3, /*num_long_term_ref_pics_sps=*/3);
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+
+	// The last valid index is still accepted.
+	slice = BuildLongTermRefPSlice(/*num_long_term_sps=*/1, /*num_long_term_pics=*/0,
+								   /*lt_idx_sps=*/2, /*num_long_term_ref_pics_sps=*/3);
+	EXPECT_TRUE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+}
+
+// ============================================================================
+// Parameter set ids
+// ============================================================================
+
+// The record keys its SPS map by sps_seq_parameter_set_id, so it must be stored.
+TEST(H265Parser, SpsIdIsParsedAndStored)
+{
+	H265SPS sps;
+	auto sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/0, /*log2_diff=*/3, /*overrides=*/{},
+							/*log2_max_pic_order_cnt_lsb_minus4=*/0, /*sps_id=*/7);
+	ASSERT_TRUE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+	EXPECT_EQ(sps.GetId(), 7u);
+}
+
+// Two SPS with different ids must both be retrievable.
+TEST(H265DecoderConfig, DistinctSpsIdsCoexist)
+{
+	auto record = std::make_shared<HEVCDecoderConfigurationRecord>();
+	record->AddNalUnit(H265NALUnitType::SPS, ToData(BuildSps(/*sao=*/false, 0, 3, {}, 0, /*sps_id=*/0)));
+	record->AddNalUnit(H265NALUnitType::SPS, ToData(BuildSps(/*sao=*/false, 0, 3, {}, 0, /*sps_id=*/1)));
+
+	ASSERT_NE(record->GetSPS(0), nullptr);
+	ASSERT_NE(record->GetSPS(1), nullptr);
+	EXPECT_EQ(record->GetSPS(0)->GetId(), 0u);
+	EXPECT_EQ(record->GetSPS(1)->GetId(), 1u);
+}
+
+// A parameter set that reuses an id is an update: the stored parse and the hvcC arrays follow it.
+TEST(H265DecoderConfig, SameSpsIdIsReplacedNotDropped)
+{
+	SpsOverrides wide;
+	wide.pic_width = 1280;
+	wide.pic_height = 720;
+
+	auto record = std::make_shared<HEVCDecoderConfigurationRecord>();
+	record->AddNalUnit(H265NALUnitType::SPS, ToData(BuildSps(/*sao=*/false)));	 // 320x240, id 0
+	ASSERT_NE(record->GetSPS(0), nullptr);
+	EXPECT_EQ(record->GetSPS(0)->GetWidth(), 320u);
+
+	const auto nal_count_before = record->GetNalUnits(H265NALUnitType::SPS).size();
+
+	// Same id, different resolution.
+	record->AddNalUnit(H265NALUnitType::SPS, ToData(BuildSps(/*sao=*/false, 0, 3, wide)));
+
+	ASSERT_NE(record->GetSPS(0), nullptr);
+	EXPECT_EQ(record->GetSPS(0)->GetWidth(), 1280u);
+	// The hvcC array holds one SPS for the id, not two.
+	EXPECT_EQ(record->GetNalUnits(H265NALUnitType::SPS).size(), nal_count_before);
+}
+
+// GetVpsSpsPpsAsAnnexB() caches its result, so a later parameter set update must clear it.
+TEST(H265DecoderConfig, AnnexBCacheFollowsSpsUpdate)
+{
+	SpsOverrides wide;
+	wide.pic_width = 1280;
+	wide.pic_height = 720;
+
+	auto record = std::make_shared<HEVCDecoderConfigurationRecord>();
+	record->AddNalUnit(H265NALUnitType::VPS, ToData(BuildVps()));
+	record->AddNalUnit(H265NALUnitType::SPS, ToData(BuildSps(/*sao=*/false)));
+	record->AddNalUnit(H265NALUnitType::PPS, ToData(BuildPps()));
+	ASSERT_TRUE(record->IsValid());
+
+	// Populate the cache.
+	auto [first_data, first_frag] = record->GetVpsSpsPpsAsAnnexB();
+	ASSERT_NE(first_data, nullptr);
+
+	// Same id, larger SPS.
+	auto wide_sps = BuildSps(/*sao=*/false, 0, 3, wide);
+	record->AddNalUnit(H265NALUnitType::SPS, ToData(wide_sps));
+
+	auto [second_data, second_frag] = record->GetVpsSpsPpsAsAnnexB();
+	ASSERT_NE(second_data, nullptr);
+	// The rebuilt Annex B must contain the new SPS, so it cannot be the cached buffer.
+	EXPECT_NE(second_data->GetLength(), first_data->GetLength());
+}
+
+// Ids out of the spec range would narrow into the uint8_t map key and alias a valid entry.
+TEST(H265Parser, SpsRejectsOutOfRangeId)
+{
+	H265SPS sps;
+	auto sps_nal = BuildSps(/*sao=*/false, 0, 3, {}, 0, /*sps_id=*/H265_MAX_SPS_ID + 1);
+	EXPECT_FALSE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+
+	sps_nal = BuildSps(/*sao=*/false, 0, 3, {}, 0, /*sps_id=*/256);	 // would wrap to 0
+	EXPECT_FALSE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+
+	sps_nal = BuildSps(/*sao=*/false, 0, 3, {}, 0, /*sps_id=*/H265_MAX_SPS_ID);
+	EXPECT_TRUE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+}
+
+TEST(H265Parser, PpsRejectsOutOfRangeId)
+{
+	H265PPS pps;
+	auto pps_nal = BuildPps(0, false, 0, false, /*pps_id=*/H265_MAX_PPS_ID + 1);
+	EXPECT_FALSE(H265Parser::ParsePPS(pps_nal.data(), pps_nal.size(), pps));
+
+	pps_nal = BuildPps(0, false, 0, false, /*pps_id=*/256);	 // would wrap to 0
+	EXPECT_FALSE(H265Parser::ParsePPS(pps_nal.data(), pps_nal.size(), pps));
+
+	// pps_seq_parameter_set_id follows the SPS range, not the PPS range.
+	pps_nal = BuildPps(0, false, 0, false, /*pps_id=*/0, /*sps_id=*/H265_MAX_SPS_ID + 1);
+	EXPECT_FALSE(H265Parser::ParsePPS(pps_nal.data(), pps_nal.size(), pps));
+
+	pps_nal = BuildPps(0, false, 0, false, /*pps_id=*/H265_MAX_PPS_ID, /*sps_id=*/H265_MAX_SPS_ID);
+	EXPECT_TRUE(H265Parser::ParsePPS(pps_nal.data(), pps_nal.size(), pps));
+}
+
+// ============================================================================
+// Values that reach ReadBits() as a bit count (uint8_t, so they can narrow)
+// ============================================================================
+
+// log2_max_pic_order_cnt_lsb_minus4 is 0..12 (7.4.3.2.1); value + 4 is used as a bit count.
+TEST(H265Parser, SpsRejectsExcessiveLog2MaxPicOrderCntLsb)
+{
+	H265SPS sps;
+	auto sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/0, /*log2_diff=*/3, /*overrides=*/{},
+							/*log2_max_pic_order_cnt_lsb_minus4=*/H265_MAX_LOG2_MAX_PIC_ORDER_CNT_LSB_MINUS4 + 1);
+	EXPECT_FALSE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+
+	sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/0, /*log2_diff=*/3, /*overrides=*/{},
+					   /*log2_max_pic_order_cnt_lsb_minus4=*/252);
+	EXPECT_FALSE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+
+	// The boundary value is still accepted.
+	sps_nal = BuildSps(/*sao=*/false, /*num_strps=*/0, /*log2_diff=*/3, /*overrides=*/{},
+					   /*log2_max_pic_order_cnt_lsb_minus4=*/H265_MAX_LOG2_MAX_PIC_ORDER_CNT_LSB_MINUS4);
+	EXPECT_TRUE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+}
+
+// offset_len_minus1 is 0..31 (7.4.7.1); at 255 the width narrows to 0 and consumes nothing.
+TEST(H265Parser, SliceHeaderRejectsExcessiveOffsetLen)
+{
+	auto record = BuildRecord(/*sao=*/false, /*num_strps=*/0, /*num_extra=*/0,
+							  /*log2_diff=*/3, /*range_extension=*/false, /*entropy_coding_sync=*/true);
+
+	H265SliceHeader shd;
+	auto slice = BuildWppIdrSlice(/*num_entry_point_offsets=*/2, /*offset_len_minus1=*/255);
+	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
+
+	slice = BuildWppIdrSlice(/*num_entry_point_offsets=*/2, /*offset_len_minus1=*/H265_MAX_OFFSET_LEN_MINUS1 + 1);
 	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
 }

--- a/src/modules/bitstream/h265/h265_parser_test.cpp
+++ b/src/modules/bitstream/h265/h265_parser_test.cpp
@@ -1090,6 +1090,33 @@ TEST(H265DecoderConfig, AnnexBCacheFollowsSpsUpdate)
 	EXPECT_NE(second_data->GetLength(), first_data->GetLength());
 }
 
+// GetData() in the base class caches the serialized record until UpdateData() is called, so a
+// later parameter set update must mark it stale or WriteHvccBox() keeps writing the old bytes.
+TEST(H265DecoderConfig, SerializedRecordFollowsSpsUpdate)
+{
+	SpsOverrides wide;
+	wide.pic_width = 1280;
+	wide.pic_height = 720;
+
+	auto record = std::make_shared<HEVCDecoderConfigurationRecord>();
+	record->AddNalUnit(H265NALUnitType::VPS, ToData(BuildVps()));
+	record->AddNalUnit(H265NALUnitType::SPS, ToData(BuildSps(/*sao=*/false)));
+	record->AddNalUnit(H265NALUnitType::PPS, ToData(BuildPps()));
+	ASSERT_TRUE(record->IsValid());
+
+	// Populate the cache.
+	auto first = record->GetData();
+	ASSERT_NE(first, nullptr);
+	const auto first_length = first->GetLength();
+
+	// Same id, larger SPS.
+	record->AddNalUnit(H265NALUnitType::SPS, ToData(BuildSps(/*sao=*/false, 0, 3, wide)));
+
+	auto second = record->GetData();
+	ASSERT_NE(second, nullptr);
+	EXPECT_NE(second->GetLength(), first_length);
+}
+
 // Ids out of the spec range would narrow into the uint8_t map key and alias a valid entry.
 TEST(H265Parser, SpsRejectsOutOfRangeId)
 {

--- a/src/modules/containers/bmff/bmff_packager.cpp
+++ b/src/modules/containers/bmff/bmff_packager.cpp
@@ -916,9 +916,8 @@ namespace bmff
 		// CENC
 		if (_cenc_property.scheme != CencProtectScheme::None)
 		{
-			// Encrypted HEVC must use the 'hvc1' sample entry (parameter sets in the sample
-			// entry), matching the 'hvc1' codec string advertised by
-			// HEVCDecoderConfigurationRecord::GetCodecsParameter(). Browser EME / Widevine
+			// Encrypted HEVC must use the 'hvc1' sample entry
+			// (parameter sets stored in the sample entry, not in-band)
 			if (WriteSinfBox(stream, "hvc1") == false)
 			{
 				logte("Packager::WriteHvc1Box() - Failed to write sinf box");
@@ -927,7 +926,7 @@ namespace bmff
 
 			return WriteBox(container_stream, "encv", *stream.GetData());
 		}
-				
+
 		return WriteBox(container_stream, "hvc1", *stream.GetData());
 	}
 	

--- a/src/modules/containers/bmff/bmff_packager.cpp
+++ b/src/modules/containers/bmff/bmff_packager.cpp
@@ -913,6 +913,21 @@ namespace bmff
 			return false;
 		}
 
+		// CENC
+		if (_cenc_property.scheme != CencProtectScheme::None)
+		{
+			// Encrypted HEVC must use the 'hvc1' sample entry (parameter sets in the sample
+			// entry), matching the 'hvc1' codec string advertised by
+			// HEVCDecoderConfigurationRecord::GetCodecsParameter(). Browser EME / Widevine
+			if (WriteSinfBox(stream, "hvc1") == false)
+			{
+				logte("Packager::WriteHvc1Box() - Failed to write sinf box");
+				return false;
+			}
+
+			return WriteBox(container_stream, "encv", *stream.GetData());
+		}
+				
 		return WriteBox(container_stream, "hvc1", *stream.GetData());
 	}
 	

--- a/src/modules/containers/bmff/bmff_packager.cpp
+++ b/src/modules/containers/bmff/bmff_packager.cpp
@@ -913,7 +913,7 @@ namespace bmff
 			return false;
 		}
 
-		return WriteBox(container_stream, "hev1", *stream.GetData());
+		return WriteBox(container_stream, "hvc1", *stream.GetData());
 	}
 	
 	bool Packager::WriteHvccBox(ov::ByteStream &container_stream)

--- a/src/modules/containers/bmff/bmff_packager.cpp
+++ b/src/modules/containers/bmff/bmff_packager.cpp
@@ -916,8 +916,7 @@ namespace bmff
 		// CENC
 		if (_cenc_property.scheme != CencProtectScheme::None)
 		{
-			// Encrypted HEVC must use the 'hvc1' sample entry
-			// (parameter sets stored in the sample entry, not in-band)
+			// Sample entry becomes 'encv'; 'hvc1' is the original_format in sinf/frma.
 			if (WriteSinfBox(stream, "hvc1") == false)
 			{
 				logte("Packager::WriteHvc1Box() - Failed to write sinf box");
@@ -929,7 +928,7 @@ namespace bmff
 
 		return WriteBox(container_stream, "hvc1", *stream.GetData());
 	}
-	
+
 	bool Packager::WriteHvccBox(ov::ByteStream &container_stream)
 	{
 		// ISO/IEC 14496-15 8.4.1.1

--- a/src/modules/containers/bmff/cenc.cpp
+++ b/src/modules/containers/bmff/cenc.cpp
@@ -106,9 +106,8 @@ namespace bmff
 		{
 			case cmn::BitstreamFormat::H264_AVCC:
 				return GenerateSubSamplesFromH264(media_packet, sub_samples);
-            case cmn::BitstreamFormat::HVCC:
-                // TODO: Implement
-                return true;
+			case cmn::BitstreamFormat::HVCC:
+				return GenerateSubSamplesFromH265(media_packet, sub_samples);
 			default:
 				// Others, full sample encryption
 				return true;
@@ -230,6 +229,12 @@ namespace bmff
 
         logtt("Subsample count : %zu Total subsamples : %u / %zu", sub_samples.size(), total_bytes, media_packet->GetDataLength());
 
+		return true;
+	}
+
+	bool Encryptor::GenerateSubSamplesFromH265(const std::shared_ptr<const MediaPacket> &media_packet, std::vector<Sample::SubSample> &sub_samples)
+	{
+		// HEVC subsample encryption is not supported in the OSS version.
 		return true;
 	}
 

--- a/src/modules/containers/bmff/cenc.cpp
+++ b/src/modules/containers/bmff/cenc.cpp
@@ -234,8 +234,10 @@ namespace bmff
 
 	bool Encryptor::GenerateSubSamplesFromH265(const std::shared_ptr<const MediaPacket> &media_packet, std::vector<Sample::SubSample> &sub_samples)
 	{
-		// HEVC subsample encryption is not supported in the OSS version.
-		return true;
+		(void)media_packet;
+		(void)sub_samples;
+		// HEVC subsample encryption is not supported in the OSS version
+		return false;
 	}
 
 	bool Encryptor::EncryptInternal(const std::shared_ptr<const ov::Data> &clear_sample_data, std::shared_ptr<ov::Data> &encrypted_sample_data, const std::vector<Sample::SubSample> &sub_samples)

--- a/src/modules/containers/bmff/cenc.h
+++ b/src/modules/containers/bmff/cenc.h
@@ -31,7 +31,7 @@ namespace bmff
 	// Codecs the CENC implementation can encrypt
 	inline bool IsCencSupportedCodec(cmn::MediaCodecId codec_id)
 	{
-		return codec_id == cmn::MediaCodecId::H264 || codec_id == cmn::MediaCodecId::Aac;
+		return codec_id == cmn::MediaCodecId::H264 || codec_id == cmn::MediaCodecId::H265 || codec_id == cmn::MediaCodecId::Aac;
 	}
 
 	namespace internal
@@ -365,6 +365,7 @@ namespace bmff
 	private:
 		bool GenerateSubSamples(const std::shared_ptr<const MediaPacket> &media_packet, std::vector<Sample::SubSample> &sub_samples);
 		bool GenerateSubSamplesFromH264(const std::shared_ptr<const MediaPacket> &media_packet, std::vector<Sample::SubSample> &sub_samples);
+		bool GenerateSubSamplesFromH265(const std::shared_ptr<const MediaPacket> &media_packet, std::vector<Sample::SubSample> &sub_samples);
 
 		// If sub_samples is empty, it means that the full sample encryption is performed.
 		bool EncryptInternal(const std::shared_ptr<const ov::Data> &clear_data, std::shared_ptr<ov::Data> &encrypted_data, const std::vector<Sample::SubSample> &sub_samples);

--- a/src/modules/containers/bmff/cenc.h
+++ b/src/modules/containers/bmff/cenc.h
@@ -31,7 +31,15 @@ namespace bmff
 	// Codecs the CENC implementation can encrypt
 	inline bool IsCencSupportedCodec(cmn::MediaCodecId codec_id)
 	{
-		return codec_id == cmn::MediaCodecId::H264 || codec_id == cmn::MediaCodecId::H265 || codec_id == cmn::MediaCodecId::Aac;
+		switch(codec_id)
+		{
+			case cmn::MediaCodecId::H264:
+				return true;
+			case cmn::MediaCodecId::Aac:
+				return true;
+			default:
+				return false;
+		}
 	}
 
 	namespace internal

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_packager.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_packager.cpp
@@ -795,8 +795,7 @@ namespace bmff
 					break;
 
 				case cmn::MediaCodecId::H265:
-					// Must match the sample entry fourcc written by `WriteHvc1Box()` (`hev1`)
-					stream.WriteText("hev1");
+					stream.WriteText("hvc1");
 					break;
 
 				case cmn::MediaCodecId::Av1:


### PR DESCRIPTION
### Summary

Adds a slice segment header parser to the H.265 parser and switches the HEVC sample entry from hev1 to hvc1.

### Chnages
- Add H265Parser::ParseSliceHeader() to parse the slice segment header and measure its size; add H265SliceHeader, GetSPS()/GetPPS() accessors, and the SPS/PPS fields it needs.
- Replace `hev1` to `hvc1` in the packaging path and in GetCodecsParameter().

### Testing 
- Publish an HEVC stream to OME using OBS with E-RTMP or SRT.
- Generate an LLHLS stream from OME using h265 encoding (HW required) or bypass options.
- Verify that the stream plays correctly across various browsers and devices.

### Unit Test
```
cmake build/debug && ninja -C build/debug ome_test_modules
./build/debug/bin/ome_test_modules --gtest_filter='H265Parser.*:H265DecoderConfig.*'
```

