### PR TITLE
refactor: harden marker handling in the packagers

### DIFF
--- a/src/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.cpp
+++ b/src/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.cpp
@@ -11,10 +11,8 @@
 #include <base/provider/application.h>
 #include <modules/bitstream/h264/h264_sei.h>
 #include <base/modules/data_format/amf_event/amf_event.h>
-#include <base/modules/data_format/cue_event/cue_event.h>
 #include <base/modules/data_format/id3v2/frames/id3v2_frames.h>
 #include <base/modules/data_format/id3v2/id3v2.h>
-#include <base/modules/data_format/scte35_event/scte35_event.h>
 #include <base/modules/data_format/webvtt/webvtt_frame.h>
 
 #include <base/event/command/commands.h>
@@ -351,18 +349,6 @@ namespace api
 				event_format = cmn::BitstreamFormat::ID3v2;
 				events_data	 = MakeID3Data(request_body["events"]);
 			}
-			else if (event_format_string.UpperCaseString() == "CUE")
-			{
-				event_format = cmn::BitstreamFormat::CUE;
-				timestamp	 = source_stream->GetCurrentTimestampMs();
-				events_data	 = MakeCueData(request_body["events"]);
-			}
-			else if (event_format_string.UpperCaseString() == "SCTE35")
-			{
-				event_format = cmn::BitstreamFormat::SCTE35;
-				timestamp	 = source_stream->GetCurrentTimestampMs();
-				events_data	 = MakeScte35Data(request_body["events"], timestamp);
-			}
 			else
 			{
 				throw http::HttpError(http::StatusCode::BadRequest, "eventFormat is not supported: [%s]", event_format_string.CStr());
@@ -415,6 +401,7 @@ namespace api
 									  "Internal Server Error - Could not inject event: [%s/%s/%s]",
 									  vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr(), stream->GetName().CStr());
 			}
+
 			return {http::StatusCode::OK};
 		}
 
@@ -758,38 +745,6 @@ namespace api
 			return id3v2_event->Serialize();
 		}
 
-		std::shared_ptr<ov::Data> StreamActionsController::MakeCueData(const Json::Value &events)
-		{
-			if (events.size() == 0)
-			{
-				throw http::HttpError(http::StatusCode::BadRequest, "events must have at least one event");
-			}
-
-			// only first event is used
-			auto event = events[0];
-			if (event.isMember("cueType") == false || event["cueType"].isString() == false)
-			{
-				throw http::HttpError(http::StatusCode::BadRequest, "cueType is required in events");
-			}
-
-			ov::String cue_type	   = event["cueType"].asString().c_str();
-			CueEvent::CueType type = CueEvent::GetCueTypeByName(cue_type);
-			if (type == CueEvent::CueType::Unknown)
-			{
-				throw http::HttpError(http::StatusCode::BadRequest, "cueType is not supported: [%s]", cue_type.CStr());
-			}
-
-			// duration (optional)
-			uint32_t duration_msec = 0;
-			if (event.isMember("duration") == true && event["duration"].isUInt() == true)
-			{
-				duration_msec = event["duration"].asUInt();
-			}
-
-			auto cue_event = CueEvent::Create(type, duration_msec);
-
-			return cue_event->Serialize();
-		}
 
 		std::shared_ptr<ov::Data> StreamActionsController::MakeAMFData(const Json::Value &events)
 		{
@@ -880,85 +835,5 @@ namespace api
 			return sei_event->Serialize();
 		}
 
-		std::shared_ptr<ov::Data> StreamActionsController::MakeScte35Data(const Json::Value &events, int64_t timestamp)
-		{
-			if (events.size() == 0)
-			{
-				throw http::HttpError(http::StatusCode::BadRequest, "events must have at least one event");
-			}
-
-			// only first event is used
-			auto event				  = events[0];
-
-			/*
-			{
-				"eventFormat": "scte35",
-				"events":[
-					{
-						"spliceCommand": "spliceInsert", // optional, spliceNull, spliceTime ...
-						"id": 12345, // optional, 32bits unsigned number, auto filled if not present
-						"type": "out", // required, out | in
-						"duration": 60500, // milliseconds, only available when cueType is out
-						"autoReturn": false 
-					}
-				]
-			}
-			*/
-
-			// spliceCommand (optional)
-			ov::String splice_command = "spliceInsert";
-			if (event.isMember("spliceCommand") == true && event["spliceCommand"].isString() == true)
-			{
-				splice_command = event["spliceCommand"].asString().c_str();
-			}
-
-			if (splice_command.UpperCaseString() != "SPLICEINSERT")
-			{
-				throw http::HttpError(http::StatusCode::BadRequest, "Now only spliceInsert is supported");
-			}
-
-			// id (required)
-			if (event.isMember("id") == false || event["id"].isUInt() == false)
-			{
-				throw http::HttpError(http::StatusCode::BadRequest, "id is required in events");
-			}
-			uint32_t id = event["id"].asUInt();
-
-			// type (required)
-			if (event.isMember("type") == false || event["type"].isString() == false)
-			{
-				throw http::HttpError(http::StatusCode::BadRequest, "type is required in events");
-			}
-
-			ov::String type = event["type"].asString().c_str();
-			if (type.UpperCaseString() != "OUT" && type.UpperCaseString() != "IN")
-			{
-				throw http::HttpError(http::StatusCode::BadRequest, "type must be 'out' or 'in'");
-			}
-
-			bool out_of_network	   = type.UpperCaseString() == "OUT";
-
-			// duration (optional)
-			uint32_t duration_msec = 0;
-			if (event.isMember("duration") == true && event["duration"].isUInt() == true)
-			{
-				duration_msec = event["duration"].asUInt();
-			}
-
-			// autoReturn (optional)
-			bool auto_return = false;
-			if (event.isMember("autoReturn") == true && event["autoReturn"].isBool() == true)
-			{
-				auto_return = event["autoReturn"].asBool();
-			}
-
-			auto scte_event = Scte35Event::Create(mpegts::SpliceCommandType::SPLICE_INSERT, id, out_of_network, timestamp, duration_msec, auto_return);
-			if (scte_event == nullptr)
-			{
-				throw http::HttpError(http::StatusCode::BadRequest, "Could not create SCTE35 event");
-			}
-
-			return scte_event->Serialize();
-		}
 	}  // namespace v1
 }  // namespace api

--- a/src/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.cpp
+++ b/src/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.cpp
@@ -301,17 +301,6 @@ namespace api
 			//   ]
 			// }
 
-			// Cue Event
-			// {
-			// 	"eventFormat": "cue",
-			// 	"events":[
-			// 		{
-			// 			"cueType": "out", // out | in
-			// 			"duration": 60500 // milliseconds, only available when cueType is out
-			// 		}
-			// 	]
-			// }
-
 			// SEI Event
 			// {
 			// 	"eventFormat": "sei",

--- a/src/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.h
+++ b/src/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.h
@@ -120,11 +120,9 @@ namespace api
 				return std::static_pointer_cast<T>(stream);
 			}
 
-			std::shared_ptr<ov::Data> MakeID3Data(const Json::Value &events);						 // ID3v2
-			std::shared_ptr<ov::Data> MakeCueData(const Json::Value &events);						 // CUE
-			std::shared_ptr<ov::Data> MakeAMFData(const Json::Value &events);						 // AMF
-			std::shared_ptr<ov::Data> MakeSEIData(const Json::Value &events);						 // SEI
-			std::shared_ptr<ov::Data> MakeScte35Data(const Json::Value &events, int64_t timestamp);	 // SCTE35
+			std::shared_ptr<ov::Data> MakeID3Data(const Json::Value &events);  // ID3v2
+			std::shared_ptr<ov::Data> MakeAMFData(const Json::Value &events);  // AMF
+			std::shared_ptr<ov::Data> MakeSEIData(const Json::Value &events);  // SEI
 		};
 	}  // namespace v1
 }  // namespace api

--- a/src/base/modules/data_format/cue_event/cue_event.cpp
+++ b/src/base/modules/data_format/cue_event/cue_event.cpp
@@ -8,9 +8,9 @@
 //==============================================================================
 #include "cue_event.h"
 
-std::shared_ptr<CueEvent> CueEvent::Create(CueType cue_type, uint32_t duration_sec, uint32_t elapsed_msec)
+std::shared_ptr<CueEvent> CueEvent::Create(CueType cue_type, uint32_t duration_sec, uint32_t elapsed_msec, bool provisional)
 {
-	return std::make_shared<CueEvent>(cue_type, duration_sec, elapsed_msec);
+	return std::make_shared<CueEvent>(cue_type, duration_sec, elapsed_msec, provisional);
 }
 
 std::shared_ptr<CueEvent> CueEvent::Parse(const std::shared_ptr<const ov::Data> &data)
@@ -22,7 +22,8 @@ std::shared_ptr<CueEvent> CueEvent::Parse(const std::shared_ptr<const ov::Data> 
 
 	ov::ByteStream stream(data);
 
-	if (data->GetLength() != 9)
+	// The provisional flag is appended only when set; older payloads are 9 bytes
+	if (data->GetLength() != 9 && data->GetLength() != 10)
 	{
 		return nullptr;
 	}
@@ -42,7 +43,13 @@ std::shared_ptr<CueEvent> CueEvent::Parse(const std::shared_ptr<const ov::Data> 
 	uint32_t duration_msec = stream.ReadBE32();
 	uint32_t elapsed_msec = stream.ReadBE32();
 
-	return Create(cue_type, duration_msec, elapsed_msec);
+	bool provisional = false;
+	if (data->GetLength() == 10)
+	{
+		provisional = stream.Read8() == 1;
+	}
+
+	return Create(cue_type, duration_msec, elapsed_msec, provisional);
 }
 
 CueEvent::CueType CueEvent::GetCueTypeByName(ov::String type)
@@ -63,20 +70,28 @@ CueEvent::CueType CueEvent::GetCueTypeByName(ov::String type)
 	return CueType::Unknown;
 }
 
-CueEvent::CueEvent(CueType cue_type, uint32_t duration_sec, uint32_t elapsed_msec)
+CueEvent::CueEvent(CueType cue_type, uint32_t duration_sec, uint32_t elapsed_msec, bool provisional)
 {
 	_cue_type = cue_type;
 	_duration_msec = duration_sec;
 	_elapsed_msec = elapsed_msec;
+	_provisional = provisional;
 }
 
 std::shared_ptr<ov::Data> CueEvent::Serialize() const
 {
-	ov::ByteStream stream(5);
+	ov::ByteStream stream(10);
 
 	stream.Write8(static_cast<uint8_t>(_cue_type));
 	stream.WriteBE32(_duration_msec);
 	stream.WriteBE32(_elapsed_msec);
+
+	// Appended only when set, so unrelated events stay wire-identical to
+	// older versions
+	if (_provisional == true)
+	{
+		stream.Write8(1);
+	}
 
 	return stream.GetDataPointer();
 }
@@ -109,4 +124,9 @@ uint32_t CueEvent::GetDurationMsec() const
 uint32_t CueEvent::GetElapsedMsec() const
 {
 	return _elapsed_msec;
+}
+
+bool CueEvent::IsProvisional() const
+{
+	return _provisional;
 }

--- a/src/base/modules/data_format/cue_event/cue_event.h
+++ b/src/base/modules/data_format/cue_event/cue_event.h
@@ -13,8 +13,10 @@
 /*
 Data Structure
 
-CueType : 8 bits 
+CueType : 8 bits
 Duration - 32 bits / milliseconds, only positive value
+Elapsed - 32 bits / milliseconds
+Provisional - 8 bits, appended only when set (older payloads omit it)
 
 */
 
@@ -24,16 +26,16 @@ public:
 	enum class CueType : uint8_t
 	{
 		Unknown = 0,
-		OUT, 
+		OUT,
 		CONT,
 		IN
 	};
 
-	static std::shared_ptr<CueEvent> Create(CueType cue_type, uint32_t duration_msec = 0, uint32_t elapsed_msec = 0);
+	static std::shared_ptr<CueEvent> Create(CueType cue_type, uint32_t duration_msec = 0, uint32_t elapsed_msec = 0, bool provisional = false);
 	static std::shared_ptr<CueEvent> Parse(const std::shared_ptr<const ov::Data> &data);
 	static CueType GetCueTypeByName(ov::String type);
-	
-	CueEvent(CueType cue_type, uint32_t duration_sec, uint32_t elapsed_msec);
+
+	CueEvent(CueType cue_type, uint32_t duration_sec, uint32_t elapsed_msec, bool provisional);
 	~CueEvent() = default;
 
 	std::shared_ptr<ov::Data> Serialize() const;
@@ -42,9 +44,13 @@ public:
 	ov::String GetCueTypeName() const;
 	uint32_t GetDurationMsec() const;
 	uint32_t GetElapsedMsec() const;
+	// A provisional IN announces the planned return point and may still be
+	// replaced by an explicit IN, earlier or later
+	bool IsProvisional() const;
 
 private:
 	CueType _cue_type;
 	uint32_t _duration_msec;
 	uint32_t _elapsed_msec;
+	bool _provisional = false;
 };

--- a/src/base/modules/data_format/scte35_event/scte35_event.cpp
+++ b/src/base/modules/data_format/scte35_event/scte35_event.cpp
@@ -11,9 +11,9 @@
 #include <modules/containers/mpegts/mpegts_section.h>
 #include <modules/containers/mpegts/scte35/mpegts_splice_insert.h>
 
-std::shared_ptr<Scte35Event> Scte35Event::Create(mpegts::SpliceCommandType splice_command_type, uint32_t id, bool out_of_network, int64_t timestamp_msec, int64_t duration_msec, bool auto_return)
+std::shared_ptr<Scte35Event> Scte35Event::Create(mpegts::SpliceCommandType splice_command_type, uint32_t id, bool out_of_network, int64_t timestamp_msec, int64_t duration_msec, bool auto_return, bool provisional)
 {
-	return std::make_shared<Scte35Event>(splice_command_type, id, out_of_network, timestamp_msec, duration_msec, auto_return);
+	return std::make_shared<Scte35Event>(splice_command_type, id, out_of_network, timestamp_msec, duration_msec, auto_return, provisional);
 }
 
 std::shared_ptr<Scte35Event> Scte35Event::Create(const std::shared_ptr<const mpegts::SpliceInfo> &splice_info)
@@ -43,7 +43,7 @@ std::shared_ptr<Scte35Event> Scte35Event::Create(const std::shared_ptr<const mpe
 				  splice_insert->GetAutoReturn());
 }
 
-Scte35Event::Scte35Event(mpegts::SpliceCommandType splice_command_type, uint32_t id, bool out_of_network, int64_t timestamp_msec, int64_t duration_msec, bool auto_return)
+Scte35Event::Scte35Event(mpegts::SpliceCommandType splice_command_type, uint32_t id, bool out_of_network, int64_t timestamp_msec, int64_t duration_msec, bool auto_return, bool provisional)
 {
 	_splice_command_type = splice_command_type;
 	_id = id;
@@ -51,6 +51,7 @@ Scte35Event::Scte35Event(mpegts::SpliceCommandType splice_command_type, uint32_t
 	_timestamp_msec = timestamp_msec;
 	_duration_msec = duration_msec;
 	_auto_return = auto_return;
+	_provisional = provisional;
 }
 
 std::shared_ptr<Scte35Event> Scte35Event::Parse(const std::shared_ptr<const ov::Data> &data)
@@ -81,7 +82,14 @@ std::shared_ptr<Scte35Event> Scte35Event::Parse(const std::shared_ptr<const ov::
 	int64_t duration_msec = stream.ReadBE64();
 	bool auto_return = stream.Read8() == 1;
 
-	return Create(splice_command_type, id, out_of_network, timestamp_msec, duration_msec, auto_return);
+	// The provisional flag is appended only when set; older payloads are 23 bytes
+	bool provisional = false;
+	if (data->GetLength() >= 24)
+	{
+		provisional = stream.Read8() == 1;
+	}
+
+	return Create(splice_command_type, id, out_of_network, timestamp_msec, duration_msec, auto_return, provisional);
 }
 
 std::shared_ptr<ov::Data> Scte35Event::Serialize() const
@@ -93,6 +101,13 @@ std::shared_ptr<ov::Data> Scte35Event::Serialize() const
 	stream.WriteBE64(_timestamp_msec);
 	stream.WriteBE64(_duration_msec);
 	stream.Write8(_auto_return ? 1 : 0);
+
+	// Appended only when set, so unrelated events stay wire-identical to
+	// older versions
+	if (_provisional == true)
+	{
+		stream.Write8(1);
+	}
 
 	return stream.GetDataPointer();
 }
@@ -126,6 +141,11 @@ int64_t Scte35Event::GetDurationMsec() const
 bool Scte35Event::IsAutoReturn() const
 {
 	return _auto_return;
+}
+
+bool Scte35Event::IsProvisional() const
+{
+	return _provisional;
 }
 
 std::shared_ptr<ov::Data> Scte35Event::MakeScteData() const

--- a/src/base/modules/data_format/scte35_event/scte35_event.h
+++ b/src/base/modules/data_format/scte35_event/scte35_event.h
@@ -21,17 +21,17 @@ OutOfNetworkIndicator : 8 bit
 Timestamp : 64 bits / 90000Hz, only positive value, maximum 33 bits (1FF FFFF FFFF)
 Duration : 64 bits / 90000Hz, only positive value, maximum 33 bits (1FF FFFF FFFF)
 autoReturn : 8 bit
-scteData : variable
+Provisional : 8 bits, appended only when set (older payloads omit it)
 */
 
 class Scte35Event
 {
 public:
-	static std::shared_ptr<Scte35Event> Create(mpegts::SpliceCommandType splice_command_type, uint32_t id, bool out_of_network, int64_t timestamp_msec, int64_t duration_msec, bool auto_return);
+	static std::shared_ptr<Scte35Event> Create(mpegts::SpliceCommandType splice_command_type, uint32_t id, bool out_of_network, int64_t timestamp_msec, int64_t duration_msec, bool auto_return, bool provisional = false);
 	static std::shared_ptr<Scte35Event> Create(const std::shared_ptr<const mpegts::SpliceInfo> &splice_info);
 	static std::shared_ptr<Scte35Event> Parse(const std::shared_ptr<const ov::Data> &data);
 
-	Scte35Event(mpegts::SpliceCommandType splice_command_type, uint32_t id, bool out_of_network, int64_t timestamp_msec, int64_t duration_msec, bool auto_return);
+	Scte35Event(mpegts::SpliceCommandType splice_command_type, uint32_t id, bool out_of_network, int64_t timestamp_msec, int64_t duration_msec, bool auto_return, bool provisional);
 	~Scte35Event() = default;
 
 	std::shared_ptr<ov::Data> Serialize() const;
@@ -43,6 +43,9 @@ public:
 	int64_t GetTimestampMsec() const;
 	int64_t GetDurationMsec() const;
 	bool IsAutoReturn() const;
+	// A provisional IN announces the planned return point and may still be
+	// replaced by an explicit IN, earlier or later
+	bool IsProvisional() const;
 
 	std::shared_ptr<ov::Data> MakeScteData() const;
 
@@ -54,4 +57,5 @@ private:
 	int64_t _timestamp_msec = 0;
 	int64_t _duration_msec = 0;
 	bool _auto_return = false;
+	bool _provisional = false;
 };

--- a/src/base/modules/marker/marker_box.cpp
+++ b/src/base/modules/marker/marker_box.cpp
@@ -371,10 +371,11 @@ std::tuple<bool, ov::String> MarkerBox::CanInsertMarker(const std::shared_ptr<Ma
 		{
 			bool last_still_pending = _markers_by_timestamp.find(_last_inserted_marker->GetTimestamp()) != _markers_by_timestamp.end();
 
-			if (_last_inserted_marker->GetTimestamp() >= marker->GetTimestamp())
+			if (last_still_pending == true && _last_inserted_marker->GetTimestamp() >= marker->GetTimestamp())
 			{
 				// An earlier IN cancels the pending one; the same timestamp is a
-				// duplicate of the same return point and replaces it harmlessly
+				// duplicate of the same return point and replaces it harmlessly.
+				// Once it has been emitted there is no open break left to modify
 			}
 			else if (_last_inserted_marker->IsProvisional() == true && last_still_pending == true && marker->IsProvisional() == false)
 			{
@@ -384,7 +385,7 @@ std::tuple<bool, ov::String> MarkerBox::CanInsertMarker(const std::shared_ptr<Ma
 			}
 			else
 			{
-				return {false, "IN marker only can be modified with the less timestamp"};
+				return {false, "IN marker can only be modified while it is pending, with an equal or earlier timestamp"};
 			}
 		}
 		// OUT -> IN

--- a/src/base/modules/marker/marker_box.cpp
+++ b/src/base/modules/marker/marker_box.cpp
@@ -116,6 +116,22 @@ std::shared_ptr<ov::Data> Marker::GetData() const
 	return _data;
 }
 
+bool Marker::IsProvisional() const
+{
+	if (_marker_format == cmn::BitstreamFormat::SCTE35)
+	{
+		auto scte_event = GetScte35Event();
+		return (scte_event != nullptr) ? scte_event->IsProvisional() : false;
+	}
+	else if (_marker_format == cmn::BitstreamFormat::CUE)
+	{
+		auto cue_event = GetCueEvent();
+		return (cue_event != nullptr) ? cue_event->IsProvisional() : false;
+	}
+
+	return false;
+}
+
 std::optional<bool> Marker::IsOutOfNetwork() const
 {
 	if (_marker_format == cmn::BitstreamFormat::SCTE35)
@@ -228,7 +244,7 @@ ov::String Marker::ToHlsTag(int64_t timestamp_offset) const
 
 			// PLANNED-DURATION
 			tag += ov::String::FormatString(",PLANNED-DURATION=%.3f", static_cast<double>(scte_event->GetDurationMsec()) / 1000.0);
-			tag += ov::String::FormatString(",SCTE35-OUT=%s", scte_data->ToHexString().CStr());
+			tag += ov::String::FormatString(",SCTE35-OUT=0x%s", scte_data->ToHexString().CStr());
 		}
 		else
 		{
@@ -254,7 +270,7 @@ ov::String Marker::ToHlsTag(int64_t timestamp_offset) const
 			// // DURATION
 			// tag += ov::String::FormatString(",DURATION=%.3f", static_cast<double>(scte_event->GetDurationMsec()) / 1000.0);
 
-			tag += ov::String::FormatString(",SCTE35-IN=%s", scte_data->ToHexString().CStr());
+			tag += ov::String::FormatString(",SCTE35-IN=0x%s", scte_data->ToHexString().CStr());
 		}
 
 		tag += "\n";
@@ -353,9 +369,18 @@ std::tuple<bool, ov::String> MarkerBox::CanInsertMarker(const std::shared_ptr<Ma
 		// IN -> IN
 		if (last_out_of_network_value == false)
 		{
-			if (_last_inserted_marker->GetTimestamp() > marker->GetTimestamp())
+			bool last_still_pending = _markers_by_timestamp.find(_last_inserted_marker->GetTimestamp()) != _markers_by_timestamp.end();
+
+			if (_last_inserted_marker->GetTimestamp() >= marker->GetTimestamp())
 			{
-				// IN -> IN with the earlier timestamp, it will cancel the last IN marker
+				// An earlier IN cancels the pending one; the same timestamp is a
+				// duplicate of the same return point and replaces it harmlessly
+			}
+			else if (_last_inserted_marker->IsProvisional() == true && last_still_pending == true && marker->IsProvisional() == false)
+			{
+				// Only an explicit IN may move a pending provisional return point
+				// later; a provisional one is the companion of a rejected OUT and
+				// must not extend the open break
 			}
 			else
 			{
@@ -428,12 +453,14 @@ bool MarkerBox::InsertMarker(const std::shared_ptr<Marker> &marker)
 	{
 		if (last_out_of_network_value == false)
 		{
-			if (_last_inserted_marker->GetTimestamp() > marker->GetTimestamp())
+			if (_last_inserted_marker->GetTimestamp() >= marker->GetTimestamp() || _last_inserted_marker->IsProvisional() == true)
 			{
-				// remove the last CUEEVENT-IN marker
+				// remove the replaced xxx-IN marker (duplicate, earlier return
+				// point, or a provisional one being confirmed or moved)
 				_markers_by_timestamp.erase(_last_inserted_marker->GetTimestamp());
+				_markers_by_sequence_number.erase(_last_inserted_marker->GetDesiredSequenceNumber());
 			}
-			
+
 			// Inherit the parent
 			marker->SetParent(_last_inserted_marker->GetParent());
 		}
@@ -560,6 +587,22 @@ uint32_t MarkerBox::GetMarkerCount() const
 	return _markers_by_timestamp.size();
 }
 
+uint32_t MarkerBox::GetMarkerCountBefore(int64_t timestamp_ms) const
+{
+	std::shared_lock<std::shared_mutex> lock(_markers_guard);
+
+	uint32_t count = 0;
+	for (auto &it : _markers_by_timestamp)
+	{
+		if (it.second->GetTimestampMs() < timestamp_ms)
+		{
+			count++;
+		}
+	}
+
+	return count;
+}
+
 bool MarkerBox::RemoveMarker(int64_t timestamp)
 {
 	std::lock_guard<std::shared_mutex> lock(_markers_guard);
@@ -577,16 +620,17 @@ bool MarkerBox::RemoveMarker(int64_t timestamp)
 	return true;
 }
 
-void MarkerBox::RemoveExpiredMarkers(int64_t current_timestamp)
+std::vector<std::shared_ptr<Marker>> MarkerBox::PopExpiredMarkers(int64_t before_timestamp)
 {
 	std::lock_guard<std::shared_mutex> lock(_markers_guard);
 
+	std::vector<std::shared_ptr<Marker>> markers;
 	for (auto it = _markers_by_timestamp.begin(); it != _markers_by_timestamp.end();)
 	{
 		auto marker = it->second;  // copy shared_ptr to prevent use-after-free after erase
-		if (marker->GetTimestamp() < current_timestamp)
+		if (marker->GetTimestamp() < before_timestamp)
 		{
-			logtc("Remove expired marker:(%" PRId64 ") %" PRId64 " - %s", current_timestamp, marker->GetTimestamp(), marker->GetTag().CStr());
+			markers.push_back(marker);
 			it = _markers_by_timestamp.erase(it);
 			_markers_by_sequence_number.erase(marker->GetDesiredSequenceNumber());
 		}
@@ -595,6 +639,8 @@ void MarkerBox::RemoveExpiredMarkers(int64_t current_timestamp)
 			++it;
 		}
 	}
+
+	return markers;
 }
 
 int64_t MarkerBox::GetCurrentSequenceNumber() const
@@ -638,8 +684,10 @@ int64_t MarkerBox::GetEstimatedSequenceNumber(int64_t timestamp_ms) const
 		estimated_sequence_number += std::ceil((time_until_marker_ms - remaining_time_in_current_segment_ms) / actual_segment_duration_ms);
 	}
 
-	// Plus previous markers count, marker makes the sequence number increase
-	auto prev_markers = GetMarkerCount();
+	// Every pending marker before this timestamp adds one segment boundary;
+	// one at or after it (e.g. the pending marker this one replaces) must
+	// not be counted
+	auto prev_markers = GetMarkerCountBefore(timestamp_ms);
 	estimated_sequence_number += prev_markers;
 
 	logtt("actual_segment_duration_ms: %f, last_sample_end_timestamp_ms: %f, time_until_marker_ms: %f, remaining_time_in_current_segment_ms: %f, estimated_sequence_number: %" PRId64 " last_segment_number: %" PRId64 " last_segment_duration: %f is_last_segment_completed: %d",
@@ -658,10 +706,15 @@ double MarkerBox::GetActualTargetSegmentDurationMs() const
 
 	double actual_segment_duration_ms = segment_info->target_segment_duration_ms;
 
-	if (segment_info->media_type != cmn::MediaType::Video)
+	// Video can only cut at keyframes, so its real cadence is the target rounded
+	// up to the keyframe interval; the interval may be unknown (0) at this point
+	if (segment_info->media_type == cmn::MediaType::Video && segment_info->framerate > 0)
 	{
 		auto keyframe_interval_ms = segment_info->keyframe_interval / segment_info->framerate * 1000;
-		actual_segment_duration_ms = std::ceil(segment_info->target_segment_duration_ms / keyframe_interval_ms) * keyframe_interval_ms;
+		if (keyframe_interval_ms > 0)
+		{
+			actual_segment_duration_ms = std::ceil(segment_info->target_segment_duration_ms / keyframe_interval_ms) * keyframe_interval_ms;
+		}
 	}
 
 	return actual_segment_duration_ms;

--- a/src/base/modules/marker/marker_box.h
+++ b/src/base/modules/marker/marker_box.h
@@ -27,6 +27,9 @@ public:
 	ov::String GetTag() const;
 	std::shared_ptr<ov::Data> GetData() const;
 	std::optional<bool> IsOutOfNetwork() const;
+	// A provisional IN announces the planned return point; while it is pending it
+	// may be replaced by an explicit IN, earlier or later
+	bool IsProvisional() const;
 	std::shared_ptr<CueEvent> GetCueEvent() const;
 	std::shared_ptr<Scte35Event> GetScte35Event() const;
 	ov::String ToHlsTag(int64_t timestamp_offset = 0) const;
@@ -71,12 +74,16 @@ protected:
 	bool HasMarker(int64_t end_timestamp) const;
 	bool HasMarkerWithSeq(int64_t sequence_number) const;
 	uint32_t GetMarkerCount() const;
+	// Markers that will cut before the given time; only these shift the sequence
+	// number of a later marker
+	uint32_t GetMarkerCountBefore(int64_t timestamp_ms) const;
 	const std::shared_ptr<Marker> GetFirstMarker() const;
 	std::vector<std::shared_ptr<Marker>> PopMarkers(int64_t start_timestamp, int64_t end_timestamp);
 	std::vector<std::shared_ptr<Marker>> PopMarkers(int64_t end_timestamp);
 	bool RemoveMarker(int64_t timestamp);
-	// remove expired markers
-	void RemoveExpiredMarkers(int64_t current_timestamp);
+	// Pop markers whose timestamp has already passed the given position; a
+	// leftover would corrupt the sequence estimation of every later marker
+	std::vector<std::shared_ptr<Marker>> PopExpiredMarkers(int64_t before_timestamp);
 	double GetActualTargetSegmentDurationMs() const;
 
 	struct SegmentationInfo

--- a/src/modules/containers/bmff/CMakeLists.txt
+++ b/src/modules/containers/bmff/CMakeLists.txt
@@ -4,3 +4,10 @@ ome_add_static_library(bmff_container
         bitstream
         ovlibrary
 )
+
+if(OME_BUILD_TESTS)
+    file(GLOB _srcs "${CMAKE_CURRENT_SOURCE_DIR}/fmp4_packager/*_test.cpp")
+    ome_add_tests(ome_test_bmff
+        SRCS ${_srcs}
+    )
+endif()

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_marker_sync_test.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_marker_sync_test.cpp
@@ -448,6 +448,70 @@ TEST(FMP4MarkerSyncTest, ProvisionalInRejectsProvisionalExtension)
 	EXPECT_TRUE(can_insert_explicit);
 }
 
+TEST(FMP4MarkerSyncTest, EmittedInRejectsDuplicate)
+{
+	constexpr double kSegmentMs = 1600.0;
+	constexpr int kGopFrames = 24;
+
+	auto observer = std::make_shared<NullStorageObserver>();
+	SingleCueRun run{MakePipeline(MakeVideoTrack(kGopFrames), observer, kSegmentMs), MakePipeline(MakeAudioTrack(), observer, kSegmentMs)};
+
+	// Feed well past the return point so both markers were emitted into segments
+	const int64_t out_ts = 4800;
+	const int64_t planned_in_ts = out_ts + 20000;
+	run.Feed(kGopFrames, planned_in_ts + 10000, out_ts, 20000, -1, 0, true);
+
+	ASSERT_EQ(CollectMarkers(run.video, CueEvent::CueType::IN).size(), 1u);
+
+	// A late duplicate of the emitted IN has no open break left to modify
+	auto data = CueEvent::Create(CueEvent::CueType::IN)->Serialize();
+	auto duplicate_marker = Marker::CreateMarker(cmn::BitstreamFormat::CUE, planned_in_ts, planned_in_ts, data);
+	auto [can_insert, message] = run.video.packager->CanInsertMarker(duplicate_marker);
+	EXPECT_FALSE(can_insert);
+
+	// An earlier IN is equally stale after the emission
+	auto earlier_marker = Marker::CreateMarker(cmn::BitstreamFormat::CUE, planned_in_ts - 5000, planned_in_ts - 5000, data);
+	auto [can_insert_earlier, message_earlier] = run.video.packager->CanInsertMarker(earlier_marker);
+	EXPECT_FALSE(can_insert_earlier);
+
+	// The next break still opens normally
+	auto out_data = CueEvent::Create(CueEvent::CueType::OUT, 20000, 0)->Serialize();
+	auto next_out_marker = Marker::CreateMarker(cmn::BitstreamFormat::CUE, planned_in_ts + 20000, planned_in_ts + 20000, out_data);
+	auto [can_insert_out, message_out] = run.video.packager->CanInsertMarker(next_out_marker);
+	EXPECT_TRUE(can_insert_out);
+}
+
+TEST(FMP4MarkerSyncTest, ForcedCompletionSettlesPendingMarkerCut)
+{
+	// A keyframe interval beyond twice the segment duration makes the storage
+	// force-complete every video segment; the forced boundary must also settle
+	// the pending marker cut, or the next keyframe cuts a spurious boundary
+	constexpr double kSegmentMs = 1600.0;
+	constexpr int kGopFrames = 240;	 // 8 s
+
+	auto observer = std::make_shared<NullStorageObserver>();
+	SingleCueRun run{MakePipeline(MakeVideoTrack(kGopFrames), observer, kSegmentMs), MakePipeline(MakeAudioTrack(), observer, kSegmentMs)};
+
+	// The OUT position falls mid-GOP, so no keyframe can serve the cut before
+	// the segment is forced closed
+	run.Feed(kGopFrames, 12000, 4000, 20000, -1, 0, true);
+
+	ASSERT_EQ(CollectMarkers(run.video, CueEvent::CueType::OUT).size(), 1u);
+
+	// Every completed video segment here is a forced one, well past the target;
+	// a short segment can only come from a stale pending cut
+	for (int64_t number = 0; number <= run.video.storage->GetLastSegmentNumber(); number++)
+	{
+		auto segment = run.video.storage->GetSegment(number);
+		if (segment == nullptr || segment->IsCompleted() == false)
+		{
+			continue;
+		}
+
+		EXPECT_GT(segment->GetDurationMs(), kSegmentMs) << "video segment " << number << " was cut by a stale pending marker cut";
+	}
+}
+
 TEST(FMP4MarkerSyncTest, HalfSegmentGop)
 {
 	// 1.6 s segments, 0.8 s keyframe interval

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_marker_sync_test.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_marker_sync_test.cpp
@@ -25,8 +25,7 @@
 // marker. This holds when the keyframe interval is strictly shorter than the
 // segment duration and divides it evenly; these tests drive the supported
 // configurations with the real packagers and verify the invariants over many
-// cues. OUT and IN arrive as separate events, as the event creation point emits
-// them.
+// cues. An OUT and its return(IN) arrive as separate events.
 
 namespace
 {
@@ -196,7 +195,7 @@ namespace
 		auto video = MakePipeline(MakeVideoTrack(gop_frames), observer, segment_duration_ms);
 		auto audio = MakePipeline(MakeAudioTrack(), observer, segment_duration_ms);
 
-		// The event creation point stamps the marker one keyframe interval ahead
+		// Marker events are stamped one keyframe interval ahead of the media time
 		const int64_t marker_lead_ms = static_cast<int64_t>(gop_ms);
 
 		std::vector<int64_t> cue_out_timestamps;

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_marker_sync_test.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_marker_sync_test.cpp
@@ -1,0 +1,468 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <map>
+#include <vector>
+
+#include <base/info/media_track.h>
+#include <base/mediarouter/media_buffer.h>
+#include <base/modules/data_format/cue_event/cue_event.h>
+
+#include "fmp4_packager.h"
+#include "fmp4_storage.h"
+
+// Cue markers must keep every track on the same segment sequence: the OUT marker
+// cuts all tracks at its timestamp, the IN marker returns them to the shared
+// segment grid, and the pacing gives each track exactly one extra boundary per
+// marker. This holds when the keyframe interval is strictly shorter than the
+// segment duration and divides it evenly; these tests drive the supported
+// configurations with the real packagers and verify the invariants over many
+// cues. OUT and IN arrive as separate events, as the event creation point emits
+// them.
+
+namespace
+{
+	constexpr double kChunkDurationMs = 400.0;
+	constexpr uint32_t kCueDurationMs = 20000;
+	constexpr int64_t kCueIntervalMs = 30000;
+	constexpr size_t kCueCount = 12;
+	constexpr double kFrameJitterMs = 45.0;	 // integer-ms timestamps wobble up to one frame
+
+	class NullStorageObserver : public bmff::FMp4StorageObserver
+	{
+	public:
+		void OnFMp4StorageInitialized(const int32_t &track_id) override {}
+		void OnMediaSegmentCreated(const int32_t &track_id, const uint32_t &segment_number) override {}
+		void OnMediaChunkUpdated(const int32_t &track_id, const uint32_t &segment_number, const uint32_t &chunk_number, bool last_chunk) override {}
+		void OnMediaSegmentDeleted(const int32_t &track_id, const uint32_t &segment_number) override {}
+		void OnMediaSegmentCompleted(const int32_t &track_id, const uint32_t &segment_number) override {}
+	};
+
+	struct TrackPipeline
+	{
+		std::shared_ptr<MediaTrack> track;
+		std::shared_ptr<bmff::FMP4Storage> storage;
+		std::shared_ptr<bmff::FMP4Packager> packager;
+	};
+
+	TrackPipeline MakePipeline(const std::shared_ptr<MediaTrack> &track, const std::shared_ptr<bmff::FMp4StorageObserver> &observer, double segment_duration_ms)
+	{
+		bmff::FMP4Storage::Config storage_config;
+		storage_config.max_segments = 100000;  // keep everything for inspection
+		storage_config.segment_duration_ms = static_cast<uint64_t>(segment_duration_ms);
+
+		bmff::FMP4Packager::Config packager_config;
+		packager_config.chunk_duration_ms = kChunkDurationMs;
+		packager_config.segment_duration_ms = segment_duration_ms;
+
+		TrackPipeline pipeline;
+		pipeline.track = track;
+		pipeline.storage = std::make_shared<bmff::FMP4Storage>(observer, track, storage_config, "marker_sync_test");
+		pipeline.packager = std::make_shared<bmff::FMP4Packager>(pipeline.storage, track, nullptr, packager_config);
+		return pipeline;
+	}
+
+	std::shared_ptr<MediaTrack> MakeVideoTrack(int gop_frames)
+	{
+		auto track = std::make_shared<MediaTrack>();
+		track->SetId(0);
+		track->SetMediaType(cmn::MediaType::Video);
+		track->SetCodecId(cmn::MediaCodecId::H264);
+		track->SetTimeBase(1, 1000);
+		track->SetFrameRateByConfig(30.0);
+		track->SetKeyFrameIntervalByConfig(gop_frames);
+		return track;
+	}
+
+	std::shared_ptr<MediaTrack> MakeAudioTrack()
+	{
+		auto track = std::make_shared<MediaTrack>();
+		track->SetId(1);
+		track->SetMediaType(cmn::MediaType::Audio);
+		track->SetCodecId(cmn::MediaCodecId::Aac);
+		track->SetTimeBase(1, 1000);
+		return track;
+	}
+
+	std::shared_ptr<MediaPacket> MakeVideoFrame(int64_t dts, int64_t duration, bool keyframe)
+	{
+		auto data = std::make_shared<ov::Data>();
+		uint8_t byte = 0x00;
+		data->Append(&byte, 1);
+		return std::make_shared<MediaPacket>(cmn::MediaType::Video, 0, data, dts, dts, duration,
+											 keyframe ? MediaPacketFlag::Key : MediaPacketFlag::NoFlag,
+											 cmn::BitstreamFormat::H264_AVCC, cmn::PacketType::NALU);
+	}
+
+	std::shared_ptr<MediaPacket> MakeAudioFrame(int64_t dts, int64_t duration)
+	{
+		auto data = std::make_shared<ov::Data>();
+		uint8_t byte = 0x00;
+		data->Append(&byte, 1);
+		return std::make_shared<MediaPacket>(cmn::MediaType::Audio, 1, data, dts, dts, duration,
+											 MediaPacketFlag::Key, cmn::BitstreamFormat::AAC_RAW, cmn::PacketType::RAW);
+	}
+
+	// Same protocol as LLHlsStream::InsertMarkerToAllPackagers: one sequence number,
+	// estimated by the video packager and lifted to the highest current sequence,
+	// shared by every track
+	bool InsertCueMarker(const TrackPipeline &video, const TrackPipeline &audio, CueEvent::CueType type, int64_t timestamp_ms, uint32_t duration_ms, bool provisional = false)
+	{
+		auto data = CueEvent::Create(type, duration_ms, 0, provisional)->Serialize();
+
+		int64_t estimated_seq = video.packager->GetEstimatedSequenceNumber(timestamp_ms);
+		int64_t max_current_seq = std::max(video.packager->GetCurrentSequenceNumber(), audio.packager->GetCurrentSequenceNumber());
+
+		for (const auto &pipeline : {video, audio})
+		{
+			auto marker = Marker::CreateMarker(cmn::BitstreamFormat::CUE, timestamp_ms, timestamp_ms, data);
+			auto [can_insert, message] = pipeline.packager->CanInsertMarker(marker);
+			if (can_insert == false)
+			{
+				ADD_FAILURE() << "CanInsertMarker failed: " << message.CStr();
+				return false;
+			}
+		}
+
+		if (max_current_seq > estimated_seq)
+		{
+			estimated_seq = max_current_seq;
+		}
+
+		for (const auto &pipeline : {video, audio})
+		{
+			auto marker = Marker::CreateMarker(cmn::BitstreamFormat::CUE, timestamp_ms, timestamp_ms, data);
+			marker->SetDesiredSequenceNumber(estimated_seq);
+			if (pipeline.packager->InsertMarker(marker) == false)
+			{
+				ADD_FAILURE() << "InsertMarker failed at " << timestamp_ms;
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	struct MarkerObservation
+	{
+		int64_t segment_number = -1;
+		double segment_start_ms = 0.0;
+		double segment_duration_ms = 0.0;
+	};
+
+	// cue index (by order of appearance) -> observation
+	std::map<size_t, MarkerObservation> CollectMarkers(const TrackPipeline &pipeline, CueEvent::CueType type)
+	{
+		std::map<size_t, MarkerObservation> observations;
+		size_t index = 0;
+
+		for (int64_t number = 0; number <= pipeline.storage->GetLastSegmentNumber(); number++)
+		{
+			auto segment = pipeline.storage->GetSegment(number);
+			if (segment == nullptr || segment->HasMarker() == false)
+			{
+				continue;
+			}
+
+			for (const auto &marker : segment->GetMarkers())
+			{
+				auto cue_event = marker->GetCueEvent();
+				if (cue_event == nullptr || cue_event->GetCueType() != type)
+				{
+					continue;
+				}
+
+				observations[index++] = {segment->GetNumber(), static_cast<double>(segment->GetStartTimestamp()), segment->GetDurationMs()};
+			}
+		}
+
+		return observations;
+	}
+
+	void RunScenario(double segment_duration_ms, int gop_frames)
+	{
+		const double gop_ms = gop_frames * 100.0 / 3.0;
+		SCOPED_TRACE(::testing::Message() << "segment " << segment_duration_ms << " ms, gop " << gop_ms << " ms");
+
+		auto observer = std::make_shared<NullStorageObserver>();
+		auto video = MakePipeline(MakeVideoTrack(gop_frames), observer, segment_duration_ms);
+		auto audio = MakePipeline(MakeAudioTrack(), observer, segment_duration_ms);
+
+		// The event creation point stamps the marker one keyframe interval ahead
+		const int64_t marker_lead_ms = static_cast<int64_t>(gop_ms);
+
+		std::vector<int64_t> cue_out_timestamps;
+		for (size_t index = 0; index < kCueCount; index++)
+		{
+			cue_out_timestamps.push_back(3000 + static_cast<int64_t>(index) * kCueIntervalMs + marker_lead_ms);
+		}
+
+		const int64_t total_duration_ms = cue_out_timestamps.back() + kCueDurationMs + 2 * static_cast<int64_t>(segment_duration_ms) + 5000;
+
+		// RTMP-style integer millisecond timestamps
+		int64_t video_index = 0;
+		int64_t audio_index = 0;
+		size_t cue_index = 0;
+
+		while (true)
+		{
+			const int64_t video_dts = video_index * 100 / 3;
+			const int64_t audio_dts = audio_index * 64 / 3;
+			const int64_t now_ms = std::min(video_dts, audio_dts);
+
+			if (now_ms >= total_duration_ms)
+			{
+				break;
+			}
+
+			// The OUT and its paired provisional IN arrive back to back, markers
+			// ahead of the media time
+			if (cue_index < kCueCount && now_ms >= cue_out_timestamps[cue_index] - marker_lead_ms)
+			{
+				ASSERT_TRUE(InsertCueMarker(video, audio, CueEvent::CueType::OUT, cue_out_timestamps[cue_index], kCueDurationMs));
+				ASSERT_TRUE(InsertCueMarker(video, audio, CueEvent::CueType::IN, cue_out_timestamps[cue_index] + kCueDurationMs, 0, true));
+
+				// An explicit IN for the same return point must replace the pending
+				// one harmlessly, on the same sequence
+				ASSERT_TRUE(InsertCueMarker(video, audio, CueEvent::CueType::IN, cue_out_timestamps[cue_index] + kCueDurationMs, 0));
+				cue_index++;
+			}
+
+			if (video_dts <= audio_dts)
+			{
+				const int64_t duration = (video_index + 1) * 100 / 3 - video_dts;
+				ASSERT_TRUE(video.packager->AppendSample(MakeVideoFrame(video_dts, duration, (video_index % gop_frames) == 0)));
+				video_index++;
+			}
+			else
+			{
+				const int64_t duration = (audio_index + 1) * 64 / 3 - audio_dts;
+				ASSERT_TRUE(audio.packager->AppendSample(MakeAudioFrame(audio_dts, duration)));
+				audio_index++;
+			}
+		}
+
+		ASSERT_EQ(cue_index, kCueCount);
+
+		auto video_out = CollectMarkers(video, CueEvent::CueType::OUT);
+		auto audio_out = CollectMarkers(audio, CueEvent::CueType::OUT);
+		auto video_in = CollectMarkers(video, CueEvent::CueType::IN);
+		auto audio_in = CollectMarkers(audio, CueEvent::CueType::IN);
+
+		ASSERT_EQ(video_out.size(), kCueCount);
+		ASSERT_EQ(audio_out.size(), kCueCount);
+		ASSERT_EQ(video_in.size(), kCueCount);
+		ASSERT_EQ(audio_in.size(), kCueCount);
+
+		for (size_t index = 0; index < kCueCount; index++)
+		{
+			const double out_ts = static_cast<double>(cue_out_timestamps[index]);
+			const double in_ts = out_ts + kCueDurationMs;
+
+			const auto &v_out = video_out[index];
+			const auto &a_out = audio_out[index];
+
+			// The OUT marker cuts every track at its timestamp, on the same sequence
+			EXPECT_EQ(v_out.segment_number, a_out.segment_number) << "OUT marker of cue " << index << " landed on different sequences";
+			EXPECT_NEAR(v_out.segment_start_ms + v_out.segment_duration_ms, out_ts, kFrameJitterMs) << "video was not cut at cue " << index;
+			EXPECT_NEAR(a_out.segment_start_ms + a_out.segment_duration_ms, out_ts, kFrameJitterMs) << "audio was not cut at cue " << index;
+
+			const auto &v_in = video_in[index];
+			const auto &a_in = audio_in[index];
+
+			// The IN marker lands on the same sequence on every track. Audio returns
+			// at the timestamp itself, video at the first keyframe at or after it.
+			EXPECT_EQ(v_in.segment_number, a_in.segment_number) << "IN marker of cue " << index << " landed on different sequences";
+			EXPECT_NEAR(a_in.segment_start_ms + a_in.segment_duration_ms, in_ts, kFrameJitterMs) << "audio did not return at cue " << index;
+
+			const double v_in_end = v_in.segment_start_ms + v_in.segment_duration_ms;
+			EXPECT_GE(v_in_end, in_ts - kFrameJitterMs) << "video returned before cue " << index << " ended";
+			EXPECT_LE(v_in_end, in_ts + gop_ms + kFrameJitterMs) << "video return exceeded one keyframe interval at cue " << index;
+		}
+
+		// The sequences must not drift apart over the whole run
+		EXPECT_LE(std::abs(video.storage->GetLastSegmentNumber() - audio.storage->GetLastSegmentNumber()), 1);
+
+		// A segment waiting for a marker may stretch up to one keyframe interval
+		// past the target, but the force-completion threshold (twice the target)
+		// must never be reached
+		for (const auto &pipeline : {video, audio})
+		{
+			for (int64_t number = 0; number <= pipeline.storage->GetLastSegmentNumber(); number++)
+			{
+				auto segment = pipeline.storage->GetSegment(number);
+				if (segment == nullptr || segment->IsCompleted() == false)
+				{
+					continue;
+				}
+
+				EXPECT_LE(segment->GetDurationMs(), segment_duration_ms + gop_ms + kFrameJitterMs)
+					<< "track " << pipeline.track->GetId() << " segment " << number << " was force-completed or overstretched";
+			}
+		}
+	}
+}  // namespace
+
+// One cue driven through the real packagers with an adjustable feed end
+namespace
+{
+	struct SingleCueRun
+	{
+		TrackPipeline video;
+		TrackPipeline audio;
+
+		void Feed(int gop_frames, int64_t until_ms, int64_t out_ts_ms, uint32_t duration_ms, int64_t extension_at_ms, int64_t extension_ts_ms, bool paired_in_provisional)
+		{
+			const int64_t marker_lead_ms = static_cast<int64_t>(gop_frames * 100.0 / 3.0);
+
+			int64_t video_index = 0;
+			int64_t audio_index = 0;
+			bool cue_sent = false;
+			bool extension_sent = (extension_at_ms < 0);
+
+			while (true)
+			{
+				const int64_t video_dts = video_index * 100 / 3;
+				const int64_t audio_dts = audio_index * 64 / 3;
+				const int64_t now_ms = std::min(video_dts, audio_dts);
+
+				if (now_ms >= until_ms)
+				{
+					break;
+				}
+
+				if (cue_sent == false && now_ms >= out_ts_ms - marker_lead_ms)
+				{
+					ASSERT_TRUE(InsertCueMarker(video, audio, CueEvent::CueType::OUT, out_ts_ms, duration_ms));
+					ASSERT_TRUE(InsertCueMarker(video, audio, CueEvent::CueType::IN, out_ts_ms + duration_ms, 0, paired_in_provisional));
+					cue_sent = true;
+				}
+
+				if (extension_sent == false && now_ms >= extension_at_ms)
+				{
+					ASSERT_TRUE(InsertCueMarker(video, audio, CueEvent::CueType::IN, extension_ts_ms, 0));
+					extension_sent = true;
+				}
+
+				if (video_dts <= audio_dts)
+				{
+					const int64_t duration = (video_index + 1) * 100 / 3 - video_dts;
+					ASSERT_TRUE(video.packager->AppendSample(MakeVideoFrame(video_dts, duration, (video_index % gop_frames) == 0)));
+					video_index++;
+				}
+				else
+				{
+					const int64_t duration = (audio_index + 1) * 64 / 3 - audio_dts;
+					ASSERT_TRUE(audio.packager->AppendSample(MakeAudioFrame(audio_dts, duration)));
+					audio_index++;
+				}
+			}
+		}
+	};
+}  // namespace
+
+TEST(FMP4MarkerSyncTest, ProvisionalInCanBeExtended)
+{
+	constexpr double kSegmentMs = 1600.0;
+	constexpr int kGopFrames = 24;	// 800 ms
+	constexpr double kGopMs = 800.0;
+
+	auto observer = std::make_shared<NullStorageObserver>();
+	SingleCueRun run{MakePipeline(MakeVideoTrack(kGopFrames), observer, kSegmentMs), MakePipeline(MakeAudioTrack(), observer, kSegmentMs)};
+
+	// OUT at 4.8 s with a planned 20 s break; at 15 s the operator moves the
+	// return point 5 s later than planned
+	const int64_t out_ts = 4800;
+	const int64_t planned_in_ts = out_ts + 20000;
+	const int64_t extended_in_ts = planned_in_ts + 5000;
+	run.Feed(kGopFrames, extended_in_ts + 10000, out_ts, 20000, 15000, extended_in_ts, true);
+
+	auto video_in = CollectMarkers(run.video, CueEvent::CueType::IN);
+	auto audio_in = CollectMarkers(run.audio, CueEvent::CueType::IN);
+
+	// Exactly one IN, at the extended position, on the same sequence
+	ASSERT_EQ(video_in.size(), 1u);
+	ASSERT_EQ(audio_in.size(), 1u);
+	EXPECT_EQ(video_in[0].segment_number, audio_in[0].segment_number);
+	EXPECT_NEAR(audio_in[0].segment_start_ms + audio_in[0].segment_duration_ms, extended_in_ts, kFrameJitterMs);
+
+	const double v_in_end = video_in[0].segment_start_ms + video_in[0].segment_duration_ms;
+	EXPECT_GE(v_in_end, extended_in_ts - kFrameJitterMs);
+	EXPECT_LE(v_in_end, extended_in_ts + kGopMs + kFrameJitterMs);
+}
+
+TEST(FMP4MarkerSyncTest, ConfirmedInRejectsExtension)
+{
+	constexpr double kSegmentMs = 1600.0;
+	constexpr int kGopFrames = 24;
+
+	auto observer = std::make_shared<NullStorageObserver>();
+	SingleCueRun run{MakePipeline(MakeVideoTrack(kGopFrames), observer, kSegmentMs), MakePipeline(MakeAudioTrack(), observer, kSegmentMs)};
+
+	// The IN of an autoReturn OUT is confirmed: the return point may only move earlier
+	const int64_t out_ts = 4800;
+	const int64_t planned_in_ts = out_ts + 20000;
+	run.Feed(kGopFrames, 15000, out_ts, 20000, -1, 0, false);
+
+	auto data = CueEvent::Create(CueEvent::CueType::IN)->Serialize();
+	auto marker = Marker::CreateMarker(cmn::BitstreamFormat::CUE, planned_in_ts + 5000, planned_in_ts + 5000, data);
+	auto [can_insert, message] = run.video.packager->CanInsertMarker(marker);
+	EXPECT_FALSE(can_insert);
+
+	// Moving it earlier stays allowed
+	auto earlier_marker = Marker::CreateMarker(cmn::BitstreamFormat::CUE, planned_in_ts - 5000, planned_in_ts - 5000, data);
+	auto [can_insert_earlier, message_earlier] = run.video.packager->CanInsertMarker(earlier_marker);
+	EXPECT_TRUE(can_insert_earlier);
+}
+
+TEST(FMP4MarkerSyncTest, ProvisionalInRejectsProvisionalExtension)
+{
+	constexpr double kSegmentMs = 1600.0;
+	constexpr int kGopFrames = 24;
+
+	auto observer = std::make_shared<NullStorageObserver>();
+	SingleCueRun run{MakePipeline(MakeVideoTrack(kGopFrames), observer, kSegmentMs), MakePipeline(MakeAudioTrack(), observer, kSegmentMs)};
+
+	// A duplicate OUT sent mid-break is rejected, but its provisional companion IN
+	// still arrives; it must not move the pending return point
+	const int64_t out_ts = 4800;
+	const int64_t planned_in_ts = out_ts + 20000;
+	run.Feed(kGopFrames, 15000, out_ts, 20000, -1, 0, true);
+
+	auto provisional_data = CueEvent::Create(CueEvent::CueType::IN, 0, 0, true)->Serialize();
+	auto provisional_marker = Marker::CreateMarker(cmn::BitstreamFormat::CUE, planned_in_ts + 5000, planned_in_ts + 5000, provisional_data);
+	auto [can_insert, message] = run.video.packager->CanInsertMarker(provisional_marker);
+	EXPECT_FALSE(can_insert);
+
+	// An explicit IN may still extend the pending provisional return point
+	auto explicit_data = CueEvent::Create(CueEvent::CueType::IN)->Serialize();
+	auto explicit_marker = Marker::CreateMarker(cmn::BitstreamFormat::CUE, planned_in_ts + 5000, planned_in_ts + 5000, explicit_data);
+	auto [can_insert_explicit, message_explicit] = run.video.packager->CanInsertMarker(explicit_marker);
+	EXPECT_TRUE(can_insert_explicit);
+}
+
+TEST(FMP4MarkerSyncTest, HalfSegmentGop)
+{
+	// 1.6 s segments, 0.8 s keyframe interval
+	RunScenario(1600.0, 24);
+}
+
+TEST(FMP4MarkerSyncTest, HalfSegmentGopLarge)
+{
+	// 3.2 s segments, 1.6 s keyframe interval
+	RunScenario(3200.0, 48);
+}
+
+TEST(FMP4MarkerSyncTest, QuarterSegmentGop)
+{
+	// 4 s segments, 1 s keyframe interval
+	RunScenario(4000.0, 30);
+}

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_packager.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_packager.cpp
@@ -7,6 +7,7 @@
 //
 //==============================================================================
 
+#include <algorithm>
 #include <cmath>
 
 #include "fmp4_packager.h"
@@ -173,7 +174,9 @@ namespace bmff
 		_segmentation_info.framerate = media_track->GetFrameRate();
 
 		// This track's own boundary supersedes a cut propagated from another track
+		// or owed to a consumed marker
 		_pending_cut_timestamp_ms = -1.0;
+		_pending_marker_cut_timestamp = -1;
 		_last_boundary_timestamp_ms = GetLastSampleEndTimestampMs();
 
 		bool init_section_created = CreateInitializationSegment();
@@ -349,6 +352,18 @@ namespace bmff
 		double next_total_sample_duration_ms = (static_cast<double>(next_total_sample_duration) / GetMediaTrack()->GetTimeBase().GetTimescale()) * 1000.0;
 		bool next_frame_is_idr = (next_frame->GetFlag() == MediaPacketFlag::Key) || (GetMediaTrack()->GetMediaType() == cmn::MediaType::Audio);
 
+		// A marker position must end the segment at the first cuttable frame at or
+		// after it, even if the marker was already consumed by an earlier chunk of
+		// this segment or sits exactly on this frame
+		bool return_cut = false;
+		if (next_frame_is_idr == true && samples != nullptr && samples->GetTotalCount() > 0)
+		{
+			// Only positions from the current samples on; an older leftover is
+			// expired and gets discarded at the next completion instead of cutting
+			return_cut = (_pending_marker_cut_timestamp >= 0 && next_frame->GetDts() >= _pending_marker_cut_timestamp) ||
+						 (HasMarker(samples->GetStartTimestamp(), next_frame->GetDts() + 1) == true);
+		}
+
 		// Marker handling
 		constexpr uint8_t kNoMarker = 0;
 		constexpr uint8_t kFlushAsSoonAsPossible = 1;
@@ -461,19 +476,27 @@ namespace bmff
 				can_be_last_chunk = true;
 			}
 
+			if (return_cut == true)
+			{
+				// The marker boundary cut overrides a deferred flush
+				can_be_last_chunk = true;
+			}
+
 			logtt("track(%d), total_sample_duration_ms: %lf, next_total_sample_duration_ms: %lf, target_chunk_duration_ms: %lf, next_frame_is_idr: %d, is_last_partial_segment: %d last_segment_duration: %lf, target_segment_duration: %f", GetMediaTrack()->GetId(), total_sample_duration_ms, next_total_sample_duration_ms, _target_chunk_duration_ms, next_frame_is_idr, can_be_last_chunk, last_segment != nullptr ? last_segment->GetDurationMs() : -1, _storage->GetTargetSegmentDuration());
 
 			// - In the last partial segment, if the next frame is a keyframe, a segment is created immediately. This allows the segment to start with a keyframe.
 			// - When adding samples, if the Part Target Duration is exceeded, a chunk is created immediately.
 			// - If it exceeds 85% and the next sample is independent, a chunk is created. This makes the next chunk start independent.
 			if (	(total_sample_duration_ms >= _target_chunk_duration_ms) ||
-				
+
 					(marker_handling == kShouldFlushImmediately) ||
+
+					(return_cut == true) ||
 
 					(can_be_last_chunk == true && GetMediaTrack()->GetMediaType() == cmn::MediaType::Video && next_frame_is_idr == true) ||
 					(can_be_last_chunk == true && GetMediaTrack()->GetMediaType() == cmn::MediaType::Audio) ||
-					
-					((next_total_sample_duration_ms > _target_chunk_duration_ms) && (total_sample_duration_ms >= _target_chunk_duration_ms * 0.85)) 
+
+					((next_total_sample_duration_ms > _target_chunk_duration_ms) && (total_sample_duration_ms >= _target_chunk_duration_ms * 0.85))
 				)
 			{
 				double reserve_buffer_size;
@@ -514,60 +537,46 @@ namespace bmff
 
 				auto chunk = chunk_stream.GetDataPointer();
 
-				auto markers = PopMarkers(samples->GetStartTimestamp(), samples->GetEndTimestamp());
+				// The marker boundary cut ends the segment exactly at this frame's
+				// position, so a marker sitting on it belongs to the closing segment
+				auto pop_end_timestamp = (return_cut == true) ? std::max(samples->GetEndTimestamp(), next_frame->GetDts() + 1) : samples->GetEndTimestamp();
+				auto markers = PopMarkers(samples->GetStartTimestamp(), pop_end_timestamp);
 
-				////////////////////////////////////////////////////
-				// Auto Insertion of Cue-In/SCTE35-IN Marker
-				// It is moved to the upper layer (LLHLS Stream) to synchronize with all tracks
-				////////////////////////////////////////////////////
-
-				// if (markers.empty() == false)
-				// {
-				// 	// If the last marker is a cue-out marker, insert a cue-in marker automatically after duration of cue-out marker
-				// 	auto last_pop_marker = markers.back();
-				// 	auto next_marker = GetFirstMarker();
-				// 	if (last_pop_marker != nullptr && last_pop_marker->IsOutOfNetwork() == true && next_marker == nullptr)
-				// 	{
-				// 		// If there is no next xxx-IN marker, insert a xxx-in marker automatically
-				// 		if (last_pop_marker->GetMarkerFormat() == cmn::BitstreamFormat::CUE)
-				// 		{
-				// 			// Insert a CUE-IN marker
-				// 			auto cue_out_event = last_pop_marker->GetCueEvent();
-				// 			if (cue_out_event != nullptr)
-				// 			{
-				// 				auto duration_msec = cue_out_event->GetDurationMsec();
-				// 				auto main_track = GetMediaTrack();
-				// 				int64_t cue_in_timestamp = (samples->GetEndTimestamp() - 1) + (static_cast<double>(duration_msec) / 1000.0 * main_track->GetTimeBase().GetTimescale());
-
-				// 				auto cue_in_marker = Marker::CreateMarker(cmn::BitstreamFormat::CUE, cue_in_timestamp, CueEvent::Create(CueEvent::CueType::IN, 0)->Serialize());
-
-				// 				InsertMarker(cue_in_marker);
-				// 			}
-				// 		}
-				// 		else if (last_pop_marker->GetMarkerFormat() == cmn::BitstreamFormat::SCTE35)
-				// 		{
-				// 			// Insert a SCTE35-IN marker
-				// 			auto scte35_out_event = last_pop_marker->GetScte35Event();
-				// 			if (scte35_out_event != nullptr)
-				// 			{
-				// 				auto duration_msec = scte35_out_event->GetDurationMsec();
-				// 				auto main_track = GetMediaTrack();
-				// 				int64_t scte35_in_timestamp = (samples->GetEndTimestamp() - 1) + (static_cast<double>(duration_msec) / 1000.0 * main_track->GetTimeBase().GetTimescale());
-
-				// 				auto scte_in_data = Scte35Event::Create(mpegts::SpliceCommandType::SPLICE_INSERT, scte35_out_event->GetID(), false, scte35_in_timestamp, duration_msec, false)->Serialize();
-
-				// 				auto marker = Marker::CreateMarker(cmn::BitstreamFormat::SCTE35, scte35_in_timestamp, scte_in_data);
-
-				// 				InsertMarker(marker);
-				// 			}
-				// 		}
-				// 	}
-				// }
+				if (return_cut == true && marker_handling != kShouldFlushImmediately)
+				{
+					for (const auto &marker : markers)
+					{
+						logti("track(%u) - Segment cut at the marker boundary (%s, timestamp: %" PRId64 ")", GetMediaTrack()->GetId(), marker->GetTag().CStr(), marker->GetTimestamp());
+					}
+				}
 
 				bool last_chunk = can_be_last_chunk && next_frame_is_idr;
 				if (marker_handling == kShouldFlushImmediately)
 				{
 					last_chunk = true;
+				}
+
+				if (last_chunk == true)
+				{
+					// A completed boundary satisfies any pending marker cut
+					_pending_marker_cut_timestamp = -1;
+
+					// A marker whose position was skipped over can never be popped by a
+					// sample range again, and a leftover would corrupt the sequence
+					// estimation of every later marker
+					for (const auto &expired_marker : PopExpiredMarkers(samples->GetStartTimestamp()))
+					{
+						logtw("track(%u) - Discarded the marker (%s, timestamp: %" PRId64 ") because its position was never reached", GetMediaTrack()->GetId(), expired_marker->GetTag().CStr(), expired_marker->GetTimestamp());
+					}
+				}
+				else
+				{
+					// A marker consumed by a mid-segment chunk still owes the segment a
+					// cut at the first cuttable frame at or after its position
+					for (const auto &marker : markers)
+					{
+						_pending_marker_cut_timestamp = std::max(_pending_marker_cut_timestamp, marker->GetTimestamp());
+					}
 				}
 
 				if (_storage != nullptr && _storage->AppendMediaChunk(chunk, 

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_packager.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_packager.cpp
@@ -556,6 +556,19 @@ namespace bmff
 					last_chunk = true;
 				}
 
+				if (_storage != nullptr && _storage->AppendMediaChunk(chunk,
+												samples->GetStartTimestamp(),
+												total_sample_duration_ms,
+												samples->IsIndependent(),
+												last_chunk,
+												markers) == false)
+				{
+					logte("FMP4Packager::AppendSample() - Failed to store media chunk");
+					return false;
+				}
+
+				// The storage may have force-completed an overlong segment, so the
+				// pending cut is settled on the flag it reports back
 				if (last_chunk == true)
 				{
 					// A completed boundary satisfies any pending marker cut
@@ -577,17 +590,6 @@ namespace bmff
 					{
 						_pending_marker_cut_timestamp = std::max(_pending_marker_cut_timestamp, marker->GetTimestamp());
 					}
-				}
-
-				if (_storage != nullptr && _storage->AppendMediaChunk(chunk, 
-												samples->GetStartTimestamp(), 
-												total_sample_duration_ms, 
-												samples->IsIndependent(), 
-												last_chunk, 
-												markers) == false)
-				{
-					logte("FMP4Packager::AppendSample() - Failed to store media chunk");
-					return false;
 				}
 
 				_sample_buffer.Reset();
@@ -697,10 +699,11 @@ namespace bmff
 			// Storage expects milliseconds, samples hold durations in timescale units
 			double total_sample_duration_ms = (static_cast<double>(samples->GetTotalDuration()) / GetMediaTrack()->GetTimeBase().GetTimescale()) * 1000.0;
 
+			bool last_chunk = true;
 			if (_storage != nullptr && _storage->AppendMediaChunk(chunk,
 											samples->GetStartTimestamp(),
 											total_sample_duration_ms,
-											samples->IsIndependent(), true) == false)
+											samples->IsIndependent(), last_chunk) == false)
 			{
 				logte("FMP4Packager::Flush() - Failed to store media chunk");
 				return false;

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_packager.h
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_packager.h
@@ -107,6 +107,11 @@ namespace bmff
 
 		// Negative when no cut is pending
 		double _pending_cut_timestamp_ms = -1.0;
+
+		// Position of a marker already consumed by a mid-segment chunk; the segment
+		// still has to end at the first cuttable frame at or after this position.
+		// Negative when none is pending, track timescale
+		int64_t _pending_marker_cut_timestamp = -1;
 		// Timestamp of the last boundary this packager handled (own track change or
 		// an applied cut), to ignore re-propagation of the same boundary event
 		double _last_boundary_timestamp_ms = -1.0;

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_storage.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_storage.cpp
@@ -557,7 +557,7 @@ namespace bmff
 		}
 	}
 
-	bool FMP4Storage::AppendMediaChunk(const std::shared_ptr<ov::Data> &chunk, int64_t start_timestamp, double duration_ms, bool independent, bool last_chunk, const std::vector<std::shared_ptr<Marker>> &markers)
+	bool FMP4Storage::AppendMediaChunk(const std::shared_ptr<ov::Data> &chunk, int64_t start_timestamp, double duration_ms, bool independent, bool &last_chunk, const std::vector<std::shared_ptr<Marker>> &markers)
 	{
 		auto segment = GetLastSegmentInternal();
 		if (segment == nullptr || segment->IsCompleted() == true)

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_storage.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_storage.cpp
@@ -577,7 +577,7 @@ namespace bmff
 			// Force to complete the segment
 			last_chunk = true;
 			// Too long segment buffered
-			logte("LLHLS stream (%s) / track (%d) - the duration of the segment being created exceeded twice the target segment duration (%.1lf ms | expected: %" PRIu64 ") because there were no IDR frames for a long time. This segment is forcibly created and may not play normally.", 
+			logte("LLHLS stream (%s) / track (%d) - the duration of the segment being created exceeded twice the target segment duration (%.1lf ms | expected: %" PRIu64 ") because no cuttable boundary (keyframe or target duration) appeared for a long time. This segment is forcibly created and may not play normally.",
 			_stream_tag.CStr(), GetTrack()->GetId(), segment->GetDurationMs(), _config.segment_duration_ms);
 		}
 
@@ -592,27 +592,15 @@ namespace bmff
 			_total_expected_duration_ms += _config.segment_duration_ms;
 			_total_segment_duration_ms += segment->GetDurationMs();
 
-			// When there is a marker, it comes out smaller than or equal to the expected Segment.
-			// Depending on the conditions, Audio may come out smaller or equal, but Video may come out smaller, equal or larger.
-			// If Audio comes out smaller and Video comes out the equal, the Sequnce is broken.
-			// Therefore, in this case, the algorithm is configured to come out smaller unconditionally.
+			// A marker segment is discounted so the following segment comes out
+			// smaller: every track gains exactly one boundary per marker and returns
+			// to the same segment grid, keeping the sequence numbers aligned.
+			// Requires the keyframe interval to be shorter than the segment duration
 			if (segment->HasMarker() == true)
 			{
 				logtd("LLHLS stream (%s) / track (%u) - segment[%" PRId64 "] has markers %s", _stream_tag.CStr(), GetTrack()->GetId(), segment->GetNumber(), segment->GetMarkers().back()->GetTag().CStr());
 
 				_total_expected_duration_ms -= _config.segment_duration_ms;
-				
-				// auto last_marker = segment->GetMarkers().back();
-				// if (last_marker != nullptr && last_marker->IsOutOfNetwork() == true)
-				// {
-				// 	// We can initialize the all time variables here
-				// 	_total_expected_duration_ms = 0;
-				// 	_total_segment_duration_ms = 0;
-				// }
-				// else if (last_marker != nullptr && last_marker->IsOutOfNetwork() == false)
-				// {
-				// 	_total_expected_duration_ms -= _config.segment_duration_ms;
-				// }
 			}
 
 			double next_target_duration = _total_expected_duration_ms - _total_segment_duration_ms + _config.segment_duration_ms;
@@ -620,53 +608,7 @@ namespace bmff
 			logtt("LLHLS stream (%s) / track (%u) - segment_seq(%" PRId64 ") segment_duration_ms: %f total_expected_duration_ms: %f, total_segment_duration_ms: %f, next_target_duration: %f",
 				_stream_tag.CStr(), GetTrack()->GetId(), segment->GetNumber(), segment->GetDurationMs(), _total_expected_duration_ms, _total_segment_duration_ms, next_target_duration);
 
-			if (next_target_duration >= static_cast<double>(_config.segment_duration_ms)/2.0)
-			{
-				_target_segment_duration_ms = next_target_duration;
-			}
-			else
-			{
-				_target_segment_duration_ms = next_target_duration; //static_cast<double>(_config.segment_duration_ms / 2);
-			}
-
-			// Make CUE-OUT-CONT
-			// TODO(Getroot): Later it will be added with server option
-			// if (segment->HasMarker())
-			// {
-			// 	for (const auto &it : segment->GetMarkers())
-			// 	{
-			// 		if (it.tag.UpperCaseString() == "CUEEVENT-OUT")
-			// 		{
-			// 			// Get duration
-			// 			auto cue_out_event = ::CueEvent::Parse(it.data);
-			// 			if (cue_out_event != nullptr)
-			// 			{
-			// 				_is_cue_out_on = true;
-			// 				_cue_out_duration_msec = cue_out_event->GetDurationMsec();
-			// 				_cue_out_elapsed_msec = 0;
-			// 			}
-
-			// 		}
-			// 		else if (it.tag.UpperCaseString() == "CUEEVENT-IN")
-			// 		{
-			// 			_is_cue_out_on = false;
-			// 			_cue_out_duration_msec = 0;
-			// 			_cue_out_elapsed_msec = 0;
-			// 		}
-			// 	}
-			// }
-			// else if (segment->HasMarker() == false && _is_cue_out_on == true)
-			// {
-			// 	_cue_out_elapsed_msec += segment->GetDuration();
-
-			// 	// Make CUE-OUT-CONT
-			// 	Marker marker;
-			// 	marker.timestamp = segment->GetStartTimestamp() + segment->GetDuration();
-			// 	marker.tag = "CUEEVENT-OUT-CONT";
-			// 	marker.data = CueEvent::Create(::CueEvent::CueType::CONT, _cue_out_duration_msec, _cue_out_elapsed_msec)->Serialize();
-
-			// 	segment->SetMarkers({ marker });
-			// }
+			_target_segment_duration_ms = next_target_duration;
 
 			logtt("LLHLS stream (%s) / track (%u) - segment_duration_ms: %f total_expected_duration_ms: %f, total_segment_duration_ms: %f, next_target_duration: %f, target_segment_duration: %f has_marker: %d",
 				_stream_tag.CStr(), GetTrack()->GetId(), segment->GetDurationMs(), _total_expected_duration_ms, _total_segment_duration_ms, next_target_duration, _target_segment_duration_ms, segment->HasMarker());

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_storage.h
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_storage.h
@@ -56,7 +56,9 @@ namespace bmff
 		std::tuple<int64_t, int64_t> GetLastPartialSegmentNumber() const override;
 		
 		bool StoreInitializationSection(const std::shared_ptr<ov::Data> &section);
-		bool AppendMediaChunk(const std::shared_ptr<ov::Data> &chunk, int64_t start_timestamp, double duration_ms, bool independent, bool last_chunk, const std::vector<std::shared_ptr<Marker>> &markers = {});
+		// last_chunk is in/out: the storage force-completes an overlong segment on
+		// its own and reports it back through this flag
+		bool AppendMediaChunk(const std::shared_ptr<ov::Data> &chunk, int64_t start_timestamp, double duration_ms, bool independent, bool &last_chunk, const std::vector<std::shared_ptr<Marker>> &markers = {});
 
 		// Switch to a new version of the track at a runtime configuration change.
 		// Completes the in-progress segment and creates subsequent segments with the

--- a/src/publishers/llhls/llhls_stream.cpp
+++ b/src/publishers/llhls/llhls_stream.cpp
@@ -10,15 +10,12 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 
 #include <base/ovlibrary/hex.h>
 #include <base/publisher/application.h>
 #include <base/publisher/stream.h>
 #include <config/config_manager.h>
-
-#include <pugixml-1.9/src/pugixml.hpp>
-
-#include <base/modules/data_format/cue_event/cue_event.h>
 
 #include <pugixml-1.9/src/pugixml.hpp>
 
@@ -1284,6 +1281,31 @@ void LLHlsStream::SendDataFrame(const std::shared_ptr<MediaPacket> &media_packet
 	}
 	else if (media_packet->GetBitstreamFormat() == cmn::BitstreamFormat::CUE || media_packet->GetBitstreamFormat() == cmn::BitstreamFormat::SCTE35)
 	{
+		// Marker alignment across tracks requires the keyframe interval to be
+		// strictly shorter than the segment duration and to divide it evenly;
+		// an equal interval also breaks the alignment
+		if (_cue_alignment_warned == false)
+		{
+			auto video_track = GetFirstTrackByType(cmn::MediaType::Video);
+			if (video_track != nullptr)
+			{
+				auto keyframe_interval_ms = video_track->GetKeyframeIntervalDurationMs();
+				auto segment_duration_ms = static_cast<double>(_storage_config.segment_duration_ms);
+				if (keyframe_interval_ms > 0)
+				{
+					auto remainder_ms = std::fmod(segment_duration_ms, keyframe_interval_ms);
+					bool divides = (remainder_ms <= 1.0) || ((keyframe_interval_ms - remainder_ms) <= 1.0);
+					bool shorter = keyframe_interval_ms < (segment_duration_ms - 1.0);
+					if (divides == false || shorter == false)
+					{
+						logtw("LLHlsStream(%s/%s) - The keyframe interval (%.0f ms) must be shorter than the segment duration (%.0f ms) and divide it evenly. CUE/SCTE-35 markers cannot be kept aligned across renditions with this configuration. Adjust the encoder GOP or <SegmentDuration>.",
+							  GetApplication()->GetVHostAppName().CStr(), GetName().CStr(), keyframe_interval_ms, segment_duration_ms);
+						_cue_alignment_warned = true;
+					}
+				}
+			}
+		}
+
 		// milliseconds scale
 		auto timestamp_ms = static_cast<double>(media_packet->GetDts()) / data_track->GetTimeBase().GetTimescale() * 1000.0;
 		std::shared_ptr<ov::Data> data = media_packet->GetData() != nullptr ? media_packet->GetData()->Clone() : nullptr;
@@ -1293,54 +1315,7 @@ void LLHlsStream::SendDataFrame(const std::shared_ptr<MediaPacket> &media_packet
 			return;
 		}
 
-		// Parse data
-		if (media_packet->GetBitstreamFormat() == cmn::BitstreamFormat::CUE)
-		{
-			auto cue_event = CueEvent::Parse(media_packet->GetData());
-			if (cue_event == nullptr)
-			{
-				logte("Failed to parse cue event");
-				return;
-			}
-
-			if (cue_event->GetCueType() == CueEvent::CueType::OUT)
-			{
-				// Make CUE-IN event
-				auto cue_out_duration_ms = cue_event->GetDurationMsec();
-				auto cue_in_timestamp_ms = timestamp_ms + cue_out_duration_ms;
-				auto cue_in_data = CueEvent::Create(CueEvent::CueType::IN)->Serialize();
-
-				if (InsertMarkerToAllPackagers(media_packet->GetTrackId(), cmn::BitstreamFormat::CUE, cue_in_timestamp_ms, cue_in_data) == false)
-				{
-					logte("Failed to insert CUE-IN marker to all packagers (track_id: %u, timestamp: %f)", media_packet->GetTrackId(), cue_in_timestamp_ms);
-					return;
-				}
-			}
-		}
-		else if (media_packet->GetBitstreamFormat() == cmn::BitstreamFormat::SCTE35)
-		{
-			auto scte35_event = Scte35Event::Parse(media_packet->GetData());
-			if (scte35_event == nullptr)
-			{
-				logte("Failed to parse scte35 event (track_id: %u, timestamp: %" PRId64 ")", media_packet->GetTrackId(), media_packet->GetDts());
-				return;
-			}
-
-			if (scte35_event->IsOutOfNetwork() == true)
-			{
-				// Make SCTE35-IN event
-				auto scte_out_duration_ms = scte35_event->GetDurationMsec();
-				auto scte_in_timestamp_ms = timestamp_ms + scte_out_duration_ms;
-				auto scte_in_data = Scte35Event::Create(mpegts::SpliceCommandType::SPLICE_INSERT, scte35_event->GetID(), false, scte_in_timestamp_ms, scte_out_duration_ms, false)->Serialize();
-
-				// xxx-OUT marker will create one more segment, so we need to shift the sequence number by 1
-				if (InsertMarkerToAllPackagers(media_packet->GetTrackId(), cmn::BitstreamFormat::SCTE35, scte_in_timestamp_ms, scte_in_data) == false)
-				{
-					logte("Failed to insert SCTE35-IN marker to all packagers (track_id: %u, timestamp: %f)", media_packet->GetTrackId(), scte_in_timestamp_ms);
-					return;
-				}
-			}
-		}
+		// The IN paired with an OUT arrives as its own event from the creation point
 	}
 	else if (media_packet->GetBitstreamFormat() == cmn::BitstreamFormat::WebVTT)
 	{
@@ -1371,9 +1346,6 @@ std::tuple<bool, ov::String> LLHlsStream::CanInsertMarker(cmn::BitstreamFormat b
 	{
 		return {false, "Could not find data track"};
 	}
-
-	auto first_video_media_track = GetFirstTrackByType(cmn::MediaType::Video);
-	auto first_video_packager = GetPackager(first_video_media_track->GetId());
 
 	// Insert marker to all packagers
 	for (const auto &it : GetTracks())
@@ -1422,10 +1394,12 @@ bool LLHlsStream::InsertMarkerToAllPackagers(uint32_t data_track_id, cmn::Bitstr
 	}
 
 	auto first_video_media_track = GetFirstTrackByType(cmn::MediaType::Video);
-	auto first_video_packager = GetPackager(first_video_media_track->GetId());
+	auto first_video_packager = (first_video_media_track != nullptr) ? GetPackager(first_video_media_track->GetId()) : nullptr;
 
-	// Create marker
-	int64_t estimated_seq = first_video_packager->GetEstimatedSequenceNumber(timestamp_ms);
+	// The estimate comes from the video packager because video owns the coarsest
+	// cut granularity; without a video track it falls back to the highest
+	// current sequence number below
+	int64_t estimated_seq = (first_video_packager != nullptr) ? first_video_packager->GetEstimatedSequenceNumber(timestamp_ms) : -1;
 	int64_t max_current_seq = 0;
 	// 0: check if it can insert
 	// 1: insert

--- a/src/publishers/llhls/llhls_stream.cpp
+++ b/src/publishers/llhls/llhls_stream.cpp
@@ -1315,7 +1315,7 @@ void LLHlsStream::SendDataFrame(const std::shared_ptr<MediaPacket> &media_packet
 			return;
 		}
 
-		// The IN paired with an OUT arrives as its own event from the creation point
+		// An OUT and its return(IN) arrive as separate events
 	}
 	else if (media_packet->GetBitstreamFormat() == cmn::BitstreamFormat::WebVTT)
 	{

--- a/src/publishers/llhls/llhls_stream.h
+++ b/src/publishers/llhls/llhls_stream.h
@@ -213,6 +213,10 @@ private:
 
 	bool InsertMarkerToAllPackagers(uint32_t data_track_id, cmn::BitstreamFormat bitstream_format, int64_t timestamp_ms, const std::shared_ptr<ov::Data> &data);
 
+	// Warn only once when markers arrive while the keyframe interval does not
+	// divide the segment duration
+	bool _cue_alignment_warned = false;
+
 	// Config
 	bmff::FMP4Packager::Config _packager_config;
 	bmff::FMP4Storage::Config _storage_config;


### PR DESCRIPTION
**Problem**

Each publisher derived the return(IN) marker from an OUT on its own at consumption time, and the marker lifecycle rules were scattered across the consumers, so a segment cut could miss the marker position depending on chunk timing and a pending return point could not be adjusted or cleaned up consistently.

**Solution**

Publishers no longer derive a return marker: the marker pipeline consumes an OUT and its return(IN) as separate events. The marker lifecycle rules are centralized in the marker box, where a return point announced by a planned duration stays adjustable by an explicit IN until it is consumed, a duplicate replaces the pending one idempotently, and leftovers are discarded with a warning. The packager guarantees a segment boundary at the first cuttable frame at or after each marker position.

**Test**

Unit tests (`ome_test_bmff`, 6 scenarios) cover cross-track sequence alignment over repeated marker events in three GOP/segment configurations, marker-position cuts, and the provisional/confirmed IN replacement rules.