### PR TITLE
fix(transcoder): handle media property changes in filters correctly

### DIFF
--- a/src/base/info/media_track.cpp
+++ b/src/base/info/media_track.cpp
@@ -92,6 +92,8 @@ bool MediaTrack::Update(const MediaTrack &media_track)
 	_resolution_conf = media_track._resolution_conf;
 	_b_frames = media_track._b_frames.load();
 	_colorspace = media_track._colorspace.load();
+	_color_matrix = media_track._color_matrix.load();
+	_color_range = media_track._color_range.load();
 	_preset = media_track._preset;
 	_profile = media_track._profile;
 	_thread_count = media_track._thread_count.load();

--- a/src/base/info/media_track_test.cpp
+++ b/src/base/info/media_track_test.cpp
@@ -1,0 +1,29 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Jeheon Han
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <base/info/media_track.h>
+#include <gtest/gtest.h>
+
+TEST(MediaTrackUpdate, CopiesColorFields)
+{
+	MediaTrack source;
+	source.SetId(1);
+	source.SetMediaType(cmn::MediaType::Video);
+	source.SetColorMatrix(cmn::ColorMatrix::BT709);
+	source.SetColorRange(cmn::ColorRange::Limited);
+
+	MediaTrack updated;
+	updated.SetId(1);
+	ASSERT_TRUE(updated.Update(source));
+	EXPECT_EQ(updated.GetColorMatrix(), cmn::ColorMatrix::BT709);
+	EXPECT_EQ(updated.GetColorRange(), cmn::ColorRange::Limited);
+
+	MediaTrack copied(source);
+	EXPECT_EQ(copied.GetColorMatrix(), cmn::ColorMatrix::BT709);
+	EXPECT_EQ(copied.GetColorRange(), cmn::ColorRange::Limited);
+}

--- a/src/base/info/video_track.cpp
+++ b/src/base/info/video_track.cpp
@@ -187,6 +187,26 @@ cmn::VideoPixelFormatId VideoTrack::GetColorspace() const
 	return _colorspace;
 }
 
+void VideoTrack::SetColorMatrix(cmn::ColorMatrix color_matrix)
+{
+	_color_matrix = color_matrix;
+}
+
+cmn::ColorMatrix VideoTrack::GetColorMatrix() const
+{
+	return _color_matrix;
+}
+
+void VideoTrack::SetColorRange(cmn::ColorRange color_range)
+{
+	_color_range = color_range;
+}
+
+cmn::ColorRange VideoTrack::GetColorRange() const
+{
+	return _color_range;
+}
+
 void VideoTrack::SetMaxFrameRate(double framerate) const
 {
 	// Measured framerate is folded in by MediaTrack::SetFrameRateByMeasured()

--- a/src/base/info/video_track.h
+++ b/src/base/info/video_track.h
@@ -45,6 +45,12 @@ public:
 	void SetColorspace(cmn::VideoPixelFormatId colorspace);
 	cmn::VideoPixelFormatId GetColorspace() const;	
 
+	void SetColorMatrix(cmn::ColorMatrix color_matrix);
+	cmn::ColorMatrix GetColorMatrix() const;
+
+	void SetColorRange(cmn::ColorRange color_range);
+	cmn::ColorRange GetColorRange() const;
+
 	void SetPreset(ov::String preset);
 	ov::String GetPreset() const;
 
@@ -116,6 +122,10 @@ protected:
 	// Colorspace of video
 	// This variable is temporarily used in the Pixel Format defined by FFMPEG.
 	std::atomic<cmn::VideoPixelFormatId> _colorspace = cmn::VideoPixelFormatId::None;	
+
+	// Color matrix coefficients and range of the video (set by decoded frames)
+	std::atomic<cmn::ColorMatrix> _color_matrix = cmn::ColorMatrix::Unspecified;
+	std::atomic<cmn::ColorRange> _color_range = cmn::ColorRange::Unspecified;
 
 	// Preset for encoder (set by user)
 	ov::String _preset OV_GUARDED_BY(_video_mutex);

--- a/src/base/mediarouter/media_type.h
+++ b/src/base/mediarouter/media_type.h
@@ -263,8 +263,20 @@ namespace cmn
 		// Limited(=narrow) range, MPEG/TV range (e.g. 16-235 for 8-bit luma)
 		Limited, 
 		// Full(=wide) range, JPEG/PC range (e.g. 0-255 for 8-bit luma)
-		Full 
+		Full
 	};
+
+	constexpr const char *GetColorRangeString(cmn::ColorRange color_range)
+	{
+		switch (color_range)
+		{
+			OV_CASE_RETURN_ENUM_STRING(ColorRange, Unspecified);
+			OV_CASE_RETURN_ENUM_STRING(ColorRange, Limited);
+			OV_CASE_RETURN_ENUM_STRING(ColorRange, Full);
+		}
+
+		return "Unknown";
+	}
 
 	// YUV matrix coefficients of the video
 	// Uses the same values as ISO/IEC 23091-2 (H.273), so it maps 1:1 to FFmpeg AVColorSpace
@@ -285,6 +297,29 @@ namespace cmn
 		ChromaDerivedCL = 13,
 		ICTCP = 14
 	};
+
+	constexpr const char *GetColorMatrixString(cmn::ColorMatrix color_matrix)
+	{
+		switch (color_matrix)
+		{
+			OV_CASE_RETURN_ENUM_STRING(ColorMatrix, RGB);
+			OV_CASE_RETURN_ENUM_STRING(ColorMatrix, BT709);
+			OV_CASE_RETURN_ENUM_STRING(ColorMatrix, Unspecified);
+			OV_CASE_RETURN_ENUM_STRING(ColorMatrix, FCC);
+			OV_CASE_RETURN_ENUM_STRING(ColorMatrix, BT470BG);
+			OV_CASE_RETURN_ENUM_STRING(ColorMatrix, SMPTE170M);
+			OV_CASE_RETURN_ENUM_STRING(ColorMatrix, SMPTE240M);
+			OV_CASE_RETURN_ENUM_STRING(ColorMatrix, YCGCO);
+			OV_CASE_RETURN_ENUM_STRING(ColorMatrix, BT2020NCL);
+			OV_CASE_RETURN_ENUM_STRING(ColorMatrix, BT2020CL);
+			OV_CASE_RETURN_ENUM_STRING(ColorMatrix, SMPTE2085);
+			OV_CASE_RETURN_ENUM_STRING(ColorMatrix, ChromaDerivedNCL);
+			OV_CASE_RETURN_ENUM_STRING(ColorMatrix, ChromaDerivedCL);
+			OV_CASE_RETURN_ENUM_STRING(ColorMatrix, ICTCP);
+		}
+
+		return "Unknown";
+	}
 
 	enum class KeyFrameIntervalType : uint8_t
 	{

--- a/src/base/mediarouter/media_type.h
+++ b/src/base/mediarouter/media_type.h
@@ -266,6 +266,26 @@ namespace cmn
 		Full 
 	};
 
+	// YUV matrix coefficients of the video
+	// Uses the same values as ISO/IEC 23091-2 (H.273), so it maps 1:1 to FFmpeg AVColorSpace
+	enum class ColorMatrix : int8_t
+	{
+		RGB = 0,
+		BT709 = 1,
+		Unspecified = 2,
+		FCC = 4,
+		BT470BG = 5,
+		SMPTE170M = 6,
+		SMPTE240M = 7,
+		YCGCO = 8,
+		BT2020NCL = 9,
+		BT2020CL = 10,
+		SMPTE2085 = 11,
+		ChromaDerivedNCL = 12,
+		ChromaDerivedCL = 13,
+		ICTCP = 14
+	};
+
 	enum class KeyFrameIntervalType : uint8_t
 	{
 		FRAME = 0,

--- a/src/modules/ffmpeg/compat.cpp
+++ b/src/modules/ffmpeg/compat.cpp
@@ -144,6 +144,43 @@ namespace ffmpeg
 		return AVCOL_RANGE_UNSPECIFIED;
 	}
 
+	cmn::ColorRange compat::ToColorRange(enum AVColorRange color_range)
+	{
+		switch (color_range)
+		{
+			OV_CASE_RETURN(AVCOL_RANGE_UNSPECIFIED, cmn::ColorRange::Unspecified);
+			OV_CASE_RETURN(AVCOL_RANGE_MPEG, cmn::ColorRange::Limited);
+			OV_CASE_RETURN(AVCOL_RANGE_JPEG, cmn::ColorRange::Full);
+			OV_CASE_RETURN(AVCOL_RANGE_NB, cmn::ColorRange::Unspecified);
+		}
+
+		return cmn::ColorRange::Unspecified;
+	}
+
+	enum AVColorSpace compat::ToAVColorSpace(cmn::ColorMatrix color_matrix)
+	{
+		// cmn::ColorMatrix uses the same H.273 values as AVColorSpace
+		int32_t value = static_cast<int32_t>(color_matrix);
+		if (value < 0 || value >= AVCOL_SPC_NB)
+		{
+			return AVCOL_SPC_UNSPECIFIED;
+		}
+
+		return static_cast<enum AVColorSpace>(value);
+	}
+
+	cmn::ColorMatrix compat::ToColorMatrix(enum AVColorSpace color_space)
+	{
+		// cmn::ColorMatrix uses the same H.273 values as AVColorSpace
+		int32_t value = static_cast<int32_t>(color_space);
+		if (value < 0 || value >= AVCOL_SPC_NB)
+		{
+			return cmn::ColorMatrix::Unspecified;
+		}
+
+		return static_cast<cmn::ColorMatrix>(value);
+	}
+
 	cmn::AudioChannel::Layout compat::ToAudioChannelLayout(int channel_layout)
 	{
 		switch (channel_layout)

--- a/src/modules/ffmpeg/compat.h
+++ b/src/modules/ffmpeg/compat.h
@@ -58,6 +58,9 @@ namespace ffmpeg
 		static AVPixelFormat ToAVPixelFormat(cmn::VideoPixelFormatId pixel_format);
 		static cmn::VideoPixelFormatId ToVideoPixelFormat(int32_t pixel_format);
 		static enum AVColorRange ToAVColorRange(cmn::ColorRange color_range);
+		static cmn::ColorRange ToColorRange(enum AVColorRange color_range);
+		static enum AVColorSpace ToAVColorSpace(cmn::ColorMatrix color_matrix);
+		static cmn::ColorMatrix ToColorMatrix(enum AVColorSpace color_space);
 		static AVPixelFormat GetAVPixelFormatOfHWDevice(cmn::MediaCodecModuleId module_id, cmn::DeviceId gpu_id, bool is_sw_format = true);
 
 		// OME-typed variant of GetAVPixelFormatOfHWDevice(). Returns cmn::VideoPixelFormatId::None when
@@ -203,6 +206,8 @@ namespace ffmpeg
 					media_frame->SetWidth(frame->width);
 					media_frame->SetHeight(frame->height);
 					media_frame->SetFormat((int32_t)ffmpeg::compat::ToVideoPixelFormat(frame->format));
+					media_frame->SetColorMatrix(ffmpeg::compat::ToColorMatrix(frame->colorspace));
+					media_frame->SetColorRange(ffmpeg::compat::ToColorRange(frame->color_range));
 					media_frame->SetPts((frame->pts == AV_NOPTS_VALUE) ? -1LL : frame->pts);
 					media_frame->SetDuration(frame->duration);
 

--- a/src/modules/ffmpeg/compat_color_test.cpp
+++ b/src/modules/ffmpeg/compat_color_test.cpp
@@ -1,0 +1,60 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Jeheon Han
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <gtest/gtest.h>
+#include <modules/ffmpeg/compat.h>
+
+// cmn::ColorMatrix mirrors the H.273 values of AVColorSpace, and the compat
+// converters rely on that 1:1 mapping. These tests pin the invariant.
+
+TEST(FFmpegCompatColor, ColorMatrixMirrorsAVColorSpace)
+{
+	EXPECT_EQ(static_cast<int>(cmn::ColorMatrix::RGB), static_cast<int>(AVCOL_SPC_RGB));
+	EXPECT_EQ(static_cast<int>(cmn::ColorMatrix::BT709), static_cast<int>(AVCOL_SPC_BT709));
+	EXPECT_EQ(static_cast<int>(cmn::ColorMatrix::Unspecified), static_cast<int>(AVCOL_SPC_UNSPECIFIED));
+	EXPECT_EQ(static_cast<int>(cmn::ColorMatrix::FCC), static_cast<int>(AVCOL_SPC_FCC));
+	EXPECT_EQ(static_cast<int>(cmn::ColorMatrix::BT470BG), static_cast<int>(AVCOL_SPC_BT470BG));
+	EXPECT_EQ(static_cast<int>(cmn::ColorMatrix::SMPTE170M), static_cast<int>(AVCOL_SPC_SMPTE170M));
+	EXPECT_EQ(static_cast<int>(cmn::ColorMatrix::SMPTE240M), static_cast<int>(AVCOL_SPC_SMPTE240M));
+	EXPECT_EQ(static_cast<int>(cmn::ColorMatrix::YCGCO), static_cast<int>(AVCOL_SPC_YCGCO));
+	EXPECT_EQ(static_cast<int>(cmn::ColorMatrix::BT2020NCL), static_cast<int>(AVCOL_SPC_BT2020_NCL));
+	EXPECT_EQ(static_cast<int>(cmn::ColorMatrix::BT2020CL), static_cast<int>(AVCOL_SPC_BT2020_CL));
+	EXPECT_EQ(static_cast<int>(cmn::ColorMatrix::SMPTE2085), static_cast<int>(AVCOL_SPC_SMPTE2085));
+	EXPECT_EQ(static_cast<int>(cmn::ColorMatrix::ChromaDerivedNCL), static_cast<int>(AVCOL_SPC_CHROMA_DERIVED_NCL));
+	EXPECT_EQ(static_cast<int>(cmn::ColorMatrix::ChromaDerivedCL), static_cast<int>(AVCOL_SPC_CHROMA_DERIVED_CL));
+	EXPECT_EQ(static_cast<int>(cmn::ColorMatrix::ICTCP), static_cast<int>(AVCOL_SPC_ICTCP));
+}
+
+TEST(FFmpegCompatColor, ColorSpaceRoundTrip)
+{
+	// Every valid AVColorSpace value survives the round trip, including values
+	// that have no named cmn::ColorMatrix enumerator (e.g. RESERVED)
+	for (int value = 0; value < AVCOL_SPC_NB; value++)
+	{
+		auto av_color_space = static_cast<enum AVColorSpace>(value);
+		EXPECT_EQ(ffmpeg::compat::ToAVColorSpace(ffmpeg::compat::ToColorMatrix(av_color_space)), av_color_space);
+	}
+}
+
+TEST(FFmpegCompatColor, ColorSpaceOutOfRangeFallsBackToUnspecified)
+{
+	EXPECT_EQ(ffmpeg::compat::ToColorMatrix(static_cast<enum AVColorSpace>(-1)), cmn::ColorMatrix::Unspecified);
+	EXPECT_EQ(ffmpeg::compat::ToColorMatrix(AVCOL_SPC_NB), cmn::ColorMatrix::Unspecified);
+	EXPECT_EQ(ffmpeg::compat::ToAVColorSpace(static_cast<cmn::ColorMatrix>(-1)), AVCOL_SPC_UNSPECIFIED);
+}
+
+TEST(FFmpegCompatColor, ColorRangeRoundTrip)
+{
+	EXPECT_EQ(ffmpeg::compat::ToColorRange(AVCOL_RANGE_UNSPECIFIED), cmn::ColorRange::Unspecified);
+	EXPECT_EQ(ffmpeg::compat::ToColorRange(AVCOL_RANGE_MPEG), cmn::ColorRange::Limited);
+	EXPECT_EQ(ffmpeg::compat::ToColorRange(AVCOL_RANGE_JPEG), cmn::ColorRange::Full);
+
+	EXPECT_EQ(ffmpeg::compat::ToAVColorRange(cmn::ColorRange::Unspecified), AVCOL_RANGE_UNSPECIFIED);
+	EXPECT_EQ(ffmpeg::compat::ToAVColorRange(cmn::ColorRange::Limited), AVCOL_RANGE_MPEG);
+	EXPECT_EQ(ffmpeg::compat::ToAVColorRange(cmn::ColorRange::Full), AVCOL_RANGE_JPEG);
+}

--- a/src/modules/ffmpeg/ffmpeg_media_frame.cpp
+++ b/src/modules/ffmpeg/ffmpeg_media_frame.cpp
@@ -88,7 +88,11 @@ namespace ffmpeg
 			return nullptr;
 		}
 
+		// av_hwframe_transfer_data() copies pixel data only, so carry over the
+		// properties needed by the filter graph
 		host->pts = _frame->pts;
+		host->colorspace = _frame->colorspace;
+		host->color_range = _frame->color_range;
 
 		return std::make_shared<FFmpegMediaFrameData>(host);
 	}

--- a/src/transcoder/filter/filter_base.h
+++ b/src/transcoder/filter/filter_base.h
@@ -72,6 +72,24 @@ public:
 		return _src_height;
 	}
 
+	// Properties of the frames arriving from the decoder. Unlike _src_pixfmt,
+	// _src_frame_pixfmt keeps the decoder-side format label (e.g. CUDA for
+	// hardware frames), so it can be compared against incoming frames directly.
+	cmn::VideoPixelFormatId GetInputFramePixelFormat() const
+	{
+		return _src_frame_pixfmt;
+	}
+
+	cmn::ColorMatrix GetInputColorMatrix() const
+	{
+		return _src_color_matrix;
+	}
+
+	cmn::ColorRange GetInputColorRange() const
+	{
+		return _src_color_range;
+	}
+
 	int32_t GetInputSampleRate() const
 	{
 		return _src_samplerate;
@@ -112,6 +130,15 @@ public:
 	void SetInputTrack(std::shared_ptr<MediaTrack> input_track)
 	{
 		_input_track = input_track;
+
+		// Captured here so that every filter implementation gets the decoder-side
+		// snapshot without having to set it in its own Initialize()
+		if (input_track != nullptr && input_track->GetMediaType() == cmn::MediaType::Video)
+		{
+			_src_frame_pixfmt = input_track->GetColorspace();
+			_src_color_matrix = input_track->GetColorMatrix();
+			_src_color_range = input_track->GetColorRange();
+		}
 	}
 
 	void SetOutputStreamInfo(std::shared_ptr<info::Stream> output_stream_info)
@@ -184,6 +211,11 @@ protected:
 	cmn::VideoPixelFormatId _src_pixfmt = cmn::VideoPixelFormatId::None;
 	int32_t 	_src_width = 0;
 	int32_t 	_src_height = 0;
+
+	// Decoder-side snapshot captured by SetInputTrack()
+	cmn::VideoPixelFormatId _src_frame_pixfmt = cmn::VideoPixelFormatId::None;
+	cmn::ColorMatrix _src_color_matrix = cmn::ColorMatrix::Unspecified;
+	cmn::ColorRange _src_color_range = cmn::ColorRange::Unspecified;
 
 	int32_t 	_src_samplerate = 0;
 	cmn::AudioChannel::Layout _src_channel_layout = cmn::AudioChannel::Layout::LayoutUnknown;

--- a/src/transcoder/filter/filter_lavfi_resampler.cpp
+++ b/src/transcoder/filter/filter_lavfi_resampler.cpp
@@ -164,9 +164,11 @@ bool FilterLavfiResampler::SendFrame(std::shared_ptr<MediaFrame> media_frame)
 		media_frame->GetChannels().GetLayout() != _src_channel_layout ||
 		media_frame->GetFormat<cmn::AudioSample::Format>() != _src_sample_format)
 	{
-		logtw("Input frame parameters do not match the expected source parameters. %dHz/%s (expected: %dHz/%s)",
+		logtw("Input frame parameters do not match the expected source parameters. %dHz/%s/%s (expected: %dHz/%s/%s)",
 			  media_frame->GetSampleRate(), media_frame->GetChannels().GetName(),
-			  _src_samplerate, cmn::AudioChannel::GetLayoutName(_src_channel_layout));
+			  cmn::AudioSample(media_frame->GetFormat<cmn::AudioSample::Format>()).GetName(),
+			  _src_samplerate, cmn::AudioChannel::GetLayoutName(_src_channel_layout),
+			  cmn::AudioSample(_src_sample_format).GetName());
 
 		return false;
 	}

--- a/src/transcoder/filter/filter_lavfi_resampler.cpp
+++ b/src/transcoder/filter/filter_lavfi_resampler.cpp
@@ -153,23 +153,46 @@ bool FilterLavfiResampler::SendFrame(std::shared_ptr<MediaFrame> media_frame)
 		return false;
 	}
 
+	if (media_frame == nullptr)
+	{
+		return false;
+	}
+
+	// Drop a frame that does not match the source parameters. The audio buffer
+	// source rejects such a frame with an error that would disable the filter.
+	if (media_frame->GetSampleRate() != _src_samplerate ||
+		media_frame->GetChannels().GetLayout() != _src_channel_layout ||
+		media_frame->GetFormat<cmn::AudioSample::Format>() != _src_sample_format)
+	{
+		logtw("Input frame parameters do not match the expected source parameters. %dHz/%s (expected: %dHz/%s)",
+			  media_frame->GetSampleRate(), media_frame->GetChannels().GetName(),
+			  _src_samplerate, cmn::AudioChannel::GetLayoutName(_src_channel_layout));
+
+		return false;
+	}
+
 	ffmpeg::CodecResult result = _graph.PushFrame(media_frame, false);
-	if (result == ffmpeg::CodecResult::NoMemory)
+
+	switch (result)
 	{
-		logte("Could not allocate the frame data");
-		SetState(State::ERROR);
-
-		return false;
+		case ffmpeg::CodecResult::Ok:
+			return true;
+		case ffmpeg::CodecResult::Eof:
+		case ffmpeg::CodecResult::Again:
+		case ffmpeg::CodecResult::InvalidData:
+			// Drop only this frame; the filter graph is still usable
+			logtw("Could not send the frame to the audio filtergraph: %s", _graph.GetLastErrorString().CStr());
+			return true;
+		case ffmpeg::CodecResult::NoMemory:
+			logte("Could not allocate the frame data");
+			SetState(State::ERROR);
+			return false;
+		case ffmpeg::CodecResult::Error:
+		default:
+			logte("An error occurred while feeding the audio filtergraph: %s", _graph.GetLastErrorString().CStr());
+			SetState(State::ERROR);
+			return false;
 	}
-	else if (result != ffmpeg::CodecResult::Ok)
-	{
-		logte("An error occurred while feeding the audio filtergraph: %s", _graph.GetLastErrorString().CStr());
-		SetState(State::ERROR);
-
-		return false;
-	}
-
-	return true;
 }
 
 std::shared_ptr<MediaFrame> FilterLavfiResampler::ReceiveFrame()

--- a/src/transcoder/filter/filter_lavfi_resampler.cpp
+++ b/src/transcoder/filter/filter_lavfi_resampler.cpp
@@ -146,6 +146,18 @@ bool FilterLavfiResampler::Initialize()
 	return true;
 }
 
+bool FilterLavfiResampler::IsSourceParametersMatched(const std::shared_ptr<MediaFrame> &media_frame) const
+{
+	if (media_frame->GetSampleRate() == _src_samplerate &&
+		media_frame->GetChannels().GetLayout() == _src_channel_layout &&
+		media_frame->GetFormat<cmn::AudioSample::Format>() == _src_sample_format)
+	{
+		return true;
+	}
+
+	return false;
+}
+
 bool FilterLavfiResampler::SendFrame(std::shared_ptr<MediaFrame> media_frame)
 {
 	if (GetState() == State::ERROR)
@@ -158,13 +170,10 @@ bool FilterLavfiResampler::SendFrame(std::shared_ptr<MediaFrame> media_frame)
 		return false;
 	}
 
-	// Drop a frame that does not match the source parameters. The audio buffer
-	// source rejects such a frame with an error that would disable the filter.
-	if (media_frame->GetSampleRate() != _src_samplerate ||
-		media_frame->GetChannels().GetLayout() != _src_channel_layout ||
-		media_frame->GetFormat<cmn::AudioSample::Format>() != _src_sample_format)
+	// Drop a frame that does not match the source parameters.
+	if (IsSourceParametersMatched(media_frame) == false)
 	{
-		logtw("Input frame parameters do not match the expected source parameters. %dHz/%s/%s (expected: %dHz/%s/%s)",
+		logtw("Input audio frame parameters do not match the expected source parameters. %dHz/%s/%s (expected: %dHz/%s/%s)",
 			  media_frame->GetSampleRate(), media_frame->GetChannels().GetName(),
 			  cmn::AudioSample(media_frame->GetFormat<cmn::AudioSample::Format>()).GetName(),
 			  _src_samplerate, cmn::AudioChannel::GetLayoutName(_src_channel_layout),

--- a/src/transcoder/filter/filter_lavfi_resampler.h
+++ b/src/transcoder/filter/filter_lavfi_resampler.h
@@ -35,6 +35,8 @@ private:
 	bool InitializeFilterDescription();
 	bool InitializeSinkFilter();
 
+	bool IsSourceParametersMatched(const std::shared_ptr<MediaFrame> &media_frame) const;
+
 	// ----- Members -----
 	ffmpeg::FFmpegFilterGraph _graph;
 };

--- a/src/transcoder/filter/filter_lavfi_rescaler.cpp
+++ b/src/transcoder/filter/filter_lavfi_rescaler.cpp
@@ -80,8 +80,6 @@ bool FilterLavfiRescaler::InitializeSourceFilter()
 	src_params.push_back(ov::String::FormatString("pix_fmt=%s", ffmpeg::compat::GetAVPixelFormatName(ffmpeg::compat::ToAVPixelFormat(_src_pixfmt)).CStr()));
 	src_params.push_back(ov::String::FormatString("time_base=%s", _input_track->GetTimeBase().GetStringExpr().CStr()));
 	src_params.push_back(ov::String::FormatString("pixel_aspect=%d/%d", 1, 1));
-	// Declare the color tags of the incoming frames so that buffersrc does not
-	// warn about on-the-fly property changes
 	src_params.push_back(ov::String::FormatString("colorspace=%d", static_cast<int32_t>(ffmpeg::compat::ToAVColorSpace(_input_track->GetColorMatrix()))));
 	src_params.push_back(ov::String::FormatString("range=%d", static_cast<int32_t>(ffmpeg::compat::ToAVColorRange(_input_track->GetColorRange()))));
 

--- a/src/transcoder/filter/filter_lavfi_rescaler.cpp
+++ b/src/transcoder/filter/filter_lavfi_rescaler.cpp
@@ -80,6 +80,10 @@ bool FilterLavfiRescaler::InitializeSourceFilter()
 	src_params.push_back(ov::String::FormatString("pix_fmt=%s", ffmpeg::compat::GetAVPixelFormatName(ffmpeg::compat::ToAVPixelFormat(_src_pixfmt)).CStr()));
 	src_params.push_back(ov::String::FormatString("time_base=%s", _input_track->GetTimeBase().GetStringExpr().CStr()));
 	src_params.push_back(ov::String::FormatString("pixel_aspect=%d/%d", 1, 1));
+	// Declare the color tags of the incoming frames so that buffersrc does not
+	// warn about on-the-fly property changes
+	src_params.push_back(ov::String::FormatString("colorspace=%d", static_cast<int32_t>(ffmpeg::compat::ToAVColorSpace(_input_track->GetColorMatrix()))));
+	src_params.push_back(ov::String::FormatString("range=%d", static_cast<int32_t>(ffmpeg::compat::ToAVColorRange(_input_track->GetColorRange()))));
 
 	_src_args = ov::String::Join(src_params, ":");
 

--- a/src/transcoder/media_frame.h
+++ b/src/transcoder/media_frame.h
@@ -162,6 +162,26 @@ public:
 		return static_cast<T>(_format);
 	}
 
+	void SetColorMatrix(cmn::ColorMatrix color_matrix)
+	{
+		_color_matrix = color_matrix;
+	}
+
+	cmn::ColorMatrix GetColorMatrix() const
+	{
+		return _color_matrix;
+	}
+
+	void SetColorRange(cmn::ColorRange color_range)
+	{
+		_color_range = color_range;
+	}
+
+	cmn::ColorRange GetColorRange() const
+	{
+		return _color_range;
+	}
+
 	int32_t GetBytesPerSample() const
 	{
 		return _bytes_per_sample;
@@ -273,6 +293,8 @@ public:
 			frame->SetWidth(_width);
 			frame->SetHeight(_height);
 			frame->SetFormat(_format);
+			frame->SetColorMatrix(_color_matrix);
+			frame->SetColorRange(_color_range);
 			frame->SetPts(_pts);
 			frame->SetDuration(_duration);
 		}
@@ -342,6 +364,8 @@ private:
 	int32_t _width = 0;
 	int32_t _height = 0;
 	int32_t _format = 0;
+	cmn::ColorMatrix _color_matrix = cmn::ColorMatrix::Unspecified;
+	cmn::ColorRange _color_range = cmn::ColorRange::Unspecified;
 
 	// Audio 
 	int32_t _bytes_per_sample = 0;

--- a/src/transcoder/transcoder_filter.cpp
+++ b/src/transcoder/transcoder_filter.cpp
@@ -340,9 +340,10 @@ bool TranscodeFilter::IsNeedUpdate(std::shared_ptr<MediaFrame> buffer)
 		return true;
 	}
 
-	// NOTE: Input format changes (resolution, audio properties) are detected per
-	// frame in ThreadLoop(). A flag set here is consumed at whatever frame the
-	// worker dequeues next, so it cannot be tied to the frame that triggered it.
+	// NOTE: Input format changes (video resolution/pixel format/color tags and
+	// audio properties) are detected per frame in ThreadLoop(). A flag set here is
+	// consumed at whatever frame the worker dequeues next, so it cannot be tied to
+	// the frame that triggered it.
 
 	// Check #2 - Filter error state
 	//  When using an XMA scaler, resource allocation failures may occur intermittently.
@@ -371,8 +372,13 @@ bool TranscodeFilter::IsFormatChanged(const std::shared_ptr<FilterBase> &base, c
 	switch (frame->GetMediaType())
 	{
 		case MediaType::Video:
+			// The pixel format is compared with the decoder-side label, so hardware
+			// frames (e.g. CUDA) do not falsely mismatch the downloaded host format
 			return (frame->GetWidth() != base->GetInputWidth() ||
-					frame->GetHeight() != base->GetInputHeight());
+					frame->GetHeight() != base->GetInputHeight() ||
+					frame->GetFormat<cmn::VideoPixelFormatId>() != base->GetInputFramePixelFormat() ||
+					frame->GetColorMatrix() != base->GetInputColorMatrix() ||
+					frame->GetColorRange() != base->GetInputColorRange());
 
 		case MediaType::Audio:
 			return (frame->GetSampleRate() != base->GetInputSampleRate() ||
@@ -393,15 +399,22 @@ void TranscodeFilter::UpdateInputTrackByFrame(const std::shared_ptr<FilterBase> 
 	switch (frame->GetMediaType())
 	{
 		case MediaType::Video:
-			logtd("[%s] input video frame resolution has been changed. track:%u. Size:%dx%d -> %dx%d",
+			logtd("[%s] input video frame properties have been changed. track:%u. %dx%d/%s(csp:%d/%d) -> %dx%d/%s(csp:%d/%d)",
 				  _input_stream_info->GetUri().CStr(),
 				  input_track->GetId(),
 				  base->GetInputWidth(),
 				  base->GetInputHeight(),
+				  cmn::GetVideoPixelFormatIdString(base->GetInputFramePixelFormat()),
+				  static_cast<int32_t>(base->GetInputColorMatrix()),
+				  static_cast<int32_t>(base->GetInputColorRange()),
 				  frame->GetWidth(),
-				  frame->GetHeight());
+				  frame->GetHeight(),
+				  cmn::GetVideoPixelFormatIdString(frame->GetFormat<cmn::VideoPixelFormatId>()),
+				  static_cast<int32_t>(frame->GetColorMatrix()),
+				  static_cast<int32_t>(frame->GetColorRange()));
 
 			input_track->SetResolution(frame->GetWidth(), frame->GetHeight());
+			input_track->SetColorspace(frame->GetFormat<cmn::VideoPixelFormatId>());
 			input_track->SetColorMatrix(frame->GetColorMatrix());
 			input_track->SetColorRange(frame->GetColorRange());
 			break;

--- a/src/transcoder/transcoder_filter.cpp
+++ b/src/transcoder/transcoder_filter.cpp
@@ -395,23 +395,25 @@ bool TranscodeFilter::IsFormatChanged(const std::shared_ptr<FilterBase> &base, c
 void TranscodeFilter::UpdateInputTrackByFrame(const std::shared_ptr<FilterBase> &base, const std::shared_ptr<MediaFrame> &frame)
 {
 	auto input_track = GetInputTrack();
+	auto output_track = GetOutputTrack();
 
 	switch (frame->GetMediaType())
 	{
 		case MediaType::Video:
-			logtd("[%s] input video frame properties have been changed. track:%u. %dx%d/%s(csp:%d/%d) -> %dx%d/%s(csp:%d/%d)",
+			logtd("[%s] input video frame properties have been changed. track:%u -> %u. %dx%d/%s(%s,%s) -> %dx%d/%s(%s,%s)",
 				  _input_stream_info->GetUri().CStr(),
 				  input_track->GetId(),
+				  output_track->GetId(),
 				  base->GetInputWidth(),
 				  base->GetInputHeight(),
 				  cmn::GetVideoPixelFormatIdString(base->GetInputFramePixelFormat()),
-				  static_cast<int32_t>(base->GetInputColorMatrix()),
-				  static_cast<int32_t>(base->GetInputColorRange()),
+				  cmn::GetColorMatrixString(base->GetInputColorMatrix()),
+				  cmn::GetColorRangeString(base->GetInputColorRange()),
 				  frame->GetWidth(),
 				  frame->GetHeight(),
 				  cmn::GetVideoPixelFormatIdString(frame->GetFormat<cmn::VideoPixelFormatId>()),
-				  static_cast<int32_t>(frame->GetColorMatrix()),
-				  static_cast<int32_t>(frame->GetColorRange()));
+				  cmn::GetColorMatrixString(frame->GetColorMatrix()),
+				  cmn::GetColorRangeString(frame->GetColorRange()));
 
 			input_track->SetResolution(frame->GetWidth(), frame->GetHeight());
 			input_track->SetColorspace(frame->GetFormat<cmn::VideoPixelFormatId>());
@@ -420,9 +422,10 @@ void TranscodeFilter::UpdateInputTrackByFrame(const std::shared_ptr<FilterBase> 
 			break;
 
 		case MediaType::Audio:
-			logtd("[%s] input audio frame properties have been changed. track:%u. %dHz/%s -> %dHz/%s",
+			logtd("[%s] input audio frame properties have been changed. track:%u -> %u. %dHz/%s -> %dHz/%s",
 				  _input_stream_info->GetUri().CStr(),
 				  input_track->GetId(),
+				  output_track->GetId(),
 				  base->GetInputSampleRate(),
 				  cmn::AudioChannel::GetLayoutName(base->GetInputChannelLayout()),
 				  frame->GetSampleRate(),

--- a/src/transcoder/transcoder_filter.cpp
+++ b/src/transcoder/transcoder_filter.cpp
@@ -229,6 +229,27 @@ void TranscodeFilter::ThreadLoop()
 			continue;
 		}
 
+		// The input format is compared per frame at the consumption position, so a
+		// format change is applied exactly at its boundary frame even when frames
+		// of the previous format are still queued behind it.
+		if (IsFormatChanged(base, media_frame) == true)
+		{
+			UpdateInputTrackByFrame(base, media_frame);
+
+			if (Initialize() == false)
+			{
+				logte("[%s] Failed to reconfigure filter", _input_stream_info->GetUri().CStr());
+
+				break;
+			}
+
+			base = GetBaseFilter();
+			if (base == nullptr)
+			{
+				continue;
+			}
+		}
+
 		// Feed the frame into the filter graph.
 		auto sent = base->ProcessFrameInternal(media_frame);
 		if (sent.result == TranscodeResult::DataError)
@@ -319,51 +340,11 @@ bool TranscodeFilter::IsNeedUpdate(std::shared_ptr<MediaFrame> buffer)
 		return true;
 	}
 
-	// Check #2 - Resolution changed. but, this is not warned because it can be a normal case.
-	if (GetInputTrack()->GetMediaType() == MediaType::Video)
-	{
-		if (buffer->GetWidth() != (int32_t)_filter_base->GetInputWidth() ||
-			buffer->GetHeight() != (int32_t)_filter_base->GetInputHeight())
-		{
-			logtd("[%s] input video frame resolution has been changed. track:%u. Size:%dx%d -> %dx%d",
-				  _input_stream_info->GetUri().CStr(),
-				  GetInputTrack()->GetId(),
-				  _filter_base->GetInputWidth(),
-				  _filter_base->GetInputHeight(),
-				  buffer->GetWidth(),
-				  buffer->GetHeight());
+	// NOTE: Input format changes (resolution, audio properties) are detected per
+	// frame in ThreadLoop(). A flag set here is consumed at whatever frame the
+	// worker dequeues next, so it cannot be tied to the frame that triggered it.
 
-			GetInputTrack()->SetResolution(buffer->GetWidth(), buffer->GetHeight());
-
-			return true;
-		}
-	}
-
-	// Check #2-audio - Input audio properties changed (e.g. a scheduled item switch).
-	// The audio buffer source rejects mismatched frames, so the filter must be rebuilt.
-	if (GetInputTrack()->GetMediaType() == MediaType::Audio)
-	{
-		if (buffer->GetSampleRate() != _filter_base->GetInputSampleRate() ||
-			buffer->GetChannels().GetLayout() != _filter_base->GetInputChannelLayout() ||
-			buffer->GetFormat<cmn::AudioSample::Format>() != _filter_base->GetInputSampleFormat())
-		{
-			logtd("[%s] input audio frame properties have been changed. track:%u. %dHz/%s -> %dHz/%s",
-				  _input_stream_info->GetUri().CStr(),
-				  GetInputTrack()->GetId(),
-				  _filter_base->GetInputSampleRate(),
-				  cmn::AudioChannel::GetLayoutName(_filter_base->GetInputChannelLayout()),
-				  buffer->GetSampleRate(),
-				  buffer->GetChannels().GetName());
-
-			GetInputTrack()->SetSampleRate(buffer->GetSampleRate());
-			GetInputTrack()->SetChannel(buffer->GetChannels());
-			GetInputTrack()->SetSampleFormat(buffer->GetFormat<cmn::AudioSample::Format>());
-
-			return true;
-		}
-	}
-
-	// Check #3 - Filter error state
+	// Check #2 - Filter error state
 	//  When using an XMA scaler, resource allocation failures may occur intermittently.
 	//  Avoid problems in this way until the underlying problem is resolved.
 	if (_filter_base->GetState() == FilterBase::State::ERROR &&
@@ -377,6 +358,71 @@ bool TranscodeFilter::IsNeedUpdate(std::shared_ptr<MediaFrame> buffer)
 	}
 
 	return false;
+}
+
+bool TranscodeFilter::IsFormatChanged(const std::shared_ptr<FilterBase> &base, const std::shared_ptr<MediaFrame> &frame) const
+{
+	// Single track(paired with encoder) does not need to be updated.
+	if (base->IsSingleTrack() == true)
+	{
+		return false;
+	}
+
+	switch (frame->GetMediaType())
+	{
+		case MediaType::Video:
+			return (frame->GetWidth() != base->GetInputWidth() ||
+					frame->GetHeight() != base->GetInputHeight());
+
+		case MediaType::Audio:
+			return (frame->GetSampleRate() != base->GetInputSampleRate() ||
+					frame->GetChannels().GetLayout() != base->GetInputChannelLayout() ||
+					frame->GetFormat<cmn::AudioSample::Format>() != base->GetInputSampleFormat());
+
+		default:
+			return false;
+	}
+}
+
+// Update the input track with the properties of the frame so that the filter is
+// rebuilt to match the frame that triggered the change.
+void TranscodeFilter::UpdateInputTrackByFrame(const std::shared_ptr<FilterBase> &base, const std::shared_ptr<MediaFrame> &frame)
+{
+	auto input_track = GetInputTrack();
+
+	switch (frame->GetMediaType())
+	{
+		case MediaType::Video:
+			logtd("[%s] input video frame resolution has been changed. track:%u. Size:%dx%d -> %dx%d",
+				  _input_stream_info->GetUri().CStr(),
+				  input_track->GetId(),
+				  base->GetInputWidth(),
+				  base->GetInputHeight(),
+				  frame->GetWidth(),
+				  frame->GetHeight());
+
+			input_track->SetResolution(frame->GetWidth(), frame->GetHeight());
+			input_track->SetColorMatrix(frame->GetColorMatrix());
+			input_track->SetColorRange(frame->GetColorRange());
+			break;
+
+		case MediaType::Audio:
+			logtd("[%s] input audio frame properties have been changed. track:%u. %dHz/%s -> %dHz/%s",
+				  _input_stream_info->GetUri().CStr(),
+				  input_track->GetId(),
+				  base->GetInputSampleRate(),
+				  cmn::AudioChannel::GetLayoutName(base->GetInputChannelLayout()),
+				  frame->GetSampleRate(),
+				  frame->GetChannels().GetName());
+
+			input_track->SetSampleRate(frame->GetSampleRate());
+			input_track->SetChannel(frame->GetChannels());
+			input_track->SetSampleFormat(frame->GetFormat<cmn::AudioSample::Format>());
+			break;
+
+		default:
+			break;
+	}
 }
 
 void TranscodeFilter::SetCompleteHandler(CompleteHandler complete_handler)

--- a/src/transcoder/transcoder_filter.h
+++ b/src/transcoder/transcoder_filter.h
@@ -56,6 +56,8 @@ private:
 	void ThreadLoop();
 
 	bool IsNeedUpdate(std::shared_ptr<MediaFrame> buffer);
+	bool IsFormatChanged(const std::shared_ptr<FilterBase> &base, const std::shared_ptr<MediaFrame> &frame) const;
+	void UpdateInputTrackByFrame(const std::shared_ptr<FilterBase> &base, const std::shared_ptr<MediaFrame> &frame);
 
 	int32_t _id;
 

--- a/src/transcoder/transcoder_filter_test.cpp
+++ b/src/transcoder/transcoder_filter_test.cpp
@@ -36,6 +36,44 @@ namespace
 		return track;
 	}
 
+	std::shared_ptr<MediaTrack> MakeVideoTrack(int32_t id, int32_t width, int32_t height)
+	{
+		auto track = std::make_shared<MediaTrack>();
+		track->SetId(id);
+		track->SetMediaType(cmn::MediaType::Video);
+		track->SetCodecId(cmn::MediaCodecId::H264);
+		track->SetCodecModuleId(cmn::MediaCodecModuleId::DEFAULT);
+		track->SetTimeBase(1, 90000);
+		track->SetFrameRateByConfig(30.0);
+		track->SetResolution(width, height);
+		track->SetColorspace(cmn::VideoPixelFormatId::YUV420P);
+
+		return track;
+	}
+
+	std::shared_ptr<MediaFrame> MakeVideoFrame(int32_t width, int32_t height, enum AVPixelFormat pix_fmt,
+											   enum AVColorSpace color_space, enum AVColorRange color_range, int64_t pts)
+	{
+		AVFrame *av_frame	  = ::av_frame_alloc();
+		av_frame->format	  = pix_fmt;
+		av_frame->width		  = width;
+		av_frame->height	  = height;
+		av_frame->colorspace  = color_space;
+		av_frame->color_range = color_range;
+		av_frame->pts		  = pts;
+
+		if (::av_frame_get_buffer(av_frame, 0) < 0)
+		{
+			::av_frame_free(&av_frame);
+			return nullptr;
+		}
+
+		auto media_frame = ffmpeg::compat::ToMediaFrame(cmn::MediaType::Video, av_frame);
+		::av_frame_free(&av_frame);
+
+		return media_frame;
+	}
+
 	// A silent stereo fltp frame, built through the same path as decoder output
 	std::shared_ptr<MediaFrame> MakeAudioFrame(int32_t sample_rate, int64_t pts, int32_t nb_samples)
 	{
@@ -114,6 +152,63 @@ TEST(TranscodeFilterFormatChange, AudioPropertyChangeWithQueuedBacklog)
 
 	EXPECT_EQ(error_count.load(), 0);
 	EXPECT_GE(output_count.load(), 30);
+}
+
+// Color tag and pixel format changes at the same resolution must also rebuild
+// the video filter at the boundary frame, without any error or warning storm
+TEST(TranscodeFilterFormatChange, VideoColorTagAndPixelFormatChange)
+{
+	auto input_stream_info	= std::make_shared<info::Stream>(StreamSourceType::Ovt);
+	auto output_stream_info = std::make_shared<info::Stream>(StreamSourceType::Ovt);
+
+	auto input_track  = MakeVideoTrack(0, 640, 360);
+	auto output_track = MakeVideoTrack(100, 640, 360);
+
+	std::atomic<int> error_count{0};
+	std::atomic<int> output_count{0};
+
+	auto filter = TranscodeFilter::Create(
+		0, input_stream_info, input_track, output_stream_info, output_track,
+		[&](TranscodeResult result, int32_t id, std::shared_ptr<MediaFrame> frame) {
+			if (result == TranscodeResult::DataReady && frame != nullptr)
+			{
+				output_count++;
+			}
+			else if (result == TranscodeResult::DataError)
+			{
+				error_count++;
+			}
+		});
+	ASSERT_NE(filter, nullptr);
+
+	// Untagged frames, then bt709-tagged frames (tag-only change), then 10-bit
+	// frames (pixel format change), all at the same resolution
+	int64_t pts = 0;
+	for (int i = 0; i < 10; i++)
+	{
+		filter->SendBuffer(MakeVideoFrame(640, 360, AV_PIX_FMT_YUV420P, AVCOL_SPC_UNSPECIFIED, AVCOL_RANGE_UNSPECIFIED, pts));
+		pts += 3000;
+	}
+	for (int i = 0; i < 10; i++)
+	{
+		filter->SendBuffer(MakeVideoFrame(640, 360, AV_PIX_FMT_YUV420P, AVCOL_SPC_BT709, AVCOL_RANGE_MPEG, pts));
+		pts += 3000;
+	}
+	for (int i = 0; i < 10; i++)
+	{
+		filter->SendBuffer(MakeVideoFrame(640, 360, AV_PIX_FMT_YUV420P10, AVCOL_SPC_BT709, AVCOL_RANGE_MPEG, pts));
+		pts += 3000;
+	}
+
+	for (int i = 0; i < 100 && output_count.load() < 25; i++)
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
+
+	filter->Stop();
+
+	EXPECT_EQ(error_count.load(), 0);
+	EXPECT_GE(output_count.load(), 25);
 }
 
 // A frame that does not match the graph must be dropped without putting the

--- a/src/transcoder/transcoder_filter_test.cpp
+++ b/src/transcoder/transcoder_filter_test.cpp
@@ -1,0 +1,153 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Jeheon Han
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include <base/info/stream.h>
+#include <modules/ffmpeg/compat.h>
+
+#include "filter/filter_lavfi_resampler.h"
+#include "transcoder_filter.h"
+
+namespace
+{
+	std::shared_ptr<MediaTrack> MakeAudioTrack(int32_t id, int32_t sample_rate)
+	{
+		auto track = std::make_shared<MediaTrack>();
+		track->SetId(id);
+		track->SetMediaType(cmn::MediaType::Audio);
+		track->SetCodecId(cmn::MediaCodecId::Aac);
+		track->SetCodecModuleId(cmn::MediaCodecModuleId::DEFAULT);
+		track->SetTimeBase(1, sample_rate);
+		track->SetSampleRate(sample_rate);
+		track->SetSampleFormat(cmn::AudioSample::Format::FltP);
+		track->SetChannelLayout(cmn::AudioChannel::Layout::LayoutStereo);
+		track->SetAudioSamplesPerFrame(1024);
+
+		return track;
+	}
+
+	// A silent stereo fltp frame, built through the same path as decoder output
+	std::shared_ptr<MediaFrame> MakeAudioFrame(int32_t sample_rate, int64_t pts, int32_t nb_samples)
+	{
+		AVFrame *av_frame	 = ::av_frame_alloc();
+		av_frame->format	 = AV_SAMPLE_FMT_FLTP;
+		av_frame->sample_rate = sample_rate;
+		av_frame->nb_samples = nb_samples;
+		av_frame->pts		 = pts;
+		::av_channel_layout_default(&av_frame->ch_layout, 2);
+
+		if (::av_frame_get_buffer(av_frame, 0) < 0)
+		{
+			::av_frame_free(&av_frame);
+			return nullptr;
+		}
+
+		::av_samples_set_silence(av_frame->extended_data, 0, nb_samples, 2, AV_SAMPLE_FMT_FLTP);
+
+		auto media_frame = ffmpeg::compat::ToMediaFrame(cmn::MediaType::Audio, av_frame);
+		::av_frame_free(&av_frame);
+
+		return media_frame;
+	}
+}  // namespace
+
+// Regression test: an input format change must be applied exactly at its
+// boundary frame even when frames of the previous format are still queued.
+// The previous flag-based rebuild pushed the queued old-format frames into the
+// rebuilt graph, which disabled the audio filter until the next format change.
+TEST(TranscodeFilterFormatChange, AudioPropertyChangeWithQueuedBacklog)
+{
+	auto input_stream_info	= std::make_shared<info::Stream>(StreamSourceType::Ovt);
+	auto output_stream_info = std::make_shared<info::Stream>(StreamSourceType::Ovt);
+
+	auto input_track  = MakeAudioTrack(0, 48000);
+	auto output_track = MakeAudioTrack(100, 48000);
+
+	std::atomic<int> error_count{0};
+	std::atomic<int> output_count{0};
+
+	auto filter = TranscodeFilter::Create(
+		0, input_stream_info, input_track, output_stream_info, output_track,
+		[&](TranscodeResult result, int32_t id, std::shared_ptr<MediaFrame> frame) {
+			if (result == TranscodeResult::DataReady && frame != nullptr)
+			{
+				output_count++;
+			}
+			else if (result == TranscodeResult::DataError)
+			{
+				error_count++;
+			}
+		});
+	ASSERT_NE(filter, nullptr);
+
+	// Burst-enqueue 48kHz frames followed by 44.1kHz frames so that the
+	// boundary frame is enqueued while older frames are still in the queue
+	int64_t pts = 0;
+	for (int i = 0; i < 20; i++)
+	{
+		filter->SendBuffer(MakeAudioFrame(48000, pts, 1024));
+		pts += 1024;
+	}
+	for (int i = 0; i < 20; i++)
+	{
+		filter->SendBuffer(MakeAudioFrame(44100, pts, 1024));
+		pts += 1024;
+	}
+
+	// Both formats resample to 48kHz, so about 40 frames are expected in total
+	for (int i = 0; i < 100 && output_count.load() < 30; i++)
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
+
+	filter->Stop();
+
+	EXPECT_EQ(error_count.load(), 0);
+	EXPECT_GE(output_count.load(), 30);
+}
+
+// A frame that does not match the graph must be dropped without putting the
+// filter into the ERROR state, so the following matching frames keep flowing
+TEST(FilterLavfiResampler, MismatchedFrameDoesNotDisableFilter)
+{
+	auto resampler = std::make_shared<FilterLavfiResampler>();
+	resampler->SetInputTrack(MakeAudioTrack(0, 48000));
+	resampler->SetOutputTrack(MakeAudioTrack(100, 48000));
+
+	ASSERT_TRUE(resampler->Initialize());
+
+	auto matched = resampler->ProcessFrameInternal(MakeAudioFrame(48000, 0, 1024));
+	EXPECT_NE(matched.result, TranscodeResult::DataError);
+
+	auto mismatched = resampler->ProcessFrameInternal(MakeAudioFrame(44100, 1024, 1024));
+	EXPECT_EQ(mismatched.result, TranscodeResult::DataError);
+	EXPECT_NE(resampler->GetState(), FilterBase::State::ERROR);
+
+	auto recovered = resampler->ProcessFrameInternal(MakeAudioFrame(48000, 2048, 1024));
+	EXPECT_NE(recovered.result, TranscodeResult::DataError);
+}
+
+TEST(MediaFrameClone, CopiesColorTags)
+{
+	auto frame = std::make_shared<MediaFrame>();
+	frame->SetMediaType(cmn::MediaType::Video);
+	frame->SetWidth(1920);
+	frame->SetHeight(1080);
+	frame->SetColorMatrix(cmn::ColorMatrix::BT709);
+	frame->SetColorRange(cmn::ColorRange::Limited);
+
+	auto clone = frame->CloneFrame();
+	ASSERT_NE(clone, nullptr);
+	EXPECT_EQ(clone->GetColorMatrix(), cmn::ColorMatrix::BT709);
+	EXPECT_EQ(clone->GetColorRange(), cmn::ColorRange::Limited);
+}

--- a/src/transcoder/transcoder_stream.cpp
+++ b/src/transcoder/transcoder_stream.cpp
@@ -1549,6 +1549,8 @@ void TranscoderStream::UpdateInputTrack(std::shared_ptr<MediaFrame> buffer)
 		case cmn::MediaType::Video: {
 			input_track->SetResolution(buffer->GetWidth(), buffer->GetHeight());
 			input_track->SetColorspace(buffer->GetFormat<cmn::VideoPixelFormatId>());
+			input_track->SetColorMatrix(buffer->GetColorMatrix());
+			input_track->SetColorRange(buffer->GetColorRange());
 		}
 		break;
 		case cmn::MediaType::Audio: {
@@ -1629,7 +1631,7 @@ void TranscoderStream::HandleInputConfigChange(const std::shared_ptr<MediaPacket
 	// No pipeline rebuild here: every element handles the change at its own
 	// consumption position without losing queued data. The decoder re-inits on an
 	// in-band format change (GetFramedPacket), the filter re-inits when the frame
-	// format changes (IsNeedUpdate), and encoders are rewired by ChangeOutputFormat.
+	// format changes (IsFormatChanged), and encoders are rewired by ChangeOutputFormat.
 	// Bypass tracks are re-parsed by the outbound mediarouter.
 	logti("%s Input track(%d) configuration has been changed. version(%u) -> version(%u)",
 		  _log_prefix.CStr(), track_id, current->GetVersion(), packet_track->GetVersion());


### PR DESCRIPTION
## Problem

When a Scheduled Channel switches between items with different media properties, the video filter logs `Changing video frame properties on the fly is not supported by all filters` at every transition because the buffer source is created without color space and range information.

There is also a race in the filter rebuild path. The rebuild flag is not tied to the frame that triggered it, so when a format boundary is crossed while older frames are still queued (for example, a channel joining playback right before an item boundary), the queued old-format frames are pushed into the rebuilt graph. The audio buffer source rejects them with an error that puts the filter into the ERROR state, and all audio input is dropped until the next format change rebuilds the filter again.

## Solution

The color matrix and range of decoded frames now flow into the input track and the buffer source arguments, and they are preserved across the GPU to host transfer, so the filter graph is always created with the same color tags as the frames it receives.

Input format changes (video resolution, pixel format, and color tags, audio sample rate/layout/format) are now detected per frame at the consumption position in the filter worker, so the filter is rebuilt exactly at the boundary frame regardless of queue depth. The pixel format is compared with the decoder-side format label, so hardware frames do not falsely mismatch the downloaded host format. The audio resampler also drops a mismatched frame instead of latching the ERROR state, matching the video rescaler behavior.

## Test

Preparation: a schedule channel with a transcoding output profile (video encode + AAC audio), whose program alternates two files, where the files differ in both color metadata and audio sample rate (for example, one bt709/tv 48kHz file and one 44.1kHz file without color metadata). The difference can be checked with `ffprobe -show_entries stream=color_space,color_range,sample_rate <file>`.

1. Play the stream and watch the server log across at least 10 item transitions.
   - Pass: video and audio play back normally across every transition, and the log shows no `Changing video frame properties on the fly is not supported by all filters` warning. This also holds when the two files have the same resolution and differ only in color metadata. Before this fix, the warning appeared at every transition between the two files.
2. Set the item durations short (2 to 3 seconds), restart the server about 10 times, and check the log and playback right after each startup.
   - Pass: no `Changing audio frame properties on the fly is not supported` error and no filtering error alert right after startup, and audio is audible from the beginning every time. This targets a startup timing issue that only occurs when playback joins the schedule just before an item boundary, so short items and repeated restarts are needed to hit it. Before this fix, when it occurred, audio stayed silent until the first item ended.

Unit tests covering the color conversion and the filter rebuild logic are included and run in CI.
