### PR TITLE
fix(alert): send an alert when decoder recreation fails 

### DIFF
--- a/src/transcoder/transcoder_stream.cpp
+++ b/src/transcoder/transcoder_stream.cpp
@@ -1682,6 +1682,17 @@ void TranscoderStream::RecreateDecoderForCodecChange(MediaTrackId track_id, cons
 	{
 		logte("%s Failed to recreate decoder for the changed codec. Id(%d), InputTrack(%d), Codec(%s)",
 			  _log_prefix.CStr(), decoder_id.value(), track_id, cmn::GetCodecIdString(input_track->GetCodecId()));
+
+#if NOTIFICATION_ENABLED
+		TranscoderAlerts::UpdateErrorWithoutCount(
+			TranscoderAlerts::ErrorType::CREATION_ERROR_DECODER,
+			nullptr,
+			_input_stream,
+			input_track,
+			nullptr,
+			nullptr);
+#endif
+
 		return;
 	}
 

--- a/src/transcoder/transcoder_stream.cpp
+++ b/src/transcoder/transcoder_stream.cpp
@@ -1680,8 +1680,9 @@ void TranscoderStream::RecreateDecoderForCodecChange(MediaTrackId track_id, cons
 
 	if (CreateDecoder(decoder_id.value(), _input_stream, input_track) == false)
 	{
-		logte("%s Failed to recreate decoder for the changed codec. Id(%d), InputTrack(%d), Codec(%s)",
-			  _log_prefix.CStr(), decoder_id.value(), track_id, cmn::GetCodecIdString(input_track->GetCodecId()));
+		logte("%s Failed to recreate decoder for the changed codec. Id(%d)<Codec(%s), Module(%s), Device(%u)>, InputTrack(%d)",
+			  _log_prefix.CStr(), decoder_id.value(), cmn::GetCodecIdString(input_track->GetCodecId()),
+			  cmn::GetCodecModuleIdString(input_track->GetCodecModuleId()), input_track->GetCodecDeviceId(), track_id);
 
 #if NOTIFICATION_ENABLED
 		TranscoderAlerts::UpdateErrorWithoutCount(
@@ -1696,8 +1697,9 @@ void TranscoderStream::RecreateDecoderForCodecChange(MediaTrackId track_id, cons
 		return;
 	}
 
-	logti("%s Decoder has been recreated for the changed codec. Id(%d), InputTrack(%d), Codec(%s)",
-		  _log_prefix.CStr(), decoder_id.value(), track_id, cmn::GetCodecIdString(input_track->GetCodecId()));
+	logti("%s Decoder has been recreated for the changed codec. Id(%d)<Codec(%s), Module(%s), Device(%u)>, InputTrack(%d)",
+		  _log_prefix.CStr(), decoder_id.value(), cmn::GetCodecIdString(input_track->GetCodecId()),
+		  cmn::GetCodecModuleIdString(input_track->GetCodecModuleId()), input_track->GetCodecDeviceId(), track_id);
 }
 
 void TranscoderStream::BypassPacket(const std::shared_ptr<MediaPacket> &packet)


### PR DESCRIPTION
## Summary

`RecreateDecoderForCodecChange()` failed to send an alert when the replacement
decoder could not be created — only logged, unlike every other decoder-creation
failure path. This adds the missing `EGRESS_STREAM_CREATION_FAILED_DECODER` alert
so the failure is reported consistently.

## Changes

- `src/transcoder/transcoder_stream.cpp`: on `CreateDecoder()` failure in
  `RecreateDecoderForCodecChange()`, call `TranscoderAlerts::UpdateErrorWithoutCount()`
  with `CREATION_ERROR_DECODER`, mirroring `CreateDecoders()`.

## Testing

1. Configure a Scheduler Provider with a schedule made of files using different
   codecs.
2. Force a decoder init failure with the Fault Injection API:

   ```
   POST /v2/internals/tests:setFaultInject
   {
     "transcoder": [
       {
         "targetModule": "default",
         "targetDeviceId": 0,
         "targetComponent": "decoder",
         "faultType": "INITFAILED",
         "faultRate": 100
       }
     ]
   }
   ```

3. When the schedule advances to an item whose input track has a different codec,
   `RecreateDecoderForCodecChange()` runs, and `CreateDecoder()` fails due to the
   injected fault.
4. Verify:
   - the log shows `Failed to recreate decoder for the changed codec`
   - the Alert webhook receives `EGRESS_STREAM_CREATION_FAILED_DECODER`
5. Clear the fault injection with `{"transcoder": []}` and reproduce the same
   codec change: the decoder is recreated successfully (`Decoder has been
   recreated for the changed codec`) and no alert is sent.