### PR TITLE
fix(transcoder): recover delayed frames and keep slot continuity at track changes

### DIFF
--- a/src/transcoder/codec/decoder/decoder_avcodec_video.cpp
+++ b/src/transcoder/codec/decoder/decoder_avcodec_video.cpp
@@ -73,6 +73,28 @@ bool AVCodecVideoDecoder::ReinitCodecIfNeed()
 			  _codec.GetWidth(), _codec.GetHeight(),
 			  _analyzer.GetWidth(), _analyzer.GetHeight());
 
+		// Drain the frames still delayed inside the codec session and hand them
+		// downstream before teardown, so the resolution change loses no frame.
+		// This is the last chance to recover them, so a corrupt frame is skipped
+		// instead of aborting (bounded against a codec stuck on invalid data)
+		if (::avcodec_send_packet(_codec.Get(), nullptr) == 0)
+		{
+			for (int attempt = 0; attempt < 64; attempt++)
+			{
+				auto received = ReceiveFrame();
+				if (received.result == TranscodeResult::DataReady || received.result == TranscodeResult::FormatChanged)
+				{
+					Complete(received.result, std::move(received.frame));
+					continue;
+				}
+				if (received.result == TranscodeResult::NoData)
+				{
+					continue;
+				}
+				break;
+			}
+		}
+
 		Uninitialize();
 
 		if (Initialize() == false)
@@ -146,8 +168,9 @@ DecodeResult AVCodecVideoDecoder::ReceiveFrame()
 {
 	auto received = _codec.ReceiveFrame();
 	auto result = received.result;
-	if (result == ffmpeg::CodecResult::Again)
+	if (result == ffmpeg::CodecResult::Again || result == ffmpeg::CodecResult::Eof)
 	{
+		// Eof only appears while draining for a reinit; the session reopens right after
 		return DecodeResult::NoOutput();
 	}
 	else if (result == ffmpeg::CodecResult::InvalidData)

--- a/src/transcoder/filter/filter_fps.cpp
+++ b/src/transcoder/filter/filter_fps.cpp
@@ -124,7 +124,7 @@ bool FilterFps::Push(std::shared_ptr<MediaFrame> media_frame)
 
 	if ((scaled_pts - _last_input_scaled_pts) != 1 && _last_input_scaled_pts != kNoPtsValue)
 	{
-		logtd("FPS filter input discontinuity: slot %" PRId64 " -> %" PRId64 " (hole %" PRId64 "), input pts %" PRId64,
+		logtt("FPS filter input discontinuity: slot %" PRId64 " -> %" PRId64 " (hole %" PRId64 "), input pts %" PRId64,
 			  _last_input_scaled_pts, scaled_pts, scaled_pts - _last_input_scaled_pts - 1, media_frame->GetPts());
 	}
 
@@ -139,10 +139,13 @@ bool FilterFps::Push(std::shared_ptr<MediaFrame> media_frame)
 	}
 	else if (_continuation_pending == true)
 	{
-		// An inherited slot position covers at most a few frames lost around the
-		// filter swap; anything farther is a real discontinuity, so re-anchor
+		// An inherited slot position covers a few frames of overlap or loss around
+		// the filter swap: a small backward overlap (an item splice re-bases the new
+		// item less than one frame after the previous one) is discarded by the queue
+		// rules, a small hole is filled. Anything farther is a real discontinuity,
+		// so re-anchor
 		constexpr int64_t kMaxContinuationGap = 15;
-		if (media_frame->GetPts() - _next_pts > kMaxContinuationGap || media_frame->GetPts() < _next_pts)
+		if (media_frame->GetPts() - _next_pts > kMaxContinuationGap || _next_pts - media_frame->GetPts() > kMaxContinuationGap)
 		{
 			_next_pts = media_frame->GetPts();
 		}

--- a/src/transcoder/filter/filter_fps_test.cpp
+++ b/src/transcoder/filter/filter_fps_test.cpp
@@ -138,12 +138,28 @@ TEST(FilterFpsTest, ContinuationReAnchorsOnRealDiscontinuity)
 	EXPECT_EQ(DrainSlots(filter), (std::vector<int64_t>{25}));
 }
 
-TEST(FilterFpsTest, ContinuationReAnchorsBackward)
+TEST(FilterFpsTest, ContinuationDiscardsSmallBackwardOverlap)
 {
 	auto filter = MakeFilter();
 	filter.SetContinuationPts(10);
 
-	// Behind the inherited position: the timeline restarted
+	// An item splice re-bases the new item less than one frame after the old
+	// one, so its first frame can land on an already-emitted slot; the overlap
+	// is discarded instead of re-emitting the slot
+	ASSERT_TRUE(filter.Push(MakeFrame(9)));
+	ASSERT_TRUE(filter.Push(MakeFrame(10)));
+	EXPECT_EQ(DrainSlots(filter), (std::vector<int64_t>{}));
+
+	ASSERT_TRUE(filter.Push(MakeFrame(11)));
+	EXPECT_EQ(DrainSlots(filter), (std::vector<int64_t>{10}));
+}
+
+TEST(FilterFpsTest, ContinuationReAnchorsBackward)
+{
+	auto filter = MakeFilter();
+	filter.SetContinuationPts(30);
+
+	// Far behind the inherited position: the timeline restarted
 	ASSERT_TRUE(filter.Push(MakeFrame(5)));
 	ASSERT_TRUE(filter.Push(MakeFrame(6)));
 

--- a/src/transcoder/transcoder_filter.cpp
+++ b/src/transcoder/transcoder_filter.cpp
@@ -148,7 +148,14 @@ std::shared_ptr<FilterBase> TranscodeFilter::CreateBaseFilter()
 	base->SetInputTrack(GetInputTrack());
 	base->SetOutputStreamInfo(GetOutputStreamInfo());
 	base->SetOutputTrack(GetOutputTrack());
-	base->SetSourceId(ov::Random::GenerateInt32());
+
+	// 0 is the encoders' "no frame seen yet" sentinel, so never assign it as an id
+	int32_t source_id = 0;
+	while (source_id == 0)
+	{
+		source_id = ov::Random::GenerateInt32();
+	}
+	base->SetSourceId(source_id);
 
 	// Fault Injection for testing
 	if (TranscodeFaultInjector::GetInstance()->IsEnabled() && (GetInputStreamInfo() != GetOutputStreamInfo()))


### PR DESCRIPTION
### Problem

At a resolution change the decoder was reinitialized without draining, losing the frames still delayed inside the codec session. Recovering them exposes a second defect: a scheduled item can start less than one frame after the previous one ends, and the fps filter re-anchored backward onto an already emitted slot, duplicating output frames and shifting the keyframe cadence and segment lengths. A randomly assigned filter source id could also collide with the "no frame seen yet" sentinel the encoders use for reinit detection.

### Solution

The decoder drains its delayed frames downstream before reinitializing. The fps filter keeps its inherited slot position over a small backward overlap, letting the queue rules discard the stale slot, and re-anchors only on a real discontinuity. A filter is never assigned source id 0, and the input discontinuity diagnostic moved to trace because rate conversion triggers it structurally.

### Test

- Unit: ome_test_transcoder 39/39, including a new FilterFps test for the backward overlap discard.
- e2e: a scheduled channel rotating two VODs (640x360/1080p, 10 s items, x264), 120 s steady state with 14 transitions. Pass conditions: every LLHLS segment exactly 4.000 s, zero out of order DTS warnings, and the frame-level trace showing no lost slot at any transition (previously every transition lost one decoder-delayed frame), with the recovered frames' slot overlaps (4 occurrences) discarded without duplicate emission.
