### PR TITLE
feat(thumbnail): add AVIF thumbnail support

### DIFF
--- a/src/base/info/media_track.cpp
+++ b/src/base/info/media_track.cpp
@@ -717,7 +717,8 @@ bool MediaTrack::IsValid() const
 		break;
 		case MediaCodecId::Jpeg:
 		case MediaCodecId::Png:
-		case MediaCodecId::Webp: {
+		case MediaCodecId::Webp:
+		case MediaCodecId::Avif: {
 			if (IsValidResolution() && IsValidTimeBase())
 			{
 				_is_valid = true;

--- a/src/base/mediarouter/media_type.h
+++ b/src/base/mediarouter/media_type.h
@@ -64,7 +64,8 @@ namespace cmn
 
 		// Backward compatibility: Logically part of Video Track. Do not change the order.
 		AV1_OBU,
-		AV1_RTP_AOM	 // AV1 over RTP (https://aomediacodec.github.io/av1-rtp-spec/); track origin, depacketized to AV1_OBU
+		AV1_RTP_AOM,  // AV1 over RTP (https://aomediacodec.github.io/av1-rtp-spec/); track origin, depacketized to AV1_OBU
+		AVIF,		  // a complete AVIF file: one AV1 still inside a HEIF container
 	};
 
 	enum class PacketType : int8_t
@@ -114,7 +115,8 @@ namespace cmn
 		Webp,
 		WebVTT,
 		Whisper,
-		Mp2
+		Mp2,
+		Avif
 	};
 
 	// DeviceId is used to identify a hwardware accelerator device.
@@ -291,6 +293,8 @@ namespace cmn
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Png, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Webp, false);
+			OV_CASE_RETURN(cmn::MediaCodecId::Avif, false);
+
 			OV_CASE_RETURN(cmn::MediaCodecId::WebVTT, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Whisper, false);
 		}
@@ -319,6 +323,8 @@ namespace cmn
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, true);
 			OV_CASE_RETURN(cmn::MediaCodecId::Png, true);
 			OV_CASE_RETURN(cmn::MediaCodecId::Webp, true);
+			OV_CASE_RETURN(cmn::MediaCodecId::Avif, true);
+
 			OV_CASE_RETURN(cmn::MediaCodecId::WebVTT, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Whisper, false);
 		}
@@ -347,6 +353,8 @@ namespace cmn
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Png, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Webp, false);
+			OV_CASE_RETURN(cmn::MediaCodecId::Avif, false);
+
 			OV_CASE_RETURN(cmn::MediaCodecId::WebVTT, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Whisper, false);
 		}
@@ -416,6 +424,7 @@ namespace cmn
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, JPEG);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, PNG);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, WEBP);
+			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, AVIF);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, ID3v2);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, OVEN_EVENT);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, CUE);
@@ -544,6 +553,7 @@ namespace cmn
 			OV_CASE_RETURN(MediaCodecId::Jpeg, "JPEG");
 			OV_CASE_RETURN(MediaCodecId::Png, "PNG");
 			OV_CASE_RETURN(MediaCodecId::Webp, "WEBP");
+			OV_CASE_RETURN(MediaCodecId::Avif, "AVIF");
 			// Audio codecs
 			OV_CASE_RETURN(MediaCodecId::Aac, "AAC");
 			OV_CASE_RETURN(MediaCodecId::Mp2, "MP2");
@@ -598,6 +608,10 @@ namespace cmn
 		else if (name.HasPrefix("WEBP"))
 		{
 			return cmn::MediaCodecId::Webp;
+		}
+		else if (name.HasPrefix("AVIF"))
+		{
+			return cmn::MediaCodecId::Avif;
 		}
 		// Audio codecs
 		else if (name.HasPrefix("AAC"))

--- a/src/mediarouter/mediarouter_nomalize.cpp
+++ b/src/mediarouter/mediarouter_nomalize.cpp
@@ -109,6 +109,7 @@ bool MediaRouterNormalize::NormalizeMediaPacket(const std::shared_ptr<info::Stre
 		case cmn::BitstreamFormat::JPEG:
 		case cmn::BitstreamFormat::PNG:
 		case cmn::BitstreamFormat::WEBP:
+		case cmn::BitstreamFormat::AVIF:
 			result = true;
 			break;
 		case cmn::BitstreamFormat::AAC_LATM:

--- a/src/modules/bitstream/av1/av1_parser.cpp
+++ b/src/modules/bitstream/av1/av1_parser.cpp
@@ -748,12 +748,16 @@ std::optional<Av1SequenceHeaderSummary> Av1Parser::ParseSequenceHeaderSummary(co
 		matrix_coefficients		 = mc;
 	}
 
+	out.color_primaries			  = color_primaries;
+	out.transfer_characteristics  = transfer_characteristics;
+	out.matrix_coefficients		  = matrix_coefficients;
+
 	if (out.monochrome != 0)
 	{
 		// AV1 spec 5.5.2 monochrome branch: read color_range, infer subsampling 4:0:0 mapped to (1,1)
 		// per spec, `chroma_sample_position = CSP_UNKNOWN (0)`.
 		AV1_READ_BITS(uint8_t, color_range_mono, 1);
-		(void)color_range_mono;
+		out.color_range				= color_range_mono;
 		out.chroma_subsampling_x	= 1;
 		out.chroma_subsampling_y	= 1;
 		out.chroma_sample_position	= 0;
@@ -761,6 +765,7 @@ std::optional<Av1SequenceHeaderSummary> Av1Parser::ParseSequenceHeaderSummary(co
 	else if ((color_primaries == 1) && (transfer_characteristics == 13) && (matrix_coefficients == 0))
 	{
 		// AV1 spec 5.5.2: sRGB shortcut - color_range = 1, subsampling 4:4:4.
+		out.color_range				= 1;
 		out.chroma_subsampling_x	= 0;
 		out.chroma_subsampling_y	= 0;
 		out.chroma_sample_position	= 0;
@@ -768,7 +773,7 @@ std::optional<Av1SequenceHeaderSummary> Av1Parser::ParseSequenceHeaderSummary(co
 	else
 	{
 		AV1_READ_BITS(uint8_t, color_range_full, 1);
-		(void)color_range_full;
+		out.color_range = color_range_full;
 		if (out.seq_profile == 0)
 		{
 			out.chroma_subsampling_x = 1;

--- a/src/modules/bitstream/av1/av1_parser_test.cpp
+++ b/src/modules/bitstream/av1/av1_parser_test.cpp
@@ -729,6 +729,109 @@ TEST(Av1ParserSequenceHeaderSummary, CapturesColorConfigFields)
 	EXPECT_EQ(summary->chroma_subsampling_x, 1);
 	EXPECT_EQ(summary->chroma_subsampling_y, 0);
 	EXPECT_EQ(summary->chroma_sample_position, 0);
+	// `color_description_present_flag == 0`: the CICP comes out as the spec's inferred values.
+	EXPECT_EQ(summary->color_primaries, 2);			 // CP_UNSPECIFIED
+	EXPECT_EQ(summary->transfer_characteristics, 2); // TC_UNSPECIFIED
+	EXPECT_EQ(summary->matrix_coefficients, 2);		 // MC_UNSPECIFIED
+	EXPECT_EQ(summary->color_range, 0);
+}
+
+TEST(Av1ParserSequenceHeaderSummary, CapturesExplicitCicp)
+{
+	// `color_description_present_flag == 1`: BT.709 primaries/transfer/matrix at full range -
+	// what OME's AVIF thumbnail encoder signals, and what its `colr` box has to restate.
+	SeqHeaderBuilder b;
+	b.seq_profile					  = 0;
+	b.operating_points_cnt_minus_1	  = 0;
+	b.operating_point_idc			  = {0};
+	b.seq_level_idx					  = {0};
+	b.frame_width_bits_minus_1		  = 8;
+	b.frame_height_bits_minus_1		  = 8;
+	b.max_frame_width_minus_1		  = 319;
+	b.max_frame_height_minus_1		  = 179;
+	b.color_description_present_flag  = 1;
+	b.color_primaries				  = 1;	// CP_BT_709
+	b.transfer_characteristics		  = 1;	// TC_BT_709
+	b.matrix_coefficients			  = 1;	// MC_BT_709
+	b.color_range					  = 1;	// full swing
+	b.chroma_sample_position		  = 0;
+
+	auto payload = BuildSequenceHeaderObuPayload(b);
+	auto summary = Av1Parser::ParseSequenceHeaderSummary(payload.data(), payload.size());
+	ASSERT_TRUE(summary.has_value());
+	EXPECT_EQ(summary->max_frame_width, 320u);
+	EXPECT_EQ(summary->max_frame_height, 180u);
+	EXPECT_EQ(summary->color_primaries, 1);
+	EXPECT_EQ(summary->transfer_characteristics, 1);
+	EXPECT_EQ(summary->matrix_coefficients, 1);
+	EXPECT_EQ(summary->color_range, 1);
+	EXPECT_EQ(summary->monochrome, 0);
+	EXPECT_EQ(summary->chroma_subsampling_x, 1);
+	EXPECT_EQ(summary->chroma_subsampling_y, 1);
+}
+
+TEST(Av1ParserSequenceHeaderSummary, CapturesColorRangeOnMonochromeBranch)
+{
+	// AV1 spec 5.5.2 monochrome branch: `color_range` is read there, and subsampling /
+	// `chroma_sample_position` are inferred rather than present.
+	SeqHeaderBuilder b;
+	b.seq_profile					 = 0;
+	b.operating_points_cnt_minus_1	 = 0;
+	b.operating_point_idc			 = {0};
+	b.seq_level_idx					 = {0};
+	b.frame_width_bits_minus_1		 = 8;
+	b.frame_height_bits_minus_1		 = 8;
+	b.max_frame_width_minus_1		 = 319;
+	b.max_frame_height_minus_1		 = 179;
+	b.monochrome					 = 1;
+	b.color_description_present_flag = 1;
+	b.color_primaries				 = 9;	// CP_BT_2020
+	b.transfer_characteristics		 = 16;	// TC_SMPTE_2084
+	b.matrix_coefficients			 = 9;	// MC_BT_2020_NCL
+	b.color_range					 = 1;
+
+	auto payload = BuildSequenceHeaderObuPayload(b);
+	auto summary = Av1Parser::ParseSequenceHeaderSummary(payload.data(), payload.size());
+	ASSERT_TRUE(summary.has_value());
+	EXPECT_EQ(summary->monochrome, 1);
+	EXPECT_EQ(summary->color_primaries, 9);
+	EXPECT_EQ(summary->transfer_characteristics, 16);
+	EXPECT_EQ(summary->matrix_coefficients, 9);
+	EXPECT_EQ(summary->color_range, 1);
+	EXPECT_EQ(summary->chroma_subsampling_x, 1);
+	EXPECT_EQ(summary->chroma_subsampling_y, 1);
+	EXPECT_EQ(summary->chroma_sample_position, 0);
+}
+
+TEST(Av1ParserSequenceHeaderSummary, InfersFullRangeOnSrgbShortcut)
+{
+	// AV1 spec 5.5.2 sRGB shortcut (CP_BT_709 + TC_SRGB + MC_IDENTITY): no `color_range` bit
+	// is present and it is inferred as full swing, with 4:4:4 subsampling.
+	SeqHeaderBuilder b;
+	b.seq_profile					 = 1;
+	b.operating_points_cnt_minus_1	 = 0;
+	b.operating_point_idc			 = {0};
+	b.seq_level_idx					 = {0};
+	b.frame_width_bits_minus_1		 = 8;
+	b.frame_height_bits_minus_1		 = 8;
+	b.max_frame_width_minus_1		 = 319;
+	b.max_frame_height_minus_1		 = 179;
+	b.color_description_present_flag = 1;
+	b.color_primaries				 = 1;	// CP_BT_709
+	b.transfer_characteristics		 = 13;	// TC_SRGB
+	b.matrix_coefficients			 = 0;	// MC_IDENTITY
+	b.color_range					 = 0;	// not written by the builder; must still parse as 1
+
+	auto payload = BuildSequenceHeaderObuPayload(b);
+	auto summary = Av1Parser::ParseSequenceHeaderSummary(payload.data(), payload.size());
+	ASSERT_TRUE(summary.has_value());
+	EXPECT_EQ(summary->color_primaries, 1);
+	EXPECT_EQ(summary->transfer_characteristics, 13);
+	EXPECT_EQ(summary->matrix_coefficients, 0);
+	EXPECT_EQ(summary->color_range, 1);
+	EXPECT_EQ(summary->chroma_subsampling_x, 0);
+	EXPECT_EQ(summary->chroma_subsampling_y, 0);
+	EXPECT_EQ(summary->chroma_sample_position, 0);
 }
 
 TEST(Av1ParserSequenceHeaderSummary, CapturesInitialDisplayDelayForOp0)

--- a/src/modules/bitstream/av1/av1_types.h
+++ b/src/modules/bitstream/av1/av1_types.h
@@ -106,6 +106,13 @@ struct Av1SequenceHeaderSummary
 	uint8_t chroma_subsampling_y = 0;
 	uint8_t chroma_sample_position = 0;
 
+	// AV1 spec 5.5.2 `color_config()` CICP. Defaults are the values the spec infers when
+	// `color_description_present_flag` is 0.
+	uint8_t color_primaries = 2;			// CP_UNSPECIFIED
+	uint8_t transfer_characteristics = 2;	// TC_UNSPECIFIED
+	uint8_t matrix_coefficients = 2;		// MC_UNSPECIFIED
+	uint8_t color_range = 0;				// 0 = studio swing, 1 = full swing
+
 	// AV1 spec 5.5.1 `sequence_header_obu()` operating-point `i == 0` initial display delay
 	// signaling. Captured for diagnostics only. NOTE: this is a Sequence Header field and is
 	// distinct from the av1C `initial_presentation_delay_minus_one`; the AV1 ISOBMFF binding

--- a/src/modules/containers/CMakeLists.txt
+++ b/src/modules/containers/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(webvtt)
+add_subdirectory(avif)
 add_subdirectory(bmff)
 add_subdirectory(flv)
 add_subdirectory(flv_v2)

--- a/src/modules/containers/avif/CMakeLists.txt
+++ b/src/modules/containers/avif/CMakeLists.txt
@@ -1,0 +1,12 @@
+ome_add_static_library(avif_container
+    DEPS
+        bitstream
+        ovlibrary
+)
+
+if(OME_BUILD_TESTS)
+    file(GLOB _srcs "${CMAKE_CURRENT_SOURCE_DIR}/*_test.cpp")
+    ome_add_tests(ome_test_modules
+        SRCS ${_srcs}
+    )
+endif()

--- a/src/modules/containers/avif/avif_packager.cpp
+++ b/src/modules/containers/avif/avif_packager.cpp
@@ -1,0 +1,345 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Keukhan
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include "avif_packager.h"
+
+#include <modules/bitstream/av1/av1_decoder_configuration_record.h>
+#include <modules/bitstream/av1/av1_parser.h>
+
+#include <optional>
+
+#include "avif_private.h"
+
+namespace avif
+{
+	namespace
+	{
+		// ISO/IEC 14496-12 4.2: size(4) + type(4)
+		constexpr size_t BOX_HEADER_SIZE = 8;
+
+		// The single image item. Item IDs are 1-based.
+		constexpr uint16_t ITEM_ID = 1;
+
+		// ipma names a property by its 1-based position in ipco, so these must match the order
+		// WriteIprpBox() writes them in (ISO/IEC 23008-12 9.3.2).
+		constexpr uint8_t PROPERTY_INDEX_AV1C = 1;
+		constexpr uint8_t PROPERTY_INDEX_ISPE = 2;
+		constexpr uint8_t PROPERTY_INDEX_PIXI = 3;
+		constexpr uint8_t PROPERTY_INDEX_COLR = 4;
+
+		// High bit of an 8-bit ipma association: a reader that does not understand the property
+		// must refuse the item rather than render it wrongly.
+		constexpr uint8_t PROPERTY_ESSENTIAL = 0x80;
+
+		// What the boxes restate about the still, all read from its sequence header.
+		struct StillInfo
+		{
+			uint32_t width	= 0;
+			uint32_t height = 0;
+			uint8_t channels = 0;
+			uint8_t bit_depth = 0;
+			uint8_t color_primaries = 0;
+			uint8_t transfer_characteristics = 0;
+			uint8_t matrix_coefficients = 0;
+			bool full_range = false;
+			std::shared_ptr<const ov::Data> av1c;  // serialized AV1CodecConfigurationRecord
+		};
+
+		bool WriteBox(ov::ByteStream &stream, const char *type, const ov::Data &payload)
+		{
+			return stream.WriteBE32(static_cast<uint32_t>(BOX_HEADER_SIZE + payload.GetLength())) &&
+				   stream.WriteText(type) &&
+				   stream.Write(payload);
+		}
+
+		bool WriteFullBox(ov::ByteStream &stream, const char *type, uint8_t version, uint32_t flags, const ov::Data &payload)
+		{
+			// ISO/IEC 14496-12 4.2 FullBox: Box + unsigned int(8) version; bit(24) flags;
+			ov::ByteStream full_box(payload.GetLength() + 4);
+
+			return full_box.WriteBE32((static_cast<uint32_t>(version) << 24) | (flags & 0x00FFFFFF)) &&
+				   full_box.Write(payload) &&
+				   WriteBox(stream, type, *full_box.GetData());
+		}
+
+		bool WriteFtypBox(ov::ByteStream &stream)
+		{
+			// ISO/IEC 23000-22 10.1: brand 'avif', compatible with HEIF ('mif1') and MIAF ('miaf').
+			ov::ByteStream payload(32);
+
+			return payload.WriteText("avif") &&			// major_brand
+				   payload.WriteBE32(0) &&				// minor_version
+				   payload.WriteText("avifmif1miaf") &&	// compatible_brands[]
+				   WriteBox(stream, "ftyp", *payload.GetData());
+		}
+
+		bool WriteHdlrBox(ov::ByteStream &stream)
+		{
+			// ISO/IEC 23008-12 6.2: image items live under the 'pict' handler.
+			ov::ByteStream payload(32);
+
+			return payload.WriteBE32(0) &&							 // pre_defined
+				   payload.WriteText("pict") &&						 // handler_type
+				   payload.WriteBE32(0) && payload.WriteBE32(0) && payload.WriteBE32(0) &&	// reserved[3]
+				   payload.WriteBE(static_cast<uint8_t>(0)) &&		 // name (empty, null-terminated)
+				   WriteFullBox(stream, "hdlr", 0, 0, *payload.GetData());
+		}
+
+		bool WritePitmBox(ov::ByteStream &stream)
+		{
+			// ISO/IEC 14496-12 8.11.4: which item is the image to display.
+			ov::ByteStream payload(8);
+
+			return payload.WriteBE16(ITEM_ID) &&
+				   WriteFullBox(stream, "pitm", 0, 0, *payload.GetData());
+		}
+
+		bool WriteIlocBox(ov::ByteStream &stream, uint32_t payload_offset, uint32_t payload_length)
+		{
+			// ISO/IEC 14496-12 8.11.3: where the item's bytes are. One extent, addressed
+			// absolutely from the start of the file (base_offset_size 0).
+			ov::ByteStream payload(32);
+
+			return payload.WriteBE(static_cast<uint8_t>((4 << 4) | 4)) &&	// offset_size(4), length_size(4)
+				   payload.WriteBE(static_cast<uint8_t>(0)) &&				// base_offset_size(4), reserved(4)
+				   payload.WriteBE16(1) &&									// item_count
+				   payload.WriteBE16(ITEM_ID) &&							// item_ID
+				   payload.WriteBE16(0) &&									// data_reference_index (0 = this file)
+				   payload.WriteBE16(1) &&									// extent_count
+				   payload.WriteBE32(payload_offset) &&						// extent_offset
+				   payload.WriteBE32(payload_length) &&						// extent_length
+				   WriteFullBox(stream, "iloc", 0, 0, *payload.GetData());
+		}
+
+		bool WriteIinfBox(ov::ByteStream &stream)
+		{
+			// ISO/IEC 14496-12 8.11.6 + one entry. Entry version 2 carries item_type, which
+			// ISO/IEC 23000-22 6 defines as 'av01' for an AV1 image item.
+			ov::ByteStream infe_payload(32);
+			if ((infe_payload.WriteBE16(ITEM_ID) &&							  // item_ID
+				 infe_payload.WriteBE16(0) &&								  // item_protection_index (0 = unprotected)
+				 infe_payload.WriteText("av01") &&							  // item_type
+				 infe_payload.WriteBE(static_cast<uint8_t>(0))) == false)	  // item_name (empty, null-terminated)
+			{
+				return false;
+			}
+
+			ov::ByteStream payload(64);
+
+			return payload.WriteBE16(1) &&	// entry_count
+				   WriteFullBox(payload, "infe", 2, 0, *infe_payload.GetData()) &&
+				   WriteFullBox(stream, "iinf", 0, 0, *payload.GetData());
+		}
+
+		bool WriteIspeBox(ov::ByteStream &stream, const StillInfo &info)
+		{
+			// ISO/IEC 23008-12 6.5.3 ImageSpatialExtentsProperty
+			ov::ByteStream payload(8);
+
+			return payload.WriteBE32(info.width) &&
+				   payload.WriteBE32(info.height) &&
+				   WriteFullBox(stream, "ispe", 0, 0, *payload.GetData());
+		}
+
+		bool WritePixiBox(ov::ByteStream &stream, const StillInfo &info)
+		{
+			// ISO/IEC 23008-12 6.5.6 PixelInformationProperty
+			ov::ByteStream payload(8);
+
+			if (payload.WriteBE(info.channels) == false)
+			{
+				return false;
+			}
+
+			for (uint8_t i = 0; i < info.channels; i++)
+			{
+				if (payload.WriteBE(info.bit_depth) == false)
+				{
+					return false;
+				}
+			}
+
+			return WriteFullBox(stream, "pixi", 0, 0, *payload.GetData());
+		}
+
+		bool WriteColrBox(ov::ByteStream &stream, const StillInfo &info)
+		{
+			// ISO/IEC 14496-12 12.1.5, 'nclx' form: restates the CICP the sequence header
+			// signals, so a reader knows the colour without decoding the bitstream first.
+			ov::ByteStream payload(16);
+
+			return payload.WriteText("nclx") &&	 // colour_type
+				   payload.WriteBE16(info.color_primaries) &&
+				   payload.WriteBE16(info.transfer_characteristics) &&
+				   payload.WriteBE16(info.matrix_coefficients) &&
+				   payload.WriteBE(static_cast<uint8_t>(info.full_range ? 0x80 : 0x00)) &&	// full_range_flag(1), reserved(7)
+				   WriteBox(stream, "colr", *payload.GetData());
+		}
+
+		bool WriteIprpBox(ov::ByteStream &stream, const StillInfo &info)
+		{
+			// ISO/IEC 23008-12 9.3: the property container plus the item-to-property associations.
+			ov::ByteStream ipco_payload(320);
+			if ((WriteBox(ipco_payload, "av1C", *info.av1c) &&	// AV1 ISOBMFF binding 2.3
+				 WriteIspeBox(ipco_payload, info) &&
+				 WritePixiBox(ipco_payload, info) &&
+				 WriteColrBox(ipco_payload, info)) == false)
+			{
+				return false;
+			}
+
+			// version 0 + flags 0 selects 16-bit item IDs and 8-bit associations. av1C is the
+			// only essential property: without it the payload cannot be decoded.
+			ov::ByteStream ipma_payload(32);
+			if ((ipma_payload.WriteBE32(1) &&																 // entry_count
+				 ipma_payload.WriteBE16(ITEM_ID) &&															 // item_ID
+				 ipma_payload.WriteBE(static_cast<uint8_t>(4)) &&											 // association_count
+				 ipma_payload.WriteBE(static_cast<uint8_t>(PROPERTY_ESSENTIAL | PROPERTY_INDEX_AV1C)) &&
+				 ipma_payload.WriteBE(static_cast<uint8_t>(PROPERTY_INDEX_ISPE)) &&
+				 ipma_payload.WriteBE(static_cast<uint8_t>(PROPERTY_INDEX_PIXI)) &&
+				 ipma_payload.WriteBE(static_cast<uint8_t>(PROPERTY_INDEX_COLR))) == false)
+			{
+				return false;
+			}
+
+			ov::ByteStream payload(384);
+
+			return WriteBox(payload, "ipco", *ipco_payload.GetData()) &&
+				   WriteFullBox(payload, "ipma", 0, 0, *ipma_payload.GetData()) &&
+				   WriteBox(stream, "iprp", *payload.GetData());
+		}
+
+		bool WriteMetaBox(ov::ByteStream &stream, const StillInfo &info, uint32_t payload_offset, uint32_t payload_length)
+		{
+			// ISO/IEC 14496-12 8.11.1: the whole description of the image item. ISO/IEC 23008-12
+			// 6.2 requires hdlr to be the first contained box.
+			ov::ByteStream payload(512);
+
+			return WriteHdlrBox(payload) &&
+				   WritePitmBox(payload) &&
+				   WriteIlocBox(payload, payload_offset, payload_length) &&
+				   WriteIinfBox(payload) &&
+				   WriteIprpBox(payload, info) &&
+				   WriteFullBox(stream, "meta", 0, 0, *payload.GetData());
+		}
+
+		std::optional<StillInfo> ReadStillInfo(const std::shared_ptr<const ov::Data> &av1_temporal_unit)
+		{
+			// The still must carry its own sequence header: it is both the av1C configOBUs and
+			// the source of every value the container restates.
+			auto sequence_header = Av1Parser::ExtractFirstSequenceHeaderObuRaw(av1_temporal_unit);
+			auto summary		 = Av1Parser::ParseSequenceHeaderSummary(Av1Parser::ExtractFirstSequenceHeaderObu(av1_temporal_unit));
+			if ((sequence_header == nullptr) || (summary.has_value() == false))
+			{
+				return std::nullopt;
+			}
+
+			AV1DecoderConfigurationRecord record;
+			record.SetSeqProfile(summary->seq_profile);
+			record.SetSeqLevelIdx0(summary->seq_level_idx_0);
+			record.SetSeqTier0(summary->seq_tier_0);
+			record.SetHighBitdepth(summary->high_bitdepth);
+			record.SetTwelveBit(summary->twelve_bit);
+			record.SetMonochrome(summary->monochrome);
+			record.SetChromaSubsamplingX(summary->chroma_subsampling_x);
+			record.SetChromaSubsamplingY(summary->chroma_subsampling_y);
+			record.SetChromaSamplePosition(summary->chroma_sample_position);
+			// A still is decodable on its own, so there is no presentation delay to signal.
+			record.SetInitialPresentationDelay(false, 0);
+			record.SetConfigObus(sequence_header->Clone());
+
+			auto av1c = record.Serialize();
+			if (av1c == nullptr)
+			{
+				return std::nullopt;
+			}
+
+			StillInfo info;
+			info.width					 = summary->max_frame_width;
+			info.height					 = summary->max_frame_height;
+			info.channels				 = (summary->monochrome != 0) ? 1 : 3;
+			info.bit_depth				 = record.BitDepth();
+			info.color_primaries		 = summary->color_primaries;
+			info.transfer_characteristics = summary->transfer_characteristics;
+			info.matrix_coefficients	 = summary->matrix_coefficients;
+			info.full_range				 = (summary->color_range != 0);
+			info.av1c					 = av1c;
+
+			if ((info.width == 0) || (info.height == 0))
+			{
+				return std::nullopt;
+			}
+
+			return info;
+		}
+	}  // namespace
+
+	std::shared_ptr<ov::Data> Packager::Pack(const std::shared_ptr<const ov::Data> &av1_temporal_unit)
+	{
+		if ((av1_temporal_unit == nullptr) || (av1_temporal_unit->GetLength() == 0))
+		{
+			return nullptr;
+		}
+
+		// The iloc extent fields are 32-bit, and mdat's size field must hold the payload plus
+		// its own box header.
+		if (av1_temporal_unit->GetLength() > (UINT32_MAX - BOX_HEADER_SIZE))
+		{
+			logtw("AV1 still of %zu bytes is too large to address from an iloc extent", av1_temporal_unit->GetLength());
+			return nullptr;
+		}
+
+		auto info = ReadStillInfo(av1_temporal_unit);
+		if (info.has_value() == false)
+		{
+			logtw("Could not read the sequence header of the AV1 still; it cannot be wrapped into AVIF");
+			return nullptr;
+		}
+
+		// An image item must be decodable on its own, so the temporal unit has to code a key
+		// frame - an inter frame would reference frames the file does not carry.
+		if (Av1Parser::IsKeyFrame(av1_temporal_unit) == false)
+		{
+			logtw("The AV1 still does not code a key frame; it cannot be wrapped into AVIF");
+			return nullptr;
+		}
+
+		const auto payload_length = static_cast<uint32_t>(av1_temporal_unit->GetLength());
+
+		ov::ByteStream measured_meta(1024);
+		if (WriteMetaBox(measured_meta, info.value(), 0, payload_length) == false)
+		{
+			logte("Could not build the AVIF meta box");
+			return nullptr;
+		}
+
+		ov::ByteStream file(measured_meta.GetLength() + payload_length + 64);
+		if (WriteFtypBox(file) == false)
+		{
+			logte("Could not build the AVIF ftyp box");
+			return nullptr;
+		}
+
+		const auto payload_offset = static_cast<uint32_t>(file.GetLength() + measured_meta.GetLength() + BOX_HEADER_SIZE);
+		if (WriteMetaBox(file, info.value(), payload_offset, payload_length) == false ||
+			file.GetLength() != payload_offset - BOX_HEADER_SIZE)
+		{
+			logte("Could not build the AVIF meta box");
+			return nullptr;
+		}
+
+		// The AV1 temporal unit, unmodified.
+		if (WriteBox(file, "mdat", *av1_temporal_unit) == false)
+		{
+			logte("Could not build the AVIF mdat box");
+			return nullptr;
+		}
+
+		return file.GetDataPointer();
+	}
+}  // namespace avif

--- a/src/modules/containers/avif/avif_packager.h
+++ b/src/modules/containers/avif/avif_packager.h
@@ -1,0 +1,29 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Keukhan
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include <base/ovlibrary/ovlibrary.h>
+
+namespace avif
+{
+	// Wraps one AV1 coded still into a one-image AVIF file.
+	//
+	// AVIF (ISO/IEC 23000-22) is an AV1 still inside a HEIF/MIAF container, so this only
+	// writes boxes around the bitstream - nothing is re-encoded. Every value the boxes need
+	// comes from the still's own in-band sequence header, so the container cannot disagree
+	// with what was encoded.
+	class Packager
+	{
+	public:
+		// `av1_temporal_unit` is one AV1 temporal unit (raw OBUs) coding a key frame plus its
+		// sequence header - what an allintra libaom encoder emits per frame. Returns nullptr
+		// if it is not a self-contained still.
+		static std::shared_ptr<ov::Data> Pack(const std::shared_ptr<const ov::Data> &av1_temporal_unit);
+	};
+}  // namespace avif

--- a/src/modules/containers/avif/avif_packager_test.cpp
+++ b/src/modules/containers/avif/avif_packager_test.cpp
@@ -1,0 +1,257 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Keukhan
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include <base/ovlibrary/data.h>
+#include <modules/containers/avif/avif_packager.h>
+
+#include <cstring>
+#include <optional>
+#include <vector>
+
+namespace
+{
+	// A real sequence header OBU from a libaom allintra still: 320x180, seq_profile 0,
+	// 8-bit 4:2:0, BT.709, full range.
+	const std::vector<uint8_t> SEQUENCE_HEADER_OBU = {
+		0x0a, 0x0e,													  // OBU_SEQUENCE_HEADER, obu_size = 14
+		0x00, 0x00, 0x00, 0x04, 0x3c, 0xfe, 0xcc, 0xff,
+		0xf8, 0x10, 0x10, 0x10, 0x18, 0x40};
+
+	constexpr uint32_t STILL_WIDTH	= 320;
+	constexpr uint32_t STILL_HEIGHT = 180;
+
+	// OBU_TEMPORAL_DELIMITER, obu_size = 0
+	const std::vector<uint8_t> TEMPORAL_DELIMITER_OBU = {0x12, 0x00};
+
+	// Stand-in OBU_FRAMEs: only `uncompressed_header()`'s leading bits are read, never the
+	// coded data. First payload byte = show_existing_frame(1) | frame_type(2) | show_frame(1).
+	const std::vector<uint8_t> FRAME_OBU			 = {0x32, 0x05, 0x10, 0xad, 0xbe, 0xef, 0x00};	// KEY_FRAME
+	const std::vector<uint8_t> INTER_FRAME_OBU		 = {0x32, 0x05, 0x30, 0xad, 0xbe, 0xef, 0x00};	// INTER_FRAME
+	const std::vector<uint8_t> SHOW_EXISTING_FRAME_OBU = {0x32, 0x05, 0x80, 0xad, 0xbe, 0xef, 0x00};	// show_existing_frame
+
+	std::shared_ptr<ov::Data> Concat(const std::vector<std::vector<uint8_t>> &parts)
+	{
+		std::vector<uint8_t> bytes;
+		for (const auto &part : parts)
+		{
+			bytes.insert(bytes.end(), part.begin(), part.end());
+		}
+		return std::make_shared<ov::Data>(bytes.data(), bytes.size());
+	}
+
+	uint16_t ReadBE16(const uint8_t *data)
+	{
+		return static_cast<uint16_t>((data[0] << 8) | data[1]);
+	}
+
+	uint32_t ReadBE32(const uint8_t *data)
+	{
+		return (static_cast<uint32_t>(data[0]) << 24) | (static_cast<uint32_t>(data[1]) << 16) |
+			   (static_cast<uint32_t>(data[2]) << 8) | static_cast<uint32_t>(data[3]);
+	}
+
+	struct FoundBox
+	{
+		const uint8_t *payload = nullptr;
+		size_t size			   = 0;	 // payload size, header excluded
+		size_t file_offset	   = 0;	 // offset of the payload from the start of the file
+	};
+
+	// Locate `name` among the sibling boxes in [data, data + size). `full_box` skips the
+	// version/flags word.
+	std::optional<FoundBox> FindBox(const uint8_t *data, size_t size, size_t base_offset, const char *name, bool full_box)
+	{
+		size_t pos = 0;
+		while ((pos + 8) <= size)
+		{
+			const size_t box_size = ReadBE32(data + pos);
+			if ((box_size < 8) || ((pos + box_size) > size))
+			{
+				return std::nullopt;
+			}
+
+			if (::memcmp(data + pos + 4, name, 4) == 0)
+			{
+				const size_t header_size = full_box ? 12 : 8;
+				if (box_size < header_size)
+				{
+					return std::nullopt;
+				}
+
+				return FoundBox{data + pos + header_size, box_size - header_size, base_offset + pos + header_size};
+			}
+
+			pos += box_size;
+		}
+
+		return std::nullopt;
+	}
+}  // namespace
+
+TEST(AvifPackager, RejectsNullInput)
+{
+	EXPECT_EQ(avif::Packager::Pack(nullptr), nullptr);
+}
+
+TEST(AvifPackager, RejectsEmptyInput)
+{
+	EXPECT_EQ(avif::Packager::Pack(std::make_shared<ov::Data>()), nullptr);
+}
+
+TEST(AvifPackager, RejectsTemporalUnitWithoutSequenceHeader)
+{
+	// Without a sequence header there is nothing to put in the av1C, and no source for the
+	// picture size or the colour tag.
+	EXPECT_EQ(avif::Packager::Pack(Concat({TEMPORAL_DELIMITER_OBU, FRAME_OBU})), nullptr);
+}
+
+TEST(AvifPackager, RejectsInterFrame)
+{
+	// An image item must decode standalone; an inter frame references frames the file does
+	// not carry.
+	EXPECT_EQ(avif::Packager::Pack(Concat({TEMPORAL_DELIMITER_OBU, SEQUENCE_HEADER_OBU, INTER_FRAME_OBU})), nullptr);
+}
+
+TEST(AvifPackager, RejectsShowExistingFrame)
+{
+	EXPECT_EQ(avif::Packager::Pack(Concat({TEMPORAL_DELIMITER_OBU, SEQUENCE_HEADER_OBU, SHOW_EXISTING_FRAME_OBU})), nullptr);
+}
+
+TEST(AvifPackager, WrapsStillIntoAvifFile)
+{
+	auto still = Concat({TEMPORAL_DELIMITER_OBU, SEQUENCE_HEADER_OBU, FRAME_OBU});
+
+	auto file = avif::Packager::Pack(still);
+	ASSERT_NE(file, nullptr);
+
+	const auto *bytes = file->GetDataAs<uint8_t>();
+	const size_t length = file->GetLength();
+
+	// ISO/IEC 23000-22 10.1: the file declares the 'avif' brand.
+	auto ftyp = FindBox(bytes, length, 0, "ftyp", false);
+	ASSERT_TRUE(ftyp.has_value());
+	EXPECT_EQ(::memcmp(ftyp->payload, "avif", 4), 0);
+
+	auto meta = FindBox(bytes, length, 0, "meta", true);
+	ASSERT_TRUE(meta.has_value());
+
+	// hdlr must be first in meta (ISO/IEC 23008-12 6.2) and use the 'pict' handler.
+	ASSERT_GE(meta->size, 16u);
+	EXPECT_EQ(::memcmp(bytes + meta->file_offset + 4, "hdlr", 4), 0);
+	auto hdlr = FindBox(meta->payload, meta->size, meta->file_offset, "hdlr", true);
+	ASSERT_TRUE(hdlr.has_value());
+	EXPECT_EQ(::memcmp(hdlr->payload + 4, "pict", 4), 0);
+
+	// The primary item is the one image item.
+	auto pitm = FindBox(meta->payload, meta->size, meta->file_offset, "pitm", true);
+	ASSERT_TRUE(pitm.has_value());
+	const uint16_t item_id = ReadBE16(pitm->payload);
+	EXPECT_EQ(item_id, 1u);
+
+	// The item is an AV1 image item.
+	auto iinf = FindBox(meta->payload, meta->size, meta->file_offset, "iinf", true);
+	ASSERT_TRUE(iinf.has_value());
+	ASSERT_GE(iinf->size, 2u);	// entry_count precedes the entries
+	auto infe = FindBox(iinf->payload + 2, iinf->size - 2, 0, "infe", true);
+	ASSERT_TRUE(infe.has_value());
+	EXPECT_EQ(ReadBE16(infe->payload), item_id);
+	EXPECT_EQ(::memcmp(infe->payload + 4, "av01", 4), 0);
+
+	// The single extent must address the temporal unit byte for byte at its real file
+	// offset - only right if meta was sized before being written.
+	auto iloc = FindBox(meta->payload, meta->size, meta->file_offset, "iloc", true);
+	ASSERT_TRUE(iloc.has_value());
+	ASSERT_EQ(iloc->size, 18u);
+	EXPECT_EQ(iloc->payload[0], 0x44);	// offset_size = 4, length_size = 4
+	EXPECT_EQ(iloc->payload[1], 0x00);	// base_offset_size = 0
+	EXPECT_EQ(ReadBE16(iloc->payload + 2), 1u);		   // item_count
+	EXPECT_EQ(ReadBE16(iloc->payload + 4), item_id);   // item_ID
+	EXPECT_EQ(ReadBE16(iloc->payload + 8), 1u);		   // extent_count
+	const uint32_t extent_offset = ReadBE32(iloc->payload + 10);
+	const uint32_t extent_length = ReadBE32(iloc->payload + 14);
+	ASSERT_EQ(extent_length, still->GetLength());
+	ASSERT_LE(extent_offset + extent_length, length);
+	EXPECT_EQ(::memcmp(bytes + extent_offset, still->GetData(), extent_length), 0);
+
+	// ...and the extent must land inside mdat, right after its box header.
+	auto mdat = FindBox(bytes, length, 0, "mdat", false);
+	ASSERT_TRUE(mdat.has_value());
+	EXPECT_EQ(mdat->file_offset, extent_offset);
+	EXPECT_EQ(mdat->size, extent_length);
+
+	auto iprp = FindBox(meta->payload, meta->size, meta->file_offset, "iprp", false);
+	ASSERT_TRUE(iprp.has_value());
+	auto ipco = FindBox(iprp->payload, iprp->size, iprp->file_offset, "ipco", false);
+	ASSERT_TRUE(ipco.has_value());
+
+	// av1C: fields read from the sequence header, plus the header itself as configOBUs.
+	auto av1c = FindBox(ipco->payload, ipco->size, ipco->file_offset, "av1C", false);
+	ASSERT_TRUE(av1c.has_value());
+	ASSERT_EQ(av1c->size, 4 + SEQUENCE_HEADER_OBU.size());
+	EXPECT_EQ(av1c->payload[0], 0x81);				  // marker = 1, version = 1
+	EXPECT_EQ(av1c->payload[1] >> 5, 0u);			  // seq_profile
+	EXPECT_EQ((av1c->payload[2] >> 6) & 0x01, 0u);	  // high_bitdepth (8-bit)
+	EXPECT_EQ((av1c->payload[2] >> 4) & 0x01, 0u);	  // monochrome
+	EXPECT_EQ((av1c->payload[2] >> 2) & 0x03, 0x03u); // chroma_subsampling_x/y (4:2:0)
+	EXPECT_EQ(::memcmp(av1c->payload + 4, SEQUENCE_HEADER_OBU.data(), SEQUENCE_HEADER_OBU.size()), 0);
+
+	// ispe restates the coded picture size.
+	auto ispe = FindBox(ipco->payload, ipco->size, ipco->file_offset, "ispe", true);
+	ASSERT_TRUE(ispe.has_value());
+	ASSERT_EQ(ispe->size, 8u);
+	EXPECT_EQ(ReadBE32(ispe->payload), STILL_WIDTH);
+	EXPECT_EQ(ReadBE32(ispe->payload + 4), STILL_HEIGHT);
+
+	// pixi: three 8-bit channels.
+	auto pixi = FindBox(ipco->payload, ipco->size, ipco->file_offset, "pixi", true);
+	ASSERT_TRUE(pixi.has_value());
+	ASSERT_EQ(pixi->size, 4u);
+	EXPECT_EQ(pixi->payload[0], 3u);
+	EXPECT_EQ(pixi->payload[1], 8u);
+	EXPECT_EQ(pixi->payload[2], 8u);
+	EXPECT_EQ(pixi->payload[3], 8u);
+
+	// colr restates the sequence header's CICP: BT.709, full range.
+	auto colr = FindBox(ipco->payload, ipco->size, ipco->file_offset, "colr", false);
+	ASSERT_TRUE(colr.has_value());
+	ASSERT_EQ(colr->size, 11u);
+	EXPECT_EQ(::memcmp(colr->payload, "nclx", 4), 0);
+	EXPECT_EQ(ReadBE16(colr->payload + 4), 1u);	 // colour_primaries
+	EXPECT_EQ(ReadBE16(colr->payload + 6), 1u);	 // transfer_characteristics
+	EXPECT_EQ(ReadBE16(colr->payload + 8), 1u);	 // matrix_coefficients
+	EXPECT_EQ(colr->payload[10], 0x80);			 // full_range_flag = 1
+
+	// All four properties associated, av1C essential. Indices are 1-based positions in ipco,
+	// so this pins the order ipco was written in.
+	auto ipma = FindBox(iprp->payload, iprp->size, iprp->file_offset, "ipma", true);
+	ASSERT_TRUE(ipma.has_value());
+	ASSERT_EQ(ipma->size, 11u);
+	EXPECT_EQ(ReadBE32(ipma->payload), 1u);			   // entry_count
+	EXPECT_EQ(ReadBE16(ipma->payload + 4), item_id);   // item_ID
+	EXPECT_EQ(ipma->payload[6], 4u);				   // association_count
+	EXPECT_EQ(ipma->payload[7], 0x80 | 1);			   // av1C, essential
+	EXPECT_EQ(ipma->payload[8], 2u);				   // ispe
+	EXPECT_EQ(ipma->payload[9], 3u);				   // pixi
+	EXPECT_EQ(ipma->payload[10], 4u);				   // colr
+}
+
+TEST(AvifPackager, WrapsStillWithoutTemporalDelimiter)
+{
+	// A temporal unit that starts straight at the sequence header is equally valid.
+	auto still = Concat({SEQUENCE_HEADER_OBU, FRAME_OBU});
+
+	auto file = avif::Packager::Pack(still);
+	ASSERT_NE(file, nullptr);
+
+	auto mdat = FindBox(file->GetDataAs<uint8_t>(), file->GetLength(), 0, "mdat", false);
+	ASSERT_TRUE(mdat.has_value());
+	EXPECT_EQ(mdat->size, still->GetLength());
+	EXPECT_EQ(::memcmp(mdat->payload, still->GetData(), still->GetLength()), 0);
+}

--- a/src/modules/containers/avif/avif_private.h
+++ b/src/modules/containers/avif/avif_private.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define OV_LOG_TAG "AVIF Packager"

--- a/src/modules/ffmpeg/compat.cpp
+++ b/src/modules/ffmpeg/compat.cpp
@@ -83,6 +83,7 @@ namespace ffmpeg
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, AV_CODEC_ID_MJPEG);
 			OV_CASE_RETURN(cmn::MediaCodecId::Png, AV_CODEC_ID_PNG);
 			OV_CASE_RETURN(cmn::MediaCodecId::Webp, AV_CODEC_ID_WEBP);
+			OV_CASE_RETURN(cmn::MediaCodecId::Avif, AV_CODEC_ID_AV1);
 			OV_CASE_RETURN(cmn::MediaCodecId::WebVTT, AV_CODEC_ID_NONE);
 			OV_CASE_RETURN(cmn::MediaCodecId::Whisper, AV_CODEC_ID_NONE);
 		}

--- a/src/modules/segment_writer/writer.cpp
+++ b/src/modules/segment_writer/writer.cpp
@@ -149,6 +149,7 @@ static AVCodecID AvCodecIdFromMediaCodecId(cmn::MediaCodecId codec_id)
 		WRITER_CASE(cmn::MediaCodecId::Jpeg, AV_CODEC_ID_JPEG2000)
 		WRITER_CASE(cmn::MediaCodecId::Png, AV_CODEC_ID_PNG)
 		WRITER_CASE(cmn::MediaCodecId::Webp, AV_CODEC_ID_WEBP)
+		WRITER_CASE(cmn::MediaCodecId::Avif, AV_CODEC_ID_NONE)
 		WRITER_CASE(cmn::MediaCodecId::Whisper, AV_CODEC_ID_NONE)
 		WRITER_CASE(cmn::MediaCodecId::WebVTT, AV_CODEC_ID_NONE)
 	}
@@ -854,6 +855,8 @@ bool Writer::WritePacket(const std::shared_ptr<const MediaPacket> &packet)
 			[[fallthrough]];
 		case cmn::BitstreamFormat::AV1_OBU:
 			[[fallthrough]];
+		case cmn::BitstreamFormat::AV1_RTP_AOM:
+			[[fallthrough]];
 		case cmn::BitstreamFormat::AAC_MPEG4_GENERIC:
 			[[fallthrough]];
 		case cmn::BitstreamFormat::AAC_LATM:
@@ -868,6 +871,8 @@ bool Writer::WritePacket(const std::shared_ptr<const MediaPacket> &packet)
 			[[fallthrough]];
 		case cmn::BitstreamFormat::WEBP:
 			[[fallthrough]];			
+		case cmn::BitstreamFormat::AVIF:
+			[[fallthrough]];
 		case cmn::BitstreamFormat::ID3v2:
 			[[fallthrough]];
 		case cmn::BitstreamFormat::MP3:

--- a/src/providers/rtmp/handlers/rtmp_chunk_handler.cpp
+++ b/src/providers/rtmp/handlers/rtmp_chunk_handler.cpp
@@ -108,6 +108,7 @@ namespace pvd::rtmp
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Png, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Webp, false);
+			OV_CASE_RETURN(cmn::MediaCodecId::Avif, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::WebVTT, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Whisper, false);
 		}

--- a/src/providers/rtmp/tracks/rtmp_track.cpp
+++ b/src/providers/rtmp/tracks/rtmp_track.cpp
@@ -35,6 +35,7 @@ namespace pvd::rtmp
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::Png, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::Webp, nullptr);
+			OV_CASE_RETURN(cmn::MediaCodecId::Avif, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::WebVTT, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::Whisper, nullptr);
 		}

--- a/src/publishers/thumbnail/thumbnail_interceptor.cpp
+++ b/src/publishers/thumbnail/thumbnail_interceptor.cpp
@@ -29,7 +29,8 @@ bool ThumbnailInterceptor::IsInterceptorForRequest(const std::shared_ptr<const h
 
 	if ((target.IndexOf(".jpg") >= 0) ||
 		(target.IndexOf(".png") >= 0) ||
-		(target.IndexOf(".webp") >= 0))
+		(target.IndexOf(".webp") >= 0) ||
+		(target.IndexOf(".avif") >= 0))
 	{
 		return true;
 	}

--- a/src/publishers/thumbnail/thumbnail_publisher.cpp
+++ b/src/publishers/thumbnail/thumbnail_publisher.cpp
@@ -199,7 +199,7 @@ bool ThumbnailPublisher::OnDeletePublisherApplication(const std::shared_ptr<pub:
 
 std::shared_ptr<ThumbnailInterceptor> ThumbnailPublisher::CreateInterceptor()
 {
-	ov::String thumbnail_url_pattern = R"(.+thumb\.(jpg|png|webp)$)";
+	ov::String thumbnail_url_pattern = R"(.+thumb\.(jpg|png|webp|avif)$)";
 
 	auto http_interceptor = std::make_shared<ThumbnailInterceptor>();
 
@@ -340,6 +340,10 @@ std::shared_ptr<ThumbnailInterceptor> ThumbnailPublisher::CreateInterceptor()
 		{
 			media_codec_id = cmn::MediaCodecId::Png;
 		}
+		else if (request_url->File().LowerCaseString().IndexOf(".avif") >= 0)
+		{
+			media_codec_id = cmn::MediaCodecId::Avif;
+		}
 		else if (request_url->File().LowerCaseString().IndexOf(".webp") >= 0)
 		{
 			media_codec_id = cmn::MediaCodecId::Webp;
@@ -429,6 +433,8 @@ ov::String ThumbnailPublisher::MimeTypeFromMediaCodecId(const cmn::MediaCodecId 
 			return "image/png";
 		case cmn::MediaCodecId::Webp:
 			return "image/webp";
+		case cmn::MediaCodecId::Avif:
+			return "image/avif";
 		default:
 			return "application/octet-stream";
 	}

--- a/src/publishers/thumbnail/thumbnail_stream.cpp
+++ b/src/publishers/thumbnail/thumbnail_stream.cpp
@@ -40,7 +40,8 @@ bool ThumbnailStream::Start()
 	{
 		if ((track->GetCodecId() == cmn::MediaCodecId::Png ||
 			 track->GetCodecId() == cmn::MediaCodecId::Jpeg ||
-			 track->GetCodecId() == cmn::MediaCodecId::Webp))
+			 track->GetCodecId() == cmn::MediaCodecId::Webp ||
+			 track->GetCodecId() == cmn::MediaCodecId::Avif))
 		{
 			found = true;
 			break;
@@ -80,7 +81,8 @@ void ThumbnailStream::SendVideoFrame(const std::shared_ptr<MediaPacket> &media_p
 
 	if (!(track->GetCodecId() == cmn::MediaCodecId::Png ||
 		  track->GetCodecId() == cmn::MediaCodecId::Jpeg ||
-		  track->GetCodecId() == cmn::MediaCodecId::Webp))
+		  track->GetCodecId() == cmn::MediaCodecId::Webp ||
+		  track->GetCodecId() == cmn::MediaCodecId::Avif))
 	{
 		// Could not support codec for image
 		return;

--- a/src/transcoder/CMakeLists.txt
+++ b/src/transcoder/CMakeLists.txt
@@ -6,6 +6,7 @@ ome_add_static_library(transcoder
         analyzer
         filter
     DEPS
+        avif_container
         bitstream
         ffmpeg_wrapper
         monitoring

--- a/src/transcoder/codec/encoder/encoder_avcodec_image.cpp
+++ b/src/transcoder/codec/encoder/encoder_avcodec_image.cpp
@@ -8,7 +8,7 @@
 //==============================================================================
 #include "encoder_avcodec_image.h"
 
-#include <unistd.h>
+#include <modules/containers/avif/avif_packager.h>
 
 #include "../../transcoder_private.h"
 
@@ -69,6 +69,35 @@ bool AVCodecImageEncoder::SetParamsWebp()
 	return true;
 }
 
+bool AVCodecImageEncoder::SetParamsAvif()
+{
+	SetParamsCommon();
+
+	_codec.SetOption("usage", "allintra");
+	_codec.SetGopSize(0);
+
+	// The context defaults to UNSPECIFIED and libaom takes the CICP verbatim, so without these
+	// the still carries no colour tag. It goes into the sequence header, hence before open.
+	//
+	// TODO(Keukhan): a non-BT.709 source (BT.601 SD, BT.2020/HLG) is mistagged - nothing in
+	// the filter graph converts the frames.
+	AVCodecContext *context	 = _codec.Get();
+	context->color_primaries = AVCOL_PRI_BT709;
+	context->color_trc		 = AVCOL_TRC_BT709;
+	context->colorspace		 = AVCOL_SPC_BT709;
+	_codec.SetColorRange(cmn::ColorRange::Limited);
+
+	_codec.SetThreadCount(1);
+
+	// The libaom encoder is very slow, so use the fastest preset FFmpeg allows and a reasonable
+	// CRF. bit_rate 0 selects pure constant quality (AOM_Q) over AOM_CQ.
+	_codec.SetOption("cpu-used", static_cast<int64_t>(8));
+	_codec.SetOption("crf", static_cast<int64_t>(23));
+	_codec.SetBitrate(0);
+
+	return true;
+}
+
 bool AVCodecImageEncoder::OpenCodec()
 {
 	if (_codec.AllocEncoder(GetCodecID()) == false)
@@ -85,6 +114,9 @@ bool AVCodecImageEncoder::OpenCodec()
 			break;
 		case cmn::MediaCodecId::Png:
 			result = SetParamsPng();
+			break;
+		case cmn::MediaCodecId::Avif:
+			result = SetParamsAvif();
 			break;
 		case cmn::MediaCodecId::Webp:
 		default:
@@ -186,6 +218,21 @@ EncodeResult AVCodecImageEncoder::ReceivePacket()
 	{
 		logte("Could not allocate the media packet");
 		return EncodeResult::Error();
+	}
+
+	// libaom emits the AV1 bitstream only, so wrap the still into its container here - an
+	// image encoder must hand downstream a complete file. Drop rather than error out: a bad
+	// thumbnail must not tear down the encode thread.
+	if (_codec_id == cmn::MediaCodecId::Avif)
+	{
+		auto avif_image = avif::Packager::Pack(media_packet->GetData());
+		if (avif_image == nullptr)
+		{
+			logtw("Could not wrap the AV1 still into an AVIF image; dropping this thumbnail frame");
+			return EncodeResult::NoOutput();
+		}
+
+		media_packet->SetData(avif_image);
 	}
 
 	if (GetRefTrack()->GetMediaType() == cmn::MediaType::Audio)

--- a/src/transcoder/codec/encoder/encoder_avcodec_image.h
+++ b/src/transcoder/codec/encoder/encoder_avcodec_image.h
@@ -11,7 +11,10 @@
 #include "../../transcoder_encoder.h"
 #include <modules/ffmpeg/ffmpeg_codec.h>
 
-// AVCodecImageEncoder handles the software FFmpeg image encoders: JPEG, PNG, WEBP.
+// AVCodecImageEncoder handles the software FFmpeg image encoders: JPEG, PNG, WEBP, AVIF.
+//
+// JPEG/PNG/WEBP encoder output is already the file format.
+// AVIF is not. libaom-av1 emits the AV1 bitstream only, so ReceivePacket() wraps each still with avif::Packager.
 class AVCodecImageEncoder : public TranscodeEncoder
 {
 public:
@@ -40,6 +43,8 @@ public:
 				return cmn::VideoPixelFormatId::YUVJ420P;
 			case cmn::MediaCodecId::Webp:
 				return cmn::VideoPixelFormatId::YUV420P;
+			case cmn::MediaCodecId::Avif:
+				return cmn::VideoPixelFormatId::YUV420P;
 			default:
 				return cmn::VideoPixelFormatId::None;
 		}
@@ -54,6 +59,8 @@ public:
 				return cmn::BitstreamFormat::JPEG;
 			case cmn::MediaCodecId::Webp:
 				return cmn::BitstreamFormat::WEBP;
+			case cmn::MediaCodecId::Avif:
+				return cmn::BitstreamFormat::AVIF;
 			default:
 				return cmn::BitstreamFormat::Unknown;
 		}
@@ -73,6 +80,7 @@ private:
 	bool SetParamsJpeg();
 	bool SetParamsPng();
 	bool SetParamsWebp();
+	bool SetParamsAvif();
 
 	// ----- Members -----
 	cmn::MediaCodecId _codec_id;

--- a/src/transcoder/transcoder_encoder.cpp
+++ b/src/transcoder/transcoder_encoder.cpp
@@ -183,6 +183,7 @@ std::shared_ptr<TranscodeEncoder> TranscodeEncoder::Instantiate(
 	else if (codec_id == cmn::MediaCodecId::Jpeg)    return std::make_shared<AVCodecImageEncoder>(stream_info, codec_id);
 	else if (codec_id == cmn::MediaCodecId::Png)     return std::make_shared<AVCodecImageEncoder>(stream_info, codec_id);
 	else if (codec_id == cmn::MediaCodecId::Webp)    return std::make_shared<AVCodecImageEncoder>(stream_info, codec_id);
+	else if (codec_id == cmn::MediaCodecId::Avif)    return std::make_shared<AVCodecImageEncoder>(stream_info, codec_id);
 	else if (codec_id == cmn::MediaCodecId::Whisper) return std::make_shared<EncoderWhisper>(stream_info);
 	else
 	{

--- a/src/transcoder/transcoder_modules.cpp
+++ b/src/transcoder/transcoder_modules.cpp
@@ -62,7 +62,7 @@ namespace tc
 		// Image Codecs
 		// --------------------------------------------------------------------------
 		Register(info::CodecModule("FFmpeg Image Codec", cmn::MediaType::Video, cmn::MediaCodecModuleId::DEFAULT, 0, "-",
-						   {cmn::MediaCodecId::Jpeg, cmn::MediaCodecId::Png, cmn::MediaCodecId::Webp},
+						   {cmn::MediaCodecId::Jpeg, cmn::MediaCodecId::Png, cmn::MediaCodecId::Webp, cmn::MediaCodecId::Avif},
 						   true, false, true, false));
 
 		// --------------------------------------------------------------------------

--- a/src/transcoder/transcoder_stream_internal.cpp
+++ b/src/transcoder/transcoder_stream_internal.cpp
@@ -120,6 +120,8 @@ cmn::Timebase TranscoderStreamInternal::GetDefaultTimebaseByCodecId(cmn::MediaCo
 		case cmn::MediaCodecId::Flv:
 		case cmn::MediaCodecId::Jpeg:
 		case cmn::MediaCodecId::Png:
+		case cmn::MediaCodecId::Webp:
+		case cmn::MediaCodecId::Avif:
 			timebase.SetNum(1);
 			timebase.SetDen(90000);
 			break;


### PR DESCRIPTION
## Summary

Adds AVIF as a thumbnail codec. Supersedes #2218 (original work by @naanlizard).

Unlike JPEG/PNG/WEBP, libaom-av1 emits only the AV1 bitstream, so each encoded still is wrapped into a HEIF container before it leaves the encoder. Known limitation: a non-BT.709 source is mistagged, since nothing in the filter graph converts the frames (TODO in `SetParamsAvif()`).

## Changes

- **`modules/containers/avif`** (new): `avif::Packager` writes the one-image AVIF boxes on top of the existing `Av1Parser` / `AV1DecoderConfigurationRecord` - no libavformat muxer. `av1C`, `ispe` and `colr` are all derived from the in-band sequence header, so the container cannot disagree with what was encoded.
- **`AVCodecImageEncoder`**: AVIF encoder parameters (allintra, CRF, CICP), and `ReceivePacket()` wraps each still through the packager.
- **`Av1SequenceHeaderSummary`**: now reports the `color_config()` CICP fields the parser already read and discarded.
- **Plumbing**: `MediaCodecId::Avif` / `BitstreamFormat::AVIF` through the transcoder, the thumbnail publisher and the codec-id switches.

## Testing

**Manual** - add an `Image` encode with the `avif` codec and enable the Thumbnail publisher:

```xml
<Encodes>
    <Image>
        <Codec>avif</Codec>
        <Width>320</Width>
        <Height>180</Height>
        <Framerate>1</Framerate>
    </Image>
</Encodes>
```

Then open `http://<host>:<port>/<app>/<stream>/thumb.avif` in a browser. The thumbnail rendering is the pass condition; a broken/blank image means the still was served without a valid container.

**Unit tests** - opt-in, as documented in `cmake/README.md`:

```bash
cmake -B build/Debug -S . -DCMAKE_BUILD_TYPE=Debug -DOME_BUILD_TESTS=ON -G Ninja
cmake --build build/Debug --target tests
ctest --test-dir build/Debug -L modules
```

The new packager and AV1 parser tests run in `ome_test_modules` (label `modules`).

**Also verified** - the packager's output decodes with libavif, and 8 consecutive live fetches over 24s produced 8 distinct decodable files, confirming libaom repeats the sequence header in every temporal unit - the assumption the packager rests on.
