### PR TITLE
feat(llhls): support runtime DRM key rotation

### DIFF
--- a/docs/streaming/low-latency-hls.md
+++ b/docs/streaming/low-latency-hls.md
@@ -303,7 +303,7 @@ Turn DRM on in the LLHLS publisher and point it at your DRM info file. `<InfoFil
 </Publishers>
 ```
 
-A stream reads the DRM info file when it starts, so edits to the file apply to streams created after the change.
+A stream reads the DRM info file when it starts.
 
 ### DRM Info File
 

--- a/docs/streaming/low-latency-hls.md
+++ b/docs/streaming/low-latency-hls.md
@@ -268,17 +268,21 @@ To assign labels to audio signals in the SRT Provider, configure the `<AudioMap>
 
 ## DRM
 
-OvenMediaEngine supports Widevine and Fairplay in LLHLS with simple setup since version 0.16.0, and PlayReady is also supported.
+OvenMediaEngine encrypts LLHLS streams with Common Encryption (CENC) and signals the keys in the playlists, so players can obtain a license and decrypt the content. Widevine, FairPlay and PlayReady are supported.
+
+Encryption keys are described in a separate DRM info file, which lets you apply different keys to different streams and change them without editing `Server.xml`.
 
 
 :::warning
 
-Currently, DRM is only supported for H.264 and AAC codecs. Support for H.265 will be added soon.
+Only H.264 video and AAC audio are encrypted. A track of any other codec is delivered without encryption, so a stream that has to be fully protected must be transcoded to H.264 and AAC.
 
 :::
 
 
-To include DRM information in your LLHLS Publisher configuration, follow these steps. You can set the `<InfoFile>` path as either a relative path, starting from the directory where `Server.xml` is located, or as an absolute path.
+### Enabling DRM
+
+Turn DRM on in the LLHLS publisher and point it at your DRM info file. `<InfoFile>` takes a path relative to the directory where `Server.xml` is located, or an absolute path.
 
 ```xml
 <!-- /Server/VirtualHosts/VirtualHost/Applications/Application -->
@@ -289,7 +293,7 @@ To include DRM information in your LLHLS Publisher configuration, follow these s
         <SegmentDuration>6</SegmentDuration>
         <SegmentCount>10</SegmentCount>
         <DRM>
-            <Enable>false</Enable>
+            <Enable>true</Enable>
             <InfoFile>path/to/file.xml</InfoFile>
         </DRM>
         <CrossDomains>
@@ -299,9 +303,11 @@ To include DRM information in your LLHLS Publisher configuration, follow these s
 </Publishers>
 ```
 
-The separation of the `<DRM>/<InfoFile>` is designed to allow dynamic changes to the file. Any modifications to the `<DRM>/<InfoFile>` will take effect when a new stream is generated.
+A stream reads the DRM info file when it starts, so edits to the file apply to streams created after the change.
 
-Here's how you should structure your DRM Info File:
+### DRM Info File
+
+The file holds one or more `<DRM>` entries. Each entry states which streams it applies to and which key protects them. A stream uses the first entry it matches, so put more specific entries before broader ones.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -310,70 +316,62 @@ Here's how you should structure your DRM Info File:
         <Name>MultiDRM</Name>
         <VirtualHostName>default</VirtualHostName>
         <ApplicationName>app</ApplicationName>
-        <StreamName>stream*</StreamName> <!-- Can be a wildcard regular expression -->
-        <CencProtectScheme>cbcs</CencProtectScheme> <!-- Currently supports cbcs only -->
-        <KeyId>572543f964e34dc68ba9ba9ef91d4xxx</KeyId> <!-- Hexadecimal -->
-        <Key>16cf4232a86364b519e1982a27d90xxx</Key> <!-- Hexadecimal -->
-        <Iv>572547f914e34dc68ba9ba9ef91d4xxx</Iv> <!-- Hexadecimal -->
-        <!-- Add one <Pssh> per DRM system.
-             For PlayReady, its systemId is 9a04f079-9840-4286-ab92-e65be0885f95
-             and the pssh Data field must hold the PlayReady Object (PRO). -->
-        <Pssh>...70737368000000009a04f07998404286ab92e65be0885f95...</Pssh> <!-- for PlayReady: 'pssh'(70737368) + version/flags(00000000) + SystemID(9a04f079...) are fixed; leading box size and trailing DataSize + PRO are per-content -->
-        <Pssh>0000003f7073736800000000edef8ba979d64acea3c827dcd51d21ed0000001f1210572547f964e34dc68ba9ba9ef91d4c4a1a05657a64726d48f3c6899xxx</Pssh> <!-- Hexadecimal, for Widevine -->
-        <!-- Add Pssh for FairPlay if needed -->
-        <FairPlayKeyUrl>skd://fiarplay_key_url</FairPlayKeyUrl> <!-- FairPlay only -->
-    </DRM>
-    <DRM>
-        <Name>MultiDRM2</Name>
-        <VirtualHostName>default</VirtualHostName>
-        <ApplicationName>app2</ApplicationName>
-        <StreamName>stream*</StreamName> <!-- Can be a wildcard regular expression -->
-        ...........
+        <StreamName>stream*</StreamName>
+
+        <CencProtectScheme>cbcs</CencProtectScheme>
+        <KeyId>572543f964e34dc68ba9ba9ef91d4c4a</KeyId>
+        <Key>16cf4232a86364b519e1982a27d90087</Key>
+        <Iv>572547f914e34dc68ba9ba9ef91d4c4a</Iv>
+        <Pssh>0000003f7073736800000000edef8ba979d64acea3c827dcd51d21ed0000001f1210572547f964e34dc68ba9ba9ef91d4c4a1a05657a64726d48f3c6899b06</Pssh>
+        <FairPlayKeyUrl>skd://fairplay_key_url</FairPlayKeyUrl>
     </DRM>
 </DRMInfo>
 ```
 
-Multiple `<DRM>` can be set. Specify the `<VirtualHostName>`, `<ApplicationName>`, and `<StreamName>` where DRM should be applied. `<StreamName>` supports wildcard regular expressions.
+**Stream matching**
 
-Currently, `<CencProtectScheme>` only supports `cbcs` since FairPlay also supports only `cbcs`. There may be limited prospects for adding other schemes in the near future.
+| Element | Description |
+| --- | --- |
+| `<Name>` | A label for the entry. It is only used to tell entries apart. |
+| `<VirtualHostName>` | Virtual host the entry applies to. |
+| `<ApplicationName>` | Application the entry applies to. |
+| `<StreamName>` | Stream the entry applies to. Wildcards are supported, so `stream*` covers every stream whose name starts with `stream`. |
 
-`<KeyId>`, `<Key>`, `<Iv>` and `<Pssh>` values are essential and should be provided by your DRM provider. `<FairPlayKeyUrl>` is only need for FairPlay and if you want to enable FairPlay to your stream, it is required. It will be also provided by your DRM provider.
+**Key material**
 
-OvenPlayer now includes DRM-related options. Enable DRM and input the License URL. Your content is now securely protected.
+Your DRM provider supplies these values.
+
+| Element | Description |
+| --- | --- |
+| `<CencProtectScheme>` | `cenc` or `cbcs`. See [Protection Schemes](#protection-schemes). |
+| `<KeyId>` | Key ID, 16 bytes in hexadecimal. |
+| `<Key>` | Content key, 16 bytes in hexadecimal. |
+| `<Iv>` | Initialization vector, 16 bytes in hexadecimal. |
+| `<Pssh>` | A protection system header in hexadecimal. Add one `<Pssh>` per DRM system you want to offer. |
+| `<FairPlayKeyUrl>` | Key URI for FairPlay. Required to offer FairPlay. |
+| `<Keyformat>` | FairPlay key format. Leave it out for FairPlay Streaming, or set it to `identity` to have the URI return the key itself. |
+
+Which DRM systems a stream offers follows from what you provide: each `<Pssh>` carries in its SystemID the system it belongs to, and `<FairPlayKeyUrl>` enables FairPlay. A PlayReady `<Pssh>` uses the SystemID `9a04f079-9840-4286-ab92-e65be0885f95` and has to carry the PlayReady Object (PRO) in its Data field.
+
+### Protection Schemes
+
+`<CencProtectScheme>` selects how the media is encrypted.
+
+| Scheme | Description |
+| --- | --- |
+| `cbcs` | AES-CBC with pattern encryption. Required for FairPlay, and supported by Widevine and PlayReady. |
+| `cenc` | AES-CTR full sample encryption. Supported by Widevine and PlayReady. |
+
+Use `cbcs` when a single stream has to serve FairPlay together with other systems.
+
+### Playback
+
+OvenPlayer provides DRM options. Enable DRM and enter the license URL of your DRM provider.
 
 ![](../images/llhls-drm-scheduled-channel.png)
 
-### Pallycon DRM
+### DRM Provider Integration
 
+The Open Source edition implements the standard side of DRM in full. It encrypts with Common Encryption and signals the keys for Widevine, FairPlay and PlayReady, which is everything a player needs to acquire a license and decrypt. A stream can therefore be served with the license server of a commercial DRM provider: you enter the key material the provider issues to you, as shown above.
 
-:::danger
-
-Pallycon is no longer supported by the Open Source project and is only supported in the [Enterprise](https://ovenmedialabs.com/docs/ome-enterprise/pre-built-package-installation/getting-started/getting-started-with-linux) version. For more information, see this [article](https://github.com/OvenMediaLabs/OvenMediaEngine/discussions/1634).
-
-:::
-
-
-OvenMediaEngine integrates with [Pallycon](https://pallycon.com/), allowing you to more easily apply DRM to LLHLS streams.
-
-To integrate Pallycon, configure the `DRMInfo.xml` file as follows.
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<DRMInfo>
-    <DRM>
-        <Name>Pallycon</Name>
-        <VirtualHostName>default</VirtualHostName>
-        <ApplicationName>app</ApplicationName>
-        <StreamName>stream*</StreamName> <!-- Can be wildcard regular expression -->
-
-        <DRMProvider>Pallycon</DRMProvider> <!-- Manual(default), Pallycon -->
-        <DRMSystem>Widevine,Fairplay</DRMSystem> <!-- Widevine, Fairplay -->
-        <CencProtectScheme>cbcs</CencProtectScheme> <!-- cbcs, cenc -->
-        <ContentId>${VHostName}_${AppName}_${StreamName}</ContentId>
-        <KMSUrl>https://kms.pallycon.com/v2/cpix/pallycon/getKey/</KMSUrl>
-        <KMSToken>xxxx</KMSToken>
-    </DRM>
-</DRMInfo>
-```
-
-Set `<DRMProvider>` to `Pallycon`. Then, set the necessary information as shown in the example. `<KMSUrl>` and `<KMSToken>` are values provided by the Pallycon console. `<ContentId>` can be created using `${VHostName}`, `${AppName}`, and `${StreamName}` macros.
+Automating key issuance and application requires integrating with the key management service (KMS) of a DRM provider such as DoveRunner, which issues a key for each stream on request. Such an integration is specific to each provider, since the service, the credentials it issues and the details of its requests are the provider's own and are revised on their schedule, and it can only be exercised with a paid account at that provider. Keeping it working therefore takes those accounts and continuous testing against the live service, and it is provided in the [Enterprise](https://ovenmedia.com/docs/ome-enterprise/features/access-control-and-security/digital-rights-management-drm) edition.

--- a/misc/conf_examples/DrmInfo.xml
+++ b/misc/conf_examples/DrmInfo.xml
@@ -7,7 +7,7 @@
         <ApplicationName>app</ApplicationName>
         <StreamName>stream*</StreamName> <!-- Can be wildcard regular expression -->
 
-        <CencProtectScheme>cbcs</CencProtectScheme> <!-- Now only support cbcs -->
+        <CencProtectScheme>cbcs</CencProtectScheme> <!-- cbcs or cenc. FairPlay requires cbcs -->
         <KeyId>572543f964e34dc68ba9ba9ef91d4c4a</KeyId> <!-- hex -->
         <Key>16cf4232a86364b519e1982a27d90087</Key> <!-- hex -->
         <Iv>572547f914e34dc68ba9ba9ef91d4c4a</Iv> <!-- hex -->
@@ -16,8 +16,7 @@
              and the pssh Data field must hold the PlayReady Object (PRO). -->
         <Pssh>0000xxxx70737368000000009a04f07998404286ab92e65be0885f95000000...</Pssh> <!-- Hexadecimal, for PlayReady -->
         <Pssh>0000003f7073736800000000edef8ba979d64acea3c827dcd51d21ed0000001f1210572547f964e34dc68ba9ba9ef91d4c4a1a05657a64726d48f3c6899b06</Pssh> <!-- hex, for Widevine -->
-        <!-- If you want to support fairplay, add pssh for it. -->
 
-        <FairPlayKeyUrl>skd://fiarplay_key_url</FairPlayKeyUrl> <!-- FairPlay only -->
+        <FairPlayKeyUrl>skd://fairplay_key_url</FairPlayKeyUrl> <!-- FairPlay only. It is enough to offer FairPlay -->
     </DRM>
 </DRMInfo>

--- a/src/base/event/command/commands.h
+++ b/src/base/event/command/commands.h
@@ -1,4 +1,5 @@
 #pragma once
 
 #include "conclude_live.h"
+#include "rotate_drm_key.h"
 #include "update_language.h"

--- a/src/base/event/command/rotate_drm_key.h
+++ b/src/base/event/command/rotate_drm_key.h
@@ -3,7 +3,7 @@
 //  MediaEvent Payload
 //
 //  Created by Getroot
-//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
 //
 //==============================================================================
 #pragma once

--- a/src/base/event/command/rotate_drm_key.h
+++ b/src/base/event/command/rotate_drm_key.h
@@ -1,0 +1,39 @@
+//==============================================================================
+//
+//  MediaEvent Payload
+//
+//  Created by Getroot
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include "../event_command.h"
+
+class EventCommandRotateDrmKey : public EventCommand
+{
+public:
+	EventCommandRotateDrmKey()
+	{
+	}
+
+	Type GetType() const override
+	{
+		return Type::RotateDrmKey;
+	}
+
+	ov::String GetTypeString() const override
+	{
+		return "RotateDrmKey";
+	}
+
+	bool Parse(const std::shared_ptr<ov::Data> &data) override
+	{
+		return true;
+	}
+
+	std::shared_ptr<ov::Data> ToData() const override
+	{
+		return std::make_shared<ov::Data>();
+	}
+};

--- a/src/base/event/event_command.h
+++ b/src/base/event/event_command.h
@@ -20,6 +20,7 @@ public:
 		UpdateSubtitleLanguage, // Detected Subtitle Language
 		// Data format (json)
 		// { "trackLabel": "Origin", "language": "en" }
+		RotateDrmKey, // Rotate the DRM key to the next key (no payload)
 	};
 
 	virtual ~EventCommand() = default;

--- a/src/base/event/media_event.cpp
+++ b/src/base/event/media_event.cpp
@@ -10,6 +10,7 @@
 #include "media_event.h"
 #include "command/update_language.h"
 #include "command/conclude_live.h"
+#include "command/rotate_drm_key.h"
 
 std::shared_ptr<MediaEvent> MediaEvent::Convert(const std::shared_ptr<MediaPacket> &packet)
 {
@@ -151,6 +152,10 @@ bool MediaEvent::ParseCommandData()
 	case EventCommand::Type::ConcludeLive:
 		// No payload
 		_command = std::make_shared<EventCommandConcludeLive>();
+		break;
+	case EventCommand::Type::RotateDrmKey:
+		// No payload
+		_command = std::make_shared<EventCommandRotateDrmKey>();
 		break;
 	case EventCommand::Type::NOP:
 		// No payload

--- a/src/modules/containers/bmff/bmff_packager.cpp
+++ b/src/modules/containers/bmff/bmff_packager.cpp
@@ -36,6 +36,11 @@ namespace bmff
 		return _data_track;
 	}
 
+	const CencProperty &Packager::GetCencProperty() const
+	{
+		return _cenc_property;
+	}
+
 	bool Packager::UpdateMediaTrack(const std::shared_ptr<const MediaTrack> &media_track)
 	{
 		if (media_track == nullptr || media_track->GetId() != _media_track->GetId())
@@ -61,6 +66,27 @@ namespace bmff
 		_sample_buffer = SampleBuffer(_media_track, _cenc_property);
 
 		return true;
+	}
+
+	void Packager::UpdateCencProperty(const CencProperty &cenc_property)
+	{
+		_cenc_property = cenc_property;
+
+		if (_media_track->GetMediaType() == cmn::MediaType::Audio)
+		{
+			_cenc_property.crypt_bytes_block = 0;
+			_cenc_property.skip_bytes_block = 0;
+		}
+
+		if (_cenc_property.scheme != CencProtectScheme::None && IsCencSupportedCodec(_media_track->GetCodecId()) == false)
+		{
+			logte("CENC is not supported for the codec(%s), track(%u) will be excluded from CENC protection", cmn::GetCodecIdString(_media_track->GetCodecId()), _media_track->GetId());
+			_cenc_property.scheme = CencProtectScheme::None;
+		}
+
+		// The samples of the previous key were already written out; rebuild the buffer so
+		// the following samples are encrypted with the new key
+		_sample_buffer = SampleBuffer(_media_track, _cenc_property);
 	}
 
 	bool Packager::WriteFtypBox(ov::ByteStream &container_stream)

--- a/src/modules/containers/bmff/bmff_packager.h
+++ b/src/modules/containers/bmff/bmff_packager.h
@@ -31,9 +31,18 @@ namespace bmff
 		const std::shared_ptr<const MediaTrack> &GetMediaTrack() const;
 		const std::shared_ptr<const MediaTrack> &GetDataTrack() const;
 
+		// The CENC key material currently in effect (codec capability already applied),
+		// so the playlist can advertise the key each segment was encrypted with
+		const CencProperty &GetCencProperty() const;
+
 		// Switch to a new version of the same track at a runtime configuration change.
 		// Re-evaluates the CENC codec capability and rebuilds the sample buffer.
 		bool UpdateMediaTrack(const std::shared_ptr<const MediaTrack> &media_track);
+
+		// Swap the CENC key material at a runtime key rotation. Rebuilds the sample
+		// buffer so following samples are encrypted with the new key; the caller
+		// regenerates the initialization segment so its tenc/pssh carry the new key.
+		void UpdateCencProperty(const CencProperty &cenc_property);
 
 		// Fytp Box
 		virtual bool WriteFtypBox(ov::ByteStream &container_stream);

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_packager.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_packager.cpp
@@ -89,7 +89,36 @@ namespace bmff
 			return false;
 		}
 
-		return StoreInitializationSection(stream.GetDataPointer());
+		if (StoreInitializationSection(stream.GetDataPointer()) == false)
+		{
+			return false;
+		}
+
+		// The moov just written carries this version's tenc/pssh, so the key it was built
+		// with is the key every segment of this version is encrypted with
+		if (_storage != nullptr)
+		{
+			auto content_version = _storage->GetContentVersion();
+			_cenc_property_by_version[content_version] = GetCencProperty();
+
+			while (_cenc_property_by_version.size() > kMaxRetainedCencVersions)
+			{
+				_cenc_property_by_version.erase(_cenc_property_by_version.begin());
+			}
+		}
+
+		return true;
+	}
+
+	std::optional<CencProperty> FMP4Packager::GetCencPropertyForVersion(uint32_t content_version) const
+	{
+		auto it = _cenc_property_by_version.find(content_version);
+		if (it == _cenc_property_by_version.end())
+		{
+			return std::nullopt;
+		}
+
+		return it->second;
 	}
 
 	bool FMP4Packager::UpdateTrack(const std::shared_ptr<const MediaTrack> &media_track)
@@ -172,9 +201,19 @@ namespace bmff
 		}
 	}
 
+	void FMP4Packager::RequestKeyRotation(const CencProperty &cenc_property)
+	{
+		_pending_key_rotation = cenc_property;
+	}
+
 	double FMP4Packager::GetLastSampleEndTimestampMs() const
 	{
 		return _segmentation_info.last_sample_timestamp_ms + _segmentation_info.last_sample_duration_ms;
+	}
+
+	uint32_t FMP4Packager::GetCurrentContentVersion() const
+	{
+		return (_storage != nullptr) ? _storage->GetContentVersion() : 0;
 	}
 
 	bool FMP4Packager::ReserveDataPacket(const std::shared_ptr<const MediaPacket> &media_packet)
@@ -547,6 +586,40 @@ namespace bmff
 				// Set the average chunk duration to config.chunk_duration_ms
 				// _target_chunk_duration_ms -= total_sample_duration_ms;
 				// _target_chunk_duration_ms += _config.chunk_duration_ms;
+			}
+		}
+
+		// A DRM key rotation changes no content, so it needs no cut: it takes effect where
+		// a new segment starts on its own. Applying it here keeps every segment on a
+		// single key and leaves the segment duration pacing untouched.
+		if (_pending_key_rotation.has_value() == true)
+		{
+			auto buffered_samples = _sample_buffer.GetSamples();
+			bool buffer_is_empty = (buffered_samples == nullptr) || (buffered_samples->GetTotalCount() == 0);
+
+			auto pending_segment = std::static_pointer_cast<FMP4Segment>(_storage->GetLastSegment());
+			bool segment_is_starting = (pending_segment == nullptr) ||
+									   ((pending_segment->IsCompleted() == false) && (pending_segment->GetPartialCount() == 0));
+
+			// The new version starts at an independently decodable sample
+			bool independent = (next_frame->GetFlag() == MediaPacketFlag::Key) || (GetMediaTrack()->GetMediaType() == cmn::MediaType::Audio);
+
+			if (buffer_is_empty == true && segment_is_starting == true && independent == true)
+			{
+				_storage->StartNewContentVersionForKeyRotation();
+
+				// Rebuild the encryptor with the new key, then regenerate the
+				// initialization section so its tenc/pssh carry that key; it is stored
+				// under the version advanced above
+				UpdateCencProperty(_pending_key_rotation.value());
+				if (CreateInitializationSegment() == false)
+				{
+					// The version has no initialization section and no key to advertise,
+					// so this track cannot be played from here on
+					logtc("FMP4Packager::AppendSample() - Failed to regenerate initialization segment for key rotation, track(%u)", GetMediaTrack()->GetId());
+				}
+
+				_pending_key_rotation.reset();
 			}
 		}
 

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_packager.h
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_packager.h
@@ -8,6 +8,8 @@
 //==============================================================================
 #pragma once
 
+#include <optional>
+
 #include <base/info/media_track.h>
 #include <base/mediarouter/media_buffer.h>
 #include <base/modules/marker/marker_box.h>

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_packager.h
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_packager.h
@@ -48,9 +48,26 @@ namespace bmff
 		// current runtime-change sources cannot interleave that way.
 		void RequestCutForDiscontinuity(double boundary_timestamp_ms);
 
+		// Rotate the DRM key from the next segment on. Nothing is cut: where the next
+		// segment starts on its own, the content version advances, the sample buffer is
+		// rebuilt with the new key and the initialization section is regenerated with the
+		// new tenc/pssh. Every segment therefore carries a single key, and no
+		// discontinuity is signaled.
+		void RequestKeyRotation(const CencProperty &cenc_property);
+
 		// End timestamp of the last appended sample, the boundary position for
 		// propagating a discontinuity to the other tracks
 		double GetLastSampleEndTimestampMs() const;
+
+		// Content version currently stamped on this track's segments. Advances on a
+		// track configuration change and on a key rotation.
+		uint32_t GetCurrentContentVersion() const;
+
+		// The CENC key material a content version was packaged with, to advertise in the
+		// playlist for that version's segments. Recorded when the version's
+		// initialization section is created, so the answer does not depend on when the
+		// segment is reported. Empty when the version is unknown (already pruned).
+		std::optional<CencProperty> GetCencPropertyForVersion(uint32_t content_version) const;
 
 		// Generate Media FMP4Segment
 		bool AppendSample(const std::shared_ptr<const MediaPacket> &media_packet);
@@ -91,6 +108,17 @@ namespace bmff
 		// Timestamp of the last boundary this packager handled (own track change or
 		// an applied cut), to ignore re-propagation of the same boundary event
 		double _last_boundary_timestamp_ms = -1.0;
+
+		// A DRM key rotation requested from the stream, applied where the next segment
+		// starts on its own
+		std::optional<CencProperty> _pending_key_rotation;
+
+		// CENC key material per content version, recorded when that version's
+		// initialization section is created. Only ever queried for a version whose segment
+		// has just been produced, so a fixed retention of the most recent versions is
+		// enough; the playlist keeps its own copy for as long as it lists that version.
+		static constexpr size_t kMaxRetainedCencVersions = 64;
+		std::map<uint32_t, CencProperty> _cenc_property_by_version;
 
 		std::queue<std::shared_ptr<const MediaPacket>> _reserved_data_packets;
 	};

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_storage.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_storage.cpp
@@ -23,6 +23,10 @@ namespace bmff
 		_track = track;
 		_observer = observer;
 
+		// Seed the content version from the track's initial version so the version-less
+		// legacy URL keeps mapping to the first initialization section
+		_content_version = track->GetVersion();
+
 		// Keep one more to prevent download failure due to timing issue
 		_target_segment_duration_ms = static_cast<int64_t>(_config.segment_duration_ms);
 		_stream_tag = stream_tag;
@@ -215,17 +219,17 @@ namespace bmff
 	bool FMP4Storage::StoreInitializationSection(const std::shared_ptr<ov::Data> &section)
 	{
 		auto track = GetTrack();
-		auto track_version = track->GetVersion();
+		auto content_version = GetContentVersion();
 
 		{
 			std::lock_guard<std::shared_mutex> lock(_initialization_sections_lock);
 
 			if (_initialization_sections.empty())
 			{
-				_initial_track_version = track_version;
+				_initial_track_version = content_version;
 			}
 
-			_initialization_sections[track_version] = section;
+			_initialization_sections[content_version] = section;
 		}
 
 		if (_observer != nullptr)
@@ -245,6 +249,10 @@ namespace bmff
 			return false;
 		}
 
+		// A track configuration change starts a new content version, so its segments
+		// and initialization section are addressed separately from the old track
+		_content_version++;
+
 		// Close the old content (the buffered samples were already flushed). The
 		// completion is reported to the caller instead of the observer here, so that
 		// it can be published after the new initialization section is stored.
@@ -254,28 +262,36 @@ namespace bmff
 
 		std::atomic_store(&_track, track);
 
-		{
-			std::lock_guard<std::shared_mutex> segments_lock(_segments_lock);
-
-			if (_segments.empty() == false)
-			{
-				auto last_segment = _segments.rbegin()->second;
-
-				// The empty segment pre-created at the last completion still carries the
-				// old track timebase and version, so rebuild it on the new track
-				if (last_segment->IsCompleted() == false && last_segment->GetPartialCount() == 0)
-				{
-					auto new_segment = std::make_shared<FMP4Segment>(last_segment->GetNumber(), _config.segment_duration_ms, track->GetTimeBase().GetExpr());
-					new_segment->SetTrackVersion(track->GetVersion());
-					new_segment->SetCodecsParameter(track->GetCodecsParameter());
-					_segments[last_segment->GetNumber()] = new_segment;
-				}
-			}
-		}
+		RebuildPendingSegmentOnCurrentTrack();
 
 		MarkPendingSegmentDiscontinuity();
 
 		return true;
+	}
+
+	void FMP4Storage::RebuildPendingSegmentOnCurrentTrack()
+	{
+		auto track = GetTrack();
+
+		std::lock_guard<std::shared_mutex> segments_lock(_segments_lock);
+
+		if (_segments.empty() == true)
+		{
+			return;
+		}
+
+		auto last_segment = _segments.rbegin()->second;
+
+		// An empty segment pre-created at the last completion still carries the track
+		// timebase and content version of that moment. Samples of the new content would
+		// land in it and be served under the old version, so rebuild it.
+		if (last_segment->IsCompleted() == false && last_segment->GetPartialCount() == 0)
+		{
+			auto new_segment = std::make_shared<FMP4Segment>(last_segment->GetNumber(), _config.segment_duration_ms, track->GetTimeBase().GetExpr());
+			new_segment->SetTrackVersion(GetContentVersion());
+			new_segment->SetCodecsParameter(track->GetCodecsParameter());
+			_segments[last_segment->GetNumber()] = new_segment;
+		}
 	}
 
 	void FMP4Storage::CutSegmentForDiscontinuity()
@@ -287,6 +303,18 @@ namespace bmff
 		MarkPendingSegmentDiscontinuity();
 
 		NotifySegmentCompleted(completed_segment_number);
+	}
+
+	void FMP4Storage::StartNewContentVersionForKeyRotation()
+	{
+		// A key change does not change the content, so no segment is cut and the duration
+		// pacing is left alone. Only the version advances, so the segments encrypted with
+		// the new key get their own initialization section and key tag.
+		_content_version++;
+
+		// The empty segment waiting for the new samples was stamped with the previous
+		// version when it was pre-created
+		RebuildPendingSegmentOnCurrentTrack();
 	}
 
 	void FMP4Storage::NotifySegmentCompleted(int64_t segment_number)
@@ -456,7 +484,7 @@ namespace bmff
 
 		// Create next segment
 		auto segment = std::make_shared<FMP4Segment>(GetLastSegmentNumber() + 1, _config.segment_duration_ms, track->GetTimeBase().GetExpr());
-		segment->SetTrackVersion(track->GetVersion());
+		segment->SetTrackVersion(GetContentVersion());
 		segment->SetCodecsParameter(track->GetCodecsParameter());
 		{
 			std::lock_guard<std::shared_mutex> lock(_segments_lock);
@@ -591,7 +619,7 @@ namespace bmff
 
 			logtt("LLHLS stream (%s) / track (%u) - segment_seq(%" PRId64 ") segment_duration_ms: %f total_expected_duration_ms: %f, total_segment_duration_ms: %f, next_target_duration: %f",
 				_stream_tag.CStr(), GetTrack()->GetId(), segment->GetNumber(), segment->GetDurationMs(), _total_expected_duration_ms, _total_segment_duration_ms, next_target_duration);
-			
+
 			if (next_target_duration >= static_cast<double>(_config.segment_duration_ms)/2.0)
 			{
 				_target_segment_duration_ms = next_target_duration;

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_storage.h
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_storage.h
@@ -72,12 +72,27 @@ namespace bmff
 		// without a configuration change (another track of the stream changed)
 		void CutSegmentForDiscontinuity();
 
+		// Start a new content version for a DRM key rotation, so the segments encrypted
+		// with the new key are addressed separately from the old key. Called when a new
+		// segment is about to start: no segment is cut, no discontinuity is marked, and
+		// the segment duration pacing is untouched, because the content is unchanged.
+		void StartNewContentVersionForKeyRotation();
+
 		uint64_t GetMaxPartialDurationMs() const override;
 		uint64_t GetMinPartialDurationMs() const override;
 
 		ov::String GetContainerExtension() const override { return "m4s"; }
 
 		double GetTargetSegmentDuration() const;
+
+		// Monotonic identifier stamped on initialization sections and segments. Both a
+		// track configuration change and a DRM key rotation advance it, because each
+		// produces a new initialization section that must be addressed separately.
+		// Non-decreasing along segment numbers. Media-thread only.
+		uint32_t GetContentVersion() const
+		{
+			return _content_version;
+		}
 
 	private:
 		std::shared_ptr<FMP4Segment> GetSegmentInternal(int64_t segment_number) const;
@@ -93,8 +108,13 @@ namespace bmff
 		// Flag the pre-created empty segment as the start of a new discontinuity domain
 		void MarkPendingSegmentDiscontinuity();
 
+		// Re-create the pre-created empty segment on the current track and content
+		// version, so content of a new version never lands in a segment stamped with the
+		// previous one
+		void RebuildPendingSegmentOnCurrentTrack();
+
 		void DropUnreferencedInitializationSections();
-		
+
 
 		// For DVR
 		class DvrInfo
@@ -224,6 +244,11 @@ namespace bmff
 		// The first stored version, served for the version-less legacy URL
 		uint32_t _initial_track_version = 0;
 		mutable std::shared_mutex _initialization_sections_lock;
+
+		// Content version, advanced on each track configuration change and DRM key
+		// rotation. Seeded from the track's initial version so the version-less legacy
+		// URL keeps mapping to the first section. Media-thread only.
+		uint32_t _content_version = 0;
 
 		// segment number : segment
 		std::map<int64_t, std::shared_ptr<FMP4Segment>> _segments;

--- a/src/publishers/llhls/llhls_chunklist.cpp
+++ b/src/publishers/llhls/llhls_chunklist.cpp
@@ -41,9 +41,30 @@ void LLHlsChunklist::SetRenditions(const std::map<int32_t, std::shared_ptr<LLHls
 	_renditions = renditions;
 }
 
-void LLHlsChunklist::EnableCenc(const bmff::CencProperty &cenc_property)
+void LLHlsChunklist::EnableCenc(uint32_t content_version, const bmff::CencProperty &cenc_property)
 {
-	_cenc_property = cenc_property;
+	std::lock_guard<std::shared_mutex> lock(_segments_guard);
+	_cenc_properties[content_version] = cenc_property;
+
+	DropUnreferencedCencProperties();
+}
+
+// Called with _segments_guard held
+void LLHlsChunklist::DropUnreferencedCencProperties()
+{
+	// A listed segment whose key is gone would inherit the previous EXT-X-KEY and fail to
+	// decrypt, so a version's key may only be dropped once no segment can list it.
+	// Dumped output keeps every segment ever produced, so every key stays referenced.
+	if (_keep_old_segments == true || _segments.empty() == true)
+	{
+		return;
+	}
+
+	// Versions are non-decreasing along segment numbers, so anything below the oldest
+	// retained segment's version can no longer appear in any view of the playlist
+	auto min_referenced_version = _segments.begin()->second->GetTrackVersion();
+
+	_cenc_properties.erase(_cenc_properties.begin(), _cenc_properties.lower_bound(min_referenced_version));
 }
 
 void LLHlsChunklist::Release()
@@ -238,14 +259,22 @@ bool LLHlsChunklist::AppendPartialSegmentInfo(uint32_t segment_sequence, const S
 				_version_codecs[info.GetTrackVersion()] = info.GetCodecsParameter();
 			}
 
+			// Only an explicitly flagged boundary (a track configuration change) is a
+			// discontinuity. A DRM key rotation also starts a new version and map but is
+			// seamless, so the chunklist must not infer a discontinuity from the version
+			// change alone.
+			if (info.IsDiscontinuity() == true)
+			{
+				segment->SetDiscontinuity();
+				_total_discontinuity_count++;
+			}
+
+			// A new version (a track change or a key rotation) makes the hinted map
+			// inline from this partial on
 			if (info.IsDiscontinuity() == true ||
 				(_last_started_track_version.has_value() == true &&
 				 _last_started_track_version.value() != info.GetTrackVersion()))
 			{
-				segment->SetDiscontinuity();
-				_total_discontinuity_count++;
-
-				// The hinted map is inline from this partial on
 				_upcoming_map_uri.Clear();
 			}
 
@@ -372,9 +401,23 @@ bool LLHlsChunklist::GetLastSequenceNumber(int64_t &msn, int64_t &psn) const
 	return true;
 }
 
-ov::String LLHlsChunklist::MakeExtXKey() const
+ov::String LLHlsChunklist::MakeExtXKey(uint32_t content_version) const
 {
-	return pub::llhls::MakeCencKeyTag(_cenc_property, pub::llhls::PlaylistType::Media);
+	auto it = _cenc_properties.find(content_version);
+	if (it == _cenc_properties.end())
+	{
+		return "";
+	}
+
+	// A version produced in the clear (a codec CENC cannot encrypt) has to end the scope of
+	// the preceding key, otherwise its segments are still covered by it and players try to
+	// decrypt them. METHOD=NONE carries no other attribute.
+	if (it->second.scheme == bmff::CencProtectScheme::None)
+	{
+		return "#EXT-X-KEY:METHOD=NONE";
+	}
+
+	return pub::llhls::MakeCencKeyTag(it->second, pub::llhls::PlaylistType::Media);
 }
 
 ov::String LLHlsChunklist::MakeChunklist(const ov::String &query_string, bool skip, bool legacy, bool rewind, bool vod, uint32_t vod_start_segment_number) const
@@ -522,6 +565,8 @@ ov::String LLHlsChunklist::MakeChunklist(const ov::String &query_string, bool sk
 	// The map of the first listed segment leads the playlist, following segments
 	// declare a new EXT-X-MAP when theirs differs
 	ov::String current_map_uri = _map_uri;
+	uint32_t current_content_version = 0;
+	bool has_current_content_version = false;
 	{
 		std::shared_ptr<SegmentInfo> first_listed_segment = first_segment;
 		if (vod == true)
@@ -538,9 +583,15 @@ ov::String LLHlsChunklist::MakeChunklist(const ov::String &query_string, bool sk
 			}
 		}
 
-		if (first_listed_segment != nullptr && first_listed_segment->GetMapUri().IsEmpty() == false)
+		if (first_listed_segment != nullptr)
 		{
-			current_map_uri = first_listed_segment->GetMapUri();
+			if (first_listed_segment->GetMapUri().IsEmpty() == false)
+			{
+				current_map_uri = first_listed_segment->GetMapUri();
+			}
+
+			current_content_version = first_listed_segment->GetTrackVersion();
+			has_current_content_version = true;
 		}
 	}
 
@@ -554,10 +605,22 @@ ov::String LLHlsChunklist::MakeChunklist(const ov::String &query_string, bool sk
 		playlist.AppendFormat("\"\n");
 	}
 
-	// CENC
-	if (_cenc_property.scheme != bmff::CencProtectScheme::None)
+	// The EXT-X-KEY in effect. Re-emitted only when the key changes (a rotation), so
+	// a track change that keeps the same key does not repeat it.
+	ov::String current_ext_x_key;
+	auto emit_ext_x_key_if_changed = [&](uint32_t content_version) {
+		auto ext_x_key = MakeExtXKey(content_version);
+		if (ext_x_key.IsEmpty() == false && ext_x_key != current_ext_x_key)
+		{
+			playlist.AppendFormat("%s\n", ext_x_key.CStr());
+			current_ext_x_key = ext_x_key;
+		}
+	};
+
+	// CENC key for the leading segment's content version
+	if (has_current_content_version == true)
 	{
-		playlist.AppendFormat("%s\n", MakeExtXKey().CStr());
+		emit_ext_x_key_if_changed(current_content_version);
 	}
 
 	if (vod == true)
@@ -583,6 +646,10 @@ ov::String LLHlsChunklist::MakeChunklist(const ov::String &query_string, bool sk
 					playlist.AppendFormat("?%s", query_string.CStr());
 				}
 				playlist.AppendFormat("\"\n");
+
+				// A new map means a new content version; its key follows the map
+				current_content_version = segment->GetTrackVersion();
+				emit_ext_x_key_if_changed(current_content_version);
 			}
 
 			std::chrono::system_clock::time_point tp{std::chrono::milliseconds{segment->GetStartTime()}};
@@ -632,6 +699,10 @@ ov::String LLHlsChunklist::MakeChunklist(const ov::String &query_string, bool sk
 				playlist.AppendFormat("?%s", query_string.CStr());
 			}
 			playlist.AppendFormat("\"\n");
+
+			// A new map means a new content version; its key follows the map
+			current_content_version = segment->GetTrackVersion();
+			emit_ext_x_key_if_changed(current_content_version);
 		}
 
 		std::chrono::system_clock::time_point tp{std::chrono::milliseconds{segment->GetStartTime()}};

--- a/src/publishers/llhls/llhls_chunklist.cpp
+++ b/src/publishers/llhls/llhls_chunklist.cpp
@@ -610,11 +610,21 @@ ov::String LLHlsChunklist::MakeChunklist(const ov::String &query_string, bool sk
 	ov::String current_ext_x_key;
 	auto emit_ext_x_key_if_changed = [&](uint32_t content_version) {
 		auto ext_x_key = MakeExtXKey(content_version);
-		if (ext_x_key.IsEmpty() == false && ext_x_key != current_ext_x_key)
+		if (ext_x_key.IsEmpty() == true || ext_x_key == current_ext_x_key)
 		{
-			playlist.AppendFormat("%s\n", ext_x_key.CStr());
-			current_ext_x_key = ext_x_key;
+			return;
 		}
+
+		// METHOD=NONE ends the scope of the key in effect, so it is only meaningful once
+		// a key has been advertised. Without this an unprotected stream, or a window that
+		// no longer lists any protected segment, would carry a tag that ends nothing.
+		if (current_ext_x_key.IsEmpty() == true && ext_x_key.HasPrefix("#EXT-X-KEY:METHOD=NONE") == true)
+		{
+			return;
+		}
+
+		playlist.AppendFormat("%s\n", ext_x_key.CStr());
+		current_ext_x_key = ext_x_key;
 	};
 
 	// CENC key for the leading segment's content version

--- a/src/publishers/llhls/llhls_chunklist.h
+++ b/src/publishers/llhls/llhls_chunklist.h
@@ -268,7 +268,10 @@ public:
 
 	~LLHlsChunklist();
 
-	void EnableCenc(const bmff::CencProperty &cenc_property);
+	// Register the CENC key material for a content version. A stream without key
+	// rotation registers a single version; each rotation registers the next one, so
+	// the chunklist can emit the EXT-X-KEY that matches each segment's version.
+	void EnableCenc(uint32_t content_version, const bmff::CencProperty &cenc_property);
 
 	// A LLHlsChunklist has circular dependency issues because it holds its own pointer and pointers to all other chunklists. 
 	// Therefore, you must call the Release function.
@@ -331,7 +334,9 @@ private:
 
 	ov::String MakeChunklist(const ov::String &query_string, bool skip, bool legacy, bool rewind, bool vod = false, uint32_t vod_start_segment_number = 0) const;
 
-	ov::String MakeExtXKey() const;
+	// EXT-X-KEY tag for the given content version, empty when that version carries
+	// no key (unencrypted, or unknown version)
+	ov::String MakeExtXKey(uint32_t content_version) const;
 
 	ov::String MakeMarkers(const std::vector<std::shared_ptr<Marker>> &markers) const;
 
@@ -391,7 +396,13 @@ private:
 	std::shared_ptr<ov::Data> _cached_default_chunklist_gzip;
 	mutable std::shared_mutex _cached_default_chunklist_gzip_guard;
 
-	bmff::CencProperty _cenc_property;
+	// CENC key material per content version, so each segment's EXT-X-KEY matches the
+	// key its version was packaged with. A single entry when there is no key rotation.
+	// Guarded by _segments_guard.
+	std::map<uint32_t, bmff::CencProperty> _cenc_properties;
+
+	// Drop the keys of versions no segment can list any more
+	void DropUnreferencedCencProperties();
 
 	bool _end_list = false;
 

--- a/src/publishers/llhls/llhls_stream.cpp
+++ b/src/publishers/llhls/llhls_stream.cpp
@@ -2323,8 +2323,8 @@ void LLHlsStream::OnMediaChunkUpdated(const int32_t &track_id, const uint32_t &s
 		// Advertise the EXT-X-KEY of the key this version was actually encrypted with.
 		// The packager recorded it when the version's initialization section was created,
 		// so this holds even when a rotation and a track change land close together. A
-		// version that was produced in the clear records a scheme of None and so
-		// registers no key.
+		// version produced in the clear is registered with a scheme of None, from which
+		// the chunklist ends the scope of the preceding key.
 		auto content_version = segment->GetTrackVersion();
 		auto registered_it = _last_registered_cenc_version.find(track_id);
 		bool already_registered = (registered_it != _last_registered_cenc_version.end() && registered_it->second >= content_version);

--- a/src/publishers/llhls/llhls_stream.cpp
+++ b/src/publishers/llhls/llhls_stream.cpp
@@ -8,6 +8,9 @@
 //==============================================================================
 #include "llhls_stream.h"
 
+#include <algorithm>
+#include <cctype>
+
 #include <base/ovlibrary/hex.h>
 #include <base/publisher/application.h>
 #include <base/publisher/stream.h>
@@ -444,11 +447,23 @@ bool LLHlsStream::GetDrmInfo(const ov::String &file_path, std::vector<bmff::Cenc
 
 				// Auto key rotation period (seconds). Absent or 0 keeps a single key for
 				// the whole stream; a RotateDrmKey event still rotates regardless.
-				ov::String rotation_period_value = drm_node.child_value("KeyRotationPeriod");
+				ov::String rotation_period_value = ov::String(drm_node.child_value("KeyRotationPeriod")).Trim();
 				if (rotation_period_value.IsEmpty() == false)
 				{
-					auto rotation_period_sec = ov::Converter::ToInt64(rotation_period_value.Trim().CStr());
-					key_rotation_period_ms = (rotation_period_sec > 0) ? static_cast<uint64_t>(rotation_period_sec) * 1000 : 0;
+					// Digits only, so a value such as "1h" is reported instead of being read
+					// as the number it happens to start with
+					auto is_seconds = std::all_of(rotation_period_value.CStr(), rotation_period_value.CStr() + rotation_period_value.GetLength(),
+												  [](char character) { return ::isdigit(static_cast<unsigned char>(character)) != 0; });
+
+					if (is_seconds == false)
+					{
+						logtw("LLHlsStream(%s/%s) - DRM info file(%s) has KeyRotationPeriod(%s), which is not a number of seconds. The key is not rotated automatically.", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr(), rotation_period_value.CStr());
+					}
+					else
+					{
+						auto rotation_period_sec = ov::Converter::ToInt64(rotation_period_value.CStr());
+						key_rotation_period_ms = (rotation_period_sec > 0) ? static_cast<uint64_t>(rotation_period_sec) * 1000 : 0;
+					}
 				}
 
 				// A <Keys> block lists the ordered keys the stream rotates through. A
@@ -460,6 +475,12 @@ bool LLHlsStream::GetDrmInfo(const ov::String &file_path, std::vector<bmff::Cenc
 					for (pugi::xml_node content_key_node = keys_node.child("ContentKey"); content_key_node; content_key_node = content_key_node.next_sibling("ContentKey"))
 					{
 						content_key_nodes.push_back(content_key_node);
+					}
+
+					if (content_key_nodes.empty() == true)
+					{
+						logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because Keys has no ContentKey", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr());
+						return false;
 					}
 				}
 				else

--- a/src/publishers/llhls/llhls_stream.cpp
+++ b/src/publishers/llhls/llhls_stream.cpp
@@ -482,6 +482,17 @@ bool LLHlsStream::GetDrmInfo(const ov::String &file_path, std::vector<bmff::Cenc
 						logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because Keys has no ContentKey", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr());
 						return false;
 					}
+
+					// Key material is read from each ContentKey. A single key layout leaves
+					// it on the DRM node, where it is not read, so say so rather than
+					// dropping it silently.
+					for (const char *element_name : {"KeyId", "Key", "Iv", "Pssh", "FairPlayKeyUrl", "Keyformat"})
+					{
+						if (drm_node.child(element_name))
+						{
+							logtw("LLHlsStream(%s/%s) - DRM info file(%s) has %s on the DRM node while Keys is used, so it is ignored. Put it in each ContentKey.", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr(), element_name);
+						}
+					}
 				}
 				else
 				{

--- a/src/publishers/llhls/llhls_stream.cpp
+++ b/src/publishers/llhls/llhls_stream.cpp
@@ -157,8 +157,16 @@ bool LLHlsStream::Start()
 	if (drm_config.IsEnabled())
 	{
 		_drm_info_path = drm_config.GetDrmInfoPath();
-		if (GetDrmInfo(_drm_info_path, _cenc_key_list, _key_rotation_period_ms) == true && _cenc_key_list.empty() == false)
+
+		// Parsed into locals and committed only on success, so a file that fails midway
+		// leaves no keys behind for a later rotation to pick up
+		std::vector<bmff::CencProperty> key_list;
+		uint64_t rotation_period_ms = 0;
+		if (GetDrmInfo(_drm_info_path, key_list, rotation_period_ms) == true && key_list.empty() == false)
 		{
+			_cenc_key_list = std::move(key_list);
+			_key_rotation_period_ms = rotation_period_ms;
+
 			// The first key in the list is the current one; rotations advance the index
 			_current_key_index = 0;
 			_cenc_property = _cenc_key_list[_current_key_index];

--- a/src/publishers/llhls/llhls_stream.cpp
+++ b/src/publishers/llhls/llhls_stream.cpp
@@ -153,7 +153,13 @@ bool LLHlsStream::Start()
 	auto drm_config = llhls_config.GetDrm();
 	if (drm_config.IsEnabled())
 	{
-		GetDrmInfo(drm_config.GetDrmInfoPath(), _cenc_property);
+		_drm_info_path = drm_config.GetDrmInfoPath();
+		if (GetDrmInfo(_drm_info_path, _cenc_key_list, _key_rotation_period_ms) == true && _cenc_key_list.empty() == false)
+		{
+			// The first key in the list is the current one; rotations advance the index
+			_current_key_index = 0;
+			_cenc_property = _cenc_key_list[_current_key_index];
+		}
 	}
 
 	_packager_config.chunk_duration_ms = llhls_config.GetChunkDuration() * 1000.0;
@@ -373,8 +379,11 @@ bool LLHlsStream::IsConcluded() const
 	return _concluded;
 }
 
-bool LLHlsStream::GetDrmInfo(const ov::String &file_path, bmff::CencProperty &cenc_property)
+bool LLHlsStream::GetDrmInfo(const ov::String &file_path, std::vector<bmff::CencProperty> &cenc_key_list, uint64_t &key_rotation_period_ms)
 {
+	cenc_key_list.clear();
+	key_rotation_period_ms = 0;
+
 	ov::String final_path = ov::GetFilePath(file_path, cfg::ConfigManager::GetInstance()->GetConfigPath());
 
 	pugi::xml_document xml_doc;
@@ -391,8 +400,6 @@ bool LLHlsStream::GetDrmInfo(const ov::String &file_path, bmff::CencProperty &ce
 		logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because root node is not found", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr());
 		return false;
 	}
-
-	bool has_fairplay_pssh_box = false;
 
 	for (pugi::xml_node drm_node = root_node.child("DRM"); drm_node; drm_node = drm_node.next_sibling("DRM"))
 	{
@@ -414,80 +421,135 @@ bool LLHlsStream::GetDrmInfo(const ov::String &file_path, bmff::CencProperty &ce
 			if (drm_provider.IsEmpty() || drm_provider.LowerCaseString() == "manual")
 			{
 				ov::String cenc_protect_scheme = drm_node.child_value("CencProtectScheme");
-				ov::String key_id = drm_node.child_value("KeyId");
-				ov::String key = drm_node.child_value("Key");
-				ov::String iv = drm_node.child_value("Iv");
-				ov::String fairplay_key_url = drm_node.child_value("FairPlayKeyUrl");
-				ov::String keyformat = drm_node.child_value("Keyformat");
-
-				// required
-				if (cenc_protect_scheme.IsEmpty() || key_id.IsEmpty() || key.IsEmpty() || iv.IsEmpty())
+				if (cenc_protect_scheme.IsEmpty())
 				{
-					logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because required field is empty", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr());
+					logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because CencProtectScheme is empty", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr());
 					return false;
 				}
 
+				bmff::CencProtectScheme scheme_enum = bmff::CencProtectScheme::None;
 				if (cenc_protect_scheme == "cbcs")
 				{
-					cenc_property.scheme = bmff::CencProtectScheme::Cbcs;
+					scheme_enum = bmff::CencProtectScheme::Cbcs;
 				}
 				else if (cenc_protect_scheme == "cenc")
 				{
-					cenc_property.scheme = bmff::CencProtectScheme::Cenc;
+					scheme_enum = bmff::CencProtectScheme::Cenc;
 				}
 				else
 				{
 					logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because CencProtectScheme(%s) is not supported", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr(), cenc_protect_scheme.CStr());
-				}
-
-				cenc_property.key_id = ov::Hex::Decode(key_id);
-				if (cenc_property.key_id == nullptr || cenc_property.key_id->GetLength() != 16)
-				{
-					logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because KeyId(%s) is invalid (must be 16 bytes HEX foramt)", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr(), key_id.CStr());
-					cenc_property.scheme = bmff::CencProtectScheme::None;
 					return false;
 				}
 
-				cenc_property.key = ov::Hex::Decode(key);
-				if (cenc_property.key == nullptr || cenc_property.key->GetLength() != 16)
+				// Auto key rotation period (seconds). Absent or 0 keeps a single key for
+				// the whole stream; a RotateDrmKey event still rotates regardless.
+				ov::String rotation_period_value = drm_node.child_value("KeyRotationPeriod");
+				if (rotation_period_value.IsEmpty() == false)
 				{
-					logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because Key(%s) is invalid (must be 16 bytes HEX format)", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr(), key.CStr());
-					cenc_property.scheme = bmff::CencProtectScheme::None;
-					return false;
+					auto rotation_period_sec = ov::Converter::ToInt64(rotation_period_value.Trim().CStr());
+					key_rotation_period_ms = (rotation_period_sec > 0) ? static_cast<uint64_t>(rotation_period_sec) * 1000 : 0;
 				}
 
-				cenc_property.iv = ov::Hex::Decode(iv);
-				if (cenc_property.iv == nullptr || cenc_property.iv->GetLength() != 16)
+				// A <Keys> block lists the ordered keys the stream rotates through. A
+				// single flat key on the <DRM> node stays supported (one-entry list).
+				std::vector<pugi::xml_node> content_key_nodes;
+				auto keys_node = drm_node.child("Keys");
+				if (keys_node)
 				{
-					logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because Iv(%s) is invalid (must be 16 bytes HEX format)", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr(), iv.CStr());
-					cenc_property.scheme = bmff::CencProtectScheme::None;
-					return false;
-				}
-
-				pugi::xml_node pssh_node = drm_node.child("Pssh");
-				while (pssh_node)
-				{
-					auto pssh_box_data = ov::Hex::Decode(pssh_node.child_value());
-					if (pssh_box_data == nullptr)
+					for (pugi::xml_node content_key_node = keys_node.child("ContentKey"); content_key_node; content_key_node = content_key_node.next_sibling("ContentKey"))
 					{
-						logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because Pssh(%s) is invalid (must be HEX format)", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr(), pssh_node.child_value());
-						cenc_property.scheme = bmff::CencProtectScheme::None;
+						content_key_nodes.push_back(content_key_node);
+					}
+				}
+				else
+				{
+					content_key_nodes.push_back(drm_node);
+				}
+
+				for (const auto &key_node : content_key_nodes)
+				{
+					bmff::CencProperty cenc_property;
+					cenc_property.scheme = scheme_enum;
+
+					ov::String key_id = key_node.child_value("KeyId");
+					ov::String key = key_node.child_value("Key");
+					ov::String iv = key_node.child_value("Iv");
+					ov::String fairplay_key_url = key_node.child_value("FairPlayKeyUrl");
+					ov::String keyformat = key_node.child_value("Keyformat");
+
+					// required
+					if (key_id.IsEmpty() || key.IsEmpty() || iv.IsEmpty())
+					{
+						logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because required field is empty", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr());
 						return false;
 					}
 
-					auto pssh_box = bmff::PsshBox(pssh_box_data);
-					cenc_property.pssh_box_list.push_back(pssh_box);
-
-					if (pssh_box.drm_system == bmff::DRMSystem::FairPlay)
+					cenc_property.key_id = ov::Hex::Decode(key_id);
+					if (cenc_property.key_id == nullptr || cenc_property.key_id->GetLength() != 16)
 					{
-						has_fairplay_pssh_box = true;
+						logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because KeyId(%s) is invalid (must be 16 bytes HEX format)", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr(), key_id.CStr());
+						return false;
 					}
 
-					pssh_node = pssh_node.next_sibling("Pssh");
-				}
+					cenc_property.key = ov::Hex::Decode(key);
+					if (cenc_property.key == nullptr || cenc_property.key->GetLength() != 16)
+					{
+						logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because Key(%s) is invalid (must be 16 bytes HEX format)", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr(), key.CStr());
+						return false;
+					}
 
-				cenc_property.fairplay_key_uri = fairplay_key_url;
-				cenc_property.keyformat = keyformat;
+					cenc_property.iv = ov::Hex::Decode(iv);
+					if (cenc_property.iv == nullptr || cenc_property.iv->GetLength() != 16)
+					{
+						logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because Iv(%s) is invalid (must be 16 bytes HEX format)", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr(), iv.CStr());
+						return false;
+					}
+
+					bool has_fairplay_pssh_box = false;
+					for (pugi::xml_node pssh_node = key_node.child("Pssh"); pssh_node; pssh_node = pssh_node.next_sibling("Pssh"))
+					{
+						auto pssh_box_data = ov::Hex::Decode(pssh_node.child_value());
+						if (pssh_box_data == nullptr)
+						{
+							logte("LLHlsStream(%s/%s) - Failed to load DRM info file(%s) because Pssh(%s) is invalid (must be HEX format)", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), final_path.CStr(), pssh_node.child_value());
+							return false;
+						}
+
+						auto pssh_box = bmff::PsshBox(pssh_box_data);
+						cenc_property.pssh_box_list.push_back(pssh_box);
+
+						if (pssh_box.drm_system == bmff::DRMSystem::FairPlay)
+						{
+							has_fairplay_pssh_box = true;
+						}
+					}
+
+					cenc_property.fairplay_key_uri = fairplay_key_url;
+					cenc_property.keyformat = keyformat;
+
+					// If a FairPlay key URI is set but no FairPlay pssh was given, add a default one
+					if (cenc_property.fairplay_key_uri.IsEmpty() == false && has_fairplay_pssh_box == false)
+					{
+						cenc_property.pssh_box_list.push_back(bmff::PsshBox("94ce86fb-07ff-4f43-adb8-93d2fa968ca2", {cenc_property.key_id}, nullptr));
+					}
+
+					// Set profiles
+					if (cenc_property.scheme == bmff::CencProtectScheme::Cenc)
+					{
+						cenc_property.crypt_bytes_block = 0;
+						cenc_property.skip_bytes_block = 0;
+						cenc_property.per_sample_iv_size = 16;
+					}
+					else if (cenc_property.scheme == bmff::CencProtectScheme::Cbcs)
+					{
+						cenc_property.crypt_bytes_block = 1;
+						cenc_property.skip_bytes_block = 9;
+						cenc_property.per_sample_iv_size = 0;
+					}
+
+					cenc_key_list.push_back(cenc_property);
+				}
 			}
 			else
 			{
@@ -498,27 +560,6 @@ bool LLHlsStream::GetDrmInfo(const ov::String &file_path, bmff::CencProperty &ce
 			// Just first DRM info matched is enough for one stream
 			break;
 		}
-	}
-
-	// If cenc_property has fairplay_key_uri, but there is no pssh box for fairplay, add it.
-	// default pssh box
-	if (cenc_property.fairplay_key_uri.IsEmpty() == false && has_fairplay_pssh_box == false)
-	{
-		cenc_property.pssh_box_list.push_back(bmff::PsshBox("94ce86fb-07ff-4f43-adb8-93d2fa968ca2", {cenc_property.key_id}, nullptr));
-	}
-
-	// Set profiles
-	if (cenc_property.scheme == bmff::CencProtectScheme::Cenc)
-	{
-		cenc_property.crypt_bytes_block = 0;
-		cenc_property.skip_bytes_block = 0;
-		cenc_property.per_sample_iv_size = 16;
-	}
-	else if (cenc_property.scheme == bmff::CencProtectScheme::Cbcs)
-	{
-		cenc_property.crypt_bytes_block = 1;
-		cenc_property.skip_bytes_block = 9;
-		cenc_property.per_sample_iv_size = 0;
 	}
 
 	return true;
@@ -577,7 +618,11 @@ std::shared_ptr<LLHlsMasterPlaylist> LLHlsStream::CreateMasterPlaylist(const std
 
 	master_playlist->SetDefaultOptions(default_query_value_hls_legacy, default_query_value_hls_rewind);
 	master_playlist->SetChunkPath(chunk_path);
-	master_playlist->SetCencProperty(_cenc_property);
+	{
+		// The current key; a rotation updates it on the media thread
+		std::shared_lock<std::shared_mutex> lock(_cenc_lock);
+		master_playlist->SetCencProperty(_cenc_property);
+	}
 
 	// Add all media candidates to master playlist
 	for (const auto &[track_id, track_group] : GetMediaTrackGroups())
@@ -1427,9 +1472,131 @@ void LLHlsStream::OnEvent(const std::shared_ptr<MediaEvent> &event)
 			}
 			break;
 		}
+		case EventCommand::Type::RotateDrmKey: {
+			RotateDrmKey();
+			break;
+		}
 		default:
 			break;
 	}
+}
+
+void LLHlsStream::RotateDrmKey()
+{
+	// Re-read the DRM info file outside the lock so operators can append keys to the
+	// list while the stream runs. Keep the current list if the re-read fails.
+	std::vector<bmff::CencProperty> reloaded_list;
+	uint64_t reloaded_period_ms = 0;
+	bool reloaded = false;
+	if (_drm_info_path.IsEmpty() == false)
+	{
+		reloaded = (GetDrmInfo(_drm_info_path, reloaded_list, reloaded_period_ms) == true) && (reloaded_list.empty() == false);
+	}
+
+	bmff::CencProperty next_property;
+	size_t next_index = 0;
+	{
+		std::unique_lock<std::shared_mutex> lock(_cenc_lock);
+
+		if (reloaded == true)
+		{
+			_cenc_key_list = reloaded_list;
+			_key_rotation_period_ms = reloaded_period_ms;
+		}
+
+		if (_cenc_key_list.empty() == true)
+		{
+			// No DRM configured on this stream
+			return;
+		}
+
+		if (_cenc_key_list.size() == 1)
+		{
+			// The auto rotation period retries every period, so warn once. The file is
+			// re-read above, so appended keys are picked up on a later attempt.
+			if (_single_key_rotation_warned == false)
+			{
+				_single_key_rotation_warned = true;
+				logtw("LLHlsStream(%s/%s) - DRM key rotation was requested but only one key is configured; keeping it. Add more keys to the DRM info file to rotate.", GetApplication()->GetVHostAppName().CStr(), GetName().CStr());
+			}
+			return;
+		}
+
+		// The configured keys form a cycle, so rotation continues for the life of the
+		// stream. Appending keys to the DRM info file lengthens the cycle; the file is
+		// re-read above on every rotation.
+		_current_key_index = (_current_key_index + 1) % _cenc_key_list.size();
+		_cenc_property = _cenc_key_list[_current_key_index];
+		next_property = _cenc_property;
+		next_index = _current_key_index;
+	}
+
+	// Every track picks the new key up where its next segment starts, so no boundary has
+	// to be negotiated between them
+	std::shared_lock<std::shared_mutex> packager_lock(_packager_map_lock);
+	auto packager_map = _packager_map;
+	packager_lock.unlock();
+
+	for (const auto &[track_id, packager] : packager_map)
+	{
+		// A track whose codec CENC cannot encrypt stays clear
+		auto track_property = next_property;
+		if (bmff::IsCencSupportedCodec(GetTrack(track_id)->GetCodecId()) == false)
+		{
+			track_property.scheme = bmff::CencProtectScheme::None;
+		}
+
+		packager->RequestKeyRotation(track_property);
+	}
+
+	// Newly served master playlists advertise the current key
+	{
+		std::unique_lock<std::mutex> guard(_master_playlists_lock);
+		_master_playlists.clear();
+	}
+
+	logti("LLHlsStream(%s/%s) - DRM key rotation to key index %zu will take effect from the next segment of each track", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), next_index);
+}
+
+void LLHlsStream::CheckAutoKeyRotation(int64_t media_time_ms)
+{
+	uint64_t period_ms = 0;
+	int64_t last_rotation_ms = -1;
+	{
+		std::shared_lock<std::shared_mutex> lock(_cenc_lock);
+		period_ms = _key_rotation_period_ms;
+		last_rotation_ms = _last_key_rotation_media_time_ms;
+	}
+
+	if (period_ms == 0)
+	{
+		// Auto rotation disabled
+		return;
+	}
+
+	// Anchor the period to the first media time seen; don't rotate on the first call
+	if (last_rotation_ms < 0)
+	{
+		std::unique_lock<std::shared_mutex> lock(_cenc_lock);
+		if (_last_key_rotation_media_time_ms < 0)
+		{
+			_last_key_rotation_media_time_ms = media_time_ms;
+		}
+		return;
+	}
+
+	if (media_time_ms - last_rotation_ms < static_cast<int64_t>(period_ms))
+	{
+		return;
+	}
+
+	// Advance the anchor before rotating so the same boundary is not retriggered
+	{
+		std::unique_lock<std::shared_mutex> lock(_cenc_lock);
+		_last_key_rotation_media_time_ms = media_time_ms;
+	}
+
+	RotateDrmKey();
 }
 
 void LLHlsStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const MediaTrack> &old_track, const std::shared_ptr<const MediaTrack> &new_track)
@@ -1492,28 +1659,18 @@ void LLHlsStream::OnTrackChanged(int32_t track_id, const std::shared_ptr<const M
 		return;
 	}
 
-	// Keep the EXT-X-KEY signaling honest about the track's real encryption state.
-	// When the codec changes to one CENC cannot encrypt (e.g. H265, AV1), the
-	// current policy is that the track keeps being produced in the clear (same as
-	// AddPackager at startup), so the playlist must stop advertising EXT-X-KEY;
-	// a return to a supported codec restores it. Leaving a stale EXT-X-KEY on clear
-	// segments would confuse players into attempting decryption.
+	// The chunklist advertises the EXT-X-KEY for the new content version as its first
+	// segment appears (OnMediaChunkUpdated), using the packager's actual encryption
+	// state. When the codec changes to one CENC cannot encrypt (e.g. H265, AV1), the
+	// current policy keeps the track producing clear output, so no key is registered
+	// for that version and the playlist stops advertising EXT-X-KEY.
 	// TODO: when the DRM-failure policy is decided, this may change to blocking the
 	// track update instead of producing clear output.
-	if (_cenc_property.scheme != bmff::CencProtectScheme::None && chunklist != nullptr)
-	{
-		auto track_cenc_property = _cenc_property;
-		if (bmff::IsCencSupportedCodec(new_track->GetCodecId()) == false)
-		{
-			track_cenc_property.scheme = bmff::CencProtectScheme::None;
-		}
-		chunklist->EnableCenc(track_cenc_property);
-	}
 
 	// The new initialization section is stored from here, safe to hint its map
 	if (has_published_content == true && chunklist != nullptr)
 	{
-		chunklist->SetUpcomingMapUri(GetMapUriForTrackVersion(track_id, new_track->GetVersion()));
+		chunklist->SetUpcomingMapUri(GetMapUriForTrackVersion(track_id, packager->GetCurrentContentVersion()));
 	}
 
 	// Players keep renditions in sync by their discontinuity sequences, so every
@@ -1637,7 +1794,12 @@ bool LLHlsStream::AddPackager(const std::shared_ptr<const MediaTrack> &media_tra
 
 	logti("LLHlsStream::AddPackager() - Track(%d) ChunkDuration(%f)", media_track->GetId(), packager_config.chunk_duration_ms);
 
-	auto cenc_property = _cenc_property;
+	bmff::CencProperty cenc_property;
+	{
+		// The current key; a rotation replaces it on the media thread
+		std::shared_lock<std::shared_mutex> lock(_cenc_lock);
+		cenc_property = _cenc_property;
+	}
 
 	auto tag = ov::String::FormatString("%s/%s", GetApplicationInfo().GetVHostAppName().CStr(), GetName().CStr());
 
@@ -1684,10 +1846,8 @@ bool LLHlsStream::AddPackager(const std::shared_ptr<const MediaTrack> &media_tra
 													  GetInitializationSegmentName(track_id),
 													  _preload_hint_enabled);
 
-	if (cenc_property.scheme != bmff::CencProtectScheme::None)
-	{
-		chunklist->EnableCenc(cenc_property);
-	}
+	// The chunklist's EXT-X-KEY is registered per content version as each version's
+	// first segment appears (OnMediaChunkUpdated), so it also covers key rotations.
 
 	{
 		std::lock_guard<std::shared_mutex> storage_lock(_storage_map_lock);
@@ -2159,6 +2319,32 @@ void LLHlsStream::OnMediaChunkUpdated(const int32_t &track_id, const uint32_t &s
 		{
 			partial_info.SetDiscontinuity();
 		}
+
+		// Advertise the EXT-X-KEY of the key this version was actually encrypted with.
+		// The packager recorded it when the version's initialization section was created,
+		// so this holds even when a rotation and a track change land close together. A
+		// version that was produced in the clear records a scheme of None and so
+		// registers no key.
+		auto content_version = segment->GetTrackVersion();
+		auto registered_it = _last_registered_cenc_version.find(track_id);
+		bool already_registered = (registered_it != _last_registered_cenc_version.end() && registered_it->second >= content_version);
+		if (already_registered == false)
+		{
+			auto packager = GetPackager(track_id);
+			if (packager != nullptr)
+			{
+				auto version_cenc_property = packager->GetCencPropertyForVersion(content_version);
+				if (version_cenc_property.has_value() == true)
+				{
+					playlist->EnableCenc(content_version, version_cenc_property.value());
+					_last_registered_cenc_version[track_id] = content_version;
+				}
+				else
+				{
+					logte("LLHlsStream(%s/%s) - No CENC key recorded for track(%d) content version %u; its segments would be advertised with the previous key", GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), track_id, content_version);
+				}
+			}
+		}
 	}
 
 	// A segment's first chunk can bring a codec into the listing; the cached
@@ -2171,6 +2357,13 @@ void LLHlsStream::OnMediaChunkUpdated(const int32_t &track_id, const uint32_t &s
 	{
 		std::unique_lock<std::mutex> guard(_master_playlists_lock);
 		_master_playlists.clear();
+	}
+
+	// Drive auto key rotation off the media timeline at each new segment
+	if (chunk_number == 0)
+	{
+		auto media_time_ms = static_cast<int64_t>((static_cast<double>(partial_segment->GetStartTimestamp()) / GetTrack(track_id)->GetTimeBase().GetTimescale()) * 1000.0);
+		CheckAutoKeyRotation(media_time_ms);
 	}
 
 	logtt("Media chunk updated : track_id = %u, segment_number = %u, chunk_number = %d, start_timestamp = %" PRId64 ", chunk_duration = %f", track_id, segment_number, chunk_number, partial_segment->GetStartTimestamp(), chunk_duration);

--- a/src/publishers/llhls/llhls_stream.h
+++ b/src/publishers/llhls/llhls_stream.h
@@ -104,7 +104,18 @@ private:
 	bool Start() override;
 	bool Stop() override;
 
-	bool GetDrmInfo(const ov::String &file_path, bmff::CencProperty &cenc_property);
+	// Parse the DRM info file into the ordered key list for the matched stream and
+	// its auto key rotation period. A single flat key yields a one-entry list.
+	bool GetDrmInfo(const ov::String &file_path, std::vector<bmff::CencProperty> &cenc_key_list, uint64_t &key_rotation_period_ms);
+
+	// Rotate the DRM key to the next key in the list, from the next segment of each
+	// track. Triggered by the auto rotation period and by a RotateDrmKey event. The
+	// keys form a cycle; a single configured key is kept as is.
+	void RotateDrmKey();
+
+	// Trigger an auto key rotation once the media time crosses a period boundary.
+	// Called as segments are produced; a no-op when auto rotation is off.
+	void CheckAutoKeyRotation(int64_t media_time_ms);
 
 	bool IsSupportedMediaCodec(cmn::MediaCodecId codec_id) const; 
 
@@ -226,6 +237,28 @@ private:
 
 	bmff::CencProperty _cenc_property;
 	ov::String _key_uri; // string, only for FairPlay
+
+	// Path of the DRM info file, re-read on each rotation so operators can append
+	// keys to the list while the stream runs
+	ov::String _drm_info_path;
+	// Ordered keys the stream rotates through (manual provider). One entry when there
+	// is no rotation. _cenc_property mirrors the current key. Guarded by _cenc_lock.
+	std::vector<bmff::CencProperty> _cenc_key_list;
+	size_t _current_key_index = 0;
+	// Auto key rotation period in media time; 0 disables auto rotation, while a
+	// RotateDrmKey event still rotates. Guarded by _cenc_lock.
+	uint64_t _key_rotation_period_ms = 0;
+	// Media time of the last applied rotation, to space out auto rotations. Guarded by _cenc_lock.
+	int64_t _last_key_rotation_media_time_ms = -1;
+	// A rotation with a single configured key is reported once, not every period.
+	// Guarded by _cenc_lock.
+	bool _single_key_rotation_warned = false;
+	mutable std::shared_mutex _cenc_lock;
+
+	// Highest content version already advertised to each track's chunklist, so a new
+	// version's EXT-X-KEY is registered once when its first segment appears.
+	// Media-thread only (the storage observer callbacks).
+	std::map<int32_t, uint32_t> _last_registered_cenc_version;
 
 	// PROGRAM-DATE-TIME
 	bool _first_chunk = true;

--- a/src/publishers/llhls/llhls_test.cpp
+++ b/src/publishers/llhls/llhls_test.cpp
@@ -46,6 +46,22 @@ namespace
 
 	const ov::String kInitialMapUri = "init_1_video_key_llhls.m4s";
 	const ov::String kSecondMapUri = "init_1_video_key_v2_llhls.m4s";
+
+	// A cbcs Widevine key. Distinct key_ids produce distinct EXT-X-KEY tags (the
+	// KEYID attribute), the way a DRM key rotation registers each content version.
+	bmff::CencProperty MakeCencProperty(const char *key_id_hex)
+	{
+		bmff::CencProperty cenc_property;
+		cenc_property.scheme = bmff::CencProtectScheme::Cbcs;
+		cenc_property.key_id = ov::Hex::Decode(key_id_hex);
+		cenc_property.key = ov::Hex::Decode("16cf4232a86364b519e1982a27d90087");
+		cenc_property.iv = ov::Hex::Decode("572547f914e34dc68ba9ba9ef91d4c4a");
+		cenc_property.pssh_box_list.push_back(bmff::PsshBox("edef8ba9-79d6-4ace-a3c8-27dcd51d21ed", {cenc_property.key_id}, nullptr));
+		return cenc_property;
+	}
+
+	const char *kKeyIdA = "572543f964e34dc68ba9ba9ef91d4c4a";
+	const char *kKeyIdB = "a1b2c3d4e5f60718293a4b5c6d7e8f90";
 } // namespace
 
 TEST(LLHlsChunklist, NoDiscontinuityTagsByDefault)
@@ -68,8 +84,10 @@ TEST(LLHlsChunklist, TrackVersionChangeInsertsTagAndNewMap)
 	AppendSegment(chunklist, 0, 1, kInitialMapUri);
 	AppendSegment(chunklist, 1, 1, kInitialMapUri);
 
-	// The next segment was packaged against a new track configuration
-	AppendSegment(chunklist, 2, 2, kSecondMapUri);
+	// The next segment was packaged against a new track configuration. A real track
+	// change flags the boundary segment as a discontinuity point (the storage marks
+	// it), which is what the chunklist turns into an EXT-X-DISCONTINUITY.
+	AppendSegment(chunklist, 2, 2, kSecondMapUri, true);
 
 	auto playlist = chunklist->ToString("", false, false, false);
 
@@ -95,7 +113,7 @@ TEST(LLHlsChunklist, DiscontinuitySequenceCountsRemovedTags)
 	auto chunklist = CreateChunklist(CreateVideoTrack());
 
 	AppendSegment(chunklist, 0, 1, kInitialMapUri);
-	AppendSegment(chunklist, 1, 2, kSecondMapUri);
+	AppendSegment(chunklist, 1, 2, kSecondMapUri, true);
 	AppendSegment(chunklist, 2, 2, kSecondMapUri);
 	AppendSegment(chunklist, 3, 2, kSecondMapUri);
 
@@ -229,4 +247,163 @@ TEST(LLHlsChunklist, VersionChangeBeforeFirstSegmentHasNoTag)
 	EXPECT_EQ(playlist.IndexOf("#EXT-X-DISCONTINUITY"), -1);
 	EXPECT_NE(playlist.IndexOf("#EXT-X-MAP:URI=\"init_1_video_key_v2_llhls.m4s\""), -1);
 	EXPECT_EQ(playlist.IndexOf("#EXT-X-MAP:URI=\"init_1_video_key_llhls.m4s\""), -1);
+}
+
+TEST(LLHlsChunklist, SingleKeyEmittedOnce)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+	chunklist->EnableCenc(1, MakeCencProperty(kKeyIdA));
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri);
+	AppendSegment(chunklist, 1, 1, kInitialMapUri);
+
+	auto playlist = chunklist->ToString("", false, false, false);
+
+	// Exactly one EXT-X-KEY for the single content version
+	auto first_key = playlist.IndexOf("#EXT-X-KEY:");
+	EXPECT_NE(first_key, -1);
+	EXPECT_EQ(playlist.IndexOf("#EXT-X-KEY:", first_key + 1), -1);
+}
+
+TEST(LLHlsChunklist, KeyRotationEmitsNewKeyWithoutDiscontinuity)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+	chunklist->EnableCenc(1, MakeCencProperty(kKeyIdA));
+	chunklist->EnableCenc(2, MakeCencProperty(kKeyIdB));
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri);
+	AppendSegment(chunklist, 1, 1, kInitialMapUri);
+
+	// A key rotation: a new content version and map, but no discontinuity flag
+	AppendSegment(chunklist, 2, 2, kSecondMapUri);
+
+	auto playlist = chunklist->ToString("", false, false, false);
+
+	// A key rotation is seamless: no discontinuity tag
+	EXPECT_EQ(playlist.IndexOf("#EXT-X-DISCONTINUITY"), -1);
+
+	// The new initialization section still switches in
+	EXPECT_NE(playlist.IndexOf("#EXT-X-MAP:URI=\"init_1_video_key_v2_llhls.m4s\""), -1);
+
+	// Both keys are advertised, the new one after the old one
+	auto key_a = ov::String::FormatString("KEYID=0x%s", ov::String(kKeyIdA).UpperCaseString().CStr());
+	auto key_b = ov::String::FormatString("KEYID=0x%s", ov::String(kKeyIdB).UpperCaseString().CStr());
+	auto key_a_index = playlist.IndexOf(key_a.CStr());
+	auto key_b_index = playlist.IndexOf(key_b.CStr());
+	EXPECT_NE(key_a_index, -1);
+	EXPECT_NE(key_b_index, -1);
+	EXPECT_LT(key_a_index, key_b_index);
+
+	// The new key precedes the segment it applies to
+	EXPECT_LT(key_b_index, playlist.IndexOf("seg_1_2_video_key_llhls.m4s"));
+}
+
+TEST(LLHlsChunklist, TrackChangeKeepingTheKeyDoesNotRepeatIt)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+
+	// A scheduled channel changes tracks often; those versions keep the current key
+	chunklist->EnableCenc(1, MakeCencProperty(kKeyIdA));
+	chunklist->EnableCenc(2, MakeCencProperty(kKeyIdA));
+	// Then a rotation brings a new key
+	chunklist->EnableCenc(3, MakeCencProperty(kKeyIdB));
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri);
+	// Track change: new version and map, discontinuity, same key
+	AppendSegment(chunklist, 1, 2, kSecondMapUri, true);
+	// Key rotation: new version and map, no discontinuity, new key
+	AppendSegment(chunklist, 2, 3, "init_1_video_key_v3_llhls.m4s");
+
+	auto playlist = chunklist->ToString("", false, false, false);
+
+	auto key_a = ov::String::FormatString("KEYID=0x%s", ov::String(kKeyIdA).UpperCaseString().CStr());
+	auto key_b = ov::String::FormatString("KEYID=0x%s", ov::String(kKeyIdB).UpperCaseString().CStr());
+
+	// The unchanged key is advertised once, not repeated for the track change
+	auto first_key_a = playlist.IndexOf(key_a.CStr());
+	EXPECT_NE(first_key_a, -1);
+	EXPECT_EQ(playlist.IndexOf(key_a.CStr(), first_key_a + 1), -1);
+
+	// The rotated key appears before the segment it applies to
+	auto key_b_index = playlist.IndexOf(key_b.CStr());
+	EXPECT_NE(key_b_index, -1);
+	EXPECT_LT(first_key_a, key_b_index);
+	EXPECT_LT(key_b_index, playlist.IndexOf("seg_1_2_video_key_llhls.m4s"));
+
+	// Only the track change carries a discontinuity, the rotation does not
+	auto discontinuity_index = playlist.IndexOf("#EXT-X-DISCONTINUITY\n");
+	EXPECT_NE(discontinuity_index, -1);
+	EXPECT_EQ(playlist.IndexOf("#EXT-X-DISCONTINUITY\n", discontinuity_index + 1), -1);
+	EXPECT_LT(discontinuity_index, key_b_index);
+}
+
+TEST(LLHlsChunklist, DumpedOutputKeepsEveryVersionKey)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+	// Dumped output lists every segment ever produced
+	chunklist->SaveOldSegmentInfo(true);
+
+	// More versions than any fixed retention would keep. A version whose key was dropped
+	// while still listed would inherit the previous EXT-X-KEY and fail to decrypt.
+	constexpr uint32_t kVersions = 70;
+	for (uint32_t version = 1; version <= kVersions; version++)
+	{
+		auto key_id = ov::String::FormatString("%032x", version);
+		chunklist->EnableCenc(version, MakeCencProperty(key_id.CStr()));
+		AppendSegment(chunklist, version - 1, version, ov::String::FormatString("init_1_video_key_v%u_llhls.m4s", version));
+	}
+
+	// The live window slides past the early segments; they stay listed in the dumped view
+	for (uint32_t sequence = 0; sequence + 10 < kVersions; sequence++)
+	{
+		chunklist->RemoveSegmentInfo(sequence);
+	}
+
+	auto playlist = chunklist->ToString("", false, false, false, true, 0);
+
+	for (uint32_t version : {static_cast<uint32_t>(1), kVersions / 2, kVersions})
+	{
+		auto key_id = ov::String::FormatString("%032x", version).UpperCaseString();
+		auto expected = ov::String::FormatString("KEYID=0x%s", key_id.CStr());
+		EXPECT_NE(playlist.IndexOf(expected.CStr()), -1) << "missing key of version " << version;
+	}
+}
+
+TEST(LLHlsChunklist, ClearVersionEndsTheKeyScope)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+
+	chunklist->EnableCenc(1, MakeCencProperty(kKeyIdA));
+	// The track changed to a codec CENC cannot encrypt, so this version is produced in
+	// the clear. Its segments must not stay covered by the preceding key.
+	chunklist->EnableCenc(2, bmff::CencProperty());
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri);
+	AppendSegment(chunklist, 1, 2, kSecondMapUri, true);
+
+	auto playlist = chunklist->ToString("", false, false, false);
+
+	auto key_id = ov::String::FormatString("KEYID=0x%s", ov::String(kKeyIdA).UpperCaseString().CStr());
+	auto key_index = playlist.IndexOf(key_id.CStr());
+	auto none_index = playlist.IndexOf("#EXT-X-KEY:METHOD=NONE");
+
+	EXPECT_NE(key_index, -1);
+	EXPECT_NE(none_index, -1);
+	EXPECT_LT(key_index, none_index);
+
+	// The scope ends before the clear segment
+	EXPECT_LT(none_index, playlist.IndexOf("seg_1_1_video_key_llhls.m4s"));
+}
+
+TEST(LLHlsChunklist, NoKeyTagWhenCencDisabled)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri);
+	AppendSegment(chunklist, 1, 1, kInitialMapUri);
+
+	auto playlist = chunklist->ToString("", false, false, false);
+
+	// No key registered, so the playlist carries no EXT-X-KEY
+	EXPECT_EQ(playlist.IndexOf("#EXT-X-KEY:"), -1);
 }

--- a/src/publishers/llhls/llhls_test.cpp
+++ b/src/publishers/llhls/llhls_test.cpp
@@ -395,6 +395,42 @@ TEST(LLHlsChunklist, ClearVersionEndsTheKeyScope)
 	EXPECT_LT(none_index, playlist.IndexOf("seg_1_1_video_key_llhls.m4s"));
 }
 
+TEST(LLHlsChunklist, ClearOnlyPlaylistHasNoKeyTag)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+
+	// A stream without DRM registers its versions with a scheme of None. There is no key
+	// scope to end, so the playlist carries no key tag at all.
+	chunklist->EnableCenc(1, bmff::CencProperty());
+	chunklist->EnableCenc(2, bmff::CencProperty());
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri);
+	AppendSegment(chunklist, 1, 2, kSecondMapUri, true);
+
+	auto playlist = chunklist->ToString("", false, false, false);
+
+	EXPECT_EQ(playlist.IndexOf("#EXT-X-KEY"), -1);
+}
+
+TEST(LLHlsChunklist, WindowStartingOnClearVersionHasNoKeyTag)
+{
+	auto chunklist = CreateChunklist(CreateVideoTrack());
+
+	chunklist->EnableCenc(1, MakeCencProperty(kKeyIdA));
+	chunklist->EnableCenc(2, bmff::CencProperty());
+
+	AppendSegment(chunklist, 0, 1, kInitialMapUri);
+	AppendSegment(chunklist, 1, 2, kSecondMapUri, true);
+
+	// The protected segment leaves the window, so the key it belonged to is no longer
+	// advertised and there is nothing left to end
+	chunklist->RemoveSegmentInfo(0);
+
+	auto playlist = chunklist->ToString("", false, false, false);
+
+	EXPECT_EQ(playlist.IndexOf("#EXT-X-KEY"), -1);
+}
+
 TEST(LLHlsChunklist, NoKeyTagWhenCencDisabled)
 {
 	auto chunklist = CreateChunklist(CreateVideoTrack());


### PR DESCRIPTION
A DRM protected LLHLS stream keeps one content key for its whole lifetime, so a key that leaks stays useful for as long as the stream runs, and a stream whose audience becomes restricted cannot make what it already handed out useless.

The DRM info file now takes an ordered list of content keys and an optional rotation period, and a stream moves to the next key from the next segment of each track, cycling through the list for as long as it runs. Each content version carries its own initialization segment and EXT-X-KEY, so segments already delivered stay playable with the key they were encrypted with, and no discontinuity is signaled because the content does not change. A version that a codec change leaves unencrypted now ends the key scope with METHOD=NONE, where before it stayed covered by the preceding key.

The DRM section of the LLHLS manual is restructured along the way, and its claim that only cbcs is supported is corrected.


Test:

Key rotation can be exercised without a DRM license server by using HLS SAMPLE-AES with `KEYFORMAT="identity"`, where the key URI returns the raw 16 byte key. Safari plays this natively. hls.js does not support SAMPLE-AES, so use Safari.

**1. Serve the keys.** Each key needs its own URL returning exactly the 16 raw bytes of the matching `<Key>`. Save the script below as `keyserver.py`.

The URL has to use HTTPS when the playlist is served over HTTPS, otherwise Safari blocks the key request as mixed content. Reuse the certificate that the LLHLS TLS port already serves, so that the host name in `<FairPlayKeyUrl>` matches a name in that certificate. In a default installation the certificate, its chain and its private key are the `<CertPath>`, `<ChainCertPath>` and `<KeyPath>` of the virtual host, and the first two are concatenated into the full chain the script loads.

```bash
cat certificate.crt certificate.ca-bundle > fullchain.pem
cp certificate.key privkey.pem
python3 keyserver.py
```

```python
import binascii, ssl
from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer

KEYS = {
    "/key/1": "16cf4232a86364b519e1982a27d90087",
    "/key/2": "0f1e2d3c4b5a69788796a5b4c3d2e1f0",
    "/key/3": "00112233445566778899aabbccddeeff",
}

class Handler(BaseHTTPRequestHandler):
    def do_GET(self):
        key_hex = KEYS.get(self.path)
        if key_hex is None:
            self.send_response(404); self.end_headers(); return
        body = binascii.unhexlify(key_hex)
        self.send_response(200)
        self.send_header("Content-Type", "application/octet-stream")
        self.send_header("Content-Length", str(len(body)))
        self.send_header("Access-Control-Allow-Origin", "*")
        self.end_headers()
        self.wfile.write(body)

httpd = ThreadingHTTPServer(("0.0.0.0", 18080), Handler)
ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
ctx.load_cert_chain("fullchain.pem", "privkey.pem")
httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
httpd.serve_forever()
```

Confirm that each URL returns its key, and that the port is reachable from the machine running Safari.

```bash
curl -s https://<host>:18080/key/1 | xxd -p
# 16cf4232a86364b519e1982a27d90087
```

**2. Enable DRM** in the LLHLS publisher of the application, with `<DRM><Enable>true</Enable><InfoFile>DrmInfo.xml</InfoFile></DRM>`.

**3. Write the DRM info file.** The `<Key>` values must match what the key server returns, each `<ContentKey>` needs its own `<FairPlayKeyUrl>`, and the host must be reachable from the machine running Safari.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<DRMInfo>
    <DRM>
        <Name>IdentityRotation</Name>
        <VirtualHostName>default</VirtualHostName>
        <ApplicationName>app</ApplicationName>
        <StreamName>stream*</StreamName>

        <CencProtectScheme>cbcs</CencProtectScheme>
        <KeyRotationPeriod>30</KeyRotationPeriod>

        <Keys>
            <ContentKey>
                <KeyId>11111111111111111111111111111111</KeyId>
                <Key>16cf4232a86364b519e1982a27d90087</Key>
                <Iv>572547f914e34dc68ba9ba9ef91d4c4a</Iv>
                <Keyformat>identity</Keyformat>
                <FairPlayKeyUrl>https://example.com:18080/key/1</FairPlayKeyUrl>
            </ContentKey>
            <ContentKey>
                <KeyId>22222222222222222222222222222222</KeyId>
                <Key>0f1e2d3c4b5a69788796a5b4c3d2e1f0</Key>
                <Iv>112233445566778899aabbccddeeff00</Iv>
                <Keyformat>identity</Keyformat>
                <FairPlayKeyUrl>https://example.com:18080/key/2</FairPlayKeyUrl>
            </ContentKey>
            <ContentKey>
                <KeyId>33333333333333333333333333333333</KeyId>
                <Key>00112233445566778899aabbccddeeff</Key>
                <Iv>ffeeddccbbaa99887766554433221100</Iv>
                <Keyformat>identity</Keyformat>
                <FairPlayKeyUrl>https://example.com:18080/key/3</FairPlayKeyUrl>
            </ContentKey>
        </Keys>
    </DRM>
</DRMInfo>
```

**4. Publish an H.264 and AAC stream** and play it in Safari. Only H.264 and AAC are encrypted, so a stream of any other codec is not a valid subject for this test. A scheduled channel that switches items every 10 seconds is worth using as well, because it makes track changes and key rotations overlap.

**5. Watch the playlist across rotations.**

```bash
watch -n2 'curl -sk "https://<host>:<tls_port>/<app>/<stream>/chunklist_0_video_<stream_key>_llhls.m3u8" | grep -E "EXT-X-KEY|EXT-X-MAP|EXT-X-DISCONTINUITY"'
```

Pass conditions, over at least 4 rotations so that the list wraps back to the first key:

- Playback continues across every rotation, with no stall, no reload and no visible artifact.
- The `EXT-X-KEY` URI advances `/key/1`, `/key/2`, `/key/3` and then back to `/key/1`.
- A new `EXT-X-MAP` accompanies each rotation, and no `EXT-X-DISCONTINUITY` is emitted for it. A track change may still emit one.
- The video and audio chunklists report the same version and the same key.
- The key server log shows a request for each key as it comes into effect.
- Every playlist, initialization segment and media segment request returns 200.

**6. Confirm the content matches the advertised key.** The initialization segment of a version carries the key id it was encrypted with, so it has to match the key the playlist advertises for that version.

```bash
curl -sk "https://<host>:<tls_port>/<app>/<stream>/init_0_video_<stream_key>_v<version>_llhls.m4s" | xxd -p | tr -d '\n' | grep -o '22222222222222222222222222222222'
```

**7. Check the configuration errors are reported.** Each of these is a separate run:

- `<KeyRotationPeriod>1h</KeyRotationPeriod>`: the log warns that the value is not a number of seconds, the key is not rotated, and DRM still applies.
- `<Keys></Keys>` with no `<ContentKey>`: the log reports the DRM info file is invalid and the stream starts without DRM.
- A single `<ContentKey>`: the log warns once that only one key is configured, and the stream plays with that key.
- `<Pssh>` or `<FairPlayKeyUrl>` left on the `<DRM>` node while `<Keys>` is used: the log warns that the element is ignored.

