### PR TITLE
fix(stream): keep runtime state shared between stream copies

### DIFF
--- a/src/base/info/stream.cpp
+++ b/src/base/info/stream.cpp
@@ -27,7 +27,6 @@ namespace info
 
 		SetId(ov::Random::GenerateUInt32() - 1);
 
-		_created_time = std::chrono::system_clock::now();
 		_source_type = source;
 	}
 
@@ -37,22 +36,21 @@ namespace info
 
 		SetId(stream_id);
 
-		_created_time = std::chrono::system_clock::now();
 		_source_type = source;
 	}
 
+	// The runtime state is shared with the source: it keeps changing after this copy was
+	// taken, and every module has to see the same values
 	Stream::Stream(const Stream &stream)
+		: _stats(stream._stats)
 	{
 		_name_path = stream.GetNamePath();
-		
+
 		_id = stream._id;
 		_internal = stream._internal;
 		_name = stream._name;
 		_source_type = stream._source_type;
-		_source_url = stream.GetMediaSource();
 		_output_profile_name = stream._output_profile_name;
-		_created_time = stream._created_time;
-		_published_time = stream._published_time;
 		_app_info = stream._app_info;
 		_origin_stream = stream._origin_stream;
 
@@ -94,7 +92,6 @@ namespace info
 		_representation_type = stream._representation_type;
 
 		_origin_stream_uuid = stream._origin_stream_uuid;
-		_on_air.store(stream._on_air);
 
 		_timestamp_mode = stream._timestamp_mode;
 	}
@@ -102,7 +99,6 @@ namespace info
 	Stream::Stream(StreamSourceType source)
 	{
 		_source_type = source;
-		_created_time = std::chrono::system_clock::now();
 	}
 
 	Stream::~Stream()
@@ -182,13 +178,11 @@ namespace info
 
 	ov::String Stream::GetMediaSource() const
 	{
-		ov::LockGuard lock(_source_url_mutex);
-		return _source_url;
+		return _stats->GetMediaSource();
 	}
 	void Stream::SetMediaSource(ov::String url)
 	{
-		ov::LockGuard lock(_source_url_mutex);
-		_source_url = url;
+		_stats->SetMediaSource(url);
 	}
 
 	void Stream::SetOutputProfileName(ov::String name)
@@ -232,7 +226,7 @@ namespace info
 		return _origin_stream_uuid;
 	}
 
-	const std::chrono::system_clock::time_point &Stream::GetInputStreamCreatedTime() const
+	std::chrono::system_clock::time_point Stream::GetInputStreamCreatedTime() const
 	{
 		if (GetLinkedInputStream() != nullptr)
 		{
@@ -242,23 +236,22 @@ namespace info
 		return GetCreatedTime();
 	}
 
-	const std::chrono::system_clock::time_point &Stream::GetCreatedTime() const
+	std::chrono::system_clock::time_point Stream::GetCreatedTime() const
 	{
-		return _created_time;
+		return _stats->GetCreatedTime();
 	}
 
 	void Stream::SetPublishedTime(const std::chrono::system_clock::time_point &time)
 	{
-		_published_time = time;
-		_on_air = true;
+		_stats->SetPublishedTime(time);
 	}
 
-	const std::chrono::system_clock::time_point &Stream::GetPublishedTime() const
+	std::chrono::system_clock::time_point Stream::GetPublishedTime() const
 	{
-		return _published_time;
+		return _stats->GetPublishedTime();
 	}
 
-	const std::chrono::system_clock::time_point &Stream::GetInputStreamPublishedTime() const
+	std::chrono::system_clock::time_point Stream::GetInputStreamPublishedTime() const
 	{
 		if (GetLinkedInputStream() != nullptr)
 		{
@@ -790,7 +783,7 @@ namespace info
 	{
 		ov::String out_str = ov::String::FormatString("\n[Stream Info]\nid(%u), output(%s), SourceType(%s), RepresentationType(%s), Created Time (%s) UUID(%s)\n",
 													  GetId(), GetName().CStr(), ::StringFromStreamSourceType(_source_type).CStr(), ::StringFromStreamRepresentationType(_representation_type).CStr(),
-													  ov::Converter::ToString(_created_time).CStr(), GetUUID().CStr());
+													  ov::Converter::ToString(GetCreatedTime()).CStr(), GetUUID().CStr());
 		if (GetLinkedInputStream() != nullptr)
 		{
 			out_str.AppendFormat("\t>> Origin Stream Info\n\tid(%u), output(%s), SourceType(%s), Created Time (%s)\n",

--- a/src/base/info/stream.h
+++ b/src/base/info/stream.h
@@ -6,6 +6,7 @@
 #include "base/info/media_track_group.h"
 #include "base/info/track_stats.h"
 #include "base/info/playlist.h"
+#include "base/info/stream_stats.h"
 #include "base/info/track_set.h"
 #include "base/ovlibrary/tsa/mutex.h"
 #include "vhost_app_name.h"
@@ -61,12 +62,19 @@ namespace info
 		void SetOriginStreamUUID(const ov::String &uuid);
 		ov::String GetOriginStreamUUID() const;
 
-		const std::chrono::system_clock::time_point &GetInputStreamCreatedTime() const;
-		const std::chrono::system_clock::time_point &GetCreatedTime() const;
+		std::chrono::system_clock::time_point GetInputStreamCreatedTime() const;
+		std::chrono::system_clock::time_point GetCreatedTime() const;
 
 		void SetPublishedTime(const std::chrono::system_clock::time_point &time);
-		const std::chrono::system_clock::time_point &GetInputStreamPublishedTime() const;
-		const std::chrono::system_clock::time_point &GetPublishedTime() const;
+		std::chrono::system_clock::time_point GetInputStreamPublishedTime() const;
+		std::chrono::system_clock::time_point GetPublishedTime() const;
+
+		// Runtime state of this stream instance. Every copy of this stream shares the
+		// same object, so state that changes after creation stays visible to all of them
+		const std::shared_ptr<StreamStats> &GetStats() const
+		{
+			return _stats;
+		}
 
 		StreamSourceType GetSourceType() const;
 		ProviderType GetProviderType() const;
@@ -165,17 +173,12 @@ namespace info
 
 		bool IsOnAir() const
 		{
-			return _on_air;
+			return _stats->IsOnAir();
 		}
 
 		void SetOnAir(bool on_air)
 		{
-			_on_air = on_air;
-
-			if (_on_air)
-			{
-				_published_time = std::chrono::system_clock::now();
-			}
+			_stats->SetOnAir(on_air);
 		}
 
 		void SetTimestampMode(TimestampMode mode)
@@ -197,9 +200,6 @@ namespace info
 	protected:
 		info::stream_id_t _id = 0;
 		ov::String _name;
-		// Rewritten on every pull-stream failover, read from monitoring/serdes/publisher threads
-		mutable ov::Mutex _source_url_mutex;
-		ov::String _source_url OV_GUARDED_BY(_source_url_mutex);
 		ov::String _output_profile_name;
 		
 		// Key : MediaTrack ID
@@ -229,8 +229,8 @@ namespace info
 		mutable ov::Mutex _name_path_mutex;
 		NamePath _name_path OV_GUARDED_BY(_name_path_mutex) = NamePath::UnknownNamePath();
 
-		std::chrono::system_clock::time_point _created_time;
-		std::chrono::system_clock::time_point _published_time;
+		// Runtime state, created with the stream and shared by every copy of it
+		std::shared_ptr<StreamStats> _stats = std::make_shared<StreamStats>();
 
 		// Where does the stream come from?
 		StreamSourceType _source_type;
@@ -251,8 +251,6 @@ namespace info
 
 		// If the source if this stream is a remote stream of the origin server, store the uuid of origin stream
 		ov::String _origin_stream_uuid;
-
-		std::atomic<bool> _on_air = false;
 
 		TimestampMode _timestamp_mode = TimestampMode::Auto;
 	};

--- a/src/base/info/stream.h
+++ b/src/base/info/stream.h
@@ -71,7 +71,7 @@ namespace info
 
 		// Runtime state of this stream instance. Every copy of this stream shares the
 		// same object, so state that changes after creation stays visible to all of them
-		const std::shared_ptr<StreamStats> &GetStats() const
+		std::shared_ptr<StreamStats> GetStats() const
 		{
 			return _stats;
 		}

--- a/src/base/info/stream_stats.cpp
+++ b/src/base/info/stream_stats.cpp
@@ -1,0 +1,79 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Getroot
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#include "stream_stats.h"
+
+namespace info
+{
+	StreamStats::StreamStats()
+		: _created_time(std::chrono::system_clock::now())
+	{
+	}
+
+	std::chrono::system_clock::time_point StreamStats::GetCreatedTime() const
+	{
+		return _created_time;
+	}
+
+	void StreamStats::SetPublishedTime(const std::chrono::system_clock::time_point &time)
+	{
+		_published_time = time.time_since_epoch().count();
+		_published_time_steady = std::chrono::steady_clock::now().time_since_epoch().count();
+
+		// Set last, so a reader that checks the on-air state finds a valid time
+		_on_air = true;
+	}
+
+	std::chrono::system_clock::time_point StreamStats::GetPublishedTime() const
+	{
+		return std::chrono::system_clock::time_point(std::chrono::system_clock::duration(_published_time.load()));
+	}
+
+	std::chrono::steady_clock::time_point StreamStats::GetPublishedTimeSteady() const
+	{
+		return std::chrono::steady_clock::time_point(std::chrono::steady_clock::duration(_published_time_steady.load()));
+	}
+
+	bool StreamStats::IsOnAir() const
+	{
+		return _on_air;
+	}
+
+	void StreamStats::SetOnAir(bool on_air)
+	{
+		if (on_air)
+		{
+			SetPublishedTime(std::chrono::system_clock::now());
+			return;
+		}
+
+		_on_air = false;
+	}
+
+	void StreamStats::SetPrepared(bool prepared)
+	{
+		_prepared_time = prepared ? std::chrono::system_clock::now().time_since_epoch().count() : 0;
+	}
+
+	std::chrono::system_clock::time_point StreamStats::GetPreparedTime() const
+	{
+		return std::chrono::system_clock::time_point(std::chrono::system_clock::duration(_prepared_time.load()));
+	}
+
+	void StreamStats::SetMediaSource(const ov::String &url)
+	{
+		ov::LockGuard lock(_media_source_mutex);
+		_media_source = url;
+	}
+
+	ov::String StreamStats::GetMediaSource() const
+	{
+		ov::LockGuard lock(_media_source_mutex);
+		return _media_source;
+	}
+}  // namespace info

--- a/src/base/info/stream_stats.cpp
+++ b/src/base/info/stream_stats.cpp
@@ -23,7 +23,6 @@ namespace info
 	void StreamStats::SetPublishedTime(const std::chrono::system_clock::time_point &time)
 	{
 		_published_time = time.time_since_epoch().count();
-		_published_time_steady = std::chrono::steady_clock::now().time_since_epoch().count();
 
 		// Set last, so a reader that checks the on-air state finds a valid time
 		_on_air = true;
@@ -32,11 +31,6 @@ namespace info
 	std::chrono::system_clock::time_point StreamStats::GetPublishedTime() const
 	{
 		return std::chrono::system_clock::time_point(std::chrono::system_clock::duration(_published_time.load()));
-	}
-
-	std::chrono::steady_clock::time_point StreamStats::GetPublishedTimeSteady() const
-	{
-		return std::chrono::steady_clock::time_point(std::chrono::steady_clock::duration(_published_time_steady.load()));
 	}
 
 	bool StreamStats::IsOnAir() const
@@ -53,6 +47,34 @@ namespace info
 		}
 
 		_on_air = false;
+	}
+
+	void StreamStats::SetFirstMediaTime()
+	{
+		if (_first_media_time.load() != 0)
+		{
+			return;
+		}
+
+		// Set the steady value first, so a reader that finds the wall clock time set
+		// always finds the steady one too
+		_first_media_time_steady = std::chrono::steady_clock::now().time_since_epoch().count();
+		_first_media_time = std::chrono::system_clock::now().time_since_epoch().count();
+	}
+
+	bool StreamStats::HasFirstMediaTime() const
+	{
+		return _first_media_time.load() != 0;
+	}
+
+	std::chrono::system_clock::time_point StreamStats::GetFirstMediaTime() const
+	{
+		return std::chrono::system_clock::time_point(std::chrono::system_clock::duration(_first_media_time.load()));
+	}
+
+	std::chrono::steady_clock::time_point StreamStats::GetFirstMediaTimeSteady() const
+	{
+		return std::chrono::steady_clock::time_point(std::chrono::steady_clock::duration(_first_media_time_steady.load()));
 	}
 
 	void StreamStats::SetPrepared(bool prepared)

--- a/src/base/info/stream_stats.h
+++ b/src/base/info/stream_stats.h
@@ -1,0 +1,63 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Getroot
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include <atomic>
+#include <chrono>
+
+#include "base/ovlibrary/ovlibrary.h"
+#include "base/ovlibrary/tsa/mutex.h"
+
+namespace info
+{
+	// Runtime state of one stream instance.
+	// This is the deliberately shared mutable state between modules: every copy of a
+	// stream shares the same StreamStats instance, while the stream description travels
+	// with the copies. State that changes after the stream was created belongs here,
+	// otherwise a copy taken before the change never sees it.
+	class StreamStats
+	{
+	public:
+		StreamStats();
+
+		std::chrono::system_clock::time_point GetCreatedTime() const;
+
+		// Stamped when the first media packet of the stream is sent to the media router.
+		// Epoch while the stream has not gone on air
+		void SetPublishedTime(const std::chrono::system_clock::time_point &time);
+		std::chrono::system_clock::time_point GetPublishedTime() const;
+
+		// Same moment as the published time, for measuring elapsed time
+		std::chrono::steady_clock::time_point GetPublishedTimeSteady() const;
+
+		bool IsOnAir() const;
+		void SetOnAir(bool on_air);
+
+		// Stamped when every track has been described and the stream is notified as
+		// prepared. Epoch while the stream is not prepared
+		void SetPrepared(bool prepared);
+		std::chrono::system_clock::time_point GetPreparedTime() const;
+
+		// Where the media is coming from. Rewritten on every pull-stream failover
+		void SetMediaSource(const ov::String &url);
+		ov::String GetMediaSource() const;
+
+	private:
+		const std::chrono::system_clock::time_point _created_time;
+
+		std::atomic<int64_t> _published_time = 0;
+		std::atomic<int64_t> _published_time_steady = 0;
+		std::atomic<bool> _on_air = false;
+
+		std::atomic<int64_t> _prepared_time = 0;
+
+		mutable ov::Mutex _media_source_mutex;
+		ov::String _media_source OV_GUARDED_BY(_media_source_mutex);
+	};
+}  // namespace info

--- a/src/base/info/stream_stats.h
+++ b/src/base/info/stream_stats.h
@@ -29,15 +29,20 @@ namespace info
 		std::chrono::system_clock::time_point GetCreatedTime() const;
 
 		// Stamped when the first media packet of the stream is sent to the media router.
-		// Epoch while the stream has not gone on air
+		// Epoch until the stream goes on air
 		void SetPublishedTime(const std::chrono::system_clock::time_point &time);
 		std::chrono::system_clock::time_point GetPublishedTime() const;
 
-		// Read when the published time is set, for measuring elapsed time
-		std::chrono::steady_clock::time_point GetPublishedTimeSteady() const;
-
 		bool IsOnAir() const;
 		void SetOnAir(bool on_air);
+
+		// Latched when the media router first sees a packet of this stream. A provider can
+		// declare itself published before media flows, so this is the only reliable anchor
+		// for how long media has actually been running
+		void SetFirstMediaTime();
+		bool HasFirstMediaTime() const;
+		std::chrono::system_clock::time_point GetFirstMediaTime() const;
+		std::chrono::steady_clock::time_point GetFirstMediaTimeSteady() const;
 
 		// Stamped when every track has been described and the stream is notified as
 		// prepared. Epoch while the stream is not prepared
@@ -52,8 +57,10 @@ namespace info
 		const std::chrono::system_clock::time_point _created_time;
 
 		std::atomic<int64_t> _published_time = 0;
-		std::atomic<int64_t> _published_time_steady = 0;
 		std::atomic<bool> _on_air = false;
+
+		std::atomic<int64_t> _first_media_time = 0;
+		std::atomic<int64_t> _first_media_time_steady = 0;
 
 		std::atomic<int64_t> _prepared_time = 0;
 

--- a/src/base/info/stream_stats.h
+++ b/src/base/info/stream_stats.h
@@ -33,7 +33,7 @@ namespace info
 		void SetPublishedTime(const std::chrono::system_clock::time_point &time);
 		std::chrono::system_clock::time_point GetPublishedTime() const;
 
-		// Same moment as the published time, for measuring elapsed time
+		// Read when the published time is set, for measuring elapsed time
 		std::chrono::steady_clock::time_point GetPublishedTimeSteady() const;
 
 		bool IsOnAir() const;

--- a/src/base/info/stream_test.cpp
+++ b/src/base/info/stream_test.cpp
@@ -14,14 +14,12 @@
 #include <thread>
 #include <vector>
 
-// Tests for `info::Stream` thread-safety fixes on this branch:
-// `_source_url` is rewritten on every pull-stream failover (`SetMediaSource()`)
-// while monitoring/serdes/publisher threads read it concurrently;
-// both accessors now synchronize on `_source_url_mutex`.
+// Tests for `info::Stream` source URL thread-safety:
+// the URL is rewritten on every pull-stream failover (`SetMediaSource()`)
+// while monitoring/serdes/publisher threads read it concurrently.
 // These tests pin the value-integrity contract
 // (a reader/copier can only ever observe a fully written value, never a torn one)
-// and are intended to run under TSan as well,
-// where the pre-fix code would report a data race.
+// and are intended to run under TSan as well.
 
 namespace
 {

--- a/src/mediarouter/mediarouter_stream.cpp
+++ b/src/mediarouter/mediarouter_stream.cpp
@@ -41,6 +41,7 @@ using namespace cmn;
 MediaRouteStream::MediaRouteStream(const std::shared_ptr<info::Stream> &stream, cmn::MediaRouterStreamType type, uint32_t worker_id)
 	: _worker_id(worker_id),
 	  _stream(stream),
+	  _stats(stream->GetStats()),
 	  _packets_queue(nullptr, 600)
 {
 	SetType(type);
@@ -91,7 +92,7 @@ void MediaRouteStream::OnStreamPrepared(bool completed)
 {
 	_is_stream_prepared = completed;
 
-	_stream->GetStats()->SetPrepared(completed);
+	_stats->SetPrepared(completed);
 }
 
 bool MediaRouteStream::IsStreamPrepared()
@@ -154,13 +155,13 @@ bool MediaRouteStream::IsStreamReady()
 // negotiated tracks (e.g. a simulcast layer or audio) never arrives, the stream hangs. Warn so it is visible.
 void MediaRouteStream::CheckUnpreparedTrackTimeout()
 {
-	if (_stream->IsOnAir() == false)
+	if (_stats->HasFirstMediaTime() == false)
 	{
 		return;
 	}
 
 	// Anchor at the first media packet so connection/handshake delay is excluded; full silence is the provider's job.
-	auto media_start_time = _stream->GetStats()->GetPublishedTimeSteady();
+	auto media_start_time = _stats->GetFirstMediaTimeSteady();
 	auto now = std::chrono::steady_clock::now();
 	auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - media_start_time).count();
 
@@ -286,6 +287,8 @@ void MediaRouteStream::DropNonDecodingPackets()
 
 void MediaRouteStream::Push(const std::shared_ptr<MediaPacket> &media_packet)
 {
+	_stats->SetFirstMediaTime();
+
 	_packets_queue.Enqueue(media_packet, media_packet->IsHighPriority());
 }
 

--- a/src/mediarouter/mediarouter_stream.cpp
+++ b/src/mediarouter/mediarouter_stream.cpp
@@ -90,6 +90,8 @@ void MediaRouteStream::SetBufferRetentionDuration(int delay_ms)
 void MediaRouteStream::OnStreamPrepared(bool completed)
 {
 	_is_stream_prepared = completed;
+
+	_stream->GetStats()->SetPrepared(completed);
 }
 
 bool MediaRouteStream::IsStreamPrepared()
@@ -111,7 +113,7 @@ void MediaRouteStream::Flush()
 
 	_is_all_tracks_parsed = false;
 
-	_is_stream_prepared = false;
+	OnStreamPrepared(false);
 	_prepared_notified = false;
 }
 
@@ -152,14 +154,18 @@ bool MediaRouteStream::IsStreamReady()
 // negotiated tracks (e.g. a simulcast layer or audio) never arrives, the stream hangs. Warn so it is visible.
 void MediaRouteStream::CheckUnpreparedTrackTimeout()
 {
-	auto now = std::chrono::steady_clock::now();
+	if (_stream->IsOnAir() == false)
+	{
+		return;
+	}
 
 	// Anchor at the first media packet so connection/handshake delay is excluded; full silence is the provider's job.
-	if (_first_media_recv_time_set == false)
+	auto media_start_time = _stream->GetStats()->GetPublishedTimeSteady();
+	auto now = std::chrono::steady_clock::now();
+	auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - media_start_time).count();
+
+	if (elapsed_ms < MEDIA_ROUTE_STREAM_TRACK_PREPARE_TIMEOUT_MS)
 	{
-		_first_media_recv_time = now;
-		_last_unprepared_warn_time = now;
-		_first_media_recv_time_set = true;
 		return;
 	}
 
@@ -169,8 +175,6 @@ void MediaRouteStream::CheckUnpreparedTrackTimeout()
 		return;
 	}
 	_last_unprepared_warn_time = now;
-
-	auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - _first_media_recv_time).count();
 
 	const auto &tracks = _stream->GetTracks();
 	for (const auto &track_it : tracks)

--- a/src/mediarouter/mediarouter_stream.h
+++ b/src/mediarouter/mediarouter_stream.h
@@ -136,6 +136,9 @@ private:
 	// Stream Information
 	std::shared_ptr<info::Stream> _stream = nullptr;
 
+	// Held next to the stream so the per-packet path does not copy the pointer
+	std::shared_ptr<info::StreamStats> _stats = nullptr;
+
 	std::map<MediaTrackId, TrackAuthorState> _track_authors;
 
 	// Temporary packet store. for calculating packet duration

--- a/src/mediarouter/mediarouter_stream.h
+++ b/src/mediarouter/mediarouter_stream.h
@@ -125,10 +125,8 @@ private:
 	std::atomic<bool> _prepared_notified = false;
 	bool _is_all_tracks_parsed = false;
 
-	// Deadline tracking for periodically warning about tracks that never become valid (anchored at the first media packet)
-	std::chrono::steady_clock::time_point _first_media_recv_time;
+	// Deadline tracking for periodically warning about tracks that never become valid
 	std::chrono::steady_clock::time_point _last_unprepared_warn_time;
-	bool _first_media_recv_time_set = false;
 
 	// Incoming/Outgoing Stream
 	cmn::MediaRouterStreamType _type;


### PR DESCRIPTION
Since #2251 every module works on its own copy of the stream info, and state written on the source after that copy was taken never reaches it. The published time is one of them: it is stamped when the stream goes on air, which is always after the copies exist, so every module reads an epoch value. Anything that consumes it is affected, and it surfaced as LLHLS and HLS emitting EXT-X-PROGRAM-DATE-TIME from 1970. The source URL, rewritten on every pull-stream failover, goes stale the same way.

Add info::StreamStats, one instance shared by every copy of a stream, and move the state that changes after the stream was created into it: the created time, the published time and on-air state, the prepared time, and the media source. This is the per-stream counterpart of TrackStats, which is already shared per track. The stream description keeps travelling with the copies as immutable snapshots.

## Test

Publish an RTMP stream and play the LLHLS playlist of the output stream. EXT-X-PROGRAM-DATE-TIME must show the wall clock time at which the input stream started, and must keep advancing in real time. Run ome_test_base and the InfoStreamSourceUrl cases must pass.
