### PR TITLE
fix(provider): honor `PacketSilenceTimeoutMs` during the pre-publish window

### DIFF
--- a/src/base/provider/push_provider/application.cpp
+++ b/src/base/provider/push_provider/application.cpp
@@ -32,12 +32,22 @@ namespace pvd
 		return AddStream(stream);
 	}
 
-	time_t PushApplication::GetConfiguredPacketSilenceTimeoutMs(ProviderType provider_type)
+	time_t PushApplication::GetConfiguredPacketSilenceTimeoutMs(ProviderType provider_type, bool *is_configured)
 	{
+		if (is_configured != nullptr)
+		{
+			*is_configured = false;
+		}
+
 		for (const auto &provider_cfg : GetConfig().GetProviders().GetProviderList())
 		{
 			if (provider_cfg->GetType() == provider_type)
 			{
+				if (is_configured != nullptr)
+				{
+					*is_configured = provider_cfg->IsPacketSilenceTimeoutMsConfigured();
+				}
+
 				return provider_cfg->GetPacketSilenceTimeoutMs();
 			}
 		}

--- a/src/base/provider/push_provider/application.cpp
+++ b/src/base/provider/push_provider/application.cpp
@@ -27,20 +27,22 @@ namespace pvd
 			return false;
 		}
 
-		int packet_silence_timeout_ms = 0;
-		auto cfg_provider_list = GetConfig().GetProviders().GetProviderList();
-		for (const auto &cfg_provider : cfg_provider_list)
-		{
-			if (cfg_provider->GetType() == GetParentProvider()->GetProviderType())
-			{
-				packet_silence_timeout_ms = cfg_provider->GetPacketSilenceTimeoutMs();
-				break;
-			}
-		}
-		
-		stream->SetPacketSilenceTimeoutMs(packet_silence_timeout_ms);
+		stream->SetPacketSilenceTimeoutMs(GetConfiguredPacketSilenceTimeoutMs(GetParentProvider()->GetProviderType()));
 
 		return AddStream(stream);
+	}
+
+	time_t PushApplication::GetConfiguredPacketSilenceTimeoutMs(ProviderType provider_type)
+	{
+		for (const auto &provider_cfg : GetConfig().GetProviders().GetProviderList())
+		{
+			if (provider_cfg->GetType() == provider_type)
+			{
+				return provider_cfg->GetPacketSilenceTimeoutMs();
+			}
+		}
+
+		return 0;
 	}
 
 	bool PushApplication::DeleteAllStreams()

--- a/src/base/provider/push_provider/application.h
+++ b/src/base/provider/push_provider/application.h
@@ -20,10 +20,10 @@ namespace pvd
 	public:
 		virtual bool JoinStream(const std::shared_ptr<PushStream> &stream);
 
-		// Returns the `PacketSilenceTimeoutMs` configured for the given provider type
-		// in this application, or `0` when it is unset or disabled.
-		// `is_configured` reports whether the option was present in the configuration, which tells a
-		// value the operator asked for apart from a provider default filled in during config parsing.
+		// Returns the effective `PacketSilenceTimeoutMs` for the given provider type in this
+		// application: the operator's value, or a default filled in during config parsing (MPEG-TS
+		// gets `1500` ms), or `0` when neither applies and the timeout is therefore disabled.
+		// `is_configured` reports whether that value is the operator's rather than a default.
 		time_t GetConfiguredPacketSilenceTimeoutMs(ProviderType provider_type, bool *is_configured = nullptr);
 
 	protected:

--- a/src/base/provider/push_provider/application.h
+++ b/src/base/provider/push_provider/application.h
@@ -20,6 +20,10 @@ namespace pvd
 	public:
 		virtual bool JoinStream(const std::shared_ptr<PushStream> &stream);
 
+		// Look up the `PacketSilenceTimeoutMs` configured for the given provider type in
+		// this application. Returns `0` when the provider is not configured.
+		time_t GetConfiguredPacketSilenceTimeoutMs(ProviderType provider_type);
+
 	protected:
 		PushApplication(const std::shared_ptr<PushProvider> &provider, const info::Application &application_info);
 		virtual bool DeleteAllStreams() override;		

--- a/src/base/provider/push_provider/application.h
+++ b/src/base/provider/push_provider/application.h
@@ -20,8 +20,8 @@ namespace pvd
 	public:
 		virtual bool JoinStream(const std::shared_ptr<PushStream> &stream);
 
-		// Look up the `PacketSilenceTimeoutMs` configured for the given provider type in
-		// this application. Returns `0` when the provider is not configured.
+		// Returns the `PacketSilenceTimeoutMs` configured for the given provider type
+		// in this application, or `0` when it is unset or disabled.
 		time_t GetConfiguredPacketSilenceTimeoutMs(ProviderType provider_type);
 
 	protected:

--- a/src/base/provider/push_provider/application.h
+++ b/src/base/provider/push_provider/application.h
@@ -22,7 +22,9 @@ namespace pvd
 
 		// Returns the `PacketSilenceTimeoutMs` configured for the given provider type
 		// in this application, or `0` when it is unset or disabled.
-		time_t GetConfiguredPacketSilenceTimeoutMs(ProviderType provider_type);
+		// `is_configured` reports whether the option was present in the configuration, which tells a
+		// value the operator asked for apart from a provider default filled in during config parsing.
+		time_t GetConfiguredPacketSilenceTimeoutMs(ProviderType provider_type, bool *is_configured = nullptr);
 
 	protected:
 		PushApplication(const std::shared_ptr<PushProvider> &provider, const info::Application &application_info);

--- a/src/base/provider/push_provider/stream.cpp
+++ b/src/base/provider/push_provider/stream.cpp
@@ -121,12 +121,15 @@ namespace pvd
 			return;
 		}
 
-		// Apply the effective `PacketSilenceTimeoutMs` for this provider.
-		// This includes any provider-specific default (MPEG-TS defaults to `1500` ms).
-		// A value of `0` means no silence timeout is configured,
-		// so the channel-creation default is left in place.
-		const auto timeout_ms = application->GetConfiguredPacketSilenceTimeoutMs(provider->GetProviderType());
-		if (timeout_ms > 0)
+		// Apply `PacketSilenceTimeoutMs` only when the operator set it to a positive value.
+		// A provider default filled in during config parsing (MPEG-TS gets `1500` ms) is not the
+		// operator's intent and keeps applying only once the stream is published, and an explicit `0`
+		// leaves the channel-creation default in place rather than removing the guard, which for
+		// MPEG-TS over UDP is the only thing that can reap a channel that never publishes.
+		bool is_configured	  = false;
+		const auto timeout_ms = application->GetConfiguredPacketSilenceTimeoutMs(provider->GetProviderType(), &is_configured);
+
+		if (is_configured && (timeout_ms > 0))
 		{
 			SetPacketSilenceTimeoutMs(timeout_ms);
 		}

--- a/src/base/provider/push_provider/stream.cpp
+++ b/src/base/provider/push_provider/stream.cpp
@@ -130,8 +130,10 @@ namespace pvd
 
 			const auto timeout_ms = provider_cfg->GetPacketSilenceTimeoutMs();
 
-			// Apply only when explicitly configured.
-			// An unset value (0) keeps the default armed at channel creation.
+			// Apply the effective `PacketSilenceTimeoutMs` for this provider.
+			// This includes any provider-specific default (MPEG-TS defaults to `1500` ms).
+			// A value of `0` means no silence timeout is configured,
+			// so the channel-creation default is left in place.
 			if (timeout_ms > 0)
 			{
 				SetPacketSilenceTimeoutMs(timeout_ms);

--- a/src/base/provider/push_provider/stream.cpp
+++ b/src/base/provider/push_provider/stream.cpp
@@ -121,25 +121,14 @@ namespace pvd
 			return;
 		}
 
-		for (const auto &provider_cfg : application->GetConfig().GetProviders().GetProviderList())
+		// Apply the effective `PacketSilenceTimeoutMs` for this provider.
+		// This includes any provider-specific default (MPEG-TS defaults to `1500` ms).
+		// A value of `0` means no silence timeout is configured,
+		// so the channel-creation default is left in place.
+		const auto timeout_ms = application->GetConfiguredPacketSilenceTimeoutMs(provider->GetProviderType());
+		if (timeout_ms > 0)
 		{
-			if (provider_cfg->GetType() != provider->GetProviderType())
-			{
-				continue;
-			}
-
-			const auto timeout_ms = provider_cfg->GetPacketSilenceTimeoutMs();
-
-			// Apply the effective `PacketSilenceTimeoutMs` for this provider.
-			// This includes any provider-specific default (MPEG-TS defaults to `1500` ms).
-			// A value of `0` means no silence timeout is configured,
-			// so the channel-creation default is left in place.
-			if (timeout_ms > 0)
-			{
-				SetPacketSilenceTimeoutMs(timeout_ms);
-			}
-
-			return;
+			SetPacketSilenceTimeoutMs(timeout_ms);
 		}
 	}
 

--- a/src/base/provider/push_provider/stream.cpp
+++ b/src/base/provider/push_provider/stream.cpp
@@ -107,6 +107,40 @@ namespace pvd
 		return static_cast<time_t>(SteadyNowMs() - last_received_time_ms);
 	}
 
+	void PushStream::ApplyConfiguredPacketSilenceTimeout(const info::VHostAppName &vhost_app_name)
+	{
+		auto provider = GetProvider();
+		if (provider == nullptr)
+		{
+			return;
+		}
+
+		auto application = provider->GetApplicationByName(vhost_app_name);
+		if (application == nullptr)
+		{
+			return;
+		}
+
+		for (const auto &provider_cfg : application->GetConfig().GetProviders().GetProviderList())
+		{
+			if (provider_cfg->GetType() != provider->GetProviderType())
+			{
+				continue;
+			}
+
+			const auto timeout_ms = provider_cfg->GetPacketSilenceTimeoutMs();
+
+			// Apply only when explicitly configured.
+			// An unset value (0) keeps the default armed at channel creation.
+			if (timeout_ms > 0)
+			{
+				SetPacketSilenceTimeoutMs(timeout_ms);
+			}
+
+			return;
+		}
+	}
+
 	bool PushStream::PublishChannel(const info::VHostAppName &vhost_app_name)
 	{
 		if(GetProvider() == nullptr)

--- a/src/base/provider/push_provider/stream.cpp
+++ b/src/base/provider/push_provider/stream.cpp
@@ -107,7 +107,7 @@ namespace pvd
 		return static_cast<time_t>(SteadyNowMs() - last_received_time_ms);
 	}
 
-	void PushStream::ApplyConfiguredPacketSilenceTimeout(const info::VHostAppName &vhost_app_name)
+	void PushStream::ApplyConfiguredPacketSilenceTimeoutMs(const info::VHostAppName &vhost_app_name)
 	{
 		auto provider = GetProvider();
 		if (provider == nullptr)

--- a/src/base/provider/push_provider/stream.h
+++ b/src/base/provider/push_provider/stream.h
@@ -46,8 +46,9 @@ namespace pvd
 		time_t GetElapsedMsSinceLastReceived();
 
 		// Apply the `PacketSilenceTimeoutMs` configured for the resolved application.
-		// Concrete providers call this once the application is known but before
-		// publishing, so the pre-publish window honors the configured value.
+		// Concrete providers call this once the application is known but before publishing, so the
+		// pre-publish window honors the configured value. An option the operator did not set leaves
+		// the channel-creation default in place.
 		void ApplyConfiguredPacketSilenceTimeoutMs(const info::VHostAppName &vhost_app_name);
 
 		uint32_t GetNumberOfAttempsToPublish()

--- a/src/base/provider/push_provider/stream.h
+++ b/src/base/provider/push_provider/stream.h
@@ -46,9 +46,10 @@ namespace pvd
 		time_t GetElapsedMsSinceLastReceived();
 
 		// Apply the `PacketSilenceTimeoutMs` configured for the resolved application.
-		// Concrete providers call this once the application is known but before publishing, so the
-		// pre-publish window honors the configured value. An option the operator did not set leaves
-		// the channel-creation default in place.
+		// Concrete providers call this as soon as the application is known, which for RTMP, MPEG-TS
+		// and SRT is while the channel is still unpublished, and for WebRTC is right after
+		// `OnChannelCreated()` overwrote the value with the channel-creation default.
+		// An option the operator did not set leaves that default in place.
 		void ApplyConfiguredPacketSilenceTimeoutMs(const info::VHostAppName &vhost_app_name);
 
 		uint32_t GetNumberOfAttempsToPublish()

--- a/src/base/provider/push_provider/stream.h
+++ b/src/base/provider/push_provider/stream.h
@@ -48,7 +48,7 @@ namespace pvd
 		// Apply the `PacketSilenceTimeoutMs` configured for the resolved application.
 		// Concrete providers call this once the application is known but before
 		// publishing, so the pre-publish window honors the configured value.
-		void ApplyConfiguredPacketSilenceTimeout(const info::VHostAppName &vhost_app_name);
+		void ApplyConfiguredPacketSilenceTimeoutMs(const info::VHostAppName &vhost_app_name);
 
 		uint32_t GetNumberOfAttempsToPublish()
 		{

--- a/src/base/provider/push_provider/stream.h
+++ b/src/base/provider/push_provider/stream.h
@@ -44,7 +44,12 @@ namespace pvd
 		void SetPacketSilenceTimeoutMs(time_t timeout_ms);
 		time_t GetPacketSilenceTimeoutMs();
 		time_t GetElapsedMsSinceLastReceived();
-		
+
+		// Apply the `PacketSilenceTimeoutMs` configured for the resolved application.
+		// Concrete providers call this once the application is known but before
+		// publishing, so the pre-publish window honors the configured value.
+		void ApplyConfiguredPacketSilenceTimeout(const info::VHostAppName &vhost_app_name);
+
 		uint32_t GetNumberOfAttempsToPublish()
 		{
 			return _attemps_publish_count;

--- a/src/config/items/virtual_hosts/applications/providers/provider.h
+++ b/src/config/items/virtual_hosts/applications/providers/provider.h
@@ -84,6 +84,14 @@ namespace cfg
 
 						Register<Optional>("PacketSilenceTimeoutMs", &_packet_silence_timeout_ms, nullptr,
 										   [=]() -> std::shared_ptr<ConfigError> {
+											   // A negative value would defeat both guards in the channel task runner:
+											   // it is not `0`, so the timeout counts as active, and every elapsed value
+											   // exceeds it - including the `-1` that means no data has arrived yet.
+											   if (_packet_silence_timeout_ms < 0)
+											   {
+												   return CreateConfigErrorPtr("PacketSilenceTimeoutMs must not be negative: %d", _packet_silence_timeout_ms);
+											   }
+
 											   // This callback only runs when the option is present in the configuration
 											   _is_packet_silence_timeout_ms_configured = true;
 

--- a/src/config/items/virtual_hosts/applications/providers/provider.h
+++ b/src/config/items/virtual_hosts/applications/providers/provider.h
@@ -25,16 +25,27 @@ namespace cfg
 					TimestampMode _timestamp_mode = TimestampMode::Auto;
 					bool _use_incoming_timestamp  = false;	// For backward compatibility
 					ov::String _timestamp_mode_str;
-					int _packet_silence_timeout_ms = 0;	 // Default value for packet silence timeout
+					int _packet_silence_timeout_ms				  = 0;	// Default value for packet silence timeout
+					// Whether `_packet_silence_timeout_ms` currently holds the value the operator asked
+					// for. Set while parsing `PacketSilenceTimeoutMs` and cleared again by
+					// `SetPacketSilenceTimeoutMs()`, which exists to fill in provider defaults.
+					bool _is_packet_silence_timeout_ms_configured = false;
 
 				public:
 					virtual ProviderType GetType() const = 0;
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetMaxConnection, _max_connection)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetTimestampMode, _timestamp_mode)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetPacketSilenceTimeoutMs, _packet_silence_timeout_ms)
+					bool IsPacketSilenceTimeoutMsConfigured() const
+					{
+						return _is_packet_silence_timeout_ms_configured;
+					}
+					// Fills in a provider default. The value is no longer the operator's after this,
+					// so anything that must honor only an explicit setting stops seeing it.
 					void SetPacketSilenceTimeoutMs(int timeout_ms)
 					{
-						_packet_silence_timeout_ms = timeout_ms;
+						_packet_silence_timeout_ms				 = timeout_ms;
+						_is_packet_silence_timeout_ms_configured = false;
 					}
 
 				protected:
@@ -73,6 +84,9 @@ namespace cfg
 
 						Register<Optional>("PacketSilenceTimeoutMs", &_packet_silence_timeout_ms, nullptr,
 										   [=]() -> std::shared_ptr<ConfigError> {
+											   // This callback only runs when the option is present in the configuration
+											   _is_packet_silence_timeout_ms_configured = true;
+
 											   switch (GetType())
 											   {
 												   case ProviderType::Rtmp:

--- a/src/config/items/virtual_hosts/applications/providers/provider.h
+++ b/src/config/items/virtual_hosts/applications/providers/provider.h
@@ -27,8 +27,8 @@ namespace cfg
 					ov::String _timestamp_mode_str;
 					int _packet_silence_timeout_ms				  = 0;	// Default value for packet silence timeout
 					// Whether `_packet_silence_timeout_ms` currently holds the value the operator asked
-					// for. Set while parsing `PacketSilenceTimeoutMs` and cleared again by
-					// `SetPacketSilenceTimeoutMs()`, which exists to fill in provider defaults.
+					// for, rather than a provider default. Set while parsing `PacketSilenceTimeoutMs`
+					// and cleared again by `SetDefaultPacketSilenceTimeoutMs()`.
 					bool _is_packet_silence_timeout_ms_configured = false;
 
 				public:
@@ -40,9 +40,9 @@ namespace cfg
 					{
 						return _is_packet_silence_timeout_ms_configured;
 					}
-					// Fills in a provider default. The value is no longer the operator's after this,
-					// so anything that must honor only an explicit setting stops seeing it.
-					void SetPacketSilenceTimeoutMs(int timeout_ms)
+					// Overrides the value with a provider default. The value is no longer the operator's
+					// after this, so anything that must honor only an explicit setting stops seeing it.
+					void SetDefaultPacketSilenceTimeoutMs(int timeout_ms)
 					{
 						_packet_silence_timeout_ms				 = timeout_ms;
 						_is_packet_silence_timeout_ms_configured = false;

--- a/src/config/items/virtual_hosts/applications/providers/providers.h
+++ b/src/config/items/virtual_hosts/applications/providers/providers.h
@@ -75,7 +75,7 @@ namespace cfg
 											   if (_mpegts_provider.GetPacketSilenceTimeoutMs() == 0)
 											   {
 												   logi("Config", "Setting default PacketSilenceTimeoutMs to 1500 ms for MPEGTS provider.");
-												   _mpegts_provider.SetPacketSilenceTimeoutMs(1500);
+												   _mpegts_provider.SetDefaultPacketSilenceTimeoutMs(1500);
 											   }
 
 											   return nullptr;

--- a/src/providers/mpegts/mpegts_provider.cpp
+++ b/src/providers/mpegts/mpegts_provider.cpp
@@ -358,6 +358,10 @@ namespace pvd
 		{
 			logti("A MPEG-TS client has connected");  // %s", remote->ToString().CStr());
 			stream_port_item->OnClientConnected(channel_id);
+
+			// The application is already known at channel creation,
+			// so honor its configured `PacketSilenceTimeoutMs` for the pre-publish window.
+			stream->ApplyConfiguredPacketSilenceTimeout(stream_port_item->GetVhostAppName());
 		}
 
 		return true;

--- a/src/providers/mpegts/mpegts_provider.cpp
+++ b/src/providers/mpegts/mpegts_provider.cpp
@@ -363,7 +363,7 @@ namespace pvd
 			// now that the application is known.
 			// For MPEG-TS this defaults to `1500` ms during config parsing,
 			// not the generic channel-creation default.
-			stream->ApplyConfiguredPacketSilenceTimeout(stream_port_item->GetVhostAppName());
+			stream->ApplyConfiguredPacketSilenceTimeoutMs(stream_port_item->GetVhostAppName());
 		}
 
 		return true;

--- a/src/providers/mpegts/mpegts_provider.cpp
+++ b/src/providers/mpegts/mpegts_provider.cpp
@@ -359,10 +359,8 @@ namespace pvd
 			logti("A MPEG-TS client has connected");  // %s", remote->ToString().CStr());
 			stream_port_item->OnClientConnected(channel_id);
 
-			// Apply the effective `PacketSilenceTimeoutMs` to the pre-publish window,
+			// Apply the configured `PacketSilenceTimeoutMs` to the pre-publish window,
 			// now that the application is known.
-			// For MPEG-TS this defaults to `1500` ms during config parsing,
-			// not the generic channel-creation default.
 			stream->ApplyConfiguredPacketSilenceTimeoutMs(stream_port_item->GetVhostAppName());
 		}
 

--- a/src/providers/mpegts/mpegts_provider.cpp
+++ b/src/providers/mpegts/mpegts_provider.cpp
@@ -359,8 +359,10 @@ namespace pvd
 			logti("A MPEG-TS client has connected");  // %s", remote->ToString().CStr());
 			stream_port_item->OnClientConnected(channel_id);
 
-			// The application is already known at channel creation,
-			// so honor its configured `PacketSilenceTimeoutMs` for the pre-publish window.
+			// Apply the effective `PacketSilenceTimeoutMs` to the pre-publish window,
+			// now that the application is known.
+			// For MPEG-TS this defaults to `1500` ms during config parsing,
+			// not the generic channel-creation default.
 			stream->ApplyConfiguredPacketSilenceTimeout(stream_port_item->GetVhostAppName());
 		}
 

--- a/src/providers/rtmp/rtmp_stream.cpp
+++ b/src/providers/rtmp/rtmp_stream.cpp
@@ -496,7 +496,7 @@ namespace pvd
 
 			// Now that the application is resolved, honor its configured `PacketSilenceTimeoutMs`
 			// during the pre-publish window as well.
-			ApplyConfiguredPacketSilenceTimeout(vhost_app_name);
+			ApplyConfiguredPacketSilenceTimeoutMs(vhost_app_name);
 
 			return true;
 		}

--- a/src/providers/rtmp/rtmp_stream.cpp
+++ b/src/providers/rtmp/rtmp_stream.cpp
@@ -493,6 +493,11 @@ namespace pvd
 		if (app_info.IsValid())
 		{
 			_app_id = app_info.GetId();
+
+			// Now that the application is resolved, honor its configured `PacketSilenceTimeoutMs`
+			// during the pre-publish window as well.
+			ApplyConfiguredPacketSilenceTimeout(vhost_app_name);
+
 			return true;
 		}
 

--- a/src/providers/rtmp/rtmp_stream_v2.cpp
+++ b/src/providers/rtmp/rtmp_stream_v2.cpp
@@ -394,7 +394,7 @@ namespace pvd::rtmp
 
 		// Now that the application is resolved, honor its configured `PacketSilenceTimeoutMs`
 		// during the pre-publish window as well.
-		ApplyConfiguredPacketSilenceTimeout(_vhost_app_name);
+		ApplyConfiguredPacketSilenceTimeoutMs(_vhost_app_name);
 
 		return true;
 	}

--- a/src/providers/rtmp/rtmp_stream_v2.cpp
+++ b/src/providers/rtmp/rtmp_stream_v2.cpp
@@ -392,6 +392,10 @@ namespace pvd::rtmp
 		_chunk_handler.UpdateNamePath(GetNamePath());
 		_chunk_handler.UpdateQueueAlias();
 
+		// Now that the application is resolved, honor its configured `PacketSilenceTimeoutMs`
+		// during the pre-publish window as well.
+		ApplyConfiguredPacketSilenceTimeout(_vhost_app_name);
+
 		return true;
 	}
 

--- a/src/providers/srt/srt_provider.cpp
+++ b/src/providers/srt/srt_provider.cpp
@@ -304,6 +304,10 @@ namespace pvd
 		stream->SetFinalUrl(final_url);
 
 		PushProvider::OnChannelCreated(remote->GetNativeHandle(), stream);
+
+		// The application is already known at channel creation,
+		// so honor its configured `PacketSilenceTimeoutMs` for the pre-publish window.
+		stream->ApplyConfiguredPacketSilenceTimeout(vhost_app_name);
 	}
 
 	void SrtProvider::OnDataReceived(const std::shared_ptr<ov::Socket> &remote,

--- a/src/providers/srt/srt_provider.cpp
+++ b/src/providers/srt/srt_provider.cpp
@@ -307,7 +307,7 @@ namespace pvd
 
 		// The application is already known at channel creation,
 		// so honor its configured `PacketSilenceTimeoutMs` for the pre-publish window.
-		stream->ApplyConfiguredPacketSilenceTimeout(vhost_app_name);
+		stream->ApplyConfiguredPacketSilenceTimeoutMs(vhost_app_name);
 	}
 
 	void SrtProvider::OnDataReceived(const std::shared_ptr<ov::Socket> &remote,

--- a/src/providers/webrtc/webrtc_provider.cpp
+++ b/src/providers/webrtc/webrtc_provider.cpp
@@ -602,6 +602,11 @@ namespace pvd
 			return false;
 		}
 
+		// This provider calls `PublishChannel()` before `OnChannelCreated()`, so the value
+		// `JoinStream()` applied has just been overwritten with the channel-creation default.
+		// Re-apply the configured one.
+		stream->ApplyConfiguredPacketSilenceTimeoutMs(final_vhost_app_name);
+
 		RegisterStreamToSessionKeyStreamMap(stream);
 
 		auto ice_timeout = application->GetConfig().GetProviders().GetWebrtcProvider().GetTimeout();
@@ -895,6 +900,11 @@ namespace pvd
 		{
 			return {http::StatusCode::InternalServerError, "Could not publish stream"};
 		}
+
+		// This provider calls `PublishChannel()` before `OnChannelCreated()`, so the value
+		// `JoinStream()` applied has just been overwritten with the channel-creation default.
+		// Re-apply the configured one.
+		stream->ApplyConfiguredPacketSilenceTimeoutMs(final_vhost_app_name);
 
 		RegisterStreamToSessionKeyStreamMap(stream);
 


### PR DESCRIPTION
## Summary

`PacketSilenceTimeoutMs` (a per-application push-provider option) was only applied when a channel published, so during the pre-publish window the channel used the hardcoded default (`DEFAULT_PUSH_CHANNEL_PACKET_SILENCE_TIMEOUT_MS`, 3000 ms) and a configured value had no effect until publish.
This PR applies the configured value as soon as the application is resolved, so the option is honored throughout the channel's lifetime.

## Motivation

The timeout is armed in two places:

- `PushProvider::OnChannelCreated()` sets the hardcoded 3000 ms default when the channel is created, because the application is not yet known at this point.
- `PushApplication::JoinStream()` replaces it with the configured `PacketSilenceTimeoutMs` only at publish time.

Between those two points the channel runs with the 3000 ms default regardless of configuration, which has two consequences:

- A configured value (for example `50000`) is ignored during the pre-publish window, and the channel is still evaluated against 3000 ms.
- A source that legitimately stays silent for a few seconds before publishing, such as a low-fps encoder whose first frame is delayed by frame-threaded encoding, is dropped about 3s after connecting, before the stream is ever created: `PushProvider | Channel N is timed out, ~3000 ms elapsed since last received, deleting it`.

## Changes

- Add `PushApplication::GetConfiguredPacketSilenceTimeoutMs(provider_type, is_configured)` and `PushStream::ApplyConfiguredPacketSilenceTimeoutMs(vhost_app_name)`, which apply `PacketSilenceTimeoutMs` to the channel only when the operator set it to a positive value. A default filled in during config parsing (MPEG-TS gets 1500 ms) is not the operator's intent and keeps applying only after publishing.
- RTMP: call it from `ValidatePublishUrl()` in both `RtmpStream` and `RtmpStreamV2`, where the application is resolved while handling the publish command, before any media arrives.
- SRT and MPEG-TS: call it right after `OnChannelCreated()`, where the application is already known at channel creation.

When the option is not set, every provider keeps the existing 3000 ms channel-creation default during the pre-publish window. An explicit `0` keeps it too: after publishing it disables the timeout as before, but removing the guard before publishing would leave an MPEG-TS/UDP channel that never publishes with nothing to reap it, because `OnDisconnected()` is not delivered for UDP.

## Configuration

```xml
<Application>
  <Providers>
    <RTMP><PacketSilenceTimeoutMs>50000</PacketSilenceTimeoutMs></RTMP>
    <SRT><PacketSilenceTimeoutMs>50000</PacketSilenceTimeoutMs></SRT>
    <MPEGTS><PacketSilenceTimeoutMs>50000</PacketSilenceTimeoutMs></MPEGTS>
  </Providers>
</Application>
```

## Testing

### Reproduce the old behavior (before this change)

1. Configure a large timeout on the RTMP provider, for example `<RTMP><PacketSilenceTimeoutMs>50000</PacketSilenceTimeoutMs></RTMP>`.
2. Push with OBS using x264, CPU preset `ultrafast`, profile `baseline`, Tune `(None)` (not `zerolatency`), and set the video frame rate to `1`, so that frame-threaded libx264 delays its first frame by roughly `thread_count / fps` seconds (well over 3s). Use OBS rather than ffmpeg here, because OBS holds all packets until the first video keyframe so nothing reaches the server during the warm-up, whereas ffmpeg's flv muxer emits data earlier and does not reproduce the pre-publish silence.
3. Observe that the channel is deleted about 3s after connecting, before the stream is published, even though `50000` is configured: `PushProvider | Channel N is timed out, ~3000 ms elapsed since last received, deleting it`. No input stream is created.

### Verify the fix

- With the same configuration and source, the pre-publish window now uses the configured value, so the channel survives the encoder warm-up and the stream is published once the first frame arrives, with no timeout log.
- Deterministic check (debug build, `PushProvider` trace log): the pre-publish checks report the configured timeout instead of the default, `PushProvider | Checking channel N, elapsed X ms, timeout 50000 ms`, and with the option unset it correctly stays `timeout 3000 ms`.
- SRT and MPEG-TS behave the same using the `<SRT>` / `<MPEGTS>` `PacketSilenceTimeoutMs`, and these can be driven with ffmpeg, where the trace-log check confirms the configured value is applied at channel creation for all three providers.
