### PR TITLE
fix(api): emit track timebase and align the stream info spec with the actual response

### DIFF
--- a/api/ome.yml
+++ b/api/ome.yml
@@ -86,7 +86,7 @@ components:
       type: object
       required: [schema,urls]
       properties:
-        schme:
+        schema:
           type: string
         urls:
           $ref: '#/components/schemas/Urls'
@@ -255,27 +255,36 @@ components:
           type: string
         input:
           type: object
-          required: [sourceType,tracks]
+          required: [createdTime,sourceType,tracks]
           properties:
             createdTime:
               type: string
               format: date-time
             sourceType:
               type: string
+              description: Provider that ingested this stream.
+              enum: [WebRTC,Ovt,Rtmp,RtmpPull,Rtsp,RtspPull,Transcoder,SRT,MPEGTS,Scheduled,Multiplex,File,Unknown]
             sourceUrl:
               type: string
+              description: Source address of the input stream. Omitted when the provider has no source address.
             tracks:
               $ref: '#/components/schemas/Tracks'
         outputs:
-          type: object
-          required: [name,tracks]
-          properties:
-            name:
-              type: string
-            tracks:
-              $ref: '#/components/schemas/Tracks'
-            playlists:
-              $ref: '#/components/schemas/Playlists'
+          type: array
+          description: For a source or transcoded stream, the output streams created by the output profiles, or an empty array until one exists. For a relay stream with no child output stream, the relay stream itself as the single entry.
+          items:
+            type: object
+            required: [name,tracks,playlists]
+            properties:
+              name:
+                type: string
+              tracks:
+                $ref: '#/components/schemas/Tracks'
+              playlists:
+                type: array
+                description: Playlists of this output stream. Empty when the output stream has no playlist.
+                items:
+                  $ref: '#/components/schemas/StreamPlaylist'
     StreamPush:
       type: object
       required: [stream,protocol,url]
@@ -639,6 +648,8 @@ components:
           type: boolean
     Timebase:
       type: object
+      required: [num,den]
+      description: Timebase of the track. The owning object omits this field when the track has no valid timebase.
       properties:
         num:
           type: integer
@@ -648,103 +659,324 @@ components:
           format: int32
     AudioTrack:
       type: object
+      required: [id,name,type,audio]
       properties:
         id:
           type: integer
-          format: uint32
+          format: int32
         name:
           type: string
+          description: Variant name of the track. Falls back to the media type name, such as Video or Audio, when no variant name is set.
         type:
           type: string
+          enum: [Audio]
         audio:
           type: object
+          required: [bypass,codec,samplerate,channel,bitrate,bitrateConf]
           properties:
+            bypass:
+              type: boolean
             codec:
               type: string
+              description: Codec of the track, such as AAC, MP3 or OPUS.
+            codecModule:
+              type: string
+              description: Codec module in use, such as default, fdkaac or libopus. Present only when bypass is false.
+            codecStatus:
+              type: string
+              enum: [Ready,Failed]
+              description: State of the codec. A bypass track always reports Ready. Other tracks omit this field until a codec reports its state.
+            language:
+              type: string
+              description: Omitted when the track has no language.
+            characteristics:
+              type: string
+              description: Omitted when the track has no characteristics.
             samplerate:
               type: integer
               format: int32
             channel:
               type: integer
               format: int32
+              description: Number of audio channels.
             bitrate:
-              type: string
+              type: integer
+              format: int32
+              description: Bitrate in bps. The configured bitrate when it is set, otherwise the measured average bitrate.
             bitrateConf:
-              type: string
+              type: integer
+              format: int32
+              description: Configured bitrate in bps. The output profile setting for an encoded track, or the value declared by the source for an input track. 0 when it is not configured.
             bitrateAvg:
-              type: string
+              type: integer
+              format: int32
+              description: Measured average bitrate in bps. Omitted when the track has no measurement.
             bitrateLatest:
+              type: integer
+              format: int32
+              description: Measured bitrate of the last second in bps. Omitted when the track has no measurement.
+            configChangeCount:
+              type: integer
+              format: int32
+              description: Number of runtime configuration changes of the track. Omitted when the track has no measurement.
+            lastConfigChanged:
               type: string
+              format: date-time
+              description: Time of the last configuration change. Present only when configChangeCount is greater than 0.
             timebase:
               $ref: '#/components/schemas/Timebase'
     VideoTrack:
       type: object
+      required: [id,name,type,video]
       properties:
         id:
           type: integer
-          format: uint32
+          format: int32
         name:
           type: string
+          description: Variant name of the track. Falls back to the media type name, such as Video or Audio, when no variant name is set.
         type:
           type: string
+          enum: [Video]
         video:
           type: object
+          required: [bypass,codec,width,maxWidth,height,maxHeight,bitrate,bitrateConf,framerate,framerateConf,maxFramerate,keyFrameInterval,keyFrameIntervalConf]
           properties:
             bypass:
               type: boolean
             codec:
               type: string
+              description: Codec of the track, such as H264, H265, VP8, VP9 or AV1.
+            codecModule:
+              type: string
+              description: Codec module in use, such as default, x264, openh264 or nv. Present only when bypass is false.
+            codecStatus:
+              type: string
+              enum: [Ready,Failed]
+              description: State of the codec. A bypass track always reports Ready. Other tracks omit this field until a codec reports its state.
+            language:
+              type: string
+              description: Omitted when the track has no language.
+            characteristics:
+              type: string
+              description: Omitted when the track has no characteristics.
             width:
               type: integer
               format: int32
             height:
               type: integer
               format: int32
+            maxWidth:
+              type: integer
+              format: int32
+              description: Highest width seen on this track. This value never decreases.
+            maxHeight:
+              type: integer
+              format: int32
+              description: Highest height seen on this track. This value never decreases.
             bitrate:
-              type: string
+              type: integer
+              format: int32
+              description: Bitrate in bps. The configured bitrate when it is set, otherwise the measured average bitrate.
             bitrateConf:
-              type: string
+              type: integer
+              format: int32
+              description: Configured bitrate in bps. The output profile setting for an encoded track, or the value declared by the source for an input track. 0 when it is not configured.
             bitrateAvg:
-              type: string
+              type: integer
+              format: int32
+              description: Measured average bitrate in bps. Omitted when the track has no measurement.
             bitrateLatest:
-              type: string
+              type: integer
+              format: int32
+              description: Measured bitrate of the last second in bps. Omitted when the track has no measurement.
             framerate:
               type: number
               format: float
+              description: The configured framerate when it is set, otherwise the measured average framerate.
             framerateConf:
               type: number
               format: float
+              description: Configured framerate. The output profile setting for an encoded track, or the value declared by the source for an input track. 0 when it is not configured.
             framerateAvg:
               type: number
               format: float
+              description: Measured average framerate. Omitted when the track has no measurement.
             framerateLatest:
               type: number
               format: float
-            timebase:
-              $ref: '#/components/schemas/Timebase'
+              description: Measured framerate of the last second. Omitted when the track has no measurement.
+            maxFramerate:
+              type: number
+              format: float
+              description: Highest framerate seen on this track. This value never decreases.
             hasBframes:
               type: boolean
+              description: Whether B frames were detected. Omitted when the track has no measurement.
             keyFrameInterval:
               type: number
               format: float
+              description: GOP size in frames. The configured value when it is set, otherwise the measured average.
             keyFrameIntervalConf:
               type: number
               format: float
+              description: Key frame interval configured by the output profile. 0 when it is not configured.
             keyFrameIntervalAvg:
               type: number
               format: float
+              description: Measured average key frame interval. Omitted when the track has no measurement.
             keyFrameIntervalLatest:
               type: number
               format: float
+              description: Most recently measured key frame interval. Omitted when the track has no measurement.
             deltaFramesSinceLastKeyFrame:
               type: integer
               format: int32
+              description: Number of delta frames after the last key frame. Omitted when the track has no measurement.
+            configChangeCount:
+              type: integer
+              format: int32
+              description: Number of runtime configuration changes of the track. Omitted when the track has no measurement.
+            lastConfigChanged:
+              type: string
+              format: date-time
+              description: Time of the last configuration change. Present only when configChangeCount is greater than 0.
+            timebase:
+              $ref: '#/components/schemas/Timebase'
+    DataTrack:
+      type: object
+      required: [id,name,type,data]
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          description: Variant name of the track. Falls back to the media type name, such as Video or Audio, when no variant name is set.
+        type:
+          type: string
+          enum: [Data]
+        data:
+          type: object
+          required: [codec]
+          properties:
+            codec:
+              type: string
+    SubtitleTrack:
+      type: object
+      required: [id,name,type,subtitle]
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          description: Variant name of the track. Falls back to the media type name, such as Video or Audio, when no variant name is set.
+        type:
+          type: string
+          enum: [Subtitle]
+        subtitle:
+          type: object
+          required: [codec,autoSelect,default,forced]
+          properties:
+            codec:
+              type: string
+              description: Codec of the track, such as WebVTT or WHISPER.
+            codecStatus:
+              type: string
+              enum: [Ready,Failed]
+              description: State of the codec. A bypass track always reports Ready. Other tracks omit this field until a codec reports its state.
+            language:
+              type: string
+              description: Omitted when the track has no language.
+            characteristics:
+              type: string
+              description: Omitted when the track has no characteristics.
+            autoSelect:
+              type: boolean
+            default:
+              type: boolean
+            forced:
+              type: boolean
+            timebase:
+              $ref: '#/components/schemas/Timebase'
+            stt:
+              type: object
+              description: Speech to text metadata. Present only when codec is WHISPER.
+              required: [translation]
+              properties:
+                engine:
+                  type: string
+                model:
+                  type: string
+                sourceLanguage:
+                  type: string
+                translation:
+                  type: boolean
+                outputLabel:
+                  type: string
+    OtherTrack:
+      type: object
+      description: Track kind that carries no media payload object. Rarely produced.
+      required: [id,name,type]
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          description: Variant name of the track. Falls back to the media type name, such as Video or Audio, when no variant name is set.
+        type:
+          type: string
+          enum: [Attachment,Unknown]
     Tracks:
       type: array
       items:
         anyOf:
           - $ref: '#/components/schemas/AudioTrack'
           - $ref: '#/components/schemas/VideoTrack'
+          - $ref: '#/components/schemas/DataTrack'
+          - $ref: '#/components/schemas/SubtitleTrack'
+          - $ref: '#/components/schemas/OtherTrack'
+    StreamRendition:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Omitted when the rendition has no name.
+        videoVariantName:
+          type: string
+          description: Omitted when the rendition has no video variant.
+        audioVariantName:
+          type: string
+          description: Omitted when the rendition has no audio variant.
+    StreamPlaylistOptions:
+      type: object
+      required: [webrtcAutoAbr,hlsChunklistPathDepth,enableTsPackaging]
+      properties:
+        webrtcAutoAbr:
+          type: boolean
+        hlsChunklistPathDepth:
+          type: integer
+          format: int32
+        enableTsPackaging:
+          type: boolean
+    StreamPlaylist:
+      type: object
+      required: [options,renditions]
+      properties:
+        name:
+          type: string
+          description: Omitted when the playlist has no name.
+        fileName:
+          type: string
+          description: Omitted when the playlist has no file name.
+        options:
+          $ref: '#/components/schemas/StreamPlaylistOptions'
+        renditions:
+          type: array
+          items:
+            $ref: '#/components/schemas/StreamRendition'
     Rendition:
       type: object
       required: [name]
@@ -833,7 +1065,7 @@ components:
           $ref: '#/components/schemas/AudioTemplate'
     Playlist:
       type: object
-      required: [name,filename]
+      required: [name,fileName]
       properties:
         name:
           type: string
@@ -1715,7 +1947,8 @@ paths:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/HttpStatus'
-                  - properties:
+                  - required: [response]
+                    properties:
                       response:
                         $ref: '#/components/schemas/Stream'
         '401':

--- a/api/ome.yml
+++ b/api/ome.yml
@@ -84,9 +84,9 @@ components:
             type: string
     Pass:
       type: object
-      required: [schema,urls]
+      required: [scheme,urls]
       properties:
-        schema:
+        scheme:
           type: string
         urls:
           $ref: '#/components/schemas/Urls'

--- a/docs/rest-api/v1/virtualhost/application/stream/README.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/README.md
@@ -315,70 +315,150 @@ Content-Type: application/json
 	"statusCode": 200,
 	"message": "OK",
 	"response": {
+		"name": "stream",
 		"input": {
-			"createdTime": "2021-01-11T03:45:21.879+09:00",
+			"createdTime": "2026-07-29T15:04:21.879+09:00",
 			"sourceType": "Rtmp",
+			"sourceUrl": "tcp://192.168.0.200:41008",
 			"tracks": [
-			{
-				"id": 0,
-				"type": "Video",
-				"video": {
-					"bitrate": "2500000",
-					"bypass": false,
-					"codec": "H264",
-					"framerate": 30.0,
-					"hasBframes": false,
-					"keyFrameInterval": 30,
-					"height": 720,
-					"width": 1280
-				}
-			},
-			{
-				"id": 1,				
-				"audio": {
-					"bitrate": "128000",
-					"bypass": false,
-					"channel": 2,
-					"codec": "AAC",
-					"samplerate": 48000
+				{
+					"id": 0,
+					"name": "Video",
+					"type": "Video",
+					"video": {
+						"bypass": false,
+						"codec": "H264",
+						"codecModule": "none",
+						"width": 1280,
+						"height": 720,
+						"maxWidth": 1280,
+						"maxHeight": 720,
+						"bitrate": 2500000,
+						"bitrateConf": 2500000,
+						"bitrateAvg": 2493184,
+						"bitrateLatest": 2501120,
+						"framerate": 30.0,
+						"framerateConf": 30.0,
+						"framerateAvg": 30.0,
+						"framerateLatest": 30.0,
+						"maxFramerate": 30.0,
+						"hasBframes": false,
+						"keyFrameInterval": 30.0,
+						"keyFrameIntervalConf": 0.0,
+						"keyFrameIntervalAvg": 30.0,
+						"keyFrameIntervalLatest": 30.0,
+						"deltaFramesSinceLastKeyFrame": 12,
+						"configChangeCount": 0,
+						"timebase": {
+							"num": 1,
+							"den": 1000
+						}
+					}
 				},
-				"type": "Audio"
-			}
+				{
+					"id": 1,
+					"name": "Audio",
+					"type": "Audio",
+					"audio": {
+						"bypass": false,
+						"codec": "AAC",
+						"codecModule": "default",
+						"samplerate": 48000,
+						"channel": 2,
+						"bitrate": 128000,
+						"bitrateConf": 128000,
+						"bitrateAvg": 127488,
+						"bitrateLatest": 128512,
+						"configChangeCount": 0,
+						"timebase": {
+							"num": 1,
+							"den": 1000
+						}
+					}
+				}
 			]
 		},
-		"name": "stream",
 		"outputs": [
-		{
-			"name": "stream",
-			"tracks": [
 			{
-				"id": 0,
-				"type": "Video",
-				"video": {
-					"bypass": true
-				}
-			},
-			{
-				"id": 1,					
-				"audio": {
-					"bypass": true
-				},
-				"type": "Audio"
-			},
-			{
-				"id": 2,					
-				"audio": {
-					"bitrate": "128000",
-					"bypass": false,
-					"channel": 2,
-					"codec": "OPUS",
-					"samplerate": 48000
-				},
-				"type": "Audio"
+				"name": "stream",
+				"tracks": [
+					{
+						"id": 0,
+						"name": "bypass_video",
+						"type": "Video",
+						"video": {
+							"bypass": true,
+							"codec": "H264",
+							"codecStatus": "Ready",
+							"width": 1280,
+							"height": 720,
+							"maxWidth": 1280,
+							"maxHeight": 720,
+							"bitrate": 2493184,
+							"bitrateConf": 0,
+							"bitrateAvg": 2493184,
+							"bitrateLatest": 2501120,
+							"framerate": 30.0,
+							"framerateConf": 0.0,
+							"framerateAvg": 30.0,
+							"framerateLatest": 30.0,
+							"maxFramerate": 30.0,
+							"hasBframes": false,
+							"keyFrameInterval": 30.0,
+							"keyFrameIntervalConf": 0.0,
+							"keyFrameIntervalAvg": 30.0,
+							"keyFrameIntervalLatest": 30.0,
+							"deltaFramesSinceLastKeyFrame": 7,
+							"configChangeCount": 0,
+							"timebase": {
+								"num": 1,
+								"den": 1000
+							}
+						}
+					},
+					{
+						"id": 1,
+						"name": "opus_audio",
+						"type": "Audio",
+						"audio": {
+							"bypass": false,
+							"codec": "OPUS",
+							"codecModule": "libopus",
+							"codecStatus": "Ready",
+							"samplerate": 48000,
+							"channel": 2,
+							"bitrate": 128000,
+							"bitrateConf": 128000,
+							"bitrateAvg": 127232,
+							"bitrateLatest": 128256,
+							"configChangeCount": 0,
+							"timebase": {
+								"num": 1,
+								"den": 48000
+							}
+						}
+					}
+				],
+				"playlists": [
+					{
+						"name": "llhls_default",
+						"fileName": "llhls",
+						"options": {
+							"webrtcAutoAbr": true,
+							"hlsChunklistPathDepth": -1,
+							"enableTsPackaging": false
+						},
+						"renditions": [
+							{
+								"name": "bypass_video_opus_audio",
+								"videoVariantName": "bypass_video",
+								"audioVariantName": "opus_audio"
+							}
+						]
+					}
+				]
 			}
-			]
-		}
-	]
+		]
 	}
 }
 
@@ -396,6 +476,15 @@ Content-Type: application/json
 keyFrameInterval is GOP size
 ```
 
+Notes on the track fields
+
+- `bitrate`, `framerate` and `keyFrameInterval` report the configured value when one is set, and the measured value otherwise. That configured value comes from the output profile on an encoded track, and from what the source declared on an input track. The `*Conf` fields report the configured value only, so they are 0 when nothing is configured. `keyFrameIntervalConf` is set by the output profile alone, so it stays 0 on an input track.
+- The `*Avg` and `*Latest` fields, `hasBframes`, `deltaFramesSinceLastKeyFrame` and `configChangeCount` come from the runtime measurement of the track. They are omitted for a track that has no measurement.
+- `lastConfigChanged` appears only when `configChangeCount` is greater than 0.
+- `maxWidth`, `maxHeight` and `maxFramerate` are high water marks of the track. They never decrease while the stream lives.
+- `codecModule` is the codec module in use, such as `default`, `x264`, `libopus` or `none`. It is omitted for a bypass track because no codec is involved.
+- `codecStatus` is always `Ready` on a bypass track, because such a track has no codec to initialize. On other tracks it appears once the codec reports `Ready` or `Failed`.
+- Values of the `framerate` and `keyFrameInterval` families are serialized from single precision floats, so a value such as 29.97 can be rendered as `29.969999313354492`. Round them on the client side instead of comparing them for equality.
 
 </details>
 
@@ -426,7 +515,7 @@ WWW-Authenticate: Basic realm=”OvenMediaEngine”
 
 <summary><span class="http-method http-method-404">404</span> Not Found</summary>
 
-The given vhost name or app name could not be found.
+The given virtual host, application or stream could not be found.
 
 **Header**
 
@@ -439,9 +528,11 @@ Content-Type: application/json
 ```json
 {
     "statusCode": 404,
-    "message": "Could not find the application or stream (404)"
+    "message": "[HTTP] Could not find the stream: [default/app/stream] (404)"
 }
 ```
+
+The message names the object that could not be found, so it differs per case. The virtual host case reads `[HTTP] Could not find the virtual host: [default] (404)`, and the application case reads `[HTTP] Could not find the application: [default/app] (404)`.
 
 </details>
 
@@ -458,10 +549,40 @@ info:
   version: 1.0.0
   description: API for stream information
 
+servers:
+  - url: http://{server}:{port}/v1
+    variables:
+      server:
+        default: localhost
+      port:
+        default: '8081'
+
+security:
+  - basicAuth: []
+
 paths:
-  /stream:
+  /vhosts/{vhost}/apps/{app}/streams/{stream}:
     get:
       summary: Get stream information
+      parameters:
+        - name: vhost
+          in: path
+          required: true
+          description: The name of the virtual host.
+          schema:
+            type: string
+        - name: app
+          in: path
+          required: true
+          description: The name of the application.
+          schema:
+            type: string
+        - name: stream
+          in: path
+          required: true
+          description: The name of the stream.
+          schema:
+            type: string
       responses:
         '200':
           description: Successful response
@@ -483,6 +604,11 @@ paths:
                 $ref: '#/components/schemas/Error404'
 
 components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+
   schemas:
     SuccessResponse:
       type: object
@@ -500,6 +626,7 @@ components:
           required:
             - name
             - input
+            - outputs
           properties:
             name:
               type: string
@@ -507,6 +634,10 @@ components:
               $ref: '#/components/schemas/Input'
             outputs:
               type: array
+              description: >-
+                For a source or transcoded stream, the output streams created by the output profiles,
+                or an empty array until one exists. For a relay stream with no child output stream,
+                the relay stream itself as the single entry.
               items:
                 $ref: '#/components/schemas/Output'
     Error401:
@@ -533,13 +664,18 @@ components:
           enum: [404]
         message:
           type: string
-          enum: ["Could not find the application or stream (404)"]
+          description: >-
+            Names the object that could not be found, so the text differs per case.
+            For example "[HTTP] Could not find the virtual host: [default] (404)",
+            "[HTTP] Could not find the application: [default/app] (404)" or
+            "[HTTP] Could not find the stream: [default/app/stream] (404)".
           
           
     VideoTrack:
       type: object
       required:
         - id
+        - name
         - type
         - video
       properties:
@@ -547,54 +683,97 @@ components:
           type: integer
         name:
           type: string
+          description: Variant name of the track. Falls back to the media type name, such as Video or Audio, when no variant name is set.
         type:
           type: string
           enum:
             - Video
         video:
           type: object
+          required:
+            - bypass
+            - codec
+            - width
+            - height
+            - maxWidth
+            - maxHeight
+            - bitrate
+            - bitrateConf
+            - framerate
+            - framerateConf
+            - maxFramerate
+            - keyFrameInterval
+            - keyFrameIntervalConf
           properties:
-            bitrate:
-              type: string
-            bitrateAvg:
-              type: string
-            bitrateConf:
-              type: string
-            bitrateLatest:
-              type: string
             bypass:
               type: boolean
             codec:
               type: string
-            deltaFramesSinceLastKeyFrame:
+            codecModule:
+              type: string
+              description: Present only when bypass is false.
+            codecStatus:
+              type: string
+              description: A bypass track always reports Ready. Other tracks omit this field until a codec reports its state.
+              enum:
+                - Ready
+                - Failed
+            language:
+              type: string
+            characteristics:
+              type: string
+            width:
+              type: integer
+            height:
+              type: integer
+            maxWidth:
+              type: integer
+            maxHeight:
+              type: integer
+            bitrate:
+              type: integer
+            bitrateConf:
+              type: integer
+            bitrateAvg:
+              type: integer
+            bitrateLatest:
               type: integer
             framerate:
               type: number
-            framerateAvg:
-              type: number
             framerateConf:
               type: number
+            framerateAvg:
+              type: number
             framerateLatest:
+              type: number
+            maxFramerate:
               type: number
             hasBframes:
               type: boolean
             keyFrameInterval:
-              type: integer
-            keyFrameIntervalAvg:
               type: number
             keyFrameIntervalConf:
               type: number
+            keyFrameIntervalAvg:
+              type: number
             keyFrameIntervalLatest:
+              type: number
+            deltaFramesSinceLastKeyFrame:
               type: integer
-            height:
+            configChangeCount:
               type: integer
-            width:
-              type: integer
-              
+            lastConfigChanged:
+              type: string
+              format: date-time
+              description: Present only when configChangeCount is greater than 0.
+            timebase:
+              $ref: '#/components/schemas/Timebase'
+
     AudioTrack:
       type: object
       required:
         - id
+        - name
         - type
         - audio
       properties:
@@ -602,112 +781,256 @@ components:
           type: integer
         name:
           type: string
+          description: Variant name of the track. Falls back to the media type name, such as Video or Audio, when no variant name is set.
         type:
           type: string
           enum:
             - Audio
         audio:
           type: object
+          required:
+            - bypass
+            - codec
+            - samplerate
+            - channel
+            - bitrate
+            - bitrateConf
           properties:
-            bitrate:
-              type: string
-            bitrateAvg:
-              type: string
-            bitrateConf:
-              type: string
-            bitrateLatest:
-              type: string
             bypass:
               type: boolean
-            channel:
-              type: integer
             codec:
+              type: string
+            codecModule:
+              type: string
+              description: Present only when bypass is false.
+            codecStatus:
+              type: string
+              description: A bypass track always reports Ready. Other tracks omit this field until a codec reports its state.
+              enum:
+                - Ready
+                - Failed
+            language:
+              type: string
+            characteristics:
               type: string
             samplerate:
               type: integer
-              
+            channel:
+              type: integer
+            bitrate:
+              type: integer
+            bitrateConf:
+              type: integer
+            bitrateAvg:
+              type: integer
+            bitrateLatest:
+              type: integer
+            configChangeCount:
+              type: integer
+            lastConfigChanged:
+              type: string
+              format: date-time
+              description: Present only when configChangeCount is greater than 0.
+            timebase:
+              $ref: '#/components/schemas/Timebase'
+
     DataTrack:
       type: object
       required:
         - id
+        - name
+        - type
+        - data
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+          description: Variant name of the track. Falls back to the media type name, such as Video or Audio, when no variant name is set.
+        type:
+          type: string
+          enum:
+            - Data
+        data:
+          type: object
+          required:
+            - codec
+          properties:
+            codec:
+              type: string
+
+    SubtitleTrack:
+      type: object
+      required:
+        - id
+        - name
+        - type
+        - subtitle
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+          description: Variant name of the track. Falls back to the media type name, such as Video or Audio, when no variant name is set.
+        type:
+          type: string
+          enum:
+            - Subtitle
+        subtitle:
+          type: object
+          required:
+            - codec
+            - autoSelect
+            - default
+            - forced
+          properties:
+            codec:
+              type: string
+            codecStatus:
+              type: string
+              description: A bypass track always reports Ready. Other tracks omit this field until a codec reports its state.
+              enum:
+                - Ready
+                - Failed
+            language:
+              type: string
+            characteristics:
+              type: string
+            autoSelect:
+              type: boolean
+            default:
+              type: boolean
+            forced:
+              type: boolean
+            timebase:
+              $ref: '#/components/schemas/Timebase'
+            stt:
+              type: object
+              description: Speech to text metadata. Present only when codec is WHISPER.
+              required:
+                - translation
+              properties:
+                engine:
+                  type: string
+                model:
+                  type: string
+                sourceLanguage:
+                  type: string
+                translation:
+                  type: boolean
+                outputLabel:
+                  type: string
+
+    Timebase:
+      type: object
+      description: Timebase of the track. The owning object omits this field when the track has no valid timebase.
+      required:
+        - num
+        - den
+      properties:
+        num:
+          type: integer
+        den:
+          type: integer
+
+    OtherTrack:
+      type: object
+      description: Track kind that carries no media payload object. Rarely produced.
+      required:
+        - id
+        - name
         - type
       properties:
         id:
           type: integer
         name:
           type: string
+          description: Variant name of the track. Falls back to the media type name, such as Video or Audio, when no variant name is set.
         type:
           type: string
           enum:
-            - Data
-            
+            - Attachment
+            - Unknown
+
     Track:
       oneOf:
         - $ref: '#/components/schemas/VideoTrack'
         - $ref: '#/components/schemas/AudioTrack'
         - $ref: '#/components/schemas/DataTrack'
+        - $ref: '#/components/schemas/SubtitleTrack'
+        - $ref: '#/components/schemas/OtherTrack'
       discriminator:
         propertyName: type
         mapping:
           Video: '#/components/schemas/VideoTrack'
           Audio: '#/components/schemas/AudioTrack'
           Data: '#/components/schemas/DataTrack'
-          
+          Subtitle: '#/components/schemas/SubtitleTrack'
+          Attachment: '#/components/schemas/OtherTrack'
+          Unknown: '#/components/schemas/OtherTrack'
+
     Rendition:
       type: object
-      required:
-        - name
       properties:
         name:
           type: string
+          description: Omitted when the rendition has no name.
         videoVariantName:
           type: string
+          description: Omitted when the rendition has no video variant.
         audioVariantName:
           type: string
-          
+          description: Omitted when the rendition has no audio variant.
+
     Playlist:
       type: object
       required:
-        - name
-        - fileName
         - options
         - renditions
       properties:
         name:
           type: string
+          description: Omitted when the playlist has no name.
         fileName:
           type: string
+          description: Omitted when the playlist has no file name.
         options:
           type: object
+          required:
+            - webrtcAutoAbr
+            - hlsChunklistPathDepth
+            - enableTsPackaging
           properties:
-            enableTsPackaging:
+            webrtcAutoAbr:
               type: boolean
             hlsChunklistPathDepth:
               type: integer
-            webrtcAutoAbr:
+            enableTsPackaging:
               type: boolean
         renditions:
           type: array
           items:
             $ref: '#/components/schemas/Rendition'
-            
+
     Output:
       type: object
       required:
         - name
         - tracks
+        - playlists
       properties:
         name:
           type: string
-        playlists:
-          type: array
-          items:
-            $ref: '#/components/schemas/Playlist'
         tracks:
           type: array
           items:
             $ref: '#/components/schemas/Track'
-            
+        playlists:
+          type: array
+          description: Empty when the output stream has no playlist.
+          items:
+            $ref: '#/components/schemas/Playlist'
+
     Input:
       type: object
       required:
@@ -720,8 +1043,24 @@ components:
           format: date-time
         sourceType:
           type: string
+          description: Provider that ingested this stream.
+          enum:
+            - WebRTC
+            - Ovt
+            - Rtmp
+            - RtmpPull
+            - Rtsp
+            - RtspPull
+            - Transcoder
+            - SRT
+            - MPEGTS
+            - Scheduled
+            - Multiplex
+            - File
+            - Unknown
         sourceUrl:
           type: string
+          description: Omitted when the provider has no source address.
         tracks:
           type: array
           items:
@@ -778,7 +1117,7 @@ Content-Type: application/json
 ```json
 {
 	"statusCode": 200,
-	"message": "OK",
+	"message": "OK"
 }
 
 

--- a/src/modules/json_serdes/stream.cpp
+++ b/src/modules/json_serdes/stream.cpp
@@ -17,7 +17,7 @@ namespace serdes
 
 	static void SetTimebase(Json::Value &parent_object, const char *key, const cmn::Timebase &timebase, Optional optional)
 	{
-		CONVERTER_RETURN_IF(timebase.GetDen() > 0, Json::objectValue);
+		CONVERTER_RETURN_IF(timebase.IsValid() == false, Json::objectValue);
 
 		SetInt(object, "num", timebase.GetNum());
 		SetInt(object, "den", timebase.GetDen());


### PR DESCRIPTION
## Summary

`GET /v1/vhosts/{vhost}/apps/{app}/streams/{stream}` never returned `timebase`, and the published spec had drifted from the serializer in field coverage, JSON types and required lists.
This fixes the inverted guard that suppressed `timebase` and rewrites the stream info schemas in `api/ome.yml` and in the REST API document directly from `serdes` code.

## Motivation

1. `serdes::SetTimebase()` returned early when the timebase was valid (`GetDen() > 0`), so `timebase` reached the response only for a track whose denominator was 0 or less. The field has been documented since the API was introduced and never shipped. The `OV_ASSERT2` inside `CONVERTER_RETURN_IF` receives the stringified condition, so the assertion is always true and never surfaced the mistake.
2. `api/ome.yml` and the document still described the response as it looked before v0.19.0 and v0.20.0: the `bitrate` family as string, a bypass track carrying only `bypass`, and no `maxWidth`, `maxHeight`, `maxFramerate`, `codecModule`, `codecStatus`, `language`, `characteristics`, `configChangeCount` or `lastConfigChanged`. Data tracks, subtitle tracks and playlists were not modelled at all.
3. The gap is customer facing. An integrator reading the spec was promised a field that never arrives (`timebase`) and types that do not match the payload.

## Changes

Code:

- `SetTimebase()` now returns early on `timebase.IsValid() == false`, which requires both numerator and denominator to be positive, matching `cmn::Timebase::IsValid()` and `MediaTrack::IsValidTimeBase()`. A valid track now carries `timebase`, and a degenerate one omits the field instead of emitting `den: 0`.
- The serializer is shared, so the same field also appears in the transcode webhook body, the alert webhook `sourceInfo` and `parentSourceInfo`, the WebRTC playlist signaling message and the local event log. The change is additive for every consumer.

Spec (`api/ome.yml`):

- `Stream.outputs` becomes an array, its relay behavior is described, and `response` is marked required on the 200 response.
- `VideoTrack` and `AudioTrack` rewritten from the serializer: integer bitrate family, `max*` fields, `codecModule`, `codecStatus`, `language`, `characteristics`, `configChangeCount`, `lastConfigChanged`, each with its presence condition.
- New `DataTrack`, `SubtitleTrack` including the Whisper `stt` object, and `OtherTrack` for track kinds that carry no payload object.
- Response only `StreamPlaylist`, `StreamRendition` and `StreamPlaylistOptions`. The configuration schemas cannot be reused because they declare `webRtcAutoAbr` while the response emits `webrtcAutoAbr`.
- `required` lists reduced to keys the serializer always writes, and `sourceType` enumerated with the values `StringFromStreamSourceType()` returns, including `SRT` and `MPEGTS`.

Document:

- 200 OK sample regenerated for a reproducible RTMP scenario, H264 passed through and AAC transcoded to OPUS. Every value is traced to the code that produces it: the 1/1000 ingest timebase of the RTMP provider, the timebase a bypass track copies from its input, codec module ids of the decoder and encoder, `codecStatus` on a bypass track, and configured versus measured bitrate.
- Field notes added for configured versus measured values, presence conditions, high water marks and float serialization.
- The embedded OpenAPI block now uses the real path with its path parameters and basic auth, matches `api/ome.yml`, and its 404 schema no longer pins a message string the server never sends.
- Response bodies are valid JSON again: the field legends moved out of the `json` fences, and one block also had a trailing comma.

## Limitations

- `Tracks` models `Attachment` and `Unknown` through `OtherTrack`, which only carries `id`, `name` and `type`. No in-tree producer emits those media types today; the branch exists for an OVT origin that sends one over the wire.
- The `framerate` and `keyFrameInterval` families are narrowed to single precision before serialization, so `29.97` is rendered as `29.969999313354492`. This is documented rather than changed, since fixing it would alter values that clients already parse.

## Known issues

- `info::Stream::_playlists` is an unguarded `std::map`. Every `GET .../streams/{stream}` adds the publishers' default playlist to the shared monitoring object through `AddPlaylist()`, while `GetPlaylist()`, `GetPlaylists()` and the copy constructor read the same map without a lock, so concurrent requests can race. This is not introduced or touched here: the write on the GET path dates back to `3b3e7cc69` and the unguarded member to `8ea69e851`. **It will be handled as a separate task.**

## Testing

### Guard behavior

The `CONVERTER_RETURN_IF` macro and the `SetTimebase()` body were extracted from the tree and compiled against the in-tree `jsoncpp` with the writer settings `ov::Json::Stringify()` uses, to confirm the before and after behavior:

```plain
before: den=90000 -> {}            den=48000 -> {}      den=0 -> {"timebase":{"den":0,"num":1}}
after : den=90000 -> {"timebase":{"den":90000,"num":1}}  num=0 -> {}
```

### Spec and document

- `api/ome.yml` and the embedded OpenAPI block: YAML parse, `$ref` resolution, and every `required` entry checked against the declared properties.
- 200 OK sample parses as JSON, and each field value was cross-checked against the code path that produces it.
- Markdown structure verified: `details` pairs and code fences balanced, `git diff --check` clean.
