### PR TITLE
fix(http2): fix HPACK stale indexes and header block interleaving

### DIFF
--- a/src/modules/http/hpack/encoder.cpp
+++ b/src/modules/http/hpack/encoder.cpp
@@ -16,6 +16,9 @@ namespace http
 	{
 		bool Encoder::UpdateDynamicTableSize(size_t size)
 		{
+			// A size update must sit at the start of a header block, so it cannot be
+			// signalled while another stream is in the middle of encoding one
+			ov::LockGuard<ov::Mutex> block_lock(_header_block_lock);
 			ov::LockGuard<ov::Mutex> lock(_encoder_lock);
 			if (_table_connector.UpdateDynamicTableSize(size) == false)
 			{

--- a/src/modules/http/hpack/encoder.h
+++ b/src/modules/http/hpack/encoder.h
@@ -9,6 +9,9 @@
 #pragma once
 
 #include <base/ovlibrary/ovlibrary.h>
+
+#include <unordered_set>
+
 #include "data_structure.h"
 #include "table_connector.h"
 
@@ -31,6 +34,28 @@ namespace http
 
 			std::shared_ptr<ov::Data> Encode(const HeaderField &header_fields, EncodingType type);
 
+			// Headers listed here carry a value that is unique per response, so indexing
+			// them never gets a table hit and only churns the dynamic table
+			static EncodingType GetEncodingTypeOf(const ov::String &header_name)
+			{
+				static const std::unordered_set<ov::String, ov::CaseInsensitiveHash, ov::CaseInsensitiveEqual> without_indexing_headers = {
+					"etag",
+				};
+
+				return (without_indexing_headers.find(header_name) != without_indexing_headers.end())
+						   ? EncodingType::LiteralWithoutIndexing
+						   : EncodingType::LiteralWithIndexing;
+			}
+
+			// The peer replays the table updates in the order the header blocks arrive on
+			// the wire, so encoding a block and sending it must be one step. Streams share
+			// this encoder, so the caller holds this from the first Encode() of a header
+			// block until its frames are sent.
+			ov::Mutex &GetHeaderBlockLock()
+			{
+				return _header_block_lock;
+			}
+
 		private:
 			bool EncodeIndexedHeaderField(ov::ByteStream &stream, const HeaderField &header_fields, uint32_t index) OV_REQUIRES(_encoder_lock);
 			bool EncodeLiteralHeaderFieldWithIndexing(ov::ByteStream &stream, const HeaderField &header_fields, uint32_t name_index) OV_REQUIRES(_encoder_lock);
@@ -50,6 +75,9 @@ namespace http
 			bool _need_signal_table_size_update OV_GUARDED_BY(_encoder_lock) = false;
 
 			ov::Mutex _encoder_lock;
+
+			// Always taken before _encoder_lock
+			ov::Mutex _header_block_lock;
 		};
 	} // namespace hpack
 } // namespace http

--- a/src/modules/http/hpack/table/table.h
+++ b/src/modules/http/hpack/table/table.h
@@ -50,6 +50,7 @@ namespace http
 				// to be emptied of all existing entries and results in an empty table.
 				if (header_field.GetSize() + _table_usage > _table_size)
 				{
+					// Not an error. The oversized entry is simply not indexed
 					return true;
 				}
 
@@ -69,7 +70,7 @@ namespace http
 
 				_table_usage += header_field.GetSize();
 
-				return false;
+				return true;
 			};
 
 			// Return: <Name indexed, Value indexed, Index Number>
@@ -79,23 +80,22 @@ namespace http
 				auto it = _header_field_sequence_map.find(header_field.GetKey().CStr());
 				if (it != _header_field_sequence_map.end())
 				{
-					// Found {name, value} in static table
-					auto sequence_number = it->second;
-					auto index = CalcIndexNumber(sequence_number, _header_fields_table.size(), _removed_count);
-
-					return {true, true, index};
+					auto index = CalcIndexNumber(it->second, _header_fields_table.size(), _removed_count);
+					if (IsLiveIndex(index))
+					{
+						return {true, true, index};
+					}
 				}
 
 				// Else if only name is matched in the table, return the index number.
 				it = _header_field_name_sequence_map.find(header_field.GetName().CStr());
 				if (it != _header_field_name_sequence_map.end())
 				{
-					// Found {name, value} in table
-					auto sequence_number = it->second;
-					auto index = CalcIndexNumber(sequence_number, _header_fields_table.size(), _removed_count);
-
-					// Found {only name} in table
-					return {true, false, index};
+					auto index = CalcIndexNumber(it->second, _header_fields_table.size(), _removed_count);
+					if (IsLiveIndex(index))
+					{
+						return {true, false, index};
+					}
 				}
 
 				return {false, false, 0};
@@ -103,7 +103,10 @@ namespace http
 
 			bool UpdateTableSize(size_t size)
 			{
-				while (_table_usage >= size)
+				// https://datatracker.ietf.org/doc/html/rfc7541#section-4.3
+				// Evict only while the usage exceeds the new size. Evicting at equality
+				// would remove one entry more than the peer does.
+				while (_table_usage > size)
 				{
 					// Pop the oldest entry from the table.
 					if (PopHeaderField() == 0)
@@ -140,10 +143,28 @@ namespace http
 				}
 
 				auto header_field = _header_fields_table.back();
+				// The oldest entry always holds this sequence number
+				auto evicted_sequence = _removed_count + 1;
+
 				_header_fields_table.pop_back();
-				
+
 				_removed_count ++;
 				_table_usage -= header_field.GetSize();
+
+				// The maps keep only the latest sequence per key, so erase an entry
+				// only while it still points at the one being evicted. Otherwise a
+				// live duplicate would lose its index.
+				auto key_it = _header_field_sequence_map.find(header_field.GetKey());
+				if ((key_it != _header_field_sequence_map.end()) && (key_it->second == evicted_sequence))
+				{
+					_header_field_sequence_map.erase(key_it);
+				}
+
+				auto name_it = _header_field_name_sequence_map.find(header_field.GetName());
+				if ((name_it != _header_field_name_sequence_map.end()) && (name_it->second == evicted_sequence))
+				{
+					_header_field_name_sequence_map.erase(name_it);
+				}
 
 				return header_field.GetSize();
 			}
@@ -158,6 +179,22 @@ namespace http
 			std::unordered_map<ov::String, uint32_t, ov::CaseInsensitiveHash, ov::CaseInsensitiveEqual> _header_field_sequence_map;
 
 		private:
+			// A live entry always maps to 1 ~ table.size(). Anything outside means a map
+			// entry outlived its table entry; sending that index would be a connection-fatal
+			// COMPRESSION_ERROR on the peer, so treat it as a miss.
+			bool IsLiveIndex(uint32_t index)
+			{
+				if ((index >= 1) && (index <= _header_fields_table.size()))
+				{
+					return true;
+				}
+
+				logw("HPACK", "STALE INDEX: suppressed an index beyond the table (index=%u, entries=%zu)",
+					 index, _header_fields_table.size());
+
+				return false;
+			}
+
 			virtual bool Insert(const HeaderField &header_field) = 0;
 
 			virtual uint32_t CalcIndexNumber(uint32_t sequence, uint32_t table_size, uint32_t removed_item_count) = 0;

--- a/src/modules/http/hpack/table_connector.cpp
+++ b/src/modules/http/hpack/table_connector.cpp
@@ -16,7 +16,7 @@ namespace http
 		bool TableConnector::GetHeaderField(size_t index, HeaderField &header_field)
 		{
 			// StaticTable : 1 ~ 61
-			if (index < _static_table->GetNumberOfTableEntries())
+			if (index <= _static_table->GetNumberOfTableEntries())
 			{
 				return _static_table->GetHeaderField(index, header_field);
 			}

--- a/src/modules/http/protocol/http2/frames/http2_continuation_frame.h
+++ b/src/modules/http/protocol/http2/frames/http2_continuation_frame.h
@@ -31,7 +31,7 @@ namespace http
 				Http2ContinuationFrame(uint32_t stream_id)
 					: Http2Frame(stream_id)
 				{
-					SetType(Http2Frame::Type::Headers);
+					SetType(Http2Frame::Type::Continuation);
 				}
 
 				Http2ContinuationFrame(const std::shared_ptr<Http2Frame> &frame)

--- a/src/modules/http/protocol/http2/frames/http2_rst_stream_frame.h
+++ b/src/modules/http/protocol/http2/frames/http2_rst_stream_frame.h
@@ -25,7 +25,7 @@ namespace http
 				Http2RstStreamFrame(uint32_t stream_id)
 					: Http2Frame(stream_id)
 				{
-					SetType(Http2Frame::Type::GoAway);
+					SetType(Http2Frame::Type::RstStream);
 				}
 
 				Http2RstStreamFrame(const std::shared_ptr<Http2Frame> &frame)

--- a/src/modules/http/server/http2/http2_response.cpp
+++ b/src/modules/http/server/http2/http2_response.cpp
@@ -47,8 +47,13 @@ namespace http
 
 			int32_t Http2Response::SendHeader()
 			{
+				// All streams on this connection share one HPACK encoder. Encoding this
+				// block and putting its frames on the wire must not be split by another
+				// stream, otherwise the peer replays the table updates in a different
+				// order and resolves our indexes to the wrong entries.
+				ov::LockGuard<ov::Mutex> block_lock(_hpack_encoder->GetHeaderBlockLock());
+
 				std::shared_ptr<ov::Data> header_block = std::make_shared<ov::Data>(65535);
-				size_t sent_size = 0;
 
 				// :status header field is must on top
 				auto header_field = _hpack_encoder->Encode({":status", ov::Converter::ToString(static_cast<uint16_t>(GetStatusCode()))}, hpack::Encoder::EncodingType::LiteralWithIndexing);
@@ -60,33 +65,23 @@ namespace http
 					{
 						// https://httpwg.org/http2-spec/draft-ietf-httpbis-http2bis.html#section-8.2
 						// Field names MUST be converted to lowercase when constructing an HTTP/2 message.
-						auto header_field = _hpack_encoder->Encode({name.LowerCaseString(), value}, hpack::Encoder::EncodingType::LiteralWithIndexing);
+						auto name_lower = name.LowerCaseString();
+
+						auto header_field = _hpack_encoder->Encode({name_lower, value}, hpack::Encoder::GetEncodingTypeOf(name_lower));
 						header_block->Append(header_field);
 					}
 				}
 
 				logtt("[Http2Response] Send header block : size(%zu)", header_block->GetLength());
 
-				std::shared_ptr<ov::Data> head_block_fragment;
-				bool fragmented = false;
-				
-				if (header_block->GetLength() > MAX_HTTP2_HEADER_SIZE)
-				{
-					head_block_fragment = header_block->Subdata(0, MAX_HTTP2_HEADER_SIZE);
-					fragmented = true;
-				}
-				else
-				{
-					head_block_fragment = header_block;
-					fragmented = false;
-				}
-				
-				// Send Headers frame
-				auto headers_frame = std::make_shared<prot::h2::Http2HeadersFrame>(_stream_id);
-				headers_frame->SetHeaderBlockFragment(head_block_fragment);
+				auto block_size = header_block->GetLength();
+				auto fragment_size = std::min(block_size, static_cast<size_t>(MAX_HTTP2_HEADER_SIZE));
 
-				// Set flags
-				if (fragmented == false)
+				// Headers frame
+				auto headers_frame = std::make_shared<prot::h2::Http2HeadersFrame>(_stream_id);
+				headers_frame->SetHeaderBlockFragment(header_block->Subdata(0, fragment_size));
+
+				if (fragment_size == block_size)
 				{
 					headers_frame->SetEndHeaders();
 				}
@@ -96,44 +91,33 @@ namespace http
 					headers_frame->SetEndStream();
 				}
 
-				if (Send(headers_frame) == false)
+				// RFC 7540 §6.2/§6.10: no other frame may appear between HEADERS and its
+				// CONTINUATION frames, so the whole sequence goes out as a single write
+				auto wire_data = headers_frame->ToData()->Clone();
+
+				auto offset = fragment_size;
+				while (offset < block_size)
+				{
+					fragment_size = std::min(block_size - offset, static_cast<size_t>(MAX_HTTP2_HEADER_SIZE));
+
+					auto continuation_frame = std::make_shared<prot::h2::Http2ContinuationFrame>(_stream_id);
+					continuation_frame->SetHeaderBlockFragment(header_block->Subdata(offset, fragment_size));
+
+					offset += fragment_size;
+					if (offset == block_size)
+					{
+						continuation_frame->SetEndHeaders();
+					}
+
+					wire_data->Append(continuation_frame->ToData());
+				}
+
+				if (HttpResponse::Send(wire_data) == false)
 				{
 					return -1;
 				}
 
-				sent_size += head_block_fragment->GetLength();
-
-				// Send Continuation frames if header block is fragmented
-				if (fragmented == true)
-				{
-					auto remaining_size = header_block->GetLength() - MAX_HTTP2_HEADER_SIZE;
-					auto remaining_data = header_block->Subdata(MAX_HTTP2_HEADER_SIZE, remaining_size);
-
-					while (remaining_size > 0)
-					{
-						auto fragment_size = remaining_size > MAX_HTTP2_HEADER_SIZE ? MAX_HTTP2_HEADER_SIZE : remaining_size;
-						auto fragment_data = remaining_data->Subdata(0, fragment_size);
-
-						auto continuation_frame = std::make_shared<prot::h2::Http2ContinuationFrame>(_stream_id);
-						continuation_frame->SetHeaderBlockFragment(fragment_data);
-
-						if (remaining_size - fragment_size == 0)
-						{
-							continuation_frame->SetEndHeaders();
-						}
-
-						if (Send(continuation_frame) == false)
-						{
-							return -1;
-						}
-
-						sent_size += fragment_size;
-						remaining_size -= fragment_size;
-						remaining_data = remaining_data->Subdata(fragment_size, remaining_size);
-					}
-				}
-
-				return sent_size;
+				return block_size;
 			}
 
 			int32_t Http2Response::SendPayload()

--- a/src/modules/http/server/http2/http2_response.cpp
+++ b/src/modules/http/server/http2/http2_response.cpp
@@ -92,8 +92,9 @@ namespace http
 				}
 
 				// RFC 7540 §6.2/§6.10: no other frame may appear between HEADERS and its
-				// CONTINUATION frames, so the whole sequence goes out as a single write
-				auto wire_data = headers_frame->ToData()->Clone();
+				// CONTINUATION frames, so the whole sequence goes out as a single write.
+				// ToData() returns a freshly allocated buffer, so appending to it is safe.
+				auto wire_data = headers_frame->ToData();
 
 				auto offset = fragment_size;
 				while (offset < block_size)

--- a/src/modules/http/server/http2/http2_response.h
+++ b/src/modules/http/server/http2/http2_response.h
@@ -13,7 +13,9 @@
 #include "../../protocol/http2/frames/http2_frames.h"
 #include "../../hpack/encoder.h"
 
-#define MAX_HTTP2_HEADER_SIZE (1024 * 1024)
+// SETTINGS_MAX_FRAME_SIZE floor (RFC 7540 §6.5.2). The peer can only raise this
+// limit, never lower it, so frames capped here are always legal to send.
+#define MAX_HTTP2_HEADER_SIZE (16384)
 #define MAX_HTTP2_DATA_SIZE (16384)
 
 namespace http

--- a/src/modules/http/server/http2/http2_response.h
+++ b/src/modules/http/server/http2/http2_response.h
@@ -13,8 +13,8 @@
 #include "../../protocol/http2/frames/http2_frames.h"
 #include "../../hpack/encoder.h"
 
-// SETTINGS_MAX_FRAME_SIZE floor (RFC 7540 §6.5.2). The peer can only raise this
-// limit, never lower it, so frames capped here are always legal to send.
+// SETTINGS_MAX_FRAME_SIZE floor (RFC 7540 §6.5.2). The advertised value can
+// never go below this, so frames capped here are always legal to send.
 #define MAX_HTTP2_HEADER_SIZE (16384)
 #define MAX_HTTP2_DATA_SIZE (16384)
 


### PR DESCRIPTION
When an HTTP/2 connection lives long enough for the HPACK dynamic table to fill up, the server keeps sending table indexes for header entries that were already evicted. The client treats this as a connection level compression error and closes the connection, so LLHLS playback stalls and reconnects in a loop. With the ETag module enabled this happens within seconds on Safari, and even without it the connection breaks about once a minute because the Date header fills the table. Responses of one connection are also produced by multiple threads, so two header blocks could interleave on the wire and corrupt the compression state the same way.

Evicted entries are now removed from the lookup state, an index that no longer exists is treated as a miss and logged instead of being sent, each header block is encoded and written to the socket as one unit per connection, header frames respect the HTTP/2 default frame size limit, and headers with a unique value per response (currently ETag) are no longer inserted into the dynamic table.

## Test

### Setup

- Run this build with HTTP2 and LLHLS modules enabled and TLS configured on the LLHLS publisher port. Enable the ETag module in Server.xml. It makes the bug reproduce within seconds instead of a minute:

```xml
<Modules>
    <ETag>
        <Enable>true</Enable>
    </ETag>
</Modules>
```

- Publish a test stream:

```sh
ffmpeg -re -f lavfi -i "testsrc2=size=1280x720:rate=30" -f lavfi -i "sine=frequency=1000" \
  -c:v libx264 -preset ultrafast -tune zerolatency -g 30 -c:a aac \
  -f flv "rtmp://<host>:1935/app/stream"
```

### Test 1. Safari playback with ETag enabled

- Play the stream over HTTPS in Safari (macOS or iOS) for at least 10 minutes.
- Pass: no stall and no periodic hiccup. On master the stream visibly stutters or stalls every 5 to 10 seconds because Safari reconnects in a loop.

### Test 2. Default configuration (ETag disabled)

- Disable the ETag module and play in Safari for at least 5 minutes.
- Pass: no stall around the 1 minute mark and none after. On master the connection silently breaks about once per minute. On a fast network playback may still look fine, so check the server log for repeated disconnect and reconnect of the playback connection instead of relying on the picture alone.

### Log check, applies to both tests

- The server log must contain no `STALE INDEX` warning. This warning comes from a guard added in this change that fires whenever the encoder is about to reference a table entry that no longer exists, so even a single occurrence is a failure regardless of how playback looks.
