### PR TITLE
fix(multiplex): fix tap queue overflow warning and unbounded growth

### DIFF
--- a/src/mediarouter/mediarouter_application.cpp
+++ b/src/mediarouter/mediarouter_application.cpp
@@ -906,17 +906,9 @@ void MediaRouteApplication::InboundWorkerThread(uint32_t worker_id)
 					{
 						stream_tap->SetNeedPastData(false);
 
-						// Keep the backfill burst below the tap's queue warning threshold,
-						// leaving headroom for live packets arriving during the burst
-						auto threshold = stream_tap->GetThreshold();
-						auto max_backfill = (threshold > MEDIA_ROUTE_STREAM_TAP_BACKFILL_HEADROOM) ? threshold - MEDIA_ROUTE_STREAM_TAP_BACKFILL_HEADROOM : threshold;
-
-						for (const auto &item : MediaRouteStream::SelectPastData(stream->GetMirrorBuffer(), max_backfill))
+						for (const auto &item : MediaRouteStream::BuildPastData(stream->GetMirrorBuffers()))
 						{
-							if (item->GetElapsedMilliseconds() < MEDIA_ROUTE_STREAM_MAX_MIRROR_BUFFER_SIZE_MS)
-							{
-								stream_tap->Push(item->packet);
-							}
+							stream_tap->PushBackfill(item->packet);
 						}
 					}
 					else
@@ -998,17 +990,9 @@ void MediaRouteApplication::OutboundWorkerThread(uint32_t worker_id)
 					{
 						stream_tap->SetNeedPastData(false);
 
-						// Keep the backfill burst below the tap's queue warning threshold,
-						// leaving headroom for live packets arriving during the burst
-						auto threshold = stream_tap->GetThreshold();
-						auto max_backfill = (threshold > MEDIA_ROUTE_STREAM_TAP_BACKFILL_HEADROOM) ? threshold - MEDIA_ROUTE_STREAM_TAP_BACKFILL_HEADROOM : threshold;
-
-						for (const auto &item : MediaRouteStream::SelectPastData(stream->GetMirrorBuffer(), max_backfill))
+						for (const auto &item : MediaRouteStream::BuildPastData(stream->GetMirrorBuffers()))
 						{
-							if (item->GetElapsedMilliseconds() < MEDIA_ROUTE_STREAM_MAX_MIRROR_BUFFER_SIZE_MS)
-							{
-								stream_tap->Push(item->packet);
-							}
+							stream_tap->PushBackfill(item->packet);
 						}
 					}
 					else

--- a/src/mediarouter/mediarouter_application.cpp
+++ b/src/mediarouter/mediarouter_application.cpp
@@ -906,7 +906,12 @@ void MediaRouteApplication::InboundWorkerThread(uint32_t worker_id)
 					{
 						stream_tap->SetNeedPastData(false);
 
-						for (const auto &item : stream->GetMirrorBuffer())
+						// Keep the backfill burst below the tap's queue warning threshold,
+						// leaving headroom for live packets arriving during the burst
+						auto threshold = stream_tap->GetThreshold();
+						auto max_backfill = (threshold > MEDIA_ROUTE_STREAM_TAP_BACKFILL_HEADROOM) ? threshold - MEDIA_ROUTE_STREAM_TAP_BACKFILL_HEADROOM : threshold;
+
+						for (const auto &item : MediaRouteStream::SelectPastData(stream->GetMirrorBuffer(), max_backfill))
 						{
 							if (item->GetElapsedMilliseconds() < MEDIA_ROUTE_STREAM_MAX_MIRROR_BUFFER_SIZE_MS)
 							{
@@ -993,7 +998,12 @@ void MediaRouteApplication::OutboundWorkerThread(uint32_t worker_id)
 					{
 						stream_tap->SetNeedPastData(false);
 
-						for (const auto &item : stream->GetMirrorBuffer())
+						// Keep the backfill burst below the tap's queue warning threshold,
+						// leaving headroom for live packets arriving during the burst
+						auto threshold = stream_tap->GetThreshold();
+						auto max_backfill = (threshold > MEDIA_ROUTE_STREAM_TAP_BACKFILL_HEADROOM) ? threshold - MEDIA_ROUTE_STREAM_TAP_BACKFILL_HEADROOM : threshold;
+
+						for (const auto &item : MediaRouteStream::SelectPastData(stream->GetMirrorBuffer(), max_backfill))
 						{
 							if (item->GetElapsedMilliseconds() < MEDIA_ROUTE_STREAM_MAX_MIRROR_BUFFER_SIZE_MS)
 							{

--- a/src/mediarouter/mediarouter_stream.cpp
+++ b/src/mediarouter/mediarouter_stream.cpp
@@ -29,7 +29,6 @@
 #include "mediarouter_stream.h"
 
 #include <algorithm>
-#include <limits>
 #include <map>
 
 #include <base/event/media_event.h>
@@ -437,21 +436,8 @@ std::shared_ptr<MediaPacket> MediaRouteStream::PopAndNormalize()
 	MediaRouterStats::Update(static_cast<uint8_t>(_type), IsStreamPrepared(), _packets_queue, GetStream(), media_track, pop_media_packet);
 
 	// Mirror Buffer
-	_mirror_buffer.emplace_back(std::make_shared<MirrorBufferItem>(pop_media_packet));
-
-	// Delete old packets
-	for (auto it = _mirror_buffer.begin(); it != _mirror_buffer.end();)
-	{
-		auto item = *it;
-		if (item->GetElapsedMilliseconds() > MEDIA_ROUTE_STREAM_MAX_MIRROR_BUFFER_SIZE_MS)
-		{
-			it = _mirror_buffer.erase(it);
-		}
-		else
-		{
-			++it;
-		}
-	}
+	int64_t dts_us = (int64_t)((double)pop_media_packet->GetDts() * 1000000.0 * media_track->GetTimeBase().GetExpr());
+	RetainMirrorBuffer(_mirror_buffers, pop_media_packet, dts_us);
 
 	return pop_media_packet;
 }
@@ -674,90 +660,140 @@ void MediaRouteStream::PublishWorkingVersion(TrackAuthorState &state, uint32_t t
 		  cmn::GetCodecIdString(new_version->GetCodecId()));
 }
 
-std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> MediaRouteStream::GetMirrorBuffer()
+MediaRouteStream::MirrorBufferMap MediaRouteStream::GetMirrorBuffers()
 {
-	return _mirror_buffer;
+	return _mirror_buffers;
 }
 
-std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> MediaRouteStream::SelectPastData(const std::vector<std::shared_ptr<MirrorBufferItem>> &mirror_buffer, size_t max_count)
+void MediaRouteStream::RetainMirrorBuffer(MirrorBufferMap &mirror_buffers, std::shared_ptr<MediaPacket> &media_packet, int64_t dts_us)
 {
-	// Most recent keyframe index per video track; 0 keeps the full range for a
-	// video track that has no keyframe in the buffer
-	std::map<uint32_t, size_t> video_start_indexes;
-	for (size_t index = 0; index < mirror_buffer.size(); index++)
+	auto &track_buffer = mirror_buffers[media_packet->GetTrackId()];
+	constexpr int64_t retention_us = MEDIA_ROUTE_STREAM_MIRROR_RETENTION_MS * 1000;
+
+	if (media_packet->GetMediaType() == cmn::MediaType::Video)
 	{
-		auto &packet = mirror_buffer[index]->packet;
-		if (packet->GetMediaType() != cmn::MediaType::Video)
+		if (media_packet->IsKeyFrame())
+		{
+			// A new keyframe supersedes the track's previous GOP
+			track_buffer.clear();
+		}
+		else
+		{
+			if (track_buffer.empty())
+			{
+				// Nothing is decodable without a keyframe; stay empty until the next one
+				return;
+			}
+
+			auto &leading_keyframe = track_buffer.front();
+			if (dts_us - leading_keyframe->dts_us > retention_us)
+			{
+				// The GOP has grown past the retention window; discard it whole
+				// and wait for the next keyframe
+				track_buffer.clear();
+				return;
+			}
+		}
+
+		track_buffer.emplace_back(std::make_shared<MirrorBufferItem>(media_packet, dts_us));
+		return;
+	}
+
+	// Non-video keeps the last retention window of content
+	track_buffer.emplace_back(std::make_shared<MirrorBufferItem>(media_packet, dts_us));
+	while (true)
+	{
+		auto &oldest_item = track_buffer.front();
+		if (dts_us - oldest_item->dts_us <= retention_us)
+		{
+			break;
+		}
+
+		track_buffer.erase(track_buffer.begin());
+	}
+}
+
+std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> MediaRouteStream::BuildPastData(const MirrorBufferMap &mirror_buffers)
+{
+	bool has_video = false;
+	int64_t earliest_keyframe_dts_us = 0;
+	std::vector<const std::vector<std::shared_ptr<MirrorBufferItem>> *> video_buffers;
+
+	// Pick the video tracks to include, and find the earliest keyframe DTS
+	// among them; it becomes the cut point that aligns the non-video tracks
+	for (const auto &[track_id, track_buffer] : mirror_buffers)
+	{
+		if (track_buffer.empty())
 		{
 			continue;
 		}
 
-		auto it = video_start_indexes.emplace(packet->GetTrackId(), 0).first;
-		if (packet->IsKeyFrame())
+		auto &leading_item = track_buffer.front();
+		if (leading_item->packet->GetMediaType() != cmn::MediaType::Video)
 		{
-			it->second = index;
+			continue;
+		}
+
+		// A stalled track may still hold an old GOP; the retention policy could
+		// not clear it because it only runs when a packet arrives
+		if (leading_item->GetElapsedMilliseconds() > MEDIA_ROUTE_STREAM_MIRROR_RETENTION_MS)
+		{
+			logtw("Past data of video track #%u is older than the retention window, so it is skipped", track_id);
+			continue;
+		}
+
+		video_buffers.push_back(&track_buffer);
+
+		if (has_video == false || leading_item->dts_us < earliest_keyframe_dts_us)
+		{
+			earliest_keyframe_dts_us = leading_item->dts_us;
+			has_video = true;
 		}
 	}
 
-	std::vector<std::shared_ptr<MirrorBufferItem>> selected;
+	std::vector<std::shared_ptr<MirrorBufferItem>> past_data;
 
-	if (video_start_indexes.empty())
+	// The included video tracks go in whole, each starting at its keyframe
+	for (const auto *video_buffer : video_buffers)
 	{
-		selected = mirror_buffer;
+		past_data.insert(past_data.end(), video_buffer->begin(), video_buffer->end());
 	}
-	else
+
+	// Non-video tracks follow, cut at the alignment point
+	for (const auto &[track_id, track_buffer] : mirror_buffers)
 	{
-		size_t non_video_start_index = std::numeric_limits<size_t>::max();
-		for (const auto &[track_id, start_index] : video_start_indexes)
+		if (track_buffer.empty())
 		{
-			non_video_start_index = std::min(non_video_start_index, start_index);
+			continue;
 		}
 
-		for (size_t index = non_video_start_index; index < mirror_buffer.size(); index++)
+		auto &leading_item = track_buffer.front();
+		if (leading_item->packet->GetMediaType() == cmn::MediaType::Video)
 		{
-			auto &packet = mirror_buffer[index]->packet;
-			if (packet->GetMediaType() == cmn::MediaType::Video && index < video_start_indexes[packet->GetTrackId()])
+			continue;
+		}
+
+		// Without a video track to align with, keep the last base window of content
+		auto &newest_item = track_buffer.back();
+		auto cut_dts_us = has_video ? earliest_keyframe_dts_us
+									: newest_item->dts_us - (MEDIA_ROUTE_STREAM_MIRROR_BASE_BACKFILL_MS * 1000);
+
+		for (auto &item : track_buffer)
+		{
+			if (item->dts_us >= cut_dts_us)
 			{
-				continue;
+				past_data.push_back(item);
 			}
-
-			selected.push_back(mirror_buffer[index]);
 		}
 	}
 
-	if (max_count > 0 && selected.size() > max_count)
-	{
-		// Keep the newest packets so the backfill burst stays below the cap
-		selected.erase(selected.begin(), selected.end() - max_count);
+	// Interleave the tracks by DTS so the backfill flows like a naturally muxed
+	// stream; the per-track order is already monotonic and stays intact
+	std::stable_sort(past_data.begin(), past_data.end(),
+					 [](const auto &left, const auto &right) {
+						 return left->dts_us < right->dts_us;
+					 });
 
-		// The front trim may leave a video track starting mid-GOP; drop its packets
-		// until its next keyframe so every video track still starts decodable
-		std::map<uint32_t, bool> keyframe_seen;
-		std::vector<std::shared_ptr<MirrorBufferItem>> trimmed;
-		trimmed.reserve(selected.size());
-		for (auto &item : selected)
-		{
-			auto &packet = item->packet;
-			if (packet->GetMediaType() == cmn::MediaType::Video)
-			{
-				auto it = keyframe_seen.emplace(packet->GetTrackId(), false).first;
-				if (packet->IsKeyFrame())
-				{
-					it->second = true;
-				}
-
-				if (it->second == false)
-				{
-					continue;
-				}
-			}
-
-			trimmed.push_back(item);
-		}
-
-		selected = std::move(trimmed);
-	}
-
-	return selected;
+	return past_data;
 }
 

--- a/src/mediarouter/mediarouter_stream.cpp
+++ b/src/mediarouter/mediarouter_stream.cpp
@@ -692,7 +692,7 @@ std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> MediaRouteStrea
 			continue;
 		}
 
-		auto [it, inserted] = video_start_indexes.emplace(packet->GetTrackId(), 0);
+		auto it = video_start_indexes.emplace(packet->GetTrackId(), 0).first;
 		if (packet->IsKeyFrame())
 		{
 			it->second = index;
@@ -740,7 +740,7 @@ std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> MediaRouteStrea
 			auto &packet = item->packet;
 			if (packet->GetMediaType() == cmn::MediaType::Video)
 			{
-				auto [it, inserted] = keyframe_seen.emplace(packet->GetTrackId(), false);
+				auto it = keyframe_seen.emplace(packet->GetTrackId(), false).first;
 				if (packet->IsKeyFrame())
 				{
 					it->second = true;

--- a/src/mediarouter/mediarouter_stream.cpp
+++ b/src/mediarouter/mediarouter_stream.cpp
@@ -701,16 +701,14 @@ void MediaRouteStream::RetainMirrorBuffer(MirrorBufferMap &mirror_buffers, std::
 
 	// Non-video keeps the last retention window of content
 	track_buffer.emplace_back(std::make_shared<MirrorBufferItem>(media_packet, dts_us));
-	while (true)
-	{
-		auto &oldest_item = track_buffer.front();
-		if (dts_us - oldest_item->dts_us <= retention_us)
-		{
-			break;
-		}
 
-		track_buffer.erase(track_buffer.begin());
+	size_t first_kept_index = 0;
+	while (dts_us - track_buffer[first_kept_index]->dts_us > retention_us)
+	{
+		first_kept_index++;
 	}
+
+	track_buffer.erase(track_buffer.begin(), track_buffer.begin() + first_kept_index);
 }
 
 std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> MediaRouteStream::BuildPastData(const MirrorBufferMap &mirror_buffers)

--- a/src/mediarouter/mediarouter_stream.cpp
+++ b/src/mediarouter/mediarouter_stream.cpp
@@ -28,6 +28,10 @@
 
 #include "mediarouter_stream.h"
 
+#include <algorithm>
+#include <limits>
+#include <map>
+
 #include <base/event/media_event.h>
 #include <base/event/command/update_language.h>
 #include <base/ovlibrary/ovlibrary.h>
@@ -673,5 +677,87 @@ void MediaRouteStream::PublishWorkingVersion(TrackAuthorState &state, uint32_t t
 std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> MediaRouteStream::GetMirrorBuffer()
 {
 	return _mirror_buffer;
+}
+
+std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> MediaRouteStream::SelectPastData(const std::vector<std::shared_ptr<MirrorBufferItem>> &mirror_buffer, size_t max_count)
+{
+	// Most recent keyframe index per video track; 0 keeps the full range for a
+	// video track that has no keyframe in the buffer
+	std::map<uint32_t, size_t> video_start_indexes;
+	for (size_t index = 0; index < mirror_buffer.size(); index++)
+	{
+		auto &packet = mirror_buffer[index]->packet;
+		if (packet->GetMediaType() != cmn::MediaType::Video)
+		{
+			continue;
+		}
+
+		auto [it, inserted] = video_start_indexes.emplace(packet->GetTrackId(), 0);
+		if (packet->IsKeyFrame())
+		{
+			it->second = index;
+		}
+	}
+
+	std::vector<std::shared_ptr<MirrorBufferItem>> selected;
+
+	if (video_start_indexes.empty())
+	{
+		selected = mirror_buffer;
+	}
+	else
+	{
+		size_t non_video_start_index = std::numeric_limits<size_t>::max();
+		for (const auto &[track_id, start_index] : video_start_indexes)
+		{
+			non_video_start_index = std::min(non_video_start_index, start_index);
+		}
+
+		for (size_t index = non_video_start_index; index < mirror_buffer.size(); index++)
+		{
+			auto &packet = mirror_buffer[index]->packet;
+			if (packet->GetMediaType() == cmn::MediaType::Video && index < video_start_indexes[packet->GetTrackId()])
+			{
+				continue;
+			}
+
+			selected.push_back(mirror_buffer[index]);
+		}
+	}
+
+	if (max_count > 0 && selected.size() > max_count)
+	{
+		// Keep the newest packets so the backfill burst stays below the cap
+		selected.erase(selected.begin(), selected.end() - max_count);
+
+		// The front trim may leave a video track starting mid-GOP; drop its packets
+		// until its next keyframe so every video track still starts decodable
+		std::map<uint32_t, bool> keyframe_seen;
+		std::vector<std::shared_ptr<MirrorBufferItem>> trimmed;
+		trimmed.reserve(selected.size());
+		for (auto &item : selected)
+		{
+			auto &packet = item->packet;
+			if (packet->GetMediaType() == cmn::MediaType::Video)
+			{
+				auto [it, inserted] = keyframe_seen.emplace(packet->GetTrackId(), false);
+				if (packet->IsKeyFrame())
+				{
+					it->second = true;
+				}
+
+				if (it->second == false)
+				{
+					continue;
+				}
+			}
+
+			trimmed.push_back(item);
+		}
+
+		selected = std::move(trimmed);
+	}
+
+	return selected;
 }
 

--- a/src/mediarouter/mediarouter_stream.h
+++ b/src/mediarouter/mediarouter_stream.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include <chrono>
+#include <map>
 #include <memory>
 #include <queue>
 #include <vector>

--- a/src/mediarouter/mediarouter_stream.h
+++ b/src/mediarouter/mediarouter_stream.h
@@ -24,11 +24,13 @@
 #include "mediarouter_alert.h"
 #include "modules/managed_queue/managed_queue.h"
 
-static constexpr int64_t MEDIA_ROUTE_STREAM_MAX_MIRROR_BUFFER_SIZE_MS = 2000; // Maximum size of mirror buffer
+// Mirror buffer retention window, measured in media time (DTS). A video track
+// keeps only its current GOP and is cleared whole when the GOP grows longer
+// than this; non-video tracks keep this much trailing content
+static constexpr int64_t MEDIA_ROUTE_STREAM_MIRROR_RETENTION_MS = 10000;
 
-// Headroom subtracted from a tap's queue warning threshold when capping past-data
-// backfill, covering live packets that arrive while the backfill is being pushed
-static constexpr size_t MEDIA_ROUTE_STREAM_TAP_BACKFILL_HEADROOM = 30;
+// Backfill depth for non-video tracks when there is no video track to align with
+static constexpr int64_t MEDIA_ROUTE_STREAM_MIRROR_BASE_BACKFILL_MS = 2000;
 
 // Warn if a track stays invalid (no decodable media) this long after the first packet, which blocks stream prepare
 static constexpr int64_t MEDIA_ROUTE_STREAM_TRACK_PREPARE_TIMEOUT_MS = 3000;
@@ -49,11 +51,10 @@ public:
 	void Push(const std::shared_ptr<MediaPacket> &media_packet);
 	std::shared_ptr<MediaPacket> PopAndNormalize();
 	
-	// Return mirror buffer reference
 	struct MirrorBufferItem
 	{
-		MirrorBufferItem(std::shared_ptr<MediaPacket> &packet)
-			: packet(packet)
+		MirrorBufferItem(std::shared_ptr<MediaPacket> &packet, int64_t dts_us)
+			: dts_us(dts_us), packet(packet)
 		{
 			created_time = std::chrono::steady_clock::now();
 		}
@@ -68,15 +69,29 @@ public:
 
 		// timepoint created
 		std::chrono::time_point<std::chrono::steady_clock> created_time;
+
+		// DTS converted to microseconds; monotonic per track and comparable
+		// across tracks of the stream
+		int64_t dts_us = 0;
+
 		std::shared_ptr<MediaPacket> packet;
 	};
-	std::vector<std::shared_ptr<MirrorBufferItem>> GetMirrorBuffer();
 
-	// Selects the past-data range to inject into a new tap: each video track starts
-	// at its most recent keyframe, non-video tracks follow the earliest video start.
-	// Falls back to the full buffer when there is no video track. If max_count > 0,
-	// keeps only the newest max_count items with video tracks still keyframe-led.
-	static std::vector<std::shared_ptr<MirrorBufferItem>> SelectPastData(const std::vector<std::shared_ptr<MirrorBufferItem>> &mirror_buffer, size_t max_count = 0);
+	// Per-track mirror buffers, each in arrival order
+	using MirrorBufferMap = std::map<MediaTrackId, std::vector<std::shared_ptr<MirrorBufferItem>>>;
+
+	MirrorBufferMap GetMirrorBuffers();
+
+	// Applies the retention policy when a packet enters its track's mirror buffer.
+	// A video track holds only its current GOP: a keyframe restarts the buffer and
+	// a GOP longer than the retention window is discarded whole, so a video track
+	// is always keyframe-led or empty. Non-video keeps a sliding content window
+	static void RetainMirrorBuffer(MirrorBufferMap &mirror_buffers, std::shared_ptr<MediaPacket> &media_packet, int64_t dts_us);
+
+	// Builds the past-data backfill for a new tap: fresh video tracks are included
+	// whole from their leading keyframe, and non-video is cut at the earliest
+	// included keyframe's DTS so the backfill starts aligned
+	static std::vector<std::shared_ptr<MirrorBufferItem>> BuildPastData(const MirrorBufferMap &mirror_buffers);
 
 	// Query original stream information
 	std::shared_ptr<info::Stream> GetStream();
@@ -157,6 +172,6 @@ private:
 	// Packets queue
 	ov::ManagedQueue<std::shared_ptr<MediaPacket>> _packets_queue;
 
-	// Mirror buffer
-	std::vector<std::shared_ptr<MirrorBufferItem>> _mirror_buffer;
+	// Mirror buffers, one per track
+	MirrorBufferMap _mirror_buffers;
 };

--- a/src/mediarouter/mediarouter_stream.h
+++ b/src/mediarouter/mediarouter_stream.h
@@ -26,6 +26,10 @@
 
 static constexpr int64_t MEDIA_ROUTE_STREAM_MAX_MIRROR_BUFFER_SIZE_MS = 2000; // Maximum size of mirror buffer
 
+// Headroom subtracted from a tap's queue warning threshold when capping past-data
+// backfill, covering live packets that arrive while the backfill is being pushed
+static constexpr size_t MEDIA_ROUTE_STREAM_TAP_BACKFILL_HEADROOM = 30;
+
 // Warn if a track stays invalid (no decodable media) this long after the first packet, which blocks stream prepare
 static constexpr int64_t MEDIA_ROUTE_STREAM_TRACK_PREPARE_TIMEOUT_MS = 3000;
 
@@ -67,6 +71,12 @@ public:
 		std::shared_ptr<MediaPacket> packet;
 	};
 	std::vector<std::shared_ptr<MirrorBufferItem>> GetMirrorBuffer();
+
+	// Selects the past-data range to inject into a new tap: each video track starts
+	// at its most recent keyframe, non-video tracks follow the earliest video start.
+	// Falls back to the full buffer when there is no video track. If max_count > 0,
+	// keeps only the newest max_count items with video tracks still keyframe-led.
+	static std::vector<std::shared_ptr<MirrorBufferItem>> SelectPastData(const std::vector<std::shared_ptr<MirrorBufferItem>> &mirror_buffer, size_t max_count = 0);
 
 	// Query original stream information
 	std::shared_ptr<info::Stream> GetStream();

--- a/src/mediarouter/mediarouter_stream_tap.cpp
+++ b/src/mediarouter/mediarouter_stream_tap.cpp
@@ -66,7 +66,6 @@ void MediaRouterStreamTap::Stop()
     _buffer.Clear();
     _backfill_buffer.Stop();
     _backfill_buffer.Clear();
-    _backfill_sent = true;
 }
 
 std::shared_ptr<MediaPacket> MediaRouterStreamTap::Pop(int timeout_in_msec)
@@ -76,16 +75,12 @@ std::shared_ptr<MediaPacket> MediaRouterStreamTap::Pop(int timeout_in_msec)
         return nullptr;
     }
 
-    // Backfill first; it is always older than any live packet
-    if (_backfill_sent == false)
+    // Backfill first; it is always older than any live packet, and live packets
+    // only start arriving after the whole backfill has been enqueued
+    auto backfill = _backfill_buffer.Dequeue(0);
+    if (backfill.has_value())
     {
-        auto backfill = _backfill_buffer.Dequeue(0);
-        if (backfill.has_value())
-        {
-            return backfill.value();
-        }
-
-        _backfill_sent = true;
+        return backfill.value();
     }
 
     auto object = _buffer.Dequeue(timeout_in_msec);
@@ -119,13 +114,7 @@ bool MediaRouterStreamTap::Push(const std::shared_ptr<MediaPacket> &media_packet
 
 bool MediaRouterStreamTap::PushBackfill(const std::shared_ptr<MediaPacket> &media_packet)
 {
-    if (PushTo(_backfill_buffer, media_packet) == false)
-    {
-        return false;
-    }
-
-    _backfill_sent = false;
-    return true;
+    return PushTo(_backfill_buffer, media_packet);
 }
 
 bool MediaRouterStreamTap::PushTo(ov::Queue<std::shared_ptr<MediaPacket>> &buffer, const std::shared_ptr<MediaPacket> &media_packet)

--- a/src/mediarouter/mediarouter_stream_tap.cpp
+++ b/src/mediarouter/mediarouter_stream_tap.cpp
@@ -15,7 +15,8 @@ std::shared_ptr<MediaRouterStreamTap> MediaRouterStreamTap::Create(size_t thresh
 }
 
 MediaRouterStreamTap::MediaRouterStreamTap(size_t threshold)
-    : _buffer("MediaRouterStreamTap", threshold), _threshold(threshold)
+    : _buffer("MediaRouterStreamTap", threshold),
+      _backfill_buffer("MediaRouterStreamTapBackfill", 0)
 {
     _id = IssueUniqueId();
 }
@@ -55,6 +56,7 @@ void MediaRouterStreamTap::Start()
 {
     _is_started = true;
 	_buffer.Start();
+    _backfill_buffer.Start();
 }
 
 void MediaRouterStreamTap::Stop()
@@ -62,13 +64,28 @@ void MediaRouterStreamTap::Stop()
     _is_started = false;
 	_buffer.Stop();
     _buffer.Clear();
+    _backfill_buffer.Stop();
+    _backfill_buffer.Clear();
+    _backfill_sent = true;
 }
 
 std::shared_ptr<MediaPacket> MediaRouterStreamTap::Pop(int timeout_in_msec)
 {
-    if (_state != State::Tapped && _buffer.IsEmpty())
+    if (_state != State::Tapped && _buffer.IsEmpty() && _backfill_buffer.IsEmpty())
     {
         return nullptr;
+    }
+
+    // Backfill first; it is always older than any live packet
+    if (_backfill_sent == false)
+    {
+        auto backfill = _backfill_buffer.Dequeue(0);
+        if (backfill.has_value())
+        {
+            return backfill.value();
+        }
+
+        _backfill_sent = true;
     }
 
     auto object = _buffer.Dequeue(timeout_in_msec);
@@ -97,6 +114,22 @@ void MediaRouterStreamTap::Destroy()
 
 bool MediaRouterStreamTap::Push(const std::shared_ptr<MediaPacket> &media_packet)
 {
+    return PushTo(_buffer, media_packet);
+}
+
+bool MediaRouterStreamTap::PushBackfill(const std::shared_ptr<MediaPacket> &media_packet)
+{
+    if (PushTo(_backfill_buffer, media_packet) == false)
+    {
+        return false;
+    }
+
+    _backfill_sent = false;
+    return true;
+}
+
+bool MediaRouterStreamTap::PushTo(ov::Queue<std::shared_ptr<MediaPacket>> &buffer, const std::shared_ptr<MediaPacket> &media_packet)
+{
     if (_state != State::Tapped)
     {
         return false;
@@ -113,7 +146,7 @@ bool MediaRouterStreamTap::Push(const std::shared_ptr<MediaPacket> &media_packet
 		return true;
 	}
 
-    _buffer.Enqueue(media_packet->ClonePacket());
+    buffer.Enqueue(media_packet->ClonePacket());
 
     return true;
 }

--- a/src/mediarouter/mediarouter_stream_tap.cpp
+++ b/src/mediarouter/mediarouter_stream_tap.cpp
@@ -9,13 +9,13 @@
 
 #include "mediarouter_stream_tap.h"
 
-std::shared_ptr<MediaRouterStreamTap> MediaRouterStreamTap::Create(size_t buffer_size)
+std::shared_ptr<MediaRouterStreamTap> MediaRouterStreamTap::Create(size_t threshold)
 {
-    return std::make_shared<MediaRouterStreamTap>(buffer_size);
+    return std::make_shared<MediaRouterStreamTap>(threshold);
 }
 
-MediaRouterStreamTap::MediaRouterStreamTap(size_t buffer_size)
-    : _buffer("MediaRouterStreamTap", buffer_size)
+MediaRouterStreamTap::MediaRouterStreamTap(size_t threshold)
+    : _buffer("MediaRouterStreamTap", threshold), _threshold(threshold)
 {
     _id = IssueUniqueId();
 }

--- a/src/mediarouter/mediarouter_stream_tap.h
+++ b/src/mediarouter/mediarouter_stream_tap.h
@@ -19,9 +19,10 @@ class MediaRouterStreamTap
 {
 friend class MediaRouteApplication;
 public:
-    static std::shared_ptr<MediaRouterStreamTap> Create(size_t buffer_size = 300);
+    // The threshold only triggers a queue-size warning log; the buffer is unbounded
+    static std::shared_ptr<MediaRouterStreamTap> Create(size_t threshold = 300);
 
-    MediaRouterStreamTap(size_t buffer_size);
+    MediaRouterStreamTap(size_t threshold);
     ~MediaRouterStreamTap();
 
     enum class State : int8_t
@@ -46,6 +47,11 @@ public:
     // If the stream is not Tapped and the buffer is empty, nullptr will be returned immediately without waiting.
     std::shared_ptr<MediaPacket> Pop(int timeout_in_msec = 0);
 
+    size_t GetThreshold() const
+    {
+        return _threshold;
+    }
+
     // return stream info reference
     std::shared_ptr<info::Stream> GetStreamInfo() const;
 
@@ -60,13 +66,14 @@ private:
 
     std::shared_ptr<info::Stream> _tapped_stream_info;
     ov::Queue<std::shared_ptr<MediaPacket>> _buffer;
+    size_t _threshold = 0;
     std::atomic<State> _state = State::Idle;
 
     std::atomic<bool> _is_destroy_requested = false;
 
     std::atomic<bool> _is_started = false;
 
-	bool _need_past_data = false;
+	std::atomic<bool> _need_past_data = false;
 
     uint32_t _id = 0;
 };

--- a/src/mediarouter/mediarouter_stream_tap.h
+++ b/src/mediarouter/mediarouter_stream_tap.h
@@ -70,10 +70,6 @@ private:
     std::shared_ptr<info::Stream> _tapped_stream_info;
     ov::Queue<std::shared_ptr<MediaPacket>> _buffer;
     ov::Queue<std::shared_ptr<MediaPacket>> _backfill_buffer;
-
-    // True once the backfill buffer has run dry (or nothing was ever backfilled),
-    // so the steady-state Pop() skips the backfill buffer without locking it
-    std::atomic<bool> _backfill_sent = true;
     std::atomic<State> _state = State::Idle;
 
     std::atomic<bool> _is_destroy_requested = false;

--- a/src/mediarouter/mediarouter_stream_tap.h
+++ b/src/mediarouter/mediarouter_stream_tap.h
@@ -44,13 +44,9 @@ public:
 	bool DoesNeedPastData() const;
 
     // If the stream is Tapped, MediaPacket will be popped from the buffer.
-    // If the stream is not Tapped and the buffer is empty, nullptr will be returned immediately without waiting.
+    // If the stream is not Tapped and the buffers are empty, nullptr will be returned immediately without waiting.
+    // The backfill buffer is drained before the live buffer; backfill is always older than any live packet.
     std::shared_ptr<MediaPacket> Pop(int timeout_in_msec = 0);
-
-    size_t GetThreshold() const
-    {
-        return _threshold;
-    }
 
     // return stream info reference
     std::shared_ptr<info::Stream> GetStreamInfo() const;
@@ -59,6 +55,13 @@ public:
 
 private:
     bool Push(const std::shared_ptr<MediaPacket> &media_packet);
+
+    // Backfill (past data) is buffered apart from the live buffer, so its one-shot
+    // burst cannot trip the live buffer's congestion warning
+    bool PushBackfill(const std::shared_ptr<MediaPacket> &media_packet);
+
+    bool PushTo(ov::Queue<std::shared_ptr<MediaPacket>> &buffer, const std::shared_ptr<MediaPacket> &media_packet);
+
     void SetStreamInfo(const std::shared_ptr<info::Stream> &stream_info);
     void SetState(State state);
 
@@ -66,7 +69,11 @@ private:
 
     std::shared_ptr<info::Stream> _tapped_stream_info;
     ov::Queue<std::shared_ptr<MediaPacket>> _buffer;
-    size_t _threshold = 0;
+    ov::Queue<std::shared_ptr<MediaPacket>> _backfill_buffer;
+
+    // True once the backfill buffer has run dry (or nothing was ever backfilled),
+    // so the steady-state Pop() skips the backfill buffer without locking it
+    std::atomic<bool> _backfill_sent = true;
     std::atomic<State> _state = State::Idle;
 
     std::atomic<bool> _is_destroy_requested = false;

--- a/src/mediarouter/mediarouter_stream_test.cpp
+++ b/src/mediarouter/mediarouter_stream_test.cpp
@@ -1,0 +1,184 @@
+//==============================================================================
+//
+//  OvenMediaEngine - Unit Tests
+//
+//  Covers: MediaRouteStream::SelectPastData - past-data range selection for
+//  new stream taps (mirror buffer backfill)
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include "mediarouter_stream.h"
+
+namespace
+{
+	std::shared_ptr<MediaRouteStream::MirrorBufferItem> MakeItem(cmn::MediaType media_type, uint32_t track_id, bool keyframe)
+	{
+		auto packet = std::make_shared<MediaPacket>(media_type, track_id, nullptr, 0, 0, 0,
+													keyframe ? MediaPacketFlag::Key : MediaPacketFlag::NoFlag,
+													cmn::BitstreamFormat::Unknown, cmn::PacketType::Unknown);
+		return std::make_shared<MediaRouteStream::MirrorBufferItem>(packet);
+	}
+}  // namespace
+
+TEST(MediaRouterSelectPastData, VideoStartsAtMostRecentKeyframe)
+{
+	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
+		MakeItem(cmn::MediaType::Video, 1, true),
+		MakeItem(cmn::MediaType::Video, 1, false),
+		MakeItem(cmn::MediaType::Video, 1, false),
+		MakeItem(cmn::MediaType::Video, 1, true),
+		MakeItem(cmn::MediaType::Video, 1, false),
+		MakeItem(cmn::MediaType::Video, 1, false),
+	};
+
+	auto selected = MediaRouteStream::SelectPastData(buffer);
+
+	ASSERT_EQ(selected.size(), 3u);
+	EXPECT_EQ(selected[0], buffer[3]);
+	EXPECT_EQ(selected[1], buffer[4]);
+	EXPECT_EQ(selected[2], buffer[5]);
+}
+
+TEST(MediaRouterSelectPastData, NonVideoFollowsEarliestVideoStart)
+{
+	// Video track 1 keyframes at 1 and 6, video track 2 keyframe at 4, audio track 3 interleaved.
+	// Expected: track 1 from 6, track 2 from 4, audio from min(6, 4) = 4.
+	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
+		MakeItem(cmn::MediaType::Audio, 3, false),	// 0: dropped
+		MakeItem(cmn::MediaType::Video, 1, true),	// 1: dropped (older keyframe)
+		MakeItem(cmn::MediaType::Video, 2, false),	// 2: dropped
+		MakeItem(cmn::MediaType::Audio, 3, false),	// 3: dropped
+		MakeItem(cmn::MediaType::Video, 2, true),	// 4: kept
+		MakeItem(cmn::MediaType::Audio, 3, false),	// 5: kept
+		MakeItem(cmn::MediaType::Video, 1, true),	// 6: kept
+		MakeItem(cmn::MediaType::Video, 2, false),	// 7: kept
+		MakeItem(cmn::MediaType::Audio, 3, false),	// 8: kept
+	};
+
+	auto selected = MediaRouteStream::SelectPastData(buffer);
+
+	ASSERT_EQ(selected.size(), 5u);
+	EXPECT_EQ(selected[0], buffer[4]);
+	EXPECT_EQ(selected[1], buffer[5]);
+	EXPECT_EQ(selected[2], buffer[6]);
+	EXPECT_EQ(selected[3], buffer[7]);
+	EXPECT_EQ(selected[4], buffer[8]);
+}
+
+TEST(MediaRouterSelectPastData, VideoBeforeItsOwnKeyframeIsDroppedAfterCommonStart)
+{
+	// Track 2's packets between the common start and its own keyframe must be dropped
+	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
+		MakeItem(cmn::MediaType::Video, 1, true),	// 0: kept (track 1 start)
+		MakeItem(cmn::MediaType::Video, 2, false),	// 1: dropped (before track 2 keyframe)
+		MakeItem(cmn::MediaType::Video, 2, true),	// 2: kept (track 2 start)
+		MakeItem(cmn::MediaType::Video, 1, false),	// 3: kept
+	};
+
+	auto selected = MediaRouteStream::SelectPastData(buffer);
+
+	ASSERT_EQ(selected.size(), 3u);
+	EXPECT_EQ(selected[0], buffer[0]);
+	EXPECT_EQ(selected[1], buffer[2]);
+	EXPECT_EQ(selected[2], buffer[3]);
+}
+
+TEST(MediaRouterSelectPastData, KeepsFullBufferWhenVideoHasNoKeyframe)
+{
+	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
+		MakeItem(cmn::MediaType::Audio, 3, false),
+		MakeItem(cmn::MediaType::Video, 1, false),
+		MakeItem(cmn::MediaType::Audio, 3, false),
+		MakeItem(cmn::MediaType::Video, 1, false),
+	};
+
+	auto selected = MediaRouteStream::SelectPastData(buffer);
+
+	ASSERT_EQ(selected.size(), buffer.size());
+	for (size_t i = 0; i < buffer.size(); i++)
+	{
+		EXPECT_EQ(selected[i], buffer[i]);
+	}
+}
+
+TEST(MediaRouterSelectPastData, KeepsFullBufferWhenNoVideoTrack)
+{
+	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
+		MakeItem(cmn::MediaType::Audio, 3, false),
+		MakeItem(cmn::MediaType::Audio, 3, false),
+	};
+
+	auto selected = MediaRouteStream::SelectPastData(buffer);
+
+	ASSERT_EQ(selected.size(), buffer.size());
+	EXPECT_EQ(selected[0], buffer[0]);
+	EXPECT_EQ(selected[1], buffer[1]);
+}
+
+TEST(MediaRouterSelectPastData, EmptyBufferReturnsEmpty)
+{
+	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer;
+
+	auto selected = MediaRouteStream::SelectPastData(buffer);
+
+	EXPECT_TRUE(selected.empty());
+}
+
+TEST(MediaRouterSelectPastData, MaxCountKeepsNewestAndVideoStaysKeyframeLed)
+{
+	// Selection is all 7 items (track 1 keyframe at 0, track 2 keyframe at 4);
+	// cap 4 keeps the newest 4, track 2 survives keyframe-led, track 1 whose
+	// keyframe fell before the cap is dropped entirely
+	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
+		MakeItem(cmn::MediaType::Video, 1, true),	// 0: dropped by cap
+		MakeItem(cmn::MediaType::Audio, 3, false),	// 1: dropped by cap
+		MakeItem(cmn::MediaType::Video, 1, false),	// 2: dropped by cap
+		MakeItem(cmn::MediaType::Audio, 3, false),	// 3: kept (audio is independent)
+		MakeItem(cmn::MediaType::Video, 2, true),	// 4: kept (keyframe survives the trim)
+		MakeItem(cmn::MediaType::Video, 2, false),	// 5: kept
+		MakeItem(cmn::MediaType::Audio, 3, false),	// 6: kept
+	};
+
+	auto selected = MediaRouteStream::SelectPastData(buffer, 4);
+
+	ASSERT_EQ(selected.size(), 4u);
+	EXPECT_EQ(selected[0], buffer[3]);
+	EXPECT_EQ(selected[1], buffer[4]);
+	EXPECT_EQ(selected[2], buffer[5]);
+	EXPECT_EQ(selected[3], buffer[6]);
+}
+
+TEST(MediaRouterSelectPastData, MaxCountDropsVideoTrackWithoutKeyframeInWindow)
+{
+	// After the cap trim track 1 has no keyframe left, so only audio survives
+	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
+		MakeItem(cmn::MediaType::Video, 1, true),	// 0: dropped by cap
+		MakeItem(cmn::MediaType::Video, 1, false),	// 1: dropped (no keyframe in window)
+		MakeItem(cmn::MediaType::Audio, 3, false),	// 2: kept
+		MakeItem(cmn::MediaType::Video, 1, false),	// 3: dropped (no keyframe in window)
+		MakeItem(cmn::MediaType::Audio, 3, false),	// 4: kept
+	};
+
+	auto selected = MediaRouteStream::SelectPastData(buffer, 4);
+
+	ASSERT_EQ(selected.size(), 2u);
+	EXPECT_EQ(selected[0], buffer[2]);
+	EXPECT_EQ(selected[1], buffer[4]);
+}
+
+TEST(MediaRouterSelectPastData, MaxCountNotExceededLeavesSelectionUnchanged)
+{
+	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
+		MakeItem(cmn::MediaType::Video, 1, true),
+		MakeItem(cmn::MediaType::Video, 1, false),
+		MakeItem(cmn::MediaType::Audio, 3, false),
+	};
+
+	auto selected = MediaRouteStream::SelectPastData(buffer, 10);
+
+	ASSERT_EQ(selected.size(), 3u);
+	EXPECT_EQ(selected[0], buffer[0]);
+	EXPECT_EQ(selected[1], buffer[1]);
+	EXPECT_EQ(selected[2], buffer[2]);
+}

--- a/src/mediarouter/mediarouter_stream_test.cpp
+++ b/src/mediarouter/mediarouter_stream_test.cpp
@@ -2,8 +2,8 @@
 //
 //  OvenMediaEngine - Unit Tests
 //
-//  Covers: MediaRouteStream::SelectPastData - past-data range selection for
-//  new stream taps (mirror buffer backfill)
+//  Covers: MediaRouteStream mirror buffer policies - RetainMirrorBuffer
+//  (per-track keyframe-led retention) and BuildPastData (tap backfill assembly)
 //
 //==============================================================================
 #include <gtest/gtest.h>
@@ -12,173 +12,174 @@
 
 namespace
 {
-	std::shared_ptr<MediaRouteStream::MirrorBufferItem> MakeItem(cmn::MediaType media_type, uint32_t track_id, bool keyframe)
+	constexpr int64_t kRetentionUs = MEDIA_ROUTE_STREAM_MIRROR_RETENTION_MS * 1000;
+	constexpr int64_t kBaseBackfillUs = MEDIA_ROUTE_STREAM_MIRROR_BASE_BACKFILL_MS * 1000;
+
+	std::shared_ptr<MediaPacket> MakePacket(cmn::MediaType media_type, uint32_t track_id, bool keyframe)
 	{
-		auto packet = std::make_shared<MediaPacket>(media_type, track_id, nullptr, 0, 0, 0,
-													keyframe ? MediaPacketFlag::Key : MediaPacketFlag::NoFlag,
-													cmn::BitstreamFormat::Unknown, cmn::PacketType::Unknown);
-		return std::make_shared<MediaRouteStream::MirrorBufferItem>(packet);
+		return std::make_shared<MediaPacket>(media_type, track_id, nullptr, 0, 0, 0,
+											 keyframe ? MediaPacketFlag::Key : MediaPacketFlag::NoFlag,
+											 cmn::BitstreamFormat::Unknown, cmn::PacketType::Unknown);
+	}
+
+	std::shared_ptr<MediaRouteStream::MirrorBufferItem> MakeItem(cmn::MediaType media_type, uint32_t track_id, bool keyframe, int64_t dts_us = 0, int64_t age_ms = 0)
+	{
+		auto packet = MakePacket(media_type, track_id, keyframe);
+		auto item = std::make_shared<MediaRouteStream::MirrorBufferItem>(packet, dts_us);
+		item->created_time = std::chrono::steady_clock::now() - std::chrono::milliseconds(age_ms);
+		return item;
 	}
 }  // namespace
 
-TEST(MediaRouterSelectPastData, VideoStartsAtMostRecentKeyframe)
+TEST(MediaRouterRetainMirrorBuffer, KeyframeSupersedesTrackGop)
 {
-	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
-		MakeItem(cmn::MediaType::Video, 1, true),
-		MakeItem(cmn::MediaType::Video, 1, false),
-		MakeItem(cmn::MediaType::Video, 1, false),
-		MakeItem(cmn::MediaType::Video, 1, true),
-		MakeItem(cmn::MediaType::Video, 1, false),
-		MakeItem(cmn::MediaType::Video, 1, false),
-	};
+	MediaRouteStream::MirrorBufferMap buffers;
+	buffers[1] = {MakeItem(cmn::MediaType::Video, 1, true), MakeItem(cmn::MediaType::Video, 1, false)};
+	buffers[3] = {MakeItem(cmn::MediaType::Audio, 3, false)};
+	auto audio = buffers[3][0];
 
-	auto selected = MediaRouteStream::SelectPastData(buffer);
+	auto keyframe = MakePacket(cmn::MediaType::Video, 1, true);
+	MediaRouteStream::RetainMirrorBuffer(buffers, keyframe, 0);
 
-	ASSERT_EQ(selected.size(), 3u);
-	EXPECT_EQ(selected[0], buffer[3]);
-	EXPECT_EQ(selected[1], buffer[4]);
-	EXPECT_EQ(selected[2], buffer[5]);
+	// Track 1 holds only the new keyframe; the audio track is untouched
+	ASSERT_EQ(buffers[1].size(), 1u);
+	EXPECT_EQ(buffers[1][0]->packet, keyframe);
+	ASSERT_EQ(buffers[3].size(), 1u);
+	EXPECT_EQ(buffers[3][0], audio);
 }
 
-TEST(MediaRouterSelectPastData, NonVideoFollowsEarliestVideoStart)
+TEST(MediaRouterRetainMirrorBuffer, VideoStaysEmptyUntilKeyframe)
 {
-	// Video track 1 keyframes at 1 and 6, video track 2 keyframe at 4, audio track 3 interleaved.
-	// Expected: track 1 from 6, track 2 from 4, audio from min(6, 4) = 4.
-	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
-		MakeItem(cmn::MediaType::Audio, 3, false),	// 0: dropped
-		MakeItem(cmn::MediaType::Video, 1, true),	// 1: dropped (older keyframe)
-		MakeItem(cmn::MediaType::Video, 2, false),	// 2: dropped
-		MakeItem(cmn::MediaType::Audio, 3, false),	// 3: dropped
-		MakeItem(cmn::MediaType::Video, 2, true),	// 4: kept
-		MakeItem(cmn::MediaType::Audio, 3, false),	// 5: kept
-		MakeItem(cmn::MediaType::Video, 1, true),	// 6: kept
-		MakeItem(cmn::MediaType::Video, 2, false),	// 7: kept
-		MakeItem(cmn::MediaType::Audio, 3, false),	// 8: kept
-	};
+	MediaRouteStream::MirrorBufferMap buffers;
 
-	auto selected = MediaRouteStream::SelectPastData(buffer);
+	auto non_key = MakePacket(cmn::MediaType::Video, 1, false);
+	MediaRouteStream::RetainMirrorBuffer(buffers, non_key, 0);
 
-	ASSERT_EQ(selected.size(), 5u);
-	EXPECT_EQ(selected[0], buffer[4]);
-	EXPECT_EQ(selected[1], buffer[5]);
-	EXPECT_EQ(selected[2], buffer[6]);
-	EXPECT_EQ(selected[3], buffer[7]);
-	EXPECT_EQ(selected[4], buffer[8]);
+	EXPECT_TRUE(buffers[1].empty());
+
+	auto keyframe = MakePacket(cmn::MediaType::Video, 1, true);
+	MediaRouteStream::RetainMirrorBuffer(buffers, keyframe, 0);
+
+	ASSERT_EQ(buffers[1].size(), 1u);
+	EXPECT_EQ(buffers[1][0]->packet, keyframe);
 }
 
-TEST(MediaRouterSelectPastData, VideoBeforeItsOwnKeyframeIsDroppedAfterCommonStart)
+TEST(MediaRouterRetainMirrorBuffer, OverlongGopDiscardedWhole)
 {
-	// Track 2's packets between the common start and its own keyframe must be dropped
-	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
-		MakeItem(cmn::MediaType::Video, 1, true),	// 0: kept (track 1 start)
-		MakeItem(cmn::MediaType::Video, 2, false),	// 1: dropped (before track 2 keyframe)
-		MakeItem(cmn::MediaType::Video, 2, true),	// 2: kept (track 2 start)
-		MakeItem(cmn::MediaType::Video, 1, false),	// 3: kept
+	// The GOP has grown past the retention window in media time, so the arriving
+	// non-key packet discards the whole GOP and the track waits for a keyframe
+	MediaRouteStream::MirrorBufferMap buffers;
+	buffers[1] = {
+		MakeItem(cmn::MediaType::Video, 1, true, 0),
+		MakeItem(cmn::MediaType::Video, 1, false, 33000),
 	};
 
-	auto selected = MediaRouteStream::SelectPastData(buffer);
+	auto non_key = MakePacket(cmn::MediaType::Video, 1, false);
+	MediaRouteStream::RetainMirrorBuffer(buffers, non_key, kRetentionUs + 1000);
 
-	ASSERT_EQ(selected.size(), 3u);
-	EXPECT_EQ(selected[0], buffer[0]);
-	EXPECT_EQ(selected[1], buffer[2]);
-	EXPECT_EQ(selected[2], buffer[3]);
+	EXPECT_TRUE(buffers[1].empty());
 }
 
-TEST(MediaRouterSelectPastData, KeepsFullBufferWhenVideoHasNoKeyframe)
+TEST(MediaRouterRetainMirrorBuffer, NonVideoKeepsRetentionWindowOfContent)
 {
-	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
-		MakeItem(cmn::MediaType::Audio, 3, false),
-		MakeItem(cmn::MediaType::Video, 1, false),
-		MakeItem(cmn::MediaType::Audio, 3, false),
-		MakeItem(cmn::MediaType::Video, 1, false),
+	MediaRouteStream::MirrorBufferMap buffers;
+	buffers[3] = {
+		MakeItem(cmn::MediaType::Audio, 3, false, 0),	  // falls out of the window
+		MakeItem(cmn::MediaType::Audio, 3, false, 2000000),
+	};
+	auto recent = buffers[3][1];
+
+	auto packet = MakePacket(cmn::MediaType::Audio, 3, false);
+	MediaRouteStream::RetainMirrorBuffer(buffers, packet, kRetentionUs + 1000000);
+
+	ASSERT_EQ(buffers[3].size(), 2u);
+	EXPECT_EQ(buffers[3][0], recent);
+	EXPECT_EQ(buffers[3][1]->packet, packet);
+}
+
+TEST(MediaRouterBuildPastData, NonVideoCutAtEarliestKeyframeDts)
+{
+	MediaRouteStream::MirrorBufferMap buffers;
+	buffers[1] = {
+		MakeItem(cmn::MediaType::Video, 1, true, 5000000),
+		MakeItem(cmn::MediaType::Video, 1, false, 5033000),
+	};
+	buffers[3] = {
+		MakeItem(cmn::MediaType::Audio, 3, false, 4900000),	 // before the keyframe DTS: cut
+		MakeItem(cmn::MediaType::Audio, 3, false, 5100000),
+		MakeItem(cmn::MediaType::Audio, 3, false, 9000000),
 	};
 
-	auto selected = MediaRouteStream::SelectPastData(buffer);
+	auto past_data = MediaRouteStream::BuildPastData(buffers);
 
-	ASSERT_EQ(selected.size(), buffer.size());
-	for (size_t i = 0; i < buffer.size(); i++)
-	{
-		EXPECT_EQ(selected[i], buffer[i]);
-	}
+	ASSERT_EQ(past_data.size(), 4u);
+	EXPECT_EQ(past_data[0], buffers[1][0]);
+	EXPECT_EQ(past_data[1], buffers[1][1]);
+	EXPECT_EQ(past_data[2], buffers[3][1]);
+	EXPECT_EQ(past_data[3], buffers[3][2]);
 }
 
-TEST(MediaRouterSelectPastData, KeepsFullBufferWhenNoVideoTrack)
+TEST(MediaRouterBuildPastData, NonVideoBaseWindowWithoutVideo)
 {
-	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
-		MakeItem(cmn::MediaType::Audio, 3, false),
-		MakeItem(cmn::MediaType::Audio, 3, false),
+	// Without video the track keeps only the last base window of content,
+	// anchored at its newest DTS
+	MediaRouteStream::MirrorBufferMap buffers;
+	buffers[3] = {
+		MakeItem(cmn::MediaType::Audio, 3, false, 5000000 - kBaseBackfillUs - 1000),  // outside the window: cut
+		MakeItem(cmn::MediaType::Audio, 3, false, 5000000 - kBaseBackfillUs + 1000),
+		MakeItem(cmn::MediaType::Audio, 3, false, 5000000),
 	};
 
-	auto selected = MediaRouteStream::SelectPastData(buffer);
+	auto past_data = MediaRouteStream::BuildPastData(buffers);
 
-	ASSERT_EQ(selected.size(), buffer.size());
-	EXPECT_EQ(selected[0], buffer[0]);
-	EXPECT_EQ(selected[1], buffer[1]);
+	ASSERT_EQ(past_data.size(), 2u);
+	EXPECT_EQ(past_data[0], buffers[3][1]);
+	EXPECT_EQ(past_data[1], buffers[3][2]);
 }
 
-TEST(MediaRouterSelectPastData, EmptyBufferReturnsEmpty)
+TEST(MediaRouterBuildPastData, StaleVideoTrackSkipped)
 {
-	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer;
+	// A stalled track still holding an old GOP contributes no past data; the
+	// audio then falls back to its own base window
+	MediaRouteStream::MirrorBufferMap buffers;
+	buffers[1] = {
+		MakeItem(cmn::MediaType::Video, 1, true, 0, MEDIA_ROUTE_STREAM_MIRROR_RETENTION_MS + 1000),
+		MakeItem(cmn::MediaType::Video, 1, false, 33000, MEDIA_ROUTE_STREAM_MIRROR_RETENTION_MS + 500),
+	};
+	buffers[3] = {MakeItem(cmn::MediaType::Audio, 3, false, 1500000)};
 
-	auto selected = MediaRouteStream::SelectPastData(buffer);
+	auto past_data = MediaRouteStream::BuildPastData(buffers);
 
-	EXPECT_TRUE(selected.empty());
+	ASSERT_EQ(past_data.size(), 1u);
+	EXPECT_EQ(past_data[0], buffers[3][0]);
 }
 
-TEST(MediaRouterSelectPastData, MaxCountKeepsNewestAndVideoStaysKeyframeLed)
+TEST(MediaRouterBuildPastData, InterleavesTracksByDts)
 {
-	// Selection is all 7 items (track 1 keyframe at 0, track 2 keyframe at 4);
-	// cap 4 keeps the newest 4, track 2 survives keyframe-led, track 1 whose
-	// keyframe fell before the cap is dropped entirely
-	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
-		MakeItem(cmn::MediaType::Video, 1, true),	// 0: dropped by cap
-		MakeItem(cmn::MediaType::Audio, 3, false),	// 1: dropped by cap
-		MakeItem(cmn::MediaType::Video, 1, false),	// 2: dropped by cap
-		MakeItem(cmn::MediaType::Audio, 3, false),	// 3: kept (audio is independent)
-		MakeItem(cmn::MediaType::Video, 2, true),	// 4: kept (keyframe survives the trim)
-		MakeItem(cmn::MediaType::Video, 2, false),	// 5: kept
-		MakeItem(cmn::MediaType::Audio, 3, false),	// 6: kept
+	MediaRouteStream::MirrorBufferMap buffers;
+	buffers[1] = {
+		MakeItem(cmn::MediaType::Video, 1, true, 1000000),
+		MakeItem(cmn::MediaType::Video, 1, false, 1066000),
+	};
+	buffers[3] = {
+		MakeItem(cmn::MediaType::Audio, 3, false, 1030000),
+		MakeItem(cmn::MediaType::Audio, 3, false, 1090000),
 	};
 
-	auto selected = MediaRouteStream::SelectPastData(buffer, 4);
+	auto past_data = MediaRouteStream::BuildPastData(buffers);
 
-	ASSERT_EQ(selected.size(), 4u);
-	EXPECT_EQ(selected[0], buffer[3]);
-	EXPECT_EQ(selected[1], buffer[4]);
-	EXPECT_EQ(selected[2], buffer[5]);
-	EXPECT_EQ(selected[3], buffer[6]);
+	ASSERT_EQ(past_data.size(), 4u);
+	EXPECT_EQ(past_data[0], buffers[1][0]);	 // video 1000000
+	EXPECT_EQ(past_data[1], buffers[3][0]);	 // audio 1030000
+	EXPECT_EQ(past_data[2], buffers[1][1]);	 // video 1066000
+	EXPECT_EQ(past_data[3], buffers[3][1]);	 // audio 1090000
 }
 
-TEST(MediaRouterSelectPastData, MaxCountDropsVideoTrackWithoutKeyframeInWindow)
+TEST(MediaRouterBuildPastData, EmptyBuffersReturnEmpty)
 {
-	// After the cap trim track 1 has no keyframe left, so only audio survives
-	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
-		MakeItem(cmn::MediaType::Video, 1, true),	// 0: dropped by cap
-		MakeItem(cmn::MediaType::Video, 1, false),	// 1: dropped (no keyframe in window)
-		MakeItem(cmn::MediaType::Audio, 3, false),	// 2: kept
-		MakeItem(cmn::MediaType::Video, 1, false),	// 3: dropped (no keyframe in window)
-		MakeItem(cmn::MediaType::Audio, 3, false),	// 4: kept
-	};
+	MediaRouteStream::MirrorBufferMap buffers;
 
-	auto selected = MediaRouteStream::SelectPastData(buffer, 4);
+	auto past_data = MediaRouteStream::BuildPastData(buffers);
 
-	ASSERT_EQ(selected.size(), 2u);
-	EXPECT_EQ(selected[0], buffer[2]);
-	EXPECT_EQ(selected[1], buffer[4]);
-}
-
-TEST(MediaRouterSelectPastData, MaxCountNotExceededLeavesSelectionUnchanged)
-{
-	std::vector<std::shared_ptr<MediaRouteStream::MirrorBufferItem>> buffer{
-		MakeItem(cmn::MediaType::Video, 1, true),
-		MakeItem(cmn::MediaType::Video, 1, false),
-		MakeItem(cmn::MediaType::Audio, 3, false),
-	};
-
-	auto selected = MediaRouteStream::SelectPastData(buffer, 10);
-
-	ASSERT_EQ(selected.size(), 3u);
-	EXPECT_EQ(selected[0], buffer[0]);
-	EXPECT_EQ(selected[1], buffer[1]);
-	EXPECT_EQ(selected[2], buffer[2]);
+	EXPECT_TRUE(past_data.empty());
 }

--- a/src/providers/multiplex/multiplex_stream.cpp
+++ b/src/providers/multiplex/multiplex_stream.cpp
@@ -12,6 +12,10 @@
 
 #include <base/provider/application.h>
 
+// Maximum packets drained from one source tap per round, so one bursty source
+// cannot monopolize the worker loop
+static constexpr int MULTIPLEX_MAX_DRAIN_PER_SOURCE = 128;
+
 namespace pvd
 {
     // Implementation of MultiplexStream
@@ -117,12 +121,15 @@ namespace pvd
             break;
         }
 
+        // The source list is fixed for the stream's lifetime; a profile change recreates the stream
+        const auto &source_streams = _multiplex_profile->GetSourceStreams();
+
         while (_worker_thread_running.load())
         {
             _mux_state = MuxState::Playing;
             bool break_loop = false;
-            // Get Streams and Push
-            auto source_streams = _multiplex_profile->GetSourceStreams();
+            bool any_packet_popped = false;
+
             for (auto &source_stream : source_streams)
             {
                 auto stream_tap = source_stream->GetStreamTap();
@@ -134,39 +141,56 @@ namespace pvd
                     break;
                 }
 
-                auto media_packet = stream_tap->Pop(100);
-                if (media_packet == nullptr)
+                // Drain without waiting so an empty source cannot throttle the other sources
+                for (int drain_count = 0; drain_count < MULTIPLEX_MAX_DRAIN_PER_SOURCE; drain_count++)
                 {
-                    continue;
+                    auto media_packet = stream_tap->Pop(0);
+                    if (media_packet == nullptr)
+                    {
+                        break;
+                    }
+
+                    any_packet_popped = true;
+
+                    if (IsPublished() == false)
+                    {
+                        if (Publish() == false)
+                        {
+                            break_loop = true;
+                            break;
+                        }
+                    }
+
+                    auto source_track_id = MakeSourceTrackIdUnique(stream_tap->GetId(), media_packet->GetTrackId());
+                    auto new_track_id = GetNewTrackId(source_track_id);
+                    if (new_track_id == 0)
+                    {
+                        continue;
+                    }
+
+                    // The stamp of the source stream does not describe this stream's
+                    // track; SendFrame() attaches this stream's own hint instead
+                    media_packet->SetTrack(nullptr);
+                    media_packet->SetTrackId(new_track_id);
+
+                    SendFrame(media_packet);
                 }
 
-				if (IsPublished() == false)
-				{
-					if (Publish() == false)
-					{
-						break_loop = true;
-						break;
-					}
-				}
-
-                auto source_track_id = MakeSourceTrackIdUnique(stream_tap->GetId(), media_packet->GetTrackId());
-                auto new_track_id = GetNewTrackId(source_track_id);
-                if (new_track_id == 0)
+                if (break_loop)
                 {
-                    continue;
+                    break;
                 }
-
-                // The stamp of the source stream does not describe this stream's
-                // track; SendFrame() attaches this stream's own hint instead
-                media_packet->SetTrack(nullptr);
-                media_packet->SetTrackId(new_track_id);
-
-                SendFrame(media_packet);
             }
 
             if (break_loop)
             {
                 break;
+            }
+
+            if (any_packet_popped == false)
+            {
+                // Every tap was empty in this round
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
         }
 

--- a/src/providers/multiplex/multiplex_stream.cpp
+++ b/src/providers/multiplex/multiplex_stream.cpp
@@ -16,6 +16,11 @@
 // cannot monopolize the worker loop
 static constexpr int MULTIPLEX_MAX_DRAIN_PER_SOURCE = 128;
 
+// Idle sleep bounds for the worker loop; the sleep backs off on consecutive
+// empty rounds so an idle channel does not burn wakeups
+static constexpr int MULTIPLEX_IDLE_SLEEP_MIN_MS = 1;
+static constexpr int MULTIPLEX_IDLE_SLEEP_MAX_MS = 10;
+
 namespace pvd
 {
     // Implementation of MultiplexStream
@@ -124,6 +129,8 @@ namespace pvd
         // The source list is fixed for the stream's lifetime; a profile change recreates the stream
         const auto &source_streams = _multiplex_profile->GetSourceStreams();
 
+        int idle_sleep_ms = MULTIPLEX_IDLE_SLEEP_MIN_MS;
+
         while (_worker_thread_running.load())
         {
             _mux_state = MuxState::Playing;
@@ -190,7 +197,17 @@ namespace pvd
             if (any_packet_popped == false)
             {
                 // Every tap was empty in this round
-                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                std::this_thread::sleep_for(std::chrono::milliseconds(idle_sleep_ms));
+
+                idle_sleep_ms *= 2;
+                if (idle_sleep_ms > MULTIPLEX_IDLE_SLEEP_MAX_MS)
+                {
+                    idle_sleep_ms = MULTIPLEX_IDLE_SLEEP_MAX_MS;
+                }
+            }
+            else
+            {
+                idle_sleep_ms = MULTIPLEX_IDLE_SLEEP_MIN_MS;
             }
         }
 


### PR DESCRIPTION
**Problem**

When a Multiplex channel taps an already running source, the whole 2 second mirror buffer is injected into the tap queue at once, which immediately triggers the MediaRouterStreamTap threshold warning on multi-track sources. Independently, the channel worker pops one packet per source per round and blocks up to 100ms on an empty tap, so when sources have different packet rates the faster tap queues grow without bound, continuously increasing latency and memory.

**Solution**

The worker now drains each tap in bounded batches without blocking and backs off its idle sleep, so one source can no longer throttle the others. The mirror buffer retains per track in media time: a video track holds only its current GOP from its latest keyframe, so the backfill always starts decodable; non-video is cut at the earliest included keyframe DTS and the result is interleaved by DTS. The backfill is delivered through a separate tap buffer, so its one-shot burst cannot trip the live queue's congestion warning, which now purely means the consumer is falling behind. The tap's need-past-data flag is now atomic, and the misleading buffer_size parameter is renamed to threshold.

**Test**

*Unit tests*

```bash
cmake -B build/Debug -S . -DOME_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -G Ninja
cmake --build build/Debug
ctest --test-dir build/Debug -L mediarouter
```

Pass condition: all mediarouter tests pass (9 mirror buffer cases cover keyframe-led retention, DTS-aligned cuts, interleaving, and stale-track handling).

*Environment setup*

Application `mux`: enable the Multiplex provider with `<MuxFilesDir>mux_files</MuxFilesDir>`, enable the LLHLS publisher, and use an OutputProfile with only `bypass_video` (`<Bypass>true</Bypass>`) and `bypass_audio` (`<Bypass>true</Bypass>`) encodes.

`mux_files/muxed.mux` (the file name must match the OutputStream Name) combines 3 sources into one output stream:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Multiplex>
    <OutputStream>
        <Name>muxed</Name>
        <BypassTranscoder>true</BypassTranscoder>
    </OutputStream>
    <SourceStreams>
        <SourceStream>
            <Name>input1</Name>
            <Url>stream://default/mux/input1</Url>
            <TrackMap>
                <Track>
                    <SourceTrackName>bypass_video</SourceTrackName>
                    <NewTrackName>input1_video</NewTrackName>
                </Track>
                <Track>
                    <SourceTrackName>bypass_audio</SourceTrackName>
                    <NewTrackName>input1_audio</NewTrackName>
                </Track>
            </TrackMap>
        </SourceStream>
        <SourceStream>
            <Name>input2</Name>
            <Url>stream://default/mux/input2</Url>
            <TrackMap>
                <Track>
                    <SourceTrackName>bypass_video</SourceTrackName>
                    <NewTrackName>input2_video</NewTrackName>
                </Track>
                <Track>
                    <SourceTrackName>bypass_audio</SourceTrackName>
                    <NewTrackName>input2_audio</NewTrackName>
                </Track>
            </TrackMap>
        </SourceStream>
        <SourceStream>
            <Name>input3</Name>
            <Url>stream://default/mux/input3</Url>
            <TrackMap>
                <Track>
                    <SourceTrackName>bypass_video</SourceTrackName>
                    <NewTrackName>input3_video</NewTrackName>
                </Track>
                <Track>
                    <SourceTrackName>bypass_audio</SourceTrackName>
                    <NewTrackName>input3_audio</NewTrackName>
                </Track>
            </TrackMap>
        </SourceStream>
    </SourceStreams>
    <Playlists>
        <Playlist>
            <Name>Mux ABR</Name>
            <FileName>abr</FileName>
            <Rendition>
                <Name>input1</Name>
                <Video>input1_video</Video>
                <Audio>input1_audio</Audio>
            </Rendition>
            <Rendition>
                <Name>input2</Name>
                <Video>input2_video</Video>
                <Audio>input2_audio</Audio>
            </Rendition>
            <Rendition>
                <Name>input3</Name>
                <Video>input3_video</Video>
                <Audio>input3_audio</Audio>
            </Rendition>
        </Playlist>
    </Playlists>
</Multiplex>
```

Feed 3 sources with different frame rates (different rates are required to reproduce the unbounded growth):

```bash
ffmpeg -re -f lavfi -i testsrc2=size=640x360:rate=30 -f lavfi -i "sine=frequency=440:sample_rate=48000" -c:v libx264 -preset veryfast -tune zerolatency -g 60 -b:v 800k -pix_fmt yuv420p -c:a aac -b:a 128k -ar 48000 -ac 2 -f flv rtmp://localhost:1935/mux/input1 -loglevel error &
ffmpeg -re -f lavfi -i testsrc2=size=640x360:rate=15 -f lavfi -i "sine=frequency=880:sample_rate=48000" -c:v libx264 -preset veryfast -tune zerolatency -g 30 -b:v 500k -pix_fmt yuv420p -c:a aac -b:a 128k -ar 48000 -ac 2 -f flv rtmp://localhost:1935/mux/input2 -loglevel error &
ffmpeg -re -f lavfi -i testsrc2=size=640x360:rate=24 -f lavfi -i "sine=frequency=1760:sample_rate=48000" -c:v libx264 -preset veryfast -tune zerolatency -g 48 -b:v 600k -pix_fmt yuv420p -c:a aac -b:a 128k -ar 48000 -ac 2 -f flv rtmp://localhost:1935/mux/input3 -loglevel error &
```

*Scenarios and pass conditions*

1. Channel start: start OME, then the 3 inputs. Pass: the `muxed` stream starts with 6 tracks and `grep -c "MediaRouterStreamTap size has exceeded" ovenmediaengine.log` stays 0.
2. Re-tap: run `touch mux_files/muxed.mux` 10 times with 10 or more seconds between touches (each touch recreates the channel and re-injects past data). Pass: warning count still 0.
3. Sustained run: keep all 3 inputs running 30 minutes or more. Pass: warning count 0 and OME memory stable. Before this fix the faster tap queues grow without bound in this scenario and the warning repeats every 5 seconds with a rising queue value.
4. Source loss and recovery: kill the input2 ffmpeg. The channel logs the untapped source and terminates, then waits for input2. Restart input2. Pass: the channel restarts automatically, warning count still 0.
5. Playback: open `http(s)://<host>:<llhls-port>/mux/muxed/abr.m3u8`. Pass: 3 renditions (30/15/24 fps) are listed and play; `ffprobe` on the URL shows 3 video and 3 audio streams.

Addresses: OvenMediaLabs/OvenMediaEngineEnterprise#125
