### PR TITLE
refactor(trs): AVFrame pixel format helpers in ffmpeg::compat

### DIFF
--- a/src/modules/ffmpeg/compat.cpp
+++ b/src/modules/ffmpeg/compat.cpp
@@ -322,6 +322,39 @@ namespace ffmpeg
 		return cmn::VideoPixelFormatId::None;
 	}
 
+	int compat::GetPlaneCount(AVPixelFormat pixel_format)
+	{
+		int planes = ::av_pix_fmt_count_planes(pixel_format);
+		return (planes < 0) ? 0 : planes;
+	}
+
+	int compat::GetPlaneCount(cmn::VideoPixelFormatId pixel_format)
+	{
+		return GetPlaneCount(ToAVPixelFormat(pixel_format));
+	}
+
+	AVPixelFormat compat::GetSampleAVPixelFormat(const AVFrame *frame)
+	{
+		// An audio frame's format is an AVSampleFormat, so it must not be read as a pixel format.
+		if (frame == nullptr || frame->width <= 0 || frame->height <= 0)
+		{
+			return AV_PIX_FMT_NONE;
+		}
+
+		if (frame->hw_frames_ctx == nullptr)
+		{
+			return static_cast<AVPixelFormat>(frame->format);
+		}
+
+		auto *frames_ctx = reinterpret_cast<AVHWFramesContext *>(frame->hw_frames_ctx->data);
+		return (frames_ctx != nullptr) ? frames_ctx->sw_format : AV_PIX_FMT_NONE;
+	}
+
+	cmn::VideoPixelFormatId compat::GetSampleVideoPixelFormat(const AVFrame *frame)
+	{
+		return ToVideoPixelFormat(GetSampleAVPixelFormat(frame));
+	}
+
 	AVPixelFormat compat::GetAVPixelFormatOfHWDevice(cmn::MediaCodecModuleId module_id, cmn::DeviceId gpu_id, bool is_sw_format)
 	{
 		auto hw_device_ctx = TranscodeGPU::GetInstance()->GetDeviceContext(module_id, gpu_id);

--- a/src/modules/ffmpeg/compat.h
+++ b/src/modules/ffmpeg/compat.h
@@ -62,6 +62,10 @@ namespace ffmpeg
 		static enum AVColorSpace ToAVColorSpace(cmn::ColorMatrix color_matrix);
 		static cmn::ColorMatrix ToColorMatrix(enum AVColorSpace color_space);
 		static AVPixelFormat GetAVPixelFormatOfHWDevice(cmn::MediaCodecModuleId module_id, cmn::DeviceId gpu_id, bool is_sw_format = true);
+		static int GetPlaneCount(AVPixelFormat pixel_format);
+		static int GetPlaneCount(cmn::VideoPixelFormatId pixel_format);
+		static AVPixelFormat GetSampleAVPixelFormat(const AVFrame *frame);
+		static cmn::VideoPixelFormatId GetSampleVideoPixelFormat(const AVFrame *frame);
 
 		// OME-typed variant of GetAVPixelFormatOfHWDevice(). Returns cmn::VideoPixelFormatId::None when
 		// the device has no matching pixel format.
@@ -599,41 +603,6 @@ namespace ffmpeg
 			}
 
 			return false;
-		}
-
-		static cmn::VideoPixelFormatId GetHWFramesConstraintsValidSWFormat(std::shared_ptr<const MediaFrame> frame)
-		{
-			if (frame == nullptr || frame->GetPrivData() == nullptr)
-			{
-				return cmn::VideoPixelFormatId::None;
-			}
-
-			auto av_frame = static_cast<AVFrame*>(frame->GetPrivData());
-			return GetHWFramesConstraintsValidSWFormat(av_frame);
-		}
-
-		static cmn::VideoPixelFormatId GetHWFramesConstraintsValidSWFormat(AVFrame* frame)
-		{
-			if (frame == nullptr)
-			{
-				return cmn::VideoPixelFormatId::None;
-			}
-
-			if (frame->hw_frames_ctx == nullptr)
-			{
-				return cmn::VideoPixelFormatId::None;
-			}
-
-			auto constraints = ::av_hwdevice_get_hwframe_constraints(frame->hw_frames_ctx, nullptr);
-			if (constraints == nullptr)
-			{
-				return cmn::VideoPixelFormatId::None;
-			}
-
-			auto valid_sw_formats = *(constraints->valid_sw_formats);
-			::av_hwframe_constraints_free(&constraints);
-
-			return ToVideoPixelFormat(valid_sw_formats);
 		}
 
 	};

--- a/src/modules/ffmpeg/ffmpeg_filter_graph.cpp
+++ b/src/modules/ffmpeg/ffmpeg_filter_graph.cpp
@@ -144,7 +144,7 @@ namespace ffmpeg
 				}
 
 				// Validate before copying the host planes into the AVFrame.
-				int planes = ::av_pix_fmt_count_planes(pix_fmt);
+				int planes = compat::GetPlaneCount(pix_fmt);
 				if (planes <= 0 || host_holder->GetPlaneCount() != planes)
 				{
 					return CodecResult::InvalidData;

--- a/src/modules/ffmpeg/ffmpeg_media_frame.cpp
+++ b/src/modules/ffmpeg/ffmpeg_media_frame.cpp
@@ -99,20 +99,12 @@ namespace ffmpeg
 
 	int FFmpegMediaFrameData::GetPlaneCount() const
 	{
-		// Host pixel planes only;
-		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr || _frame->width <= 0 || _frame->height <= 0)
-		{
-			return 0;
-		}
-
-		int planes = ::av_pix_fmt_count_planes(static_cast<AVPixelFormat>(_frame->format));
-		return (planes < 0) ? 0 : planes;
+		return ffmpeg::compat::GetPlaneCount(ffmpeg::compat::GetSampleAVPixelFormat(_frame));
 	}
 
-	const uint8_t *FFmpegMediaFrameData::GetPlaneData(int plane) const
+	uint8_t *FFmpegMediaFrameData::GetPlaneData(int plane)
 	{
-		// Host pixel planes only; a hardware frame has no CPU-side data.
-		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr || _frame->width <= 0 || _frame->height <= 0 ||
+		if (_frame == nullptr || _frame->width <= 0 || _frame->height <= 0 ||
 			plane < 0 || plane >= AV_NUM_DATA_POINTERS)
 		{
 			return nullptr;
@@ -123,8 +115,7 @@ namespace ffmpeg
 
 	int FFmpegMediaFrameData::GetStride(int plane) const
 	{
-		// Host pixel planes only; a hardware frame has no CPU-side data.
-		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr || _frame->width <= 0 || _frame->height <= 0 ||
+		if (_frame == nullptr || _frame->width <= 0 || _frame->height <= 0 ||
 			plane < 0 || plane >= AV_NUM_DATA_POINTERS)
 		{
 			return 0;
@@ -135,12 +126,7 @@ namespace ffmpeg
 
 	cmn::VideoPixelFormatId FFmpegMediaFrameData::GetPixelFormat() const
 	{
-		if (_frame == nullptr || _frame->hw_frames_ctx != nullptr || _frame->width <= 0 || _frame->height <= 0)
-		{
-			return cmn::VideoPixelFormatId::None;
-		}
-
-		return ffmpeg::compat::ToVideoPixelFormat(_frame->format);
+		return ffmpeg::compat::GetSampleVideoPixelFormat(_frame);
 	}
 
 	void FFmpegMediaFrameData::FillZero()

--- a/src/modules/ffmpeg/ffmpeg_media_frame.h
+++ b/src/modules/ffmpeg/ffmpeg_media_frame.h
@@ -40,7 +40,7 @@ namespace ffmpeg
 		void FillZero() override;
 
 		int GetPlaneCount() const override;
-		const uint8_t *GetPlaneData(int plane) const override;
+		uint8_t *GetPlaneData(int plane) override;
 		int GetStride(int plane) const override;
 		cmn::VideoPixelFormatId GetPixelFormat() const override;
 

--- a/src/transcoder/filter/filter_lavfi_rescaler.cpp
+++ b/src/transcoder/filter/filter_lavfi_rescaler.cpp
@@ -329,8 +329,6 @@ std::shared_ptr<MediaFrame> FilterLavfiRescaler::ReceiveFrame()
 			continue;
 		}
 
-		// Convert duration to output track timebase
-		output_frame->SetDuration((int64_t)((double)output_frame->GetDuration() * _input_track->GetTimeBase().GetExpr() / _output_track->GetTimeBase().GetExpr()));
 		output_frame->SetSourceId(_source_id);
 
 #if _SIMULATE_PROCESSING_DELAY_ENABLED

--- a/src/transcoder/media_frame.h
+++ b/src/transcoder/media_frame.h
@@ -43,7 +43,7 @@ public:
 	virtual void FillZero() = 0;
 
 	virtual int GetPlaneCount() const { return 0; }
-	virtual const uint8_t *GetPlaneData(int plane) const { return nullptr; }
+	virtual uint8_t *GetPlaneData(int plane) { return nullptr; }
 	virtual int GetStride(int plane) const { return 0; }
 	virtual cmn::VideoPixelFormatId GetPixelFormat() const { return cmn::VideoPixelFormatId::None; }
 


### PR DESCRIPTION
## Summary

No functional change: `PixelFormat` and `PlaneCount` resolution is consolidated into `ffmpeg::compat` helpers.

One regression is fixed along the way: the rescaler filter converted a frame's duration to the output track timebase a second time, after `settb` had already done it.

## Changes

- `ffmpeg::compat`: add `GetSampleAVPixelFormat()` / `GetSampleVideoPixelFormat()` / `GetPlaneCount()` and drop the unused `GetHWFramesConstraintsValidSWFormat()`, so `FFmpegMediaFrameData` resolves format, plane count and stride through one place — including hardware frames, whose layout comes from the frames context's `sw_format`.
- `MediaFrameData::GetPlaneData()`: drop the `const` qualifier and return `uint8_t *`, so in-place stages do not need a `const_cast`. Read-only callers are unaffected.
- `FFmpegFilterGraph::PushFrame()`: use `compat::GetPlaneCount()`.
- `FilterLavfiRescaler::ReceiveFrame()`: drop the duplicate duration timebase conversion.

## Test

Not needed. Refactoring with no behavior change.
