### PR TITLE
fix(transcoder): fix out of memory caused by unbounded frame buffering

### DIFF
--- a/src/transcoder/filter/filter_audio_base.cpp
+++ b/src/transcoder/filter/filter_audio_base.cpp
@@ -20,29 +20,21 @@ FilterResult FilterAudioBase::ProcessFrameInternal(const std::shared_ptr<MediaFr
 		return FilterResult::Error();
 	}
 
-	// Drain every frame produced by this push into the output queue.
-	while (auto completed_frame = ReceiveFrame())
-	{
-		_output_frames.push(std::move(completed_frame));
-	}
-
-	if (GetState() == State::ERROR)
-	{
-		return FilterResult::Error();
-	}
-
 	return FilterResult::NoOutput();
 }
 
 FilterResult FilterAudioBase::PopCompletedFrameInternal()
 {
-	if (_output_frames.empty())
+	if(GetState() == FilterBase::State::ERROR)
+	{
+		return FilterResult::Error();
+	}
+
+	auto completed_frame = ReceiveFrame();
+	if(completed_frame == nullptr)
 	{
 		return FilterResult::NoOutput();
 	}
 
-	auto output_frame = std::move(_output_frames.front());
-	_output_frames.pop();
-
-	return FilterResult::Ready(std::move(output_frame));
+	return FilterResult::Ready(std::move(completed_frame));
 }

--- a/src/transcoder/filter/filter_audio_base.cpp
+++ b/src/transcoder/filter/filter_audio_base.cpp
@@ -15,9 +15,14 @@
 
 FilterResult FilterAudioBase::ProcessFrameInternal(const std::shared_ptr<MediaFrame> &media_frame)
 {
+	if (media_frame == nullptr)
+	{
+		return FilterResult::Error("Received frame is null");
+	}
+
 	if (SendFrame(media_frame) == false)
 	{
-		return FilterResult::Error();
+		logtw("[%s] Dropped a frame that could not be pushed into the backend resampler.", GetLogPrefix().CStr());
 	}
 
 	return FilterResult::NoOutput();
@@ -25,14 +30,21 @@ FilterResult FilterAudioBase::ProcessFrameInternal(const std::shared_ptr<MediaFr
 
 FilterResult FilterAudioBase::PopCompletedFrameInternal()
 {
-	if(GetState() == FilterBase::State::ERROR)
+	if (GetState() == FilterBase::State::ERROR)
 	{
-		return FilterResult::Error();
+		return FilterResult::Error("The filter is in the error state");
 	}
 
 	auto completed_frame = ReceiveFrame();
-	if(completed_frame == nullptr)
+	if (completed_frame == nullptr)
 	{
+		// ReceiveFrame() also returns nullptr when it fails, so the state decides whether
+		// this is an empty pipeline or an error that has to be reported right away.
+		if (GetState() == FilterBase::State::ERROR)
+		{
+			return FilterResult::Error("Failed to receive frame from backend resampler");
+		}
+
 		return FilterResult::NoOutput();
 	}
 

--- a/src/transcoder/filter/filter_base.h
+++ b/src/transcoder/filter/filter_base.h
@@ -235,7 +235,4 @@ protected:
 	bool _use_hwframe_transfer = false;
 
 	int32_t _source_id = 0;
-
-	// Output frames drained from the backend pipeline, served by PopCompletedFrameInternal().
-	std::queue<std::shared_ptr<MediaFrame>> _output_frames;
 };

--- a/src/transcoder/filter/filter_lavfi_rescaler.cpp
+++ b/src/transcoder/filter/filter_lavfi_rescaler.cpp
@@ -223,8 +223,6 @@ bool FilterLavfiRescaler::Initialize()
 	_skip_frames	  = _skip_frames_conf;
 #endif
 
-	_is_first_frame = true;
-
 	SetState(State::STARTED);
 
 	return true;

--- a/src/transcoder/filter/filter_video_base.cpp
+++ b/src/transcoder/filter/filter_video_base.cpp
@@ -95,17 +95,6 @@ FilterResult FilterVideoBase::ProcessFrameInternal(const std::shared_ptr<MediaFr
 			}
 		}
 
-		// Drain every frame produced by this push into the output queue.
-		while (auto completed_frame = ReceiveFrame())
-		{
-			_output_frames.push(std::move(completed_frame));
-		}
-
-		if (GetState() == State::ERROR)
-		{
-			return FilterResult::Error();
-		}
-
 		auto elapsed_time_us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start_time).count();
 
 		// Update the weighted average frame processing time
@@ -122,15 +111,18 @@ FilterResult FilterVideoBase::ProcessFrameInternal(const std::shared_ptr<MediaFr
 
 FilterResult FilterVideoBase::PopCompletedFrameInternal()
 {
-	if (_output_frames.empty())
+	if(GetState() == FilterBase::State::ERROR)
+	{
+		return FilterResult::Error();
+	}
+
+	auto completed_frame = ReceiveFrame();
+	if(completed_frame == nullptr)
 	{
 		return FilterResult::NoOutput();
 	}
 
-	auto output_frame = std::move(_output_frames.front());
-	_output_frames.pop();
-
-	return FilterResult::Ready(std::move(output_frame));
+	return FilterResult::Ready(std::move(completed_frame));
 }
 
 #if _SKIP_FRAMES_ENABLED

--- a/src/transcoder/filter/filter_video_base.cpp
+++ b/src/transcoder/filter/filter_video_base.cpp
@@ -11,7 +11,6 @@
 
 #include <base/ovlibrary/ovlibrary.h>
 
-#include "../transcoder_gpu.h"
 #include "../transcoder_private.h"
 #include "../transcoder_stream_internal.h"
 
@@ -62,67 +61,86 @@ FilterResult FilterVideoBase::ProcessFrameInternal(const std::shared_ptr<MediaFr
 		}
 	}
 
-	if (media_frame != nullptr)
+	if (media_frame == nullptr)
 	{
-		_fps_filter.Push(media_frame);
+		return FilterResult::Error("Received frame is null");
 	}
 
-	static constexpr double kProcessingTimeEmaAlpha = 0.1;
-
-	while (auto frame = _fps_filter.Pop())
+	if (_fps_filter.Push(media_frame) == false)
 	{
-		auto start_time = std::chrono::steady_clock::now();
-
-		if (_is_first_frame && GetOutputTrack()->GetCodecModuleId() == cmn::MediaCodecModuleId::XMA)
-		{
-			// Some hardware (e.g. Xilinx U30) may expand their memory pool while processing the first frame, which is not thread safe.
-			// The first frame is processed under the device mutex to prevent allocation failures.
-			ov::ScopedLock first_frame_lock(TranscodeGPU::GetInstance()->GetDeviceMutex());
- 			_is_first_frame = false;
-			if(SendFrame(frame) == false)
-			{
-				logte("[%s] Failed to push frame into backend pipeline.", GetLogPrefix().CStr());
-				return FilterResult::Error();
-			}				
-
-		}
-		else
-		{
-			if (SendFrame(frame) == false)
-			{
-				logte("[%s] Failed to push frame into backend pipeline.", GetLogPrefix().CStr());
-				return FilterResult::Error();
-			}
-		}
-
-		auto elapsed_time_us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start_time).count();
-
-		// Update the weighted average frame processing time
-		// It includes the time taken for filtering + overlay + delivery to the encoder (including waiting time if there is a load on the encoder).
-		_weighted_avg_frame_processing_time_us = (_weighted_avg_frame_processing_time_us * (1.0 - kProcessingTimeEmaAlpha)) + (elapsed_time_us * kProcessingTimeEmaAlpha);
+		logtw("[%s] Dropped a frame because the FPS filter is full.", GetLogPrefix().CStr());
 	}
-
-#if _SKIP_FRAMES_ENABLED
-	UpdateSkipFrames();
-#endif
 
 	return FilterResult::NoOutput();
 }
 
 FilterResult FilterVideoBase::PopCompletedFrameInternal()
 {
-	if(GetState() == FilterBase::State::ERROR)
+	if (GetState() == FilterBase::State::ERROR)
 	{
-		return FilterResult::Error();
+		_pending_processing_time_us = 0;
+
+		return FilterResult::Error("The filter is in the error state");
 	}
 
-	auto completed_frame = ReceiveFrame();
-	if(completed_frame == nullptr)
-	{
-		return FilterResult::NoOutput();
-	}
+	auto start_time = std::chrono::steady_clock::now();
 
-	return FilterResult::Ready(std::move(completed_frame));
+	while (true)
+	{
+		auto completed_frame = ReceiveFrame();
+		if (completed_frame != nullptr)
+		{
+			UpdateProcessingTimePerFrame(start_time);
+
+			return FilterResult::Ready(std::move(completed_frame));
+		}
+
+		if (GetState() == FilterBase::State::ERROR)
+		{
+			// The measured time belongs to work that will never complete.
+			_pending_processing_time_us = 0;
+
+			return FilterResult::Error("Failed to receive frame from backend rescaler");
+		}
+
+		// Drain FPS filter to get completed frames.
+		auto frame = _fps_filter.Pop();
+		if (frame == nullptr)
+		{
+			// No completed frame available yet. Update pending processing time
+			_pending_processing_time_us += ElapsedTimeInUs(start_time);
+
+#if _SKIP_FRAMES_ENABLED
+			// Update skip frames based on the current processing time and framerate.
+			UpdateSkipFrames();
+#endif
+
+			return FilterResult::NoOutput();
+		}
+
+		if (SendFrame(frame) == false)
+		{
+			// The measured time belongs to work that will never complete.
+			_pending_processing_time_us = 0;
+
+			return FilterResult::Error("Failed to push frame into backend rescaler");
+		}
+	}
+}
+
+int64_t FilterVideoBase::ElapsedTimeInUs(const std::chrono::steady_clock::time_point &start_time) const
+{
+	return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start_time).count();
+}
+
+void FilterVideoBase::UpdateProcessingTimePerFrame(const std::chrono::steady_clock::time_point &start_time)
+{
+	static constexpr double kProcessingTimeEmaAlpha = 0.1;
+
+	auto elapsed_time_us = _pending_processing_time_us + ElapsedTimeInUs(start_time);
+
+	_pending_processing_time_us				= 0;
+	_weighted_avg_frame_processing_time_us	= (_weighted_avg_frame_processing_time_us * (1.0 - kProcessingTimeEmaAlpha)) + (elapsed_time_us * kProcessingTimeEmaAlpha);
 }
 
 #if _SKIP_FRAMES_ENABLED

--- a/src/transcoder/filter/filter_video_base.cpp
+++ b/src/transcoder/filter/filter_video_base.cpp
@@ -100,7 +100,7 @@ FilterResult FilterVideoBase::PopCompletedFrameInternal()
 			// The measured time belongs to work that will never complete.
 			_pending_processing_time_us = 0;
 
-			return FilterResult::Error("Failed to receive frame from backend rescaler");
+			return FilterResult::Error("The backend rescaler has failed");
 		}
 
 		// Drain FPS filter to get completed frames.
@@ -120,10 +120,9 @@ FilterResult FilterVideoBase::PopCompletedFrameInternal()
 
 		if (SendFrame(frame) == false)
 		{
-			// The measured time belongs to work that will never complete.
-			_pending_processing_time_us = 0;
-
-			return FilterResult::Error("Failed to push frame into backend rescaler");
+			// A fatal failure is carried in the filter state and reported by the check at the
+			// top of the next round. Anything else only dropped this frame.
+			logtw("[%s] Dropped a frame that could not be pushed into the backend rescaler.", GetLogPrefix().CStr());
 		}
 	}
 }

--- a/src/transcoder/filter/filter_video_base.h
+++ b/src/transcoder/filter/filter_video_base.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <chrono>
+
 #include "../media_frame.h"
 #include "base/mediarouter/media_buffer.h"
 #include "base/mediarouter/media_type.h"
@@ -41,11 +43,13 @@ protected:
 	int32_t _skip_frames				   = -1;
 #endif
 
+
+	int64_t ElapsedTimeInUs(const std::chrono::steady_clock::time_point &start_time) const;
+	void UpdateProcessingTimePerFrame(const std::chrono::steady_clock::time_point &start_time);
+
 	// Weighted average of frame processing time.
 	double _weighted_avg_frame_processing_time_us = 0.0;
 
-	// Some devices (e.g. XMA) expand their memory pool while processing the first
-	// frame, which is not thread safe. The first frame is processed under the
-	// device mutex to prevent allocation failures.
-	bool _is_first_frame = true;
+	// Processing time that has not been charged to a completed frame yet.
+	int64_t _pending_processing_time_us = 0;
 };

--- a/src/transcoder/transcoder_decoder.cpp
+++ b/src/transcoder/transcoder_decoder.cpp
@@ -304,12 +304,34 @@ void TranscodeDecoder::ThreadLoop()
 		while (!_kill_flag)
 		{
 			auto received = ReceiveFrame();
-			if (received.result == TranscodeResult::Again)
+			if (received.result == TranscodeResult::FormatChanged ||
+				received.result == TranscodeResult::DataReady)
 			{
+				Complete(received.result, std::move(received.frame));
+
+				// Keep draining to check whether more frames are pending.
+				continue;
+			}
+			else if (received.result == TranscodeResult::Again)
+			{
+				// The decoder is not ready to hand over a frame; leave the loop.
 				break;
 			}
-			
-			Complete(received.result, std::move(received.frame));
+			else if (received.result == TranscodeResult::NoData ||
+					 received.result == TranscodeResult::DataError)
+			{
+				Complete(received.result, std::move(received.frame));
+
+				// The frame handed over is empty or missing, so stop draining rather than
+				// asking the decoder again - it would keep returning the same result.
+				break;
+			}
+			else
+			{
+				// Unexpected result; stop draining.
+				logtw("Unexpected result from ReceiveFrame(): %d", ov::ToUnderlyingType(received.result));
+				break;
+			}
 		}
 	}
 

--- a/src/transcoder/transcoder_encoder.cpp
+++ b/src/transcoder/transcoder_encoder.cpp
@@ -560,8 +560,7 @@ void TranscodeEncoder::ThreadLoop()
 				Complete(recv.result, std::move(recv.packet));
 				break;
 			}
-			else if (recv.result == TranscodeResult::DataReady ||
-					 recv.result == TranscodeResult::NoData)
+			else if (recv.result == TranscodeResult::DataReady)
 			{
 				Complete(recv.result, std::move(recv.packet));
 

--- a/src/transcoder/transcoder_encoder.cpp
+++ b/src/transcoder/transcoder_encoder.cpp
@@ -505,16 +505,19 @@ void TranscodeEncoder::ThreadLoop()
 				break;
 			}
 
-			// Flush encoder and drain remaining packets. 
+			// Flush encoder and drain remaining packets.
 			while (!_kill_flag)
 			{
 				auto received = ReceivePacket();
-				if ( received.result == TranscodeResult::Again)
+				if (received.result == TranscodeResult::DataReady)
 				{
-					break;
+					Complete(received.result, std::move(received.packet));
+
+					// Keep draining to check whether more packets are pending.
+					continue;
 				}
 
-				Complete(received.result, std::move(received.packet));
+				break;
 			}
 
 			if (Reinitialize() == false)
@@ -543,17 +546,32 @@ void TranscodeEncoder::ThreadLoop()
 		while (!_kill_flag)
 		{
 			auto recv = ReceivePacket();
-			if (recv.result == TranscodeResult::Again)
+			if (recv.result == TranscodeResult::Again ||
+				recv.result == TranscodeResult::EndOfFile)
 			{
+				// The encoder has no more packets to hand over; leave the loop.
 				break;
-			}
-			else if (recv.result == TranscodeResult::DataReady)
-			{
-				Complete(recv.result, std::move(recv.packet));
 			}
 			else if (recv.result == TranscodeResult::DataError)
 			{
 				logte("Error occurred while receiving a packet for encoding. frame_pts(%" PRId64 "), reason(%s)", media_frame->GetPts(), recv.error.CStr());
+
+				// Report the error so the stream can account for it, then stop draining.
+				Complete(recv.result, std::move(recv.packet));
+				break;
+			}
+			else if (recv.result == TranscodeResult::DataReady ||
+					 recv.result == TranscodeResult::NoData)
+			{
+				Complete(recv.result, std::move(recv.packet));
+
+				// Keep draining to check whether more packets are pending.
+				continue;
+			}
+			else
+			{
+				// Unhandled result; leave the loop
+				logtw("Unexpected result while receiving a packet for encoding. result(%d)", static_cast<int32_t>(recv.result));
 				break;
 			}
 		}

--- a/src/transcoder/transcoder_filter.cpp
+++ b/src/transcoder/transcoder_filter.cpp
@@ -12,7 +12,7 @@
 using namespace cmn;
 
 #define PTS_INCREMENT_LIMIT 15
-#define MAX_QUEUE_SIZE 5
+#define MAX_QUEUE_SIZE 2
 #define ENABLE_QUEUE_EXCEED_WAIT true
 
 TranscodeFilter::TranscodeFilter()
@@ -319,14 +319,22 @@ bool TranscodeFilter::SendBuffer(std::shared_ptr<MediaFrame> buffer)
 	// Check if the filter is ready to process frames
 	{
 		ov::SharedLockGuard lock(_mutex);
-		if (_filter_base == nullptr ||
-			_filter_base->GetState() == FilterBase::State::ERROR ||
-			_filter_base->GetState() == FilterBase::State::STOPPED)
+		if (_filter_base == nullptr)
+		{
+			logtw("[%s] Filter is not created yet. track:%u",
+				  _input_stream_info->GetUri().CStr(),
+				  GetInputTrack()->GetId());
+
+			return false;
+		}
+
+		auto state = _filter_base->GetState();
+		if (state == FilterBase::State::ERROR || state == FilterBase::State::STOPPED)
 		{
 			logtw("[%s] Filter is not ready to process frames. track:%u, state:%d",
 				  _input_stream_info->GetUri().CStr(),
 				  GetInputTrack()->GetId(),
-				  (int32_t)_filter_base->GetState());
+				  (int32_t)state);
 
 			return false;
 		}

--- a/src/transcoder/transcoder_filter.cpp
+++ b/src/transcoder/transcoder_filter.cpp
@@ -387,14 +387,7 @@ bool TranscodeFilter::IsNeedUpdate(std::shared_ptr<MediaFrame> buffer)
 		return true;
 	}
 
-	// NOTE: Input format changes (video resolution/pixel format/color tags and
-	// audio properties) are detected per frame in ThreadLoop(). A flag set here is
-	// consumed at whatever frame the worker dequeues next, so it cannot be tied to
-	// the frame that triggered it.
-
-	// Check #2 - Filter error state
-	//  When using an XMA scaler, resource allocation failures may occur intermittently.
-	//  Avoid problems in this way until the underlying problem is resolved.
+	// TODO(Keukhan): This will be deprecated soon. It doesn't matter even if this code is dead code.
 	if (_filter_base->GetState() == FilterBase::State::ERROR &&
 		GetInputTrack()->GetCodecModuleId() == cmn::MediaCodecModuleId::XMA &&
 		GetOutputTrack()->GetCodecModuleId() == cmn::MediaCodecModuleId::XMA)

--- a/src/transcoder/transcoder_filter.cpp
+++ b/src/transcoder/transcoder_filter.cpp
@@ -264,12 +264,33 @@ void TranscodeFilter::ThreadLoop()
 		while (!_kill_flag)
 		{
 			auto recv = base->PopCompletedFrameInternal();
-			if (recv.result == TranscodeResult::Again)
+			if (recv.result == TranscodeResult::DataReady)
 			{
+				OnComplete(recv.result, std::move(recv.frame));
+
+				// Keep draining to check whether more frames are pending.
+				continue;
+			}
+			else if (recv.result == TranscodeResult::Again)
+			{
+				// The filter has no more frames to hand over; leave the loop.
 				break;
 			}
+			else if (recv.result == TranscodeResult::DataError)
+			{
+				logte("[%s] Error occurred while draining filtered frames. reason(%s)", _input_stream_info->GetUri().CStr(), recv.error.CStr());
 
-			OnComplete(recv.result, std::move(recv.frame));
+				// Report the error, then stop draining rather than asking the filter
+				// again - it would keep returning the same error.
+				OnComplete(recv.result, std::move(recv.frame));
+				break;
+			}
+			else
+			{
+				// Unhandled result; leave the loop rather than spinning forever.
+				logtw("[%s] Unexpected result while draining filtered frames. result(%d)", _input_stream_info->GetUri().CStr(), static_cast<int32_t>(recv.result));
+				break;
+			}
 		}
 	}
 }

--- a/src/transcoder/transcoder_filter.cpp
+++ b/src/transcoder/transcoder_filter.cpp
@@ -357,7 +357,7 @@ bool TranscodeFilter::SendBuffer(std::shared_ptr<MediaFrame> buffer)
 
 bool TranscodeFilter::IsNeedUpdate(std::shared_ptr<MediaFrame> buffer)
 {
-	ov::SharedLockGuard lock(_mutex);
+	ov::LockGuard lock(_mutex);
 
 	// Single track(paired with encoder) does not need to be updated.
 	if (_filter_base == nullptr || _filter_base->IsSingleTrack() == true)
@@ -388,10 +388,8 @@ bool TranscodeFilter::IsNeedUpdate(std::shared_ptr<MediaFrame> buffer)
 	}
 
 	// Check #2 - Filter error state
-	//  TODO(Keukhan): XMA support is scheduled for removal, so this recovery path is not
-	//  maintained. SendBuffer() already rejects frames while the filter is in the ERROR
-	//  state, which makes this branch dead code, and it will be deleted along with the
-	//  rest of the XMA code.
+	//  Rarely reached, because SendBuffer() already rejects frames in the ERROR state.
+	//  TODO(Keukhan): Will be removed together with the XMA code.
 	if (_filter_base->GetState() == FilterBase::State::ERROR &&
 		GetInputTrack()->GetCodecModuleId() == cmn::MediaCodecModuleId::XMA &&
 		GetOutputTrack()->GetCodecModuleId() == cmn::MediaCodecModuleId::XMA)

--- a/src/transcoder/transcoder_filter.cpp
+++ b/src/transcoder/transcoder_filter.cpp
@@ -316,6 +316,23 @@ void TranscodeFilter::Stop()
 
 bool TranscodeFilter::SendBuffer(std::shared_ptr<MediaFrame> buffer)
 {
+	// Check if the filter is ready to process frames
+	{
+		ov::SharedLockGuard lock(_mutex);
+		if (_filter_base == nullptr ||
+			_filter_base->GetState() == FilterBase::State::ERROR ||
+			_filter_base->GetState() == FilterBase::State::STOPPED)
+		{
+			logtw("[%s] Filter is not ready to process frames. track:%u, state:%d",
+				  _input_stream_info->GetUri().CStr(),
+				  GetInputTrack()->GetId(),
+				  (int32_t)_filter_base->GetState());
+
+			return false;
+		}
+	}
+
+	// Check if the filter needs to be updated
 	if (IsNeedUpdate(buffer) == true)
 	{
 		logtd("[%s] Filter needs to be updated. reinitialize the filter. track:%u, pts:%" PRId64,
@@ -324,6 +341,7 @@ bool TranscodeFilter::SendBuffer(std::shared_ptr<MediaFrame> buffer)
 		_setup_pending = true;
 	}
 
+	// Enqueue the buffer to the input buffer queue for processing by the worker thread.
 	_input_buffer.Enqueue(std::move(buffer));
 
 	return true;

--- a/src/transcoder/transcoder_filter.cpp
+++ b/src/transcoder/transcoder_filter.cpp
@@ -316,28 +316,9 @@ void TranscodeFilter::Stop()
 
 bool TranscodeFilter::SendBuffer(std::shared_ptr<MediaFrame> buffer)
 {
-	// Check if the filter is ready to process frames
+	if (IsReadyToProcess() == false)
 	{
-		ov::SharedLockGuard lock(_mutex);
-		if (_filter_base == nullptr)
-		{
-			logtd("[%s] Filter is not created yet. track:%u",
-				  _input_stream_info->GetUri().CStr(),
-				  GetInputTrack()->GetId());
-
-			return false;
-		}
-
-		auto state = _filter_base->GetState();
-		if (state == FilterBase::State::ERROR || state == FilterBase::State::STOPPED)
-		{
-			logtd("[%s] Filter is not ready to process frames. track:%u, state:%d",
-				  _input_stream_info->GetUri().CStr(),
-				  GetInputTrack()->GetId(),
-				  (int32_t)state);
-
-			return false;
-		}
+		return false;
 	}
 
 	// Check if the filter needs to be updated
@@ -351,6 +332,45 @@ bool TranscodeFilter::SendBuffer(std::shared_ptr<MediaFrame> buffer)
 
 	// Enqueue the buffer to the input buffer queue for processing by the worker thread.
 	_input_buffer.Enqueue(std::move(buffer));
+
+	return true;
+}
+
+bool TranscodeFilter::IsReadyToProcess()
+{
+	ov::SharedLockGuard lock(_mutex);
+
+	if (_filter_base == nullptr)
+	{
+		// This case can only occur if the TranscoderFilter object has been destroyed, so it
+		// should not happen. However, we handle the exception just in case.
+		return false;
+	}
+
+	auto state = _filter_base->GetState();
+	if (state == FilterBase::State::ERROR)
+	{
+		// Reported once per failure. Frames are rejected from here on and the worker stops
+		// reporting, so this is the last signal that the track went dark.
+		if (_failure_reported.exchange(true) == false)
+		{
+			logtw("[%s] Filter has failed, so frames are dropped from now on. track:%u",
+				  _input_stream_info->GetUri().CStr(), GetInputTrack()->GetId());
+		}
+
+		return false;
+	}
+
+	if (state == FilterBase::State::STOPPED)
+	{
+		// Expected while the filter is being torn down.
+		logtd("[%s] Filter is not ready to process frames. track:%u",
+			  _input_stream_info->GetUri().CStr(), GetInputTrack()->GetId());
+
+		return false;
+	}
+
+	_failure_reported = false;
 
 	return true;
 }

--- a/src/transcoder/transcoder_filter.cpp
+++ b/src/transcoder/transcoder_filter.cpp
@@ -321,7 +321,7 @@ bool TranscodeFilter::SendBuffer(std::shared_ptr<MediaFrame> buffer)
 		ov::SharedLockGuard lock(_mutex);
 		if (_filter_base == nullptr)
 		{
-			logtw("[%s] Filter is not created yet. track:%u",
+			logtd("[%s] Filter is not created yet. track:%u",
 				  _input_stream_info->GetUri().CStr(),
 				  GetInputTrack()->GetId());
 
@@ -331,7 +331,7 @@ bool TranscodeFilter::SendBuffer(std::shared_ptr<MediaFrame> buffer)
 		auto state = _filter_base->GetState();
 		if (state == FilterBase::State::ERROR || state == FilterBase::State::STOPPED)
 		{
-			logtw("[%s] Filter is not ready to process frames. track:%u, state:%d",
+			logtd("[%s] Filter is not ready to process frames. track:%u, state:%d",
 				  _input_stream_info->GetUri().CStr(),
 				  GetInputTrack()->GetId(),
 				  (int32_t)state);
@@ -387,7 +387,11 @@ bool TranscodeFilter::IsNeedUpdate(std::shared_ptr<MediaFrame> buffer)
 		return true;
 	}
 
-	// TODO(Keukhan): This will be deprecated soon. It doesn't matter even if this code is dead code.
+	// Check #2 - Filter error state
+	//  TODO(Keukhan): XMA support is scheduled for removal, so this recovery path is not
+	//  maintained. SendBuffer() already rejects frames while the filter is in the ERROR
+	//  state, which makes this branch dead code, and it will be deleted along with the
+	//  rest of the XMA code.
 	if (_filter_base->GetState() == FilterBase::State::ERROR &&
 		GetInputTrack()->GetCodecModuleId() == cmn::MediaCodecModuleId::XMA &&
 		GetOutputTrack()->GetCodecModuleId() == cmn::MediaCodecModuleId::XMA)

--- a/src/transcoder/transcoder_filter.h
+++ b/src/transcoder/transcoder_filter.h
@@ -55,6 +55,7 @@ private:
 
 	void ThreadLoop();
 
+	bool IsReadyToProcess();
 	bool IsNeedUpdate(std::shared_ptr<MediaFrame> buffer);
 	bool IsFormatChanged(const std::shared_ptr<FilterBase> &base, const std::shared_ptr<MediaFrame> &frame) const;
 	void UpdateInputTrackByFrame(const std::shared_ptr<FilterBase> &base, const std::shared_ptr<MediaFrame> &frame);
@@ -79,6 +80,7 @@ private:
 	ov::ManagedQueue<std::shared_ptr<MediaFrame>> _input_buffer;
 
 	std::atomic<bool> _setup_pending{false};
+	std::atomic<bool> _failure_reported{false};
 
 	mutable ov::SharedMutex _mutex;
 	std::shared_ptr<FilterBase> _filter_base OV_GUARDED_BY(_mutex);


### PR DESCRIPTION
## Summary

On a busy server the transcoder's memory kept growing until the process was OOM-killed. The filter held far more frames at once than it needed to:

- `FilterVideoBase`/`FilterAudioBase` collected **everything a single push produced** before any of it was delivered. `ProcessFrameInternal()` drained the backend pipeline into an intermediate `_output_frames` queue, and only after that did the worker start handing frames downstream. Every frame of that batch is alive at the same time, and for hardware pipelines each one pins a GPU surface. `v0.20.7.1` pulled one frame and delivered it right away; the queue was introduced later.
- `SendBuffer()` enqueued frames even when the filter was not created yet, in the `ERROR` state, or already stopped, so frames piled up for a filter that would never drain them.
- The filter input queue allowed 5 frames per track.

The branch also keeps its original fix: the decoder, encoder, and filter worker threads drain their component in a `while (!_kill_flag)` loop, but each loop only recognized a subset of the results its component can return. Unhandled values fell through to the next iteration, so the loop asked again immediately and got the same answer — pinning a core and flooding the log when the value persisted.

## Changes

- **One frame in flight instead of a whole batch** — `_output_frames` is gone. `PopCompletedFrameInternal()` now returns a single completed frame, and the worker calls it until the filter reports `Again`. On the video side it also drives the push: when the backend pipeline has nothing left, it takes the next frame from the FPS filter and feeds it in, so `ProcessFrameInternal()` only hands the input frame to the FPS filter. A frame is delivered downstream as soon as it exists, so a push that produces several frames no longer keeps all of them alive at once.
- **Frames are rejected for a filter that cannot use them** — `SendBuffer()` checks the filter up front and returns `false` when it is missing, in `ERROR`, or `STOPPED`, instead of queueing the frame.
- **Smaller filter input queue** — `MAX_QUEUE_SIZE` 5 → 2.
- **One error report per frame** — errors are reported from the pull side only. A push failure leaves the filter state behind and `PopCompletedFrameInternal()` reports it exactly once, so a single failing frame no longer counts as two `FILTERING_ERROR`s. Failures that only drop a frame and leave the filter usable (FPS filter full, a frame the backend refuses) are logged instead of being raised as errors.
- **Frame processing time is measured where the work happens** — libavfilter does the filtering while the frame is pulled out of the sink, so the weighted average now covers the push *and* `ReceiveFrame()`. Without it the average collapsed to a few microseconds and automatic frame skipping never engaged under load. Delivery to the encoder stays outside the measured region, as before.
- **XMA first-frame device lock dropped** — XMA support is scheduled for removal, so the XMA-only path that processed the first frame under the device mutex is not carried over.
- **Drain loops handle every documented result** — the decoder, encoder, and filter loops now handle every value in `DecodeResult`, `EncodeResult`, and `FilterResult`, and exit with a warning on anything unrecognized.
  - **Decoder** — `NoData`/`DataError` are forwarded once and then end the loop instead of being retried immediately.
  - **Encoder** — `NoData`/`EndOfFile` no longer fall through with no exit; `DataError` is forwarded through `Complete()` before exiting, so `OnEncodedPacket()` counts it toward the encoding-error alert (previously it was only logged).
  - **Filter** — `DataError` is reported once and then ends the loop.

  Exiting a drain loop is not a lost-work path: the thread returns to its blocking input dequeue and drains again on the next packet or frame.

## Testing

1. Configure an encoding profile that uses hardware acceleration and publish a stream to OME (RTMP or another provider).
2. Publish more streams the same way, increasing the number of input streams.
3. Once the added load starves the transcoder of resources and frames start piling up in the queues, watch the GPU memory usage with `nvidia-smi`.
4. **Pass** — GPU memory usage stops growing. **Fail** — it keeps climbing.
