### PR TITLE
fix(base): guard `info::Stream::_playlists` against concurrent access

### DIFF
--- a/src/base/info/stream.cpp
+++ b/src/base/info/stream.cpp
@@ -87,7 +87,12 @@ namespace info
 
 		_from_origin_map_store = stream._from_origin_map_store;
 
-		_playlists = stream._playlists;
+		{
+			// The source keeps accepting playlists while this copy is taken
+			ov::SharedLockGuard lock(stream._playlists_mutex);
+			_playlists = stream._playlists;
+		}
+
 		_track_sets = stream._track_sets;
 		_representation_type = stream._representation_type;
 
@@ -716,12 +721,16 @@ namespace info
 
 	bool Stream::AddPlaylist(const std::shared_ptr<const Playlist> &playlist)
 	{
+		ov::ScopedLock lock(_playlists_mutex);
+
 		auto result = _playlists.emplace(playlist->GetFileName(), playlist);
 		return result.second;
 	}
 
 	std::shared_ptr<const Playlist> Stream::GetPlaylist(const ov::String &file_name) const
 	{
+		ov::SharedLockGuard lock(_playlists_mutex);
+
 		auto item = _playlists.find(file_name);
 		if (item == _playlists.end())
 		{
@@ -731,8 +740,11 @@ namespace info
 		return item->second;
 	}
 
-	const std::map<ov::String, std::shared_ptr<const Playlist>> &Stream::GetPlaylists() const
+	std::map<ov::String, std::shared_ptr<const Playlist>> Stream::GetPlaylists() const
 	{
+		// The entries are immutable and shared, so the snapshot stays valid after the lock is dropped
+		ov::SharedLockGuard lock(_playlists_mutex);
+
 		return _playlists;
 	}
 

--- a/src/base/info/stream.h
+++ b/src/base/info/stream.h
@@ -138,7 +138,9 @@ namespace info
 
 		bool AddPlaylist(const std::shared_ptr<const Playlist> &playlist);
 		std::shared_ptr<const Playlist> GetPlaylist(const ov::String &file_name) const;
-		const std::map<ov::String, std::shared_ptr<const Playlist>> &GetPlaylists() const;
+		// Returns a snapshot: playlists are still inserted after the stream is published,
+		// so handing out a reference would let a caller iterate while another thread inserts.
+		std::map<ov::String, std::shared_ptr<const Playlist>> GetPlaylists() const;
 
 		bool AddTrackSet(const std::shared_ptr<const TrackSet> &track_set);
 		std::shared_ptr<const TrackSet> GetTrackSet(const ov::String &name) const;
@@ -218,7 +220,8 @@ namespace info
 		std::map<int32_t, std::shared_ptr<TrackStats>> _track_stats;
 
 		// File name : Playlist
-		std::map<ov::String, std::shared_ptr<const Playlist>> _playlists;
+		mutable ov::SharedMutex _playlists_mutex;
+		std::map<ov::String, std::shared_ptr<const Playlist>> _playlists OV_GUARDED_BY(_playlists_mutex);
 
 		// Name : TrackSet
 		std::map<ov::String, std::shared_ptr<const TrackSet>> _track_sets;


### PR DESCRIPTION
## Summary

`info::Stream::_playlists` is an unsynchronized `std::map` that is still written to after the stream is published and shared across threads.

The stream info API is the main writer. `StreamsController::OnGetStream` calls `AddPlaylist()` on the `mon::StreamMetrics` object it is about to serialize, and that object is long-lived shared state held in `ApplicationMetrics::_streams`, not a per-request copy. The same handler then reads the map back through `serdes::SetOutputStreams`, which received a reference to the live map.

Concurrent requests land on different threads by default: the API creates a separate `HttpServer` per bound IP, and the plain and TLS listeners are separate instances with their own workers. Two clients polling the same stream can have one thread inserting into the map while another walks it.

A second writer reaches the same field after publication: on an OVT pull failover, `PullStream::Resume()` -> `OvtStream::ReceiveDescribe()` calls `AddPlaylist()` from the collector thread on a stream the MediaRouter already holds.

## Changes

- Guard `_playlists` with a `mutable ov::SharedMutex` via `OV_GUARDED_BY`. `AddPlaylist()` locks exclusively, `GetPlaylist()` in shared mode.
- Return a snapshot from `GetPlaylists()` instead of a reference, so callers can no longer iterate the map outside the lock. The entries are `shared_ptr<const Playlist>`, so the snapshot stays valid after the lock is dropped.
- Lock the source in the copy constructor, which keeps accepting playlists while the copy is taken.

No call site needed changes: every reader uses `.size()`, a range-for, or a `const &` parameter. None is on a per-packet path, so the snapshot copy is not on a hot path.

## Out of scope

The API side effect itself stays, and with it a functional bug: HLS and SRT share the default playlist file name `playlist`, and `AddPlaylist()` uses `emplace`, so the SRT default playlist never reaches the response when both publishers are enabled. Tracked separately. This PR only removes the data race.
