### PR TITLE
fix(thumbnail): a thumbnail request delays other sockets

### DIFF
--- a/src/publishers/thumbnail/thumbnail_publisher.cpp
+++ b/src/publishers/thumbnail/thumbnail_publisher.cpp
@@ -355,9 +355,8 @@ std::shared_ptr<ThumbnailInterceptor> ThumbnailPublisher::CreateInterceptor()
 			return http::svr::NextHandler::DoNotCall;	
 		}
 
-		// Return the cached image without waiting, this handler runs on the socket worker thread
-		// TODO(Keukhan): PullStream() and the AdmissionWebhooks call still block that thread. The exchange
-		// should be handed over to a worker thread as the HLS publisher does, then it can wait again.
+		// Do not wait here, this handler runs on the socket worker thread
+		// TODO(Keukhan): PullStream() and AdmissionWebhooks still block it, handle this on a worker thread
 		auto endcoded_video_frame = std::static_pointer_cast<ThumbnailStream>(stream)->GetVideoFrameByCodecId(media_codec_id, 0);
 		if (endcoded_video_frame == nullptr)
 		{

--- a/src/publishers/thumbnail/thumbnail_publisher.cpp
+++ b/src/publishers/thumbnail/thumbnail_publisher.cpp
@@ -357,8 +357,8 @@ std::shared_ptr<ThumbnailInterceptor> ThumbnailPublisher::CreateInterceptor()
 
 		// Do not wait here, this handler runs on the socket worker thread
 		// TODO(Keukhan): PullStream() and AdmissionWebhooks still block it, handle this on a worker thread
-		auto endcoded_video_frame = std::static_pointer_cast<ThumbnailStream>(stream)->GetVideoFrameByCodecId(media_codec_id, 0);
-		if (endcoded_video_frame == nullptr)
+		auto encoded_video_frame = std::static_pointer_cast<ThumbnailStream>(stream)->GetVideoFrameByCodecId(media_codec_id, 0);
+		if (encoded_video_frame == nullptr)
 		{
 			response->AppendString(ov::String::FormatString("There is no thumbnail image"));
 			response->SetStatusCode(http::StatusCode::NotFound);
@@ -367,7 +367,7 @@ std::shared_ptr<ThumbnailInterceptor> ThumbnailPublisher::CreateInterceptor()
 
 		response->SetHeader("Content-Type", MimeTypeFromMediaCodecId(media_codec_id));
 		response->SetStatusCode(http::StatusCode::OK);
-		response->AppendData(endcoded_video_frame);
+		response->AppendData(encoded_video_frame);
 		auto sent_size = response->Response();
 		exchange->Release();
 

--- a/src/publishers/thumbnail/thumbnail_publisher.cpp
+++ b/src/publishers/thumbnail/thumbnail_publisher.cpp
@@ -355,12 +355,14 @@ std::shared_ptr<ThumbnailInterceptor> ThumbnailPublisher::CreateInterceptor()
 			return http::svr::NextHandler::DoNotCall;	
 		}
 
-		// Wait O seconds for thumbnail image to be received
+		// TODO(Keukhan): This handler runs on the socket worker thread, so waiting here also stalls the
+		// publishers sharing the port. The exchange should be handed over to a worker thread and answered
+		// there, as the HLS publisher does with Stream::SendMessage() + DoNotCallAndDoNotResponse.
 		auto endcoded_video_frame = std::static_pointer_cast<ThumbnailStream>(stream)->GetVideoFrameByCodecId(media_codec_id, 5000);
 		if (endcoded_video_frame == nullptr)
 		{
 			response->AppendString(ov::String::FormatString("There is no thumbnail image"));
-			response->SetStatusCode(http::StatusCode::NotFound);					
+			response->SetStatusCode(http::StatusCode::NotFound);
 			return http::svr::NextHandler::DoNotCall;
 		}
 

--- a/src/publishers/thumbnail/thumbnail_publisher.cpp
+++ b/src/publishers/thumbnail/thumbnail_publisher.cpp
@@ -355,10 +355,10 @@ std::shared_ptr<ThumbnailInterceptor> ThumbnailPublisher::CreateInterceptor()
 			return http::svr::NextHandler::DoNotCall;	
 		}
 
-		// TODO(Keukhan): This handler runs on the socket worker thread, so waiting here also stalls the
-		// publishers sharing the port. The exchange should be handed over to a worker thread and answered
-		// there, as the HLS publisher does with Stream::SendMessage() + DoNotCallAndDoNotResponse.
-		auto endcoded_video_frame = std::static_pointer_cast<ThumbnailStream>(stream)->GetVideoFrameByCodecId(media_codec_id, 5000);
+		// Return the cached image without waiting, this handler runs on the socket worker thread
+		// TODO(Keukhan): PullStream() and the AdmissionWebhooks call still block that thread. The exchange
+		// should be handed over to a worker thread as the HLS publisher does, then it can wait again.
+		auto endcoded_video_frame = std::static_pointer_cast<ThumbnailStream>(stream)->GetVideoFrameByCodecId(media_codec_id, 0);
 		if (endcoded_video_frame == nullptr)
 		{
 			response->AppendString(ov::String::FormatString("There is no thumbnail image"));

--- a/src/publishers/thumbnail/thumbnail_publisher.cpp
+++ b/src/publishers/thumbnail/thumbnail_publisher.cpp
@@ -368,7 +368,7 @@ std::shared_ptr<ThumbnailInterceptor> ThumbnailPublisher::CreateInterceptor()
 
 		response->SetHeader("Content-Type", MimeTypeFromMediaCodecId(media_codec_id));
 		response->SetStatusCode(http::StatusCode::OK);
-		response->AppendData(endcoded_video_frame->Clone());
+		response->AppendData(endcoded_video_frame);
 		auto sent_size = response->Response();
 		exchange->Release();
 

--- a/src/publishers/thumbnail/thumbnail_stream.cpp
+++ b/src/publishers/thumbnail/thumbnail_stream.cpp
@@ -103,7 +103,7 @@ void ThumbnailStream::SendAudioFrame(const std::shared_ptr<MediaPacket> &media_p
 
 std::shared_ptr<ov::Data> ThumbnailStream::GetVideoFrameByCodecId(cmn::MediaCodecId codec_id, int64_t timeout_ms)
 {
-	// If the stream has no track for the codec, return nullptr immediately
+	// There is no track for this codec, so the image will never arrive
 	auto tracks = GetTracks();
 	if (std::any_of(tracks.begin(), tracks.end(), [codec_id](const auto &item) {
 			return (item.second != nullptr) && (item.second->GetCodecId() == codec_id);

--- a/src/publishers/thumbnail/thumbnail_stream.cpp
+++ b/src/publishers/thumbnail/thumbnail_stream.cpp
@@ -106,9 +106,12 @@ std::shared_ptr<ov::Data> ThumbnailStream::GetVideoFrameByCodecId(cmn::MediaCode
 	// If the stream has no track for the codec, return nullptr immediately
 	auto tracks = GetTracks();
 	if (std::any_of(tracks.begin(), tracks.end(), [codec_id](const auto &item) {
-			return item.second->GetCodecId() == codec_id;
+			return (item.second != nullptr) && (item.second->GetCodecId() == codec_id);
 		}) == false)
 	{
+		logtd("There is no %s track in the stream [%s/%s]",
+			  cmn::GetCodecIdString(codec_id), GetApplicationName(), GetName().CStr());
+
 		return nullptr;
 	}
 

--- a/src/publishers/thumbnail/thumbnail_stream.cpp
+++ b/src/publishers/thumbnail/thumbnail_stream.cpp
@@ -1,5 +1,6 @@
 #include "thumbnail_stream.h"
 
+#include <algorithm>
 #include <regex>
 
 #include "base/publisher/application.h"
@@ -102,8 +103,17 @@ void ThumbnailStream::SendAudioFrame(const std::shared_ptr<MediaPacket> &media_p
 
 std::shared_ptr<ov::Data> ThumbnailStream::GetVideoFrameByCodecId(cmn::MediaCodecId codec_id, int64_t timeout_ms)
 {
+	// If the stream has no track for the codec, return nullptr immediately
+	auto tracks = GetTracks();
+	if (std::any_of(tracks.begin(), tracks.end(), [codec_id](const auto &item) {
+			return item.second->GetCodecId() == codec_id;
+		}) == false)
+	{
+		return nullptr;
+	}
+
 	ov::StopWatch	watch;
-	
+
 	watch.Start();
 
 	do

--- a/src/publishers/thumbnail/thumbnail_stream.h
+++ b/src/publishers/thumbnail/thumbnail_stream.h
@@ -20,6 +20,8 @@ public:
 	void SendAudioFrame(const std::shared_ptr<MediaPacket> &media_packet) override;
 	void SendDataFrame(const std::shared_ptr<MediaPacket> &media_packet) override {} // Not supported
 
+	// Returns nullptr if the stream has no track for the codec, or if no image
+	// has arrived until timeout_ms has elapsed
 	std::shared_ptr<ov::Data> GetVideoFrameByCodecId(cmn::MediaCodecId codec_id, int64_t timeout_ms = 0);
 private:
 	bool Start() override;

--- a/src/publishers/thumbnail/thumbnail_stream.h
+++ b/src/publishers/thumbnail/thumbnail_stream.h
@@ -20,7 +20,8 @@ public:
 	void SendAudioFrame(const std::shared_ptr<MediaPacket> &media_packet) override;
 	void SendDataFrame(const std::shared_ptr<MediaPacket> &media_packet) override {} // Not supported
 
-	// Returns nullptr if no image is available until timeout_ms has elapsed
+	// Returns nullptr immediately if the stream has no track for codec_id, or if no image is
+	// cached by the time timeout_ms elapses (timeout_ms = 0 checks the cache once and returns)
 	std::shared_ptr<ov::Data> GetVideoFrameByCodecId(cmn::MediaCodecId codec_id, int64_t timeout_ms = 0);
 private:
 	bool Start() override;

--- a/src/publishers/thumbnail/thumbnail_stream.h
+++ b/src/publishers/thumbnail/thumbnail_stream.h
@@ -20,8 +20,7 @@ public:
 	void SendAudioFrame(const std::shared_ptr<MediaPacket> &media_packet) override;
 	void SendDataFrame(const std::shared_ptr<MediaPacket> &media_packet) override {} // Not supported
 
-	// Returns nullptr if the stream has no track for the codec, or if no image
-	// has arrived until timeout_ms has elapsed
+	// Returns nullptr if no image is available until timeout_ms has elapsed
 	std::shared_ptr<ov::Data> GetVideoFrameByCodecId(cmn::MediaCodecId codec_id, int64_t timeout_ms = 0);
 private:
 	bool Start() override;


### PR DESCRIPTION
## Summary

A thumbnail request waited up to 5 seconds for an image to arrive on the socket worker thread. Since a physical port uses a single worker by default, every other socket on that port — including the HLS/LLHLS publishers sharing the TLS port — was delayed as well. Requesting a codec that is not configured (e.g. `.png` when only JPEG/WEBP are enabled) hit the full 5 seconds every time, because the image would never arrive.

The policy is now to return immediately: if no image is cached for the requested codec, the request is answered with 404 right away and the worker thread is never held.

Related: OvenMediaLabs/OvenMediaEngineEnterprise#166

## Changes

- The request handler no longer waits for an image (`GetVideoFrameByCodecId(codec_id, 0)`).
- `ThumbnailStream::GetVideoFrameByCodecId()` returns `nullptr` immediately if the stream has no track for the requested codec, and logs which codec is missing.
- Guarded against a null track slot in the codec scan, matching `Stream::GetFirstTrackByType()`.
- Dropped a redundant `Clone()` before `AppendData()`, which already clones.
- Added a `TODO(Keukhan)`: `PullStream()` and the AdmissionWebhooks call still block the socket worker thread. Once the exchange is handed over to a worker thread, waiting for an image can be restored.

## Note

A request issued before the first image has been encoded now returns 404 instead of the image. This is an intentional trade-off — never holding the shared socket worker takes priority.

## Testing

1. HLS + LLHLS + Thumbnail (JPEG/WEBP only, no PNG) on a shared TLS port.
2. Start HLS/LLHLS playback, then request `thumb.png` repeatedly.
3. 404 returns immediately and playback keeps running. `thumb.jpg` still works.
