### PR TITLE
docs: correct DRM systems and codec support in feature lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ OvenSpace is a sub-second latency streaming demo service using [OvenMediaEngine]
   * DVR (Live Rewind)
   * Dump for VoD
   * ID3v2 timed metadata
-  * DRM (Widevine, Fairplay)
+  * DRM (Widevine, FairPlay, PlayReady)
   * Subtitle (WebVTT)
 * Sub-Second Latency Streaming using WebRTC
   * WebRTC over TCP (With Embedded TURN Server)
@@ -53,7 +53,7 @@ OvenSpace is a sub-second latency streaming demo service using [OvenMediaEngine]
   * MPEG-2 TS Container
   * Audio/Video Muxed
 * Embedded Live Transcoder
-  * Video: VP8, H.264, H.265(Hardware only), Pass-through
+  * Video: VP8, H.264, H.265(Hardware only), AV1, Pass-through
   * Audio: Opus, AAC, Pass-through
 * Clustering (Origin-Edge Structure)
 * Monitoring

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -27,7 +27,7 @@ Our goal is to make it easier for you to build a stable broadcasting/streaming s
   * DVR (Live Rewind)
   * Dump for VoD
   * ID3v2 timed metadata
-  * DRM (Widevine, Fairplay)
+  * DRM (Widevine, FairPlay, PlayReady)
 * **Sub-Second Latency Streaming using WebRTC**
   * WebRTC over TCP (with embedded TURN server)
   * Embedded WebRTC Signaling Server (WebSocket based)
@@ -45,10 +45,10 @@ Our goal is to make it easier for you to build a stable broadcasting/streaming s
   * MPEG-2 TS Container
   * Audio/Video Muxed
 * **Enhanced RTMP (E-RTMP) for Advanced Codec Support**
-  * _H.264, H.265, AAC_
+  * _H.264, H.265, AV1, AAC_
   * More codec support will be added continuously
 * **Embedded Live Transcoder**
-  * Video: VP8, H.264, H.265 (Hardware only), Pass-through
+  * Video: VP8, H.264, H.265 (Hardware only), AV1, Pass-through
   * Audio: Opus, AAC, Pass-through
 * **Clustering** (Origin-Edge Structure)
 * **Monitoring**

--- a/docs/streaming/low-latency-hls.md
+++ b/docs/streaming/low-latency-hls.md
@@ -273,13 +273,6 @@ OvenMediaEngine encrypts LLHLS streams with Common Encryption (CENC) and signals
 Encryption keys are described in a separate DRM info file, which lets you apply different keys to different streams and change them without editing `Server.xml`.
 
 
-:::warning
-
-Only H.264 video and AAC audio are encrypted. A track of any other codec is delivered without encryption, so a stream that has to be fully protected must be transcoded to H.264 and AAC.
-
-:::
-
-
 ### Enabling DRM
 
 Turn DRM on in the LLHLS publisher and point it at your DRM info file. `<InfoFile>` takes a path relative to the directory where `Server.xml` is located, or an absolute path.


### PR DESCRIPTION
## What

The feature lists in `README.md` and `docs/intro.md` were behind what OvenMediaEngine actually supports:

- LLHLS DRM was listed as `DRM (Widevine, Fairplay)`, even though the LLHLS document already describes PSSH and key signaling for **PlayReady** as well. Now `DRM (Widevine, FairPlay, PlayReady)` (also fixing the `Fairplay` spelling).
- **AV1** was missing from the E-RTMP ingest codec list (`docs/intro.md`) and from the live transcoder video codec list (both files).

The LLHLS DRM section also carried a warning that only H.264 video and AAC audio are encrypted. CENC now covers H.265 too — `IsCencSupportedCodec()` in [`src/modules/containers/bmff/cenc.h`](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/src/modules/containers/bmff/cenc.h) accepts H.264, H.265 and AAC since HEVC subsample encryption was added in #2264 — so the warning no longer holds and is removed.

## Changes

| File | Change |
| --- | --- |
| `README.md` | `DRM (Widevine, FairPlay, PlayReady)`; AV1 added to transcoder video codecs |
| `docs/intro.md` | Same DRM line; AV1 added to E-RTMP codecs and transcoder video codecs |
| `docs/streaming/low-latency-hls.md` | Removed the "only H.264 and AAC are encrypted" warning |

Documentation only — no code changes.
