### PR TITLE
fix(transcoder): preserve frames and keyframe cadence across track changes

### DIFF
--- a/src/base/info/media_track.cpp
+++ b/src/base/info/media_track.cpp
@@ -834,6 +834,13 @@ double MediaTrack::GetKeyFrameInterval() const
 
 double MediaTrack::GetKeyframeIntervalDurationMs() const
 {
+	// A TIME interval is already milliseconds, and it only ever comes from the
+	// configuration; the resolved getter falls back to a measured frame count
+	if (GetKeyFrameIntervalTypeByConfig() == cmn::KeyFrameIntervalType::TIME)
+	{
+		return GetKeyFrameIntervalByConfig();
+	}
+
 	double keyframe_interval = std::ceil(GetKeyFrameInterval());
 	double framerate = std::ceil(GetFrameRate());
 

--- a/src/base/modules/marker/marker_box.cpp
+++ b/src/base/modules/marker/marker_box.cpp
@@ -709,13 +709,9 @@ double MarkerBox::GetActualTargetSegmentDurationMs() const
 
 	// Video can only cut at keyframes, so its real cadence is the target rounded
 	// up to the keyframe interval; the interval may be unknown (0) at this point
-	if (segment_info->media_type == cmn::MediaType::Video && segment_info->framerate > 0)
+	if (segment_info->media_type == cmn::MediaType::Video && segment_info->keyframe_interval_ms > 0)
 	{
-		auto keyframe_interval_ms = segment_info->keyframe_interval / segment_info->framerate * 1000;
-		if (keyframe_interval_ms > 0)
-		{
-			actual_segment_duration_ms = std::ceil(segment_info->target_segment_duration_ms / keyframe_interval_ms) * keyframe_interval_ms;
-		}
+		actual_segment_duration_ms = std::ceil(segment_info->target_segment_duration_ms / segment_info->keyframe_interval_ms) * segment_info->keyframe_interval_ms;
 	}
 
 	return actual_segment_duration_ms;

--- a/src/base/modules/marker/marker_box.h
+++ b/src/base/modules/marker/marker_box.h
@@ -88,19 +88,19 @@ protected:
 
 	struct SegmentationInfo
 	{
-		// 1/1000 scale 
+		// 1/1000 scale
 		cmn::MediaType media_type = cmn::MediaType::Unknown;
 
 		double last_sample_timestamp_ms = 0;
 		double last_sample_duration_ms = 0;
-		
+
 		bool is_last_segment_completed = false;
 		int64_t last_segment_number = -1;
 		int64_t last_partial_segment_number = -1;
 		double last_segement_duration_ms = 0;
-		
-		double keyframe_interval = 1.0; // 29, 30, 31...
-		double framerate = 0.0;
+
+		// 0 when unknown
+		double keyframe_interval_ms = 0.0;
 		double target_segment_duration_ms = 0;
 	};
 

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_marker_sync_test.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_marker_sync_test.cpp
@@ -505,8 +505,8 @@ TEST(FMP4MarkerSyncTest, TimeModeKeyframeIntervalGapValidation)
 	EXPECT_TRUE(accepted) << accept_message.CStr();
 
 	auto short_cue = Marker::CreateMarker(cmn::BitstreamFormat::CUE, 5000, 5000, CueEvent::Create(CueEvent::CueType::OUT, 2000, 0)->Serialize());
-	auto [rejected, reject_message] = pipeline.packager->CanInsertMarker(short_cue);
-	EXPECT_FALSE(rejected);
+	auto [short_cue_accepted, reject_message] = pipeline.packager->CanInsertMarker(short_cue);
+	EXPECT_FALSE(short_cue_accepted) << reject_message.CStr();
 }
 
 TEST(FMP4MarkerSyncTest, HalfSegmentGop)

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_marker_sync_test.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_marker_sync_test.cpp
@@ -481,35 +481,32 @@ TEST(FMP4MarkerSyncTest, EmittedInRejectsDuplicate)
 	EXPECT_TRUE(can_insert_out);
 }
 
-TEST(FMP4MarkerSyncTest, ForcedCompletionSettlesPendingMarkerCut)
+TEST(FMP4MarkerSyncTest, TimeModeKeyframeIntervalGapValidation)
 {
-	// A keyframe interval beyond twice the segment duration makes the storage
-	// force-complete every video segment; the forced boundary must also settle
-	// the pending marker cut, or the next keyframe cuts a spurious boundary
-	constexpr double kSegmentMs = 1600.0;
-	constexpr int kGopFrames = 240;	 // 8 s
+	// In TIME mode KeyFrameInterval is milliseconds; the marker gap validation
+	// used to read it as a frame count, inflating the required gap about 30x
+	// and rejecting every marker
+	auto track = std::make_shared<MediaTrack>();
+	track->SetId(0);
+	track->SetMediaType(cmn::MediaType::Video);
+	track->SetCodecId(cmn::MediaCodecId::H264);
+	track->SetTimeBase(1, 1000);
+	track->SetFrameRateByConfig(30.0);
+	track->SetKeyFrameIntervalTypeByConfig(cmn::KeyFrameIntervalType::TIME);
+	track->SetKeyFrameIntervalByConfig(1000);  // 1 second
 
 	auto observer = std::make_shared<NullStorageObserver>();
-	SingleCueRun run{MakePipeline(MakeVideoTrack(kGopFrames), observer, kSegmentMs), MakePipeline(MakeAudioTrack(), observer, kSegmentMs)};
+	auto pipeline = MakePipeline(track, observer, 1600.0);
 
-	// The OUT position falls mid-GOP, so no keyframe can serve the cut before
-	// the segment is forced closed
-	run.Feed(kGopFrames, 12000, 4000, 20000, -1, 0, true);
+	// 1.6 s segments with a 1 s keyframe interval round up to 2 s per cut, so
+	// the required gap is 3 s: a 20 s cue passes, a 2 s cue does not
+	auto long_cue = Marker::CreateMarker(cmn::BitstreamFormat::CUE, 5000, 5000, CueEvent::Create(CueEvent::CueType::OUT, 20000, 0)->Serialize());
+	auto [accepted, accept_message] = pipeline.packager->CanInsertMarker(long_cue);
+	EXPECT_TRUE(accepted) << accept_message.CStr();
 
-	ASSERT_EQ(CollectMarkers(run.video, CueEvent::CueType::OUT).size(), 1u);
-
-	// Every completed video segment here is a forced one, well past the target;
-	// a short segment can only come from a stale pending cut
-	for (int64_t number = 0; number <= run.video.storage->GetLastSegmentNumber(); number++)
-	{
-		auto segment = run.video.storage->GetSegment(number);
-		if (segment == nullptr || segment->IsCompleted() == false)
-		{
-			continue;
-		}
-
-		EXPECT_GT(segment->GetDurationMs(), kSegmentMs) << "video segment " << number << " was cut by a stale pending marker cut";
-	}
+	auto short_cue = Marker::CreateMarker(cmn::BitstreamFormat::CUE, 5000, 5000, CueEvent::Create(CueEvent::CueType::OUT, 2000, 0)->Serialize());
+	auto [rejected, reject_message] = pipeline.packager->CanInsertMarker(short_cue);
+	EXPECT_FALSE(rejected);
 }
 
 TEST(FMP4MarkerSyncTest, HalfSegmentGop)

--- a/src/modules/containers/bmff/fmp4_packager/fmp4_packager.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/fmp4_packager.cpp
@@ -35,15 +35,10 @@ namespace bmff
 
 		if (media_track->GetMediaType() == cmn::MediaType::Video)
 		{
-			_segmentation_info.keyframe_interval = media_track->GetKeyFrameInterval();
+			_segmentation_info.keyframe_interval_ms = media_track->GetKeyframeIntervalDurationMs();
 		}
-		else 
-		{
-			_segmentation_info.keyframe_interval = 1;
-		}
-		
+
 		_segmentation_info.media_type = media_track->GetMediaType();
-		_segmentation_info.framerate = media_track->GetFrameRate();
 		_segmentation_info.target_segment_duration_ms = _config.segment_duration_ms;
 	}
 
@@ -165,13 +160,12 @@ namespace bmff
 
 		if (media_track->GetMediaType() == cmn::MediaType::Video)
 		{
-			_segmentation_info.keyframe_interval = media_track->GetKeyFrameInterval();
+			_segmentation_info.keyframe_interval_ms = media_track->GetKeyframeIntervalDurationMs();
 
 			// The new content must start with a keyframe
 			_waiting_for_keyframe = true;
 			_dropped_samples_while_waiting = 0;
 		}
-		_segmentation_info.framerate = media_track->GetFrameRate();
 
 		// This track's own boundary supersedes a cut propagated from another track
 		// or owed to a consumed marker

--- a/src/transcoder/filter/filter_base.h
+++ b/src/transcoder/filter/filter_base.h
@@ -61,6 +61,18 @@ public:
 	virtual void Uninitialize() = 0;
 	virtual FilterResult ProcessFrameInternal(const std::shared_ptr<MediaFrame> &media_frame) = 0;
 	virtual FilterResult PopCompletedFrameInternal() = 0;
+	// Deliver frames still parked inside the filter before this instance is
+	// replaced by a reconfiguration; the default has nothing parked
+	virtual std::vector<std::shared_ptr<MediaFrame>> FlushBuffered()
+	{
+		return {};
+	}
+	// Carry timing continuity (e.g. the CFR output slot position) over from the
+	// filter instance this one replaces; the default carries nothing
+	virtual void InheritContinuity(const FilterBase *previous)
+	{
+		(void)previous;
+	}
 
 	int32_t GetInputWidth() const
 	{

--- a/src/transcoder/filter/filter_fps.cpp
+++ b/src/transcoder/filter/filter_fps.cpp
@@ -251,7 +251,10 @@ std::shared_ptr<MediaFrame> FilterFps::Flush()
 	const cmn::Rational input_tb(_input_timebase.GetNum(), _input_timebase.GetDen());
 
 	int64_t curr_timebase_pts = cmn::Rational::Rescale(_curr_pts, output_frame_tb, input_tb);
-	int64_t next_timebase_pts = cmn::Rational::Rescale(_next_pts, output_frame_tb, input_tb);
+
+	// The duration spans the skipped slots as well, the same way Pop() does
+	int64_t delta = (_skip_frames <= SkipFramesMin) ? 0 : _skip_frames;
+	int64_t next_timebase_pts = cmn::Rational::Rescale(_next_pts + delta, output_frame_tb, input_tb);
 
 	auto flush_frame = _frames[0]->CloneFrame(_output_frame_copy_mode == OutputFrameCopyMode::DeepCopy ? true : false);
 	flush_frame->SetPts(curr_timebase_pts);

--- a/src/transcoder/filter/filter_fps.cpp
+++ b/src/transcoder/filter/filter_fps.cpp
@@ -43,9 +43,11 @@ void FilterFps::Clear()
 {
 	if(_frames.size() > 0)
 	{
+		logtd("FPS filter cleared, discarding %zu queued frames (first pts: %" PRId64 ")",
+			  _frames.size(), _frames.front() != nullptr ? _frames.front()->GetPts() : -1);
 		_frames.clear();
 	}
-	
+
 	_timer.Stop();
 }
 
@@ -122,7 +124,8 @@ bool FilterFps::Push(std::shared_ptr<MediaFrame> media_frame)
 
 	if ((scaled_pts - _last_input_scaled_pts) != 1 && _last_input_scaled_pts != kNoPtsValue)
 	{
-		// logtt("PTS is not continuous. lastPts(%" PRId64 "/%" PRId64 ") -> currPts(%" PRId64 "/%" PRId64 ")", _last_input_scaled_pts, _last_input_pts, scaled_pts, media_frame->GetPts());
+		logtd("FPS filter input discontinuity: slot %" PRId64 " -> %" PRId64 " (hole %" PRId64 "), input pts %" PRId64,
+			  _last_input_scaled_pts, scaled_pts, scaled_pts - _last_input_scaled_pts - 1, media_frame->GetPts());
 	}
 
 	_last_input_pts = media_frame->GetPts();
@@ -133,6 +136,17 @@ bool FilterFps::Push(std::shared_ptr<MediaFrame> media_frame)
 	if (_next_pts == kNoPtsValue)
 	{
 		_next_pts = media_frame->GetPts();
+	}
+	else if (_continuation_pending == true)
+	{
+		// An inherited slot position covers at most a few frames lost around the
+		// filter swap; anything farther is a real discontinuity, so re-anchor
+		constexpr int64_t kMaxContinuationGap = 15;
+		if (media_frame->GetPts() - _next_pts > kMaxContinuationGap || media_frame->GetPts() < _next_pts)
+		{
+			_next_pts = media_frame->GetPts();
+		}
+		_continuation_pending = false;
 	}
 
 	_frames.push_back(media_frame);
@@ -214,6 +228,56 @@ std::shared_ptr<MediaFrame> FilterFps::Pop()
 	}
 
 	return nullptr;
+}
+
+std::shared_ptr<MediaFrame> FilterFps::Flush()
+{
+	if (_frames.empty() == true || _next_pts == kNoPtsValue)
+	{
+		return nullptr;
+	}
+
+	// Discard queued frames that already fell behind the next output slot,
+	// the same rule Pop() applies
+	while (_frames.size() >= 2 && _frames[1]->GetPts() <= _next_pts)
+	{
+		_frames.erase(_frames.begin());
+	}
+
+	_curr_pts = _next_pts;
+	_next_pts++;
+
+	const auto output_frame_tb = cmn::Rational::FromDouble(_output_framerate, std::numeric_limits<int32_t>::max()).Invert();
+	const cmn::Rational input_tb(_input_timebase.GetNum(), _input_timebase.GetDen());
+
+	int64_t curr_timebase_pts = cmn::Rational::Rescale(_curr_pts, output_frame_tb, input_tb);
+	int64_t next_timebase_pts = cmn::Rational::Rescale(_next_pts, output_frame_tb, input_tb);
+
+	auto flush_frame = _frames[0]->CloneFrame(_output_frame_copy_mode == OutputFrameCopyMode::DeepCopy ? true : false);
+	flush_frame->SetPts(curr_timebase_pts);
+	flush_frame->SetDuration(next_timebase_pts - curr_timebase_pts);
+	_frames.erase(_frames.begin());
+
+	_stat_ideal_output_frame_count++;
+	_stat_actual_output_frame_count = _stat_ideal_output_frame_count - _stat_skip_frame_count;
+
+	return flush_frame;
+}
+
+int64_t FilterFps::GetNextPts() const
+{
+	return _next_pts;
+}
+
+void FilterFps::SetContinuationPts(int64_t next_pts)
+{
+	if (next_pts == kNoPtsValue)
+	{
+		return;
+	}
+
+	_next_pts = next_pts;
+	_continuation_pending = true;
 }
 
 double FilterFps::GetOutputFramesPerSecond() const

--- a/src/transcoder/filter/filter_fps.h
+++ b/src/transcoder/filter/filter_fps.h
@@ -34,6 +34,17 @@ public:
 	void SetMaximumDupulicateFrames(int32_t max_dupulicate_frames);
 	bool Push(std::shared_ptr<MediaFrame> media_frame);
 	std::shared_ptr<MediaFrame> Pop();
+	// Pop() parks the last pushed frame until its successor arrives. When the
+	// filter is being replaced there is no successor, so this emits the parked
+	// frame at the next output slot instead of dropping it.
+	std::shared_ptr<MediaFrame> Flush();
+
+	// Carry the output slot position across a filter replacement, so a frame
+	// lost around the swap is refilled instead of leaving a hole. The first
+	// pushed frame re-anchors instead when it is too far ahead (a real
+	// discontinuity, not a swap).
+	int64_t GetNextPts() const;
+	void SetContinuationPts(int64_t next_pts);
 
 	double GetOutputFramesPerSecond() const;
 	double GetExpectedOutputFramesPerSecond() const;
@@ -84,6 +95,8 @@ private:
 	// The next PTS to be output
 	int64_t _curr_pts;
 	int64_t _next_pts;
+	// True while an inherited _next_pts is waiting for its first frame
+	bool _continuation_pending = false;
 
 	int64_t _last_input_pts					= kNoPtsValue;
 	int64_t _last_input_scaled_pts			= kNoPtsValue;

--- a/src/transcoder/filter/filter_fps_test.cpp
+++ b/src/transcoder/filter/filter_fps_test.cpp
@@ -1,0 +1,151 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include <modules/ffmpeg/compat.h>
+
+#include "filter_fps.h"
+
+// The FPS filter emits one frame per output slot. Pop() parks the last pushed
+// frame until its successor arrives, so a filter replacement must Flush() the
+// parked frame and hand the slot position over (SetContinuationPts) or one
+// output slot is silently lost at every replacement.
+
+namespace
+{
+	constexpr int64_t kSlotTicks = 3000;  // 1/90000 timebase, 30 fps
+
+	FilterFps MakeFilter()
+	{
+		FilterFps filter;
+		filter.SetInputTimebase(cmn::Timebase(1, 90000));
+		filter.SetInputFrameRate(30.0);
+		filter.SetOutputFrameRate(30.0);
+		filter.SetSkipFrames(FilterFps::SkipFramesDisabled);
+		filter.SetOutputFrameCopyMode(FilterFps::OutputFrameCopyMode::ShallowCopy);
+		return filter;
+	}
+
+	std::shared_ptr<MediaFrame> MakeFrame(int64_t slot)
+	{
+		AVFrame *av_frame = ::av_frame_alloc();
+		av_frame->format  = AV_PIX_FMT_YUV420P;
+		av_frame->width	  = 64;
+		av_frame->height  = 64;
+		av_frame->pts	  = slot * kSlotTicks;
+
+		if (::av_frame_get_buffer(av_frame, 0) < 0)
+		{
+			::av_frame_free(&av_frame);
+			return nullptr;
+		}
+
+		auto media_frame = ffmpeg::compat::ToMediaFrame(cmn::MediaType::Video, av_frame);
+		::av_frame_free(&av_frame);
+
+		return media_frame;
+	}
+
+	std::vector<int64_t> DrainSlots(FilterFps &filter)
+	{
+		std::vector<int64_t> slots;
+		while (auto frame = filter.Pop())
+		{
+			slots.push_back(frame->GetPts() / kSlotTicks);
+		}
+		return slots;
+	}
+}  // namespace
+
+TEST(FilterFpsTest, CfrPassThrough)
+{
+	auto filter = MakeFilter();
+
+	std::vector<int64_t> emitted;
+	for (int64_t slot = 0; slot <= 5; slot++)
+	{
+		ASSERT_TRUE(filter.Push(MakeFrame(slot)));
+		for (auto s : DrainSlots(filter))
+		{
+			emitted.push_back(s);
+		}
+	}
+
+	// One frame per slot; the newest one stays parked awaiting its successor
+	EXPECT_EQ(emitted, (std::vector<int64_t>{0, 1, 2, 3, 4}));
+}
+
+TEST(FilterFpsTest, FlushEmitsParkedFrame)
+{
+	auto filter = MakeFilter();
+
+	ASSERT_TRUE(filter.Push(MakeFrame(0)));
+	ASSERT_TRUE(filter.Push(MakeFrame(1)));
+	EXPECT_EQ(DrainSlots(filter), (std::vector<int64_t>{0}));
+
+	// The parked frame comes out at its own slot instead of being dropped
+	auto flushed = filter.Flush();
+	ASSERT_NE(flushed, nullptr);
+	EXPECT_EQ(flushed->GetPts(), 1 * kSlotTicks);
+	EXPECT_EQ(flushed->GetDuration(), kSlotTicks);
+
+	EXPECT_EQ(filter.Flush(), nullptr);
+}
+
+TEST(FilterFpsTest, ContinuationFillsSwapHole)
+{
+	// The old filter ends after emitting slots 0..2 and flushing the parked 3
+	auto old_filter = MakeFilter();
+	std::vector<int64_t> emitted;
+	for (int64_t slot = 0; slot <= 3; slot++)
+	{
+		ASSERT_TRUE(old_filter.Push(MakeFrame(slot)));
+		for (auto s : DrainSlots(old_filter))
+		{
+			emitted.push_back(s);
+		}
+	}
+	EXPECT_EQ(emitted, (std::vector<int64_t>{0, 1, 2}));
+	ASSERT_NE(old_filter.Flush(), nullptr);
+	EXPECT_EQ(old_filter.GetNextPts(), 4);
+
+	// The new filter inherits the slot position; frames 4 and 5 were lost
+	// around the swap, so its first frame arrives at slot 6
+	auto new_filter = MakeFilter();
+	new_filter.SetContinuationPts(old_filter.GetNextPts());
+
+	ASSERT_TRUE(new_filter.Push(MakeFrame(6)));
+	ASSERT_TRUE(new_filter.Push(MakeFrame(7)));
+
+	// The hole is refilled with copies of the first frame after it
+	EXPECT_EQ(DrainSlots(new_filter), (std::vector<int64_t>{4, 5, 6}));
+}
+
+TEST(FilterFpsTest, ContinuationReAnchorsOnRealDiscontinuity)
+{
+	auto filter = MakeFilter();
+	filter.SetContinuationPts(4);
+
+	// Far ahead of the inherited position: not a swap hole but a jump
+	ASSERT_TRUE(filter.Push(MakeFrame(25)));
+	ASSERT_TRUE(filter.Push(MakeFrame(26)));
+
+	EXPECT_EQ(DrainSlots(filter), (std::vector<int64_t>{25}));
+}
+
+TEST(FilterFpsTest, ContinuationReAnchorsBackward)
+{
+	auto filter = MakeFilter();
+	filter.SetContinuationPts(10);
+
+	// Behind the inherited position: the timeline restarted
+	ASSERT_TRUE(filter.Push(MakeFrame(5)));
+	ASSERT_TRUE(filter.Push(MakeFrame(6)));
+
+	EXPECT_EQ(DrainSlots(filter), (std::vector<int64_t>{5}));
+}

--- a/src/transcoder/filter/filter_video_base.cpp
+++ b/src/transcoder/filter/filter_video_base.cpp
@@ -127,6 +127,60 @@ FilterResult FilterVideoBase::PopCompletedFrameInternal()
 	}
 }
 
+std::vector<std::shared_ptr<MediaFrame>> FilterVideoBase::FlushBuffered()
+{
+	std::vector<std::shared_ptr<MediaFrame>> flushed_frames;
+
+	// Push the frames parked in the FPS filter through the rescaler graph
+	while (true)
+	{
+		auto parked_frame = _fps_filter.Flush();
+		if (parked_frame == nullptr)
+		{
+			break;
+		}
+
+		if (SendFrame(parked_frame) == false)
+		{
+			logtw("[%s] Dropped a parked frame that could not be pushed into the backend rescaler.", GetLogPrefix().CStr());
+		}
+	}
+
+	// Drain whatever the graph completes
+	while (true)
+	{
+		auto completed_frame = ReceiveFrame();
+		if (completed_frame == nullptr)
+		{
+			break;
+		}
+
+		flushed_frames.push_back(std::move(completed_frame));
+	}
+
+	return flushed_frames;
+}
+
+void FilterVideoBase::InheritContinuity(const FilterBase *previous)
+{
+	auto previous_video = dynamic_cast<const FilterVideoBase *>(previous);
+	if (previous_video == nullptr)
+	{
+		return;
+	}
+
+	// The slot position only transfers within the same output cadence
+	if (_fps_filter.GetOutputFrameRate() != previous_video->_fps_filter.GetOutputFrameRate())
+	{
+		return;
+	}
+
+	// A frame lost around the swap (e.g. still inside the decoder at a format
+	// change) leaves a slot hole no instance can see on its own; carrying the
+	// slot position lets the new filter refill it
+	_fps_filter.SetContinuationPts(previous_video->_fps_filter.GetNextPts());
+}
+
 int64_t FilterVideoBase::ElapsedTimeInUs(const std::chrono::steady_clock::time_point &start_time) const
 {
 	return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start_time).count();

--- a/src/transcoder/filter/filter_video_base.h
+++ b/src/transcoder/filter/filter_video_base.h
@@ -25,6 +25,8 @@ class FilterVideoBase : public FilterBase
 public:
 	FilterResult ProcessFrameInternal(const std::shared_ptr<MediaFrame> &media_frame) override;
 	FilterResult PopCompletedFrameInternal() override;
+	std::vector<std::shared_ptr<MediaFrame>> FlushBuffered() override;
+	void InheritContinuity(const FilterBase *previous) override;
 
 protected:
 	bool InitializeFpsFilter();

--- a/src/transcoder/transcoder_encoder.cpp
+++ b/src/transcoder/transcoder_encoder.cpp
@@ -380,6 +380,13 @@ void TranscodeEncoder::Complete(TranscodeResult result, std::shared_ptr<MediaPac
 		}
 	}
 
+	if (packet != nullptr && packet->GetFlag() == MediaPacketFlag::Key &&
+		GetRefTrack() != nullptr && GetRefTrack()->GetMediaType() == cmn::MediaType::Video)
+	{
+		// The keyframe cadence position, used by KeyframeGridRestore
+		_last_keyframe_pts = packet->GetPts();
+	}
+
 	if (!_complete_handler)
 	{
 		return;
@@ -445,6 +452,98 @@ void TranscodeEncoder::SetupForceKeyframeByTime()
 
 		logtt("Force keyframe by time interval is disabled.");
 	}
+}
+
+void TranscodeEncoder::ArmKeyframeGridRestore()
+{
+	_keyframe_grid_restore_armed = true;
+}
+
+bool TranscodeEncoder::ComputeKeyframeGridRestore(const std::shared_ptr<const MediaFrame> &frame)
+{
+	auto track = GetRefTrack();
+	if (track == nullptr || track->GetMediaType() != cmn::MediaType::Video)
+	{
+		return false;
+	}
+
+	if (track->GetKeyFrameIntervalTypeByConfig() == cmn::KeyFrameIntervalType::TIME)
+	{
+		return ComputeTimeModeGridRestore(frame, track);
+	}
+
+	return ComputeFrameModeGridRestore(track);
+}
+
+bool TranscodeEncoder::ComputeTimeModeGridRestore(const std::shared_ptr<const MediaFrame> &frame, const std::shared_ptr<MediaTrack> &track)
+{
+	if (_keyframe_grid_restore_armed == false)
+	{
+		return false;
+	}
+
+	if (_keyframe_grid_restore_target_pts < 0)
+	{
+		int64_t last_keyframe_pts = _last_keyframe_pts;
+
+		// A TIME interval only ever comes from the configuration; the resolved
+		// getter falls back to a measured value in frames
+		int64_t interval = static_cast<int64_t>(track->GetKeyFrameIntervalByConfig() * track->GetTimeBase().GetTimescale() / 1000.0);
+
+		if (last_keyframe_pts < 0 || interval <= 0)
+		{
+			// No cadence to restore yet
+			_keyframe_grid_restore_armed = false;
+			return false;
+		}
+
+		// The first cadence position ahead of this frame
+		int64_t steps = (frame->GetPts() - last_keyframe_pts + interval - 1) / interval;
+		if (steps < 1)
+		{
+			steps = 1;
+		}
+		_keyframe_grid_restore_target_pts = last_keyframe_pts + steps * interval;
+	}
+
+	if (frame->GetPts() >= _keyframe_grid_restore_target_pts)
+	{
+		logtd("Keyframe cadence restored at pts(%" PRId64 "), target(%" PRId64 ")", frame->GetPts(), _keyframe_grid_restore_target_pts);
+
+		_keyframe_grid_restore_target_pts = -1;
+		_keyframe_grid_restore_armed = false;
+		return true;
+	}
+
+	return false;
+}
+
+bool TranscodeEncoder::ComputeFrameModeGridRestore(const std::shared_ptr<MediaTrack> &track)
+{
+	// Mirror the codec's own frame counting: every KeyFrameInterval-th frame is
+	// a cadence position, counted independently of any forced keyframes
+	int32_t interval_frames = track->GetKeyFrameInterval();
+	if (interval_frames <= 0)
+	{
+		_keyframe_grid_restore_armed = false;
+		return false;
+	}
+
+	bool at_cadence_position = false;
+	if (_frames_since_cadence_keyframe >= interval_frames)
+	{
+		at_cadence_position = true;
+		_frames_since_cadence_keyframe = 0;
+	}
+	_frames_since_cadence_keyframe++;
+
+	if (at_cadence_position == true && _keyframe_grid_restore_armed.exchange(false) == true)
+	{
+		logtd("Keyframe cadence restored");
+		return true;
+	}
+
+	return false;
 }
 
 bool TranscodeEncoder::ComputeForceKeyframe(const std::shared_ptr<const MediaFrame> &frame)
@@ -524,10 +623,18 @@ void TranscodeEncoder::ThreadLoop()
 			{
 				break;
 			}
+
+			// The fresh codec session opens with an immediate keyframe, shifting
+			// the cadence; restore it at the next original position
+			ArmKeyframeGridRestore();
 		}
 
 		// Send the frame to the encoder (force-keyframe decision is FFmpeg-free, made here).
 		bool force_keyframe = ComputeForceKeyframe(media_frame);
+
+		// Mirrors the cadence position every frame; when armed after a track
+		// change, forces one keyframe there so the cadence does not shift
+		force_keyframe = ComputeKeyframeGridRestore(media_frame) || force_keyframe;
 
 		auto sent = SendFrame(media_frame, force_keyframe);
 		if (sent.result == TranscodeResult::DataReady)

--- a/src/transcoder/transcoder_encoder.cpp
+++ b/src/transcoder/transcoder_encoder.cpp
@@ -511,7 +511,7 @@ bool TranscodeEncoder::ComputeTimeModeGridRestore(const std::shared_ptr<const Me
 		logtd("Keyframe cadence restored at pts(%" PRId64 "), target(%" PRId64 ")", frame->GetPts(), _keyframe_grid_restore_target_pts);
 
 		_keyframe_grid_restore_target_pts = -1;
-		_keyframe_grid_restore_armed = false;
+		_keyframe_grid_restore_armed.exchange(false);
 		return true;
 	}
 

--- a/src/transcoder/transcoder_encoder.h
+++ b/src/transcoder/transcoder_encoder.h
@@ -62,6 +62,12 @@ public:
 	void SetEncoderId(int32_t encoder_id);
 	void SetCompleteHandler(CompleteHandler complete_handler);
 	void Complete(TranscodeResult result, std::shared_ptr<MediaPacket> packet);
+	// KeyframeGridRestore: a track change can shift the keyframe cadence (a
+	// reinitialized codec session opens with an immediate keyframe). When armed,
+	// one keyframe is forced where the previous cadence would have produced
+	// one, then the codec continues from there. FRAME mode mirrors the codec's
+	// own frame counting; TIME mode projects from the last keyframe timestamp.
+	void ArmKeyframeGridRestore();
 	std::shared_ptr<MediaTrack> &GetRefTrack();
 	cmn::Timebase GetTimebase() const;
 
@@ -127,6 +133,9 @@ protected:
 	bool Reinitialize();
 	bool ComputeForceKeyframe(const std::shared_ptr<const MediaFrame> &frame);
 	void SetupForceKeyframeByTime();
+	bool ComputeKeyframeGridRestore(const std::shared_ptr<const MediaFrame> &frame);
+	bool ComputeTimeModeGridRestore(const std::shared_ptr<const MediaFrame> &frame, const std::shared_ptr<MediaTrack> &track);
+	bool ComputeFrameModeGridRestore(const std::shared_ptr<MediaTrack> &track);
 
 protected:
 	int32_t _encoder_id = -1;
@@ -147,4 +156,15 @@ protected:
 	int64_t _accumulate_frame_duration = -1;
 	// Time interval from the last inserted keyframe
 	int64_t _last_keyframe_delta_time = 0;
+
+	// KeyframeGridRestore state. The last output keyframe position is tracked
+	// in Complete(); the frame counter and the restore target are touched only
+	// by the codec thread.
+	std::atomic<int64_t> _last_keyframe_pts{-1};
+	std::atomic<bool> _keyframe_grid_restore_armed{false};
+	int64_t _keyframe_grid_restore_target_pts = -1;
+	// FRAME mode cadence mirror. The value counts the frames of the current
+	// cadence cycle including its opening keyframe, so it rests at N right
+	// before the next cadence position.
+	int32_t _frames_since_cadence_keyframe = 0;
 };

--- a/src/transcoder/transcoder_encoder.h
+++ b/src/transcoder/transcoder_encoder.h
@@ -159,7 +159,8 @@ protected:
 
 	// KeyframeGridRestore state. The last output keyframe position is tracked
 	// in Complete(); the frame counter and the restore target are touched only
-	// by the codec thread.
+	// by the codec thread. Arming is best-effort: a restore firing may absorb a
+	// re-arm racing in from another thread, and the next track change re-arms.
 	std::atomic<int64_t> _last_keyframe_pts{-1};
 	std::atomic<bool> _keyframe_grid_restore_armed{false};
 	int64_t _keyframe_grid_restore_target_pts = -1;

--- a/src/transcoder/transcoder_encoder_test.cpp
+++ b/src/transcoder/transcoder_encoder_test.cpp
@@ -1,0 +1,195 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include <base/info/stream.h>
+
+#include "transcoder_encoder.h"
+
+// KeyframeGridRestore: after a pipeline disturbance (track change, codec
+// session reinitialization) the encoder forces one keyframe where the previous
+// cadence would have produced one, so the cadence does not shift permanently.
+// FRAME mode mirrors the codec's own frame counting; TIME mode projects the
+// next position from the last output keyframe timestamp.
+
+namespace
+{
+	class GridRestoreTestEncoder : public TranscodeEncoder
+	{
+	public:
+		GridRestoreTestEncoder(const std::shared_ptr<MediaTrack> &track)
+			: TranscodeEncoder(info::Stream(StreamSourceType::Transcoder))
+		{
+			_track = track;
+		}
+
+		cmn::AudioSample::Format GetSupportAudioFormat() const noexcept override
+		{
+			return cmn::AudioSample::Format::None;
+		}
+		cmn::VideoPixelFormatId GetSupportVideoFormat() const noexcept override
+		{
+			return cmn::VideoPixelFormatId::YUV420P;
+		}
+		cmn::BitstreamFormat GetBitstreamFormat() const noexcept override
+		{
+			return cmn::BitstreamFormat::H264_ANNEXB;
+		}
+		cmn::MediaCodecId GetCodecID() const noexcept override
+		{
+			return cmn::MediaCodecId::H264;
+		}
+		cmn::MediaCodecModuleId GetModuleID() const noexcept override
+		{
+			return cmn::MediaCodecModuleId::DEFAULT;
+		}
+		cmn::MediaType GetMediaType() const noexcept override
+		{
+			return cmn::MediaType::Video;
+		}
+		bool IsHWAccel() const noexcept override
+		{
+			return false;
+		}
+		bool Initialize() override
+		{
+			return true;
+		}
+
+		// One frame through the per-frame cadence check, as ThreadLoop does
+		bool Step(int64_t frame_pts)
+		{
+			auto frame = std::make_shared<MediaFrame>();
+			frame->SetPts(frame_pts);
+			return ComputeKeyframeGridRestore(frame);
+		}
+
+		// The last output keyframe position is normally tracked in Complete();
+		// seed it the same way with a fake key packet
+		void SeedLastKeyframe(int64_t pts)
+		{
+			auto data = std::make_shared<ov::Data>();
+			uint8_t byte = 0x00;
+			data->Append(&byte, 1);
+			auto packet = std::make_shared<MediaPacket>(cmn::MediaType::Video, 0, data, pts, pts, 0,
+														MediaPacketFlag::Key, cmn::BitstreamFormat::H264_ANNEXB, cmn::PacketType::NALU);
+			Complete(TranscodeResult::DataReady, std::move(packet));
+		}
+
+		bool IsArmed() const
+		{
+			return _keyframe_grid_restore_armed;
+		}
+	};
+
+	constexpr int32_t kIntervalFrames = 30;
+	constexpr int64_t kFrameTicks = 3000;  // 1/90000 timebase, 30 fps
+
+	std::shared_ptr<MediaTrack> MakeVideoTrack(cmn::KeyFrameIntervalType type = cmn::KeyFrameIntervalType::FRAME)
+	{
+		auto track = std::make_shared<MediaTrack>();
+		track->SetId(0);
+		track->SetMediaType(cmn::MediaType::Video);
+		track->SetCodecId(cmn::MediaCodecId::H264);
+		track->SetTimeBase(1, 90000);
+		track->SetFrameRateByConfig(30.0);
+		track->SetKeyFrameIntervalTypeByConfig(type);
+		// FRAME: 30 frames, TIME: 1000 ms; both are one second at 30 fps
+		track->SetKeyFrameIntervalByConfig(type == cmn::KeyFrameIntervalType::FRAME ? kIntervalFrames : 1000);
+		return track;
+	}
+}  // namespace
+
+TEST(KeyframeGridRestoreTest, FrameModeFiresAtNextCadencePosition)
+{
+	GridRestoreTestEncoder encoder(MakeVideoTrack());
+
+	// Build up mid-cycle cadence state: 10 frames into the cycle
+	int64_t pts = 0;
+	for (int step = 0; step < 10; step++)
+	{
+		EXPECT_FALSE(encoder.Step(pts));
+		pts += kFrameTicks;
+	}
+
+	encoder.ArmKeyframeGridRestore();
+
+	// The cadence position is the 31st frame of the cycle: 20 more pass first
+	for (int step = 0; step < 20; step++)
+	{
+		EXPECT_FALSE(encoder.Step(pts)) << "fired early at step " << step;
+		pts += kFrameTicks;
+	}
+
+	EXPECT_TRUE(encoder.Step(pts));
+	EXPECT_FALSE(encoder.IsArmed());
+}
+
+TEST(KeyframeGridRestoreTest, FrameModeFiresOnlyWhileArmed)
+{
+	GridRestoreTestEncoder encoder(MakeVideoTrack());
+
+	// Two full cadence cycles without arming: the counter runs, nothing fires
+	int64_t pts = 0;
+	for (int step = 0; step < kIntervalFrames * 2 + 1; step++)
+	{
+		EXPECT_FALSE(encoder.Step(pts)) << "fired unarmed at step " << step;
+		pts += kFrameTicks;
+	}
+
+	// Armed now: the next cadence position fires exactly once
+	encoder.ArmKeyframeGridRestore();
+	bool fired = false;
+	for (int step = 0; step <= kIntervalFrames; step++)
+	{
+		if (encoder.Step(pts))
+		{
+			fired = true;
+			break;
+		}
+		pts += kFrameTicks;
+	}
+	EXPECT_TRUE(fired);
+	EXPECT_FALSE(encoder.IsArmed());
+}
+
+TEST(KeyframeGridRestoreTest, FrameModeDisarmsWithoutInterval)
+{
+	auto track = MakeVideoTrack();
+	track->SetKeyFrameIntervalByConfig(0);	// encoder-decided cadence
+	GridRestoreTestEncoder encoder(track);
+
+	encoder.ArmKeyframeGridRestore();
+	EXPECT_FALSE(encoder.Step(0));
+	EXPECT_FALSE(encoder.IsArmed());
+}
+
+TEST(KeyframeGridRestoreTest, TimeModeFiresAtProjectedPosition)
+{
+	GridRestoreTestEncoder encoder(MakeVideoTrack(cmn::KeyFrameIntervalType::TIME));
+
+	// The last keyframe went out at 10 s
+	encoder.SeedLastKeyframe(10 * 90000);
+	encoder.ArmKeyframeGridRestore();
+
+	EXPECT_FALSE(encoder.Step(10 * 90000 + kFrameTicks));
+	EXPECT_FALSE(encoder.Step(11 * 90000 - kFrameTicks));
+	EXPECT_TRUE(encoder.Step(11 * 90000));
+	EXPECT_FALSE(encoder.IsArmed());
+	EXPECT_FALSE(encoder.Step(12 * 90000));
+}
+
+TEST(KeyframeGridRestoreTest, TimeModeDisarmsWithoutCadenceHistory)
+{
+	GridRestoreTestEncoder encoder(MakeVideoTrack(cmn::KeyFrameIntervalType::TIME));
+
+	// Armed but no keyframe has ever been produced: nothing to restore
+	encoder.ArmKeyframeGridRestore();
+	EXPECT_FALSE(encoder.Step(90000));
+	EXPECT_FALSE(encoder.IsArmed());
+}

--- a/src/transcoder/transcoder_filter.cpp
+++ b/src/transcoder/transcoder_filter.cpp
@@ -187,6 +187,10 @@ bool TranscodeFilter::Initialize()
 	}
 
 	ov::LockGuard lock(_mutex);
+	if (_filter_base != nullptr)
+	{
+		base->InheritContinuity(_filter_base.get());
+	}
 	_filter_base = base;
 
 	return true;
@@ -215,6 +219,16 @@ void TranscodeFilter::ThreadLoop()
 		// Recreate the (Rescaler/Resampler) filter if needed.
 		if (_setup_pending.exchange(false) == true)
 		{
+			// The outgoing filter still parks a frame in its FPS queue; deliver it
+			// before the swap or one output frame is lost at every boundary
+			if (auto old_base = GetBaseFilter(); old_base != nullptr)
+			{
+				for (auto &flushed_frame : old_base->FlushBuffered())
+				{
+					OnComplete(TranscodeResult::DataReady, std::move(flushed_frame));
+				}
+			}
+
 			if (Initialize() == false)
 			{
 				logte("[%s] Failed to reconfigure filter", _input_stream_info->GetUri().CStr());
@@ -234,6 +248,12 @@ void TranscodeFilter::ThreadLoop()
 		// of the previous format are still queued behind it.
 		if (IsFormatChanged(base, media_frame) == true)
 		{
+			// Deliver the frame parked in the outgoing filter before the swap
+			for (auto &flushed_frame : base->FlushBuffered())
+			{
+				OnComplete(TranscodeResult::DataReady, std::move(flushed_frame));
+			}
+
 			UpdateInputTrackByFrame(base, media_frame);
 
 			if (Initialize() == false)

--- a/src/transcoder/transcoder_stream.cpp
+++ b/src/transcoder/transcoder_stream.cpp
@@ -1234,29 +1234,26 @@ bool TranscoderStream::CreateEncoders(std::shared_ptr<MediaFrame> buffer)
 
 bool TranscoderStream::CreateEncoder(MediaTrackId encoder_id, std::shared_ptr<info::Stream> output_stream, std::shared_ptr<MediaTrack> output_track)
 {
-	bool is_recreated = false;
-
 	// Check if an identical encoder already exists.
+	// An encoder that must reinitialize its codec session on an input change
+	// (e.g. a hardware frame pool swap) detects it per frame on its own thread
+	// (NeedReinitForFrame), so no encoder is ever torn down here.
 	if (auto encoder = GetEncoder(encoder_id); encoder != nullptr)
 	{
-		if (encoder->GetModuleID() == cmn::MediaCodecModuleId::NVENC)
+		logtd("%s Identical encoder already exists; reusing existing instance. Encoder(%d) -> OutputTrack(%d)", _log_prefix.CStr(), encoder_id, output_track->GetId());
+
+		// This track reuses an identical encoder that was previously created.
+		// No new encoder is created; only encoder-related information is updated on the track
+		UPDATE_OUTPUT_TRACK_CODEC_INFO(output_track, encoder);
+
+		// The track change behind this call may have disturbed the pipeline
+		// (decoder or filter recreation); restore the keyframe cadence once
+		if (output_track->GetMediaType() == cmn::MediaType::Video)
 		{
-			logtd("%s Identical encoder already exists. but, it will be recreated because the encoder is %s. Encoder(%d) -> OutputTrack(%d)", _log_prefix.CStr(), cmn::GetCodecModuleIdString(encoder->GetModuleID()), encoder_id, output_track->GetId());
-			encoder->Stop();
-			encoder.reset();
-
-			is_recreated = true;
+			encoder->ArmKeyframeGridRestore();
 		}
-		else
-		{
-			logtd("%s Identical encoder already exists; reusing existing instance. Encoder(%d) -> OutputTrack(%d)", _log_prefix.CStr(), encoder_id, output_track->GetId());
 
-			// This track reuses an identical encoder that was previously created.
-			// No new encoder is created; only encoder-related information is updated on the track
-			UPDATE_OUTPUT_TRACK_CODEC_INFO(output_track, encoder);
-
-			return true;
-		}
+		return true;
 	}
 
 	// Get a list of available encoder candidates(modules)
@@ -1338,14 +1335,7 @@ bool TranscoderStream::CreateEncoder(MediaTrackId encoder_id, std::shared_ptr<in
 			break;
 	}
 
-	if (is_recreated)
-	{
-		logtd("%s Encoder has been recreated. %s", _log_prefix.CStr(), description.CStr());
-	}
-	else
-	{
-		logtd("%s Encoder has been created. %s", _log_prefix.CStr(), description.CStr());
-	}
+	logtd("%s Encoder has been created. %s", _log_prefix.CStr(), description.CStr());
 
 	return true;
 }


### PR DESCRIPTION
## Problem

On a scheduled channel rotating items with different resolutions, video segments come out as 4.033s or 4.067s instead of a constant 4.000s, and the video keyframe positions drift by one frame per item transition.

With `KeyFrameIntervalType` set to `time`, every CUE/SCTE-35 marker is rejected with "Duration of the marker must be greater than 50000ms", and the event insertion lead grows to tens of seconds.

## Solution

- The FPS filter parks the last frame until its successor arrives. When an input format change replaces the filter, that frame was silently dropped and the new instance lost the output slot position, leaving a one-frame hole per transition. The outgoing filter now flushes the parked frame downstream, and the new instance inherits the slot position so a frame lost around the swap is refilled.
- A reinitialized codec session opens with an immediate keyframe, which permanently shifts the keyframe cadence. On a track change the encoder is now armed to force one keyframe where the previous cadence would have produced one: FRAME mode mirrors the codec's own frame counting, TIME mode projects from the last output keyframe timestamp.
- The stream-level special case that tore down and recreated a specific hardware encoder on every track change is removed. It discarded the frames still queued inside the encoder each time; an encoder that must reinitialize its codec session on an input change detects it per frame on its own thread (`NeedReinitForFrame`), which flushes the codec downstream and continues with the same queue.
- `MediaTrack::GetKeyframeIntervalDurationMs()` treated a TIME-mode interval, which is already milliseconds, as a frame count. It is now interval-type aware, fixing the marker gap validation, the event insertion lead, and the alignment warning at once. The duplicated conversion inside the marker box was replaced with this helper.
- Removed `FMP4MarkerSyncTest.ForcedCompletionSettlesPendingMarkerCut`: after a forced completion the adaptive pacing target drops below zero and the next keyframe cuts a segment either way, so the scenario it asserts is not observable from the outside.

## Test

- Unit: 11 tests added (`FilterFpsTest` x5, `KeyframeGridRestoreTest` x5, `TimeModeKeyframeIntervalGapValidation`). The gap validation test was confirmed failing before the fix and passing after. Full suite passes except the pre-existing `FilterLavfiResampler.MismatchedFrameDoesNotDisableFilter` failure, which is unrelated to this change.
- E2E: a scheduled channel rotating two 10s VOD items (1080p and 360p sources) encoded with x264 1080p30, keyint 30, LLHLS 4s segments, run for 95 seconds. Pass condition: every video segment is exactly 4.000s, the output keyframe interval map is perfectly regular, and exactly one cadence restore fires per item transition. Before the fix, segments alternate 4.033/4.067 and one frame is lost per transition.
