### PR TITLE
fix: include the downstream handoff wait in the SkipFrames load metric

### DIFF
--- a/src/base/ovlibrary/clock.h
+++ b/src/base/ovlibrary/clock.h
@@ -61,7 +61,7 @@ namespace ov
 			lsw = (uint32_t)((double)(now.tv_nsec/1000)*(double)(((uint64_t)1)<<32)*1.0e-6);
 		}
 
-		static uint64_t GetElapsedMiliSecondsFromNow(std::chrono::steady_clock::time_point time)
+		static int64_t GetElapsedMiliSecondsFromNow(std::chrono::steady_clock::time_point time)
 		{
 			auto current = std::chrono::steady_clock::now();
 			return std::chrono::duration_cast<std::chrono::milliseconds>(current - time).count();

--- a/src/base/ovlibrary/clock.h
+++ b/src/base/ovlibrary/clock.h
@@ -66,5 +66,11 @@ namespace ov
 			auto current = std::chrono::steady_clock::now();
 			return std::chrono::duration_cast<std::chrono::milliseconds>(current - time).count();
 		}
+
+		static int64_t GetElapsedMicroSecondsFromNow(std::chrono::steady_clock::time_point time)
+		{
+			auto current = std::chrono::steady_clock::now();
+			return std::chrono::duration_cast<std::chrono::microseconds>(current - time).count();
+		}
 	};
 }

--- a/src/transcoder/filter/filter_base.h
+++ b/src/transcoder/filter/filter_base.h
@@ -74,6 +74,13 @@ public:
 		(void)previous;
 	}
 
+	// How long the handoff of a completed frame blocked the filter thread. A full
+	// queue on the far side throttles the filter as much as slow filtering does.
+	virtual void AddHandoffTime(int64_t elapsed_us)
+	{
+		(void)elapsed_us;
+	}
+
 	int32_t GetInputWidth() const
 	{
 		return _src_width;

--- a/src/transcoder/filter/filter_video_base.cpp
+++ b/src/transcoder/filter/filter_video_base.cpp
@@ -78,7 +78,7 @@ FilterResult FilterVideoBase::PopCompletedFrameInternal()
 {
 	if (GetState() == FilterBase::State::ERROR)
 	{
-		_pending_processing_time_us = 0;
+		ClearPendingTime();
 
 		return FilterResult::Error("The filter is in the error state");
 	}
@@ -90,15 +90,14 @@ FilterResult FilterVideoBase::PopCompletedFrameInternal()
 		auto completed_frame = ReceiveFrame();
 		if (completed_frame != nullptr)
 		{
-			UpdateProcessingTimePerFrame(start_time);
+			CommitPendingTime(start_time);
 
 			return FilterResult::Ready(std::move(completed_frame));
 		}
 
 		if (GetState() == FilterBase::State::ERROR)
 		{
-			// The measured time belongs to work that will never complete.
-			_pending_processing_time_us = 0;
+			ClearPendingTime();
 
 			return FilterResult::Error("The backend rescaler has failed");
 		}
@@ -107,8 +106,7 @@ FilterResult FilterVideoBase::PopCompletedFrameInternal()
 		auto frame = _fps_filter.Pop();
 		if (frame == nullptr)
 		{
-			// No completed frame available yet. Update pending processing time
-			_pending_processing_time_us += ElapsedTimeInUs(start_time);
+			AddProcessingTime(start_time);
 
 #if _SKIP_FRAMES_ENABLED
 			// Update skip frames based on the current processing time and framerate.
@@ -181,19 +179,36 @@ void FilterVideoBase::InheritContinuity(const FilterBase *previous)
 	_fps_filter.SetContinuationPts(previous_video->_fps_filter.GetNextPts());
 }
 
-int64_t FilterVideoBase::ElapsedTimeInUs(const std::chrono::steady_clock::time_point &start_time) const
+void FilterVideoBase::AddHandoffTime(int64_t elapsed_us)
 {
-	return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start_time).count();
+	// Called on the filter thread, so no synchronization is needed.
+	_pending_handoff_time_us += elapsed_us;
 }
 
-void FilterVideoBase::UpdateProcessingTimePerFrame(const std::chrono::steady_clock::time_point &start_time)
+void FilterVideoBase::CommitPendingTime(const std::chrono::steady_clock::time_point &start_time)
 {
 	static constexpr double kProcessingTimeEmaAlpha = 0.1;
 
-	auto elapsed_time_us = _pending_processing_time_us + ElapsedTimeInUs(start_time);
+	auto processing_time_us = _pending_processing_time_us + ov::Clock::GetElapsedMicroSecondsFromNow(start_time);
+	auto handoff_time_us	= _pending_handoff_time_us;
 
-	_pending_processing_time_us				= 0;
-	_weighted_avg_frame_processing_time_us	= (_weighted_avg_frame_processing_time_us * (1.0 - kProcessingTimeEmaAlpha)) + (elapsed_time_us * kProcessingTimeEmaAlpha);
+	ClearPendingTime();
+
+	_weighted_avg_frame_processing_time_us	= (_weighted_avg_frame_processing_time_us * (1.0 - kProcessingTimeEmaAlpha)) + (processing_time_us * kProcessingTimeEmaAlpha);
+	_weighted_avg_frame_handoff_time_us		= (_weighted_avg_frame_handoff_time_us * (1.0 - kProcessingTimeEmaAlpha)) + (handoff_time_us * kProcessingTimeEmaAlpha);
+}
+
+void FilterVideoBase::AddProcessingTime(const std::chrono::steady_clock::time_point &start_time)
+{
+	// No frame came out this round, so the time waits for one that does.
+	_pending_processing_time_us += ov::Clock::GetElapsedMicroSecondsFromNow(start_time);
+}
+
+void FilterVideoBase::ClearPendingTime()
+{
+	// Time spent on work that failed must not be pinned on a later frame.
+	_pending_processing_time_us = 0;
+	_pending_handoff_time_us	= 0;
 }
 
 #if _SKIP_FRAMES_ENABLED
@@ -240,31 +255,21 @@ void FilterVideoBase::UpdateSkipFrames()
 	}
 	_skip_frames_last_check_time = curr_time;
 
-	// Remain for debugging and future improvement for queue-based skip frame adjustment
-	// -----------------------------------------------------------------------------
-	// double actual_input_fps			   = _fps_filter.GetInputFramesPerSecond();
-	// double expected_input_fps		   = _fps_filter.GetInputFrameRate();
-
-	// double expected_output_fps		   = _fps_filter.GetExpectedOutputFramesPerSecond();
-
-	// int64_t queue_waiting_deviation_us = _input_buffer.GetWaitingTimeInUs();
-	// double expected_frame_interval_us  = (expected_input_fps > 0.0) ? (1000000.0 / expected_input_fps) : 0.0;
-	// bool is_queue_overload			   = (expected_frame_interval_us > 0.0) &&
-	// 						 (queue_waiting_deviation_us > expected_frame_interval_us * _SKIP_FRAMES_QUEUE_BACKLOG_RATIO);
-	// bool is_queue_stable = (expected_frame_interval_us > 0.0) &&
-	// 					   (queue_waiting_deviation_us < expected_frame_interval_us * _SKIP_FRAMES_QUEUE_RECOVERY_RATIO);
-
 	double fixed_output_fps			   = _fps_filter.GetOutputFrameRate();
 	double expected_output_fps		   = _fps_filter.GetExpectedOutputFramesPerSecond();
 	double actual_output_fps		   = _fps_filter.GetOutputFramesPerSecond();
 
-	if (_weighted_avg_frame_processing_time_us <= 0.0 || fixed_output_fps <= 0.0)
+	// A slow rescaler and a backed-up encoder each throttle this thread, and it
+	// cannot outrun their sum, so the skip decision uses the total.
+	double frame_budget_us = _weighted_avg_frame_processing_time_us + _weighted_avg_frame_handoff_time_us;
+
+	if (frame_budget_us <= 0.0 || fixed_output_fps <= 0.0)
 	{
 		return;
 	}
 
 	// Calculate the maximum possible frames per second.
-	double max_frames_per_second = (1000000.0 / _weighted_avg_frame_processing_time_us);
+	double max_frames_per_second = (1000000.0 / frame_budget_us);
 	// To ensure stability, set a margin and use OO% of the calculated maximum FPS.
 	double ideal_frames_per_second = max_frames_per_second * _SKIP_FRAMES_ENSURE_FPS_MARGIN_RATIO;
 
@@ -285,12 +290,15 @@ void FilterVideoBase::UpdateSkipFrames()
 		next_skip_frames = FilterFps::SkipFramesMin;
 	}
 
-	ov::String common_log = ov::String::FormatString("Possible FPS: %.2f/%.2f(ideal), Output FPS: %.2f/%.2f/%.2f", max_frames_per_second, ideal_frames_per_second, fixed_output_fps, expected_output_fps, actual_output_fps);
+	ov::String common_log = ov::String::FormatString("Output FPS: %.2f (Conf: %.2f, Expect: %.2f), Frame Budget: %.2fus (Inproc: %.2fus + Handoff: %.2fus = Possible FPS: %.2f)",
+													 actual_output_fps, fixed_output_fps, expected_output_fps,
+													 frame_budget_us, _weighted_avg_frame_processing_time_us, _weighted_avg_frame_handoff_time_us,
+													ideal_frames_per_second);
 
 	// Increase skip frames immediately when bottleneck occurs.
 	if (_skip_frames < next_skip_frames)
 	{
-		logtw("[%s] Changed SkipFrames %d -> %d (Bottleneck). %s", GetLogPrefix().CStr(), _skip_frames, next_skip_frames, common_log.CStr());
+		logtw("[%s] Changed SkipFrames() %d -> %d (Bottleneck). %s", GetLogPrefix().CStr(), _skip_frames, next_skip_frames, common_log.CStr());
 
 		_skip_frames = next_skip_frames;
 		_fps_filter.SetSkipFrames(_skip_frames);

--- a/src/transcoder/filter/filter_video_base.cpp
+++ b/src/transcoder/filter/filter_video_base.cpp
@@ -66,10 +66,16 @@ FilterResult FilterVideoBase::ProcessFrameInternal(const std::shared_ptr<MediaFr
 		return FilterResult::Error("Received frame is null");
 	}
 
+	auto start_time = std::chrono::steady_clock::now();
+
 	if (_fps_filter.Push(media_frame) == false)
 	{
 		logtw("[%s] Dropped a frame because the FPS filter is full.", GetLogPrefix().CStr());
 	}
+
+	// The push runs on the filter thread like everything else, so it counts toward how
+	// busy the thread was this window.
+	_window_busy_time_us += ov::Clock::GetElapsedMicroSecondsFromNow(start_time);
 
 	return FilterResult::NoOutput();
 }
@@ -166,7 +172,6 @@ void FilterVideoBase::InheritContinuity(const FilterBase *previous)
 	{
 		return;
 	}
-
 	// The slot position only transfers within the same output cadence
 	if (_fps_filter.GetOutputFrameRate() != previous_video->_fps_filter.GetOutputFrameRate())
 	{
@@ -177,11 +182,57 @@ void FilterVideoBase::InheritContinuity(const FilterBase *previous)
 	// change) leaves a slot hole no instance can see on its own; carrying the
 	// slot position lets the new filter refill it
 	_fps_filter.SetContinuationPts(previous_video->_fps_filter.GetNextPts());
+
+
+	// The encoder does not empty out because this filter was replaced, so the load the
+	// outgoing filter measured still describes the pipeline.
+	_weighted_avg_frame_processing_time_us = previous_video->_weighted_avg_frame_processing_time_us;
+	_weighted_avg_frame_handoff_time_us	   = previous_video->_weighted_avg_frame_handoff_time_us;
+
+#if _SKIP_FRAMES_ENABLED
+	// Only the automatic skip level transfers; a configured one was already applied from
+	// config.
+	if (_skip_frames_conf == 0 && previous_video->_skip_frames_conf == 0)
+	{
+		_skip_frames				   = previous_video->_skip_frames;
+		_skip_frames_bottleneck_count  = previous_video->_skip_frames_bottleneck_count;
+		_skip_frames_last_changed_time = previous_video->_skip_frames_last_changed_time;
+
+		_fps_filter.SetSkipFrames(_skip_frames);
+	}
+#endif
 }
+
+// Most a single handoff may contribute, as a multiple of the output frame interval.
+static constexpr double kHandoffSampleClampRatio = 4.0;
 
 void FilterVideoBase::AddHandoffTime(int64_t elapsed_us)
 {
 	// Called on the filter thread, so no synchronization is needed.
+	if (elapsed_us <= 0)
+	{
+		return;
+	}
+
+	// The thread was blocked for the whole wait, however long it was.
+	_window_busy_time_us += elapsed_us;
+
+	// A one-off stall on the far side - an encoder reinit, GPU contention, a queue
+	// enqueue timing out - says nothing about how many frames this filter can sustain,
+	// so cap what a single handoff may contribute. Sustained overload still pins the
+	// average at the cap.
+	double output_fps = _fps_filter.GetOutputFrameRate();
+	if (output_fps > 0.0)
+	{
+		auto clamp_us = static_cast<int64_t>((1000000.0 / output_fps) * kHandoffSampleClampRatio);
+		if (elapsed_us > clamp_us)
+		{
+			logtd("[%s] Clamped a handoff sample: %" PRId64 "us -> %" PRId64 "us", GetLogPrefix().CStr(), elapsed_us, clamp_us);
+
+			elapsed_us = clamp_us;
+		}
+	}
+
 	_pending_handoff_time_us += elapsed_us;
 }
 
@@ -189,8 +240,13 @@ void FilterVideoBase::CommitPendingTime(const std::chrono::steady_clock::time_po
 {
 	static constexpr double kProcessingTimeEmaAlpha = 0.1;
 
-	auto processing_time_us = _pending_processing_time_us + ov::Clock::GetElapsedMicroSecondsFromNow(start_time);
+	auto elapsed_us			= ov::Clock::GetElapsedMicroSecondsFromNow(start_time);
+	auto processing_time_us = _pending_processing_time_us + elapsed_us;
 	auto handoff_time_us	= _pending_handoff_time_us;
+
+	// Only this round is added; the pending rounds already went into the window when
+	// they were measured.
+	_window_busy_time_us += elapsed_us;
 
 	ClearPendingTime();
 
@@ -200,15 +256,20 @@ void FilterVideoBase::CommitPendingTime(const std::chrono::steady_clock::time_po
 
 void FilterVideoBase::AddProcessingTime(const std::chrono::steady_clock::time_point &start_time)
 {
-	// No frame came out this round, so the time waits for one that does.
-	_pending_processing_time_us += ov::Clock::GetElapsedMicroSecondsFromNow(start_time);
+	auto elapsed_us = ov::Clock::GetElapsedMicroSecondsFromNow(start_time);
+
+	// No frame came out this round, so the time waits for one that does - but the thread
+	// was busy either way, and the window tracks the thread rather than the frame.
+	_pending_processing_time_us += elapsed_us;
+	_window_busy_time_us += elapsed_us;
 }
 
 void FilterVideoBase::ClearPendingTime()
 {
-	// Called once the pending time has been charged to a completed frame, and on
-	// the failure paths, where time spent on work that will never complete must
-	// not be pinned on a later frame.
+	// Called once the pending time has been charged to a completed frame, and on the
+	// failure paths, where time spent on work that will never complete must not be
+	// pinned on a later frame. The window is deliberately left alone: the thread was
+	// busy whether or not the work produced anything.
 	_pending_processing_time_us = 0;
 	_pending_handoff_time_us	= 0;
 }
@@ -217,6 +278,10 @@ void FilterVideoBase::ClearPendingTime()
 #define _SKIP_FRAMES_EVALUATION_INTERVAL_MS 	1000	// 1s
 #define _SKIP_FRAMES_RECOVERY_HOLD_INTERVAL_MS 	5000	// 5s
 #define _SKIP_FRAMES_ENSURE_FPS_MARGIN_RATIO 	0.9f	// 90%
+#define _SKIP_FRAMES_SATURATION_RATIO 			0.95f	// 95% of the window with no idle time
+#define _SKIP_FRAMES_RECOVERY_BUSY_RATIO 		0.80f	// headroom required before stepping back down
+#define _SKIP_FRAMES_BOTTLENECK_HOLD_COUNT 		2		// consecutive windows
+#define _SKIP_FRAMES_MAX_INCREASE_PER_STEP 		1
 
 void FilterVideoBase::UpdateSkipFrames()
 {
@@ -257,6 +322,14 @@ void FilterVideoBase::UpdateSkipFrames()
 	}
 	_skip_frames_last_check_time = curr_time;
 
+	// Whatever is left of the window went to waiting for input. A thread with idle time
+	// left is keeping up no matter how long its handoffs blocked, so close the window
+	// here - before any of the early returns below can skip the reset.
+	double window_us   = static_cast<double>(elapsed_check_time) * 1000.0;
+	double utilization = (window_us > 0.0) ? (static_cast<double>(_window_busy_time_us) / window_us) : 0.0;
+
+	_window_busy_time_us = 0;
+
 	double fixed_output_fps			   = _fps_filter.GetOutputFrameRate();
 	double expected_output_fps		   = _fps_filter.GetExpectedOutputFramesPerSecond();
 	double actual_output_fps		   = _fps_filter.GetOutputFramesPerSecond();
@@ -292,10 +365,54 @@ void FilterVideoBase::UpdateSkipFrames()
 		next_skip_frames = FilterFps::SkipFramesMin;
 	}
 
-	ov::String common_log = ov::String::FormatString("Possible FPS: %.2f/%.2f(ideal), Output FPS: %.2f/%.2f/%.2f, Frame Budget: %.2fus (Inproc: %.2fus + Handoff: %.2fus)",
+	// The frame budget only measures capacity while the thread has nothing else to do.
+	// The encoder queue is two frames deep and the handoff waits on it, so a burst of
+	// input or one jittery encode blocks this thread on a chain that is comfortably
+	// keeping up. Idle time left in the window is what separates the two.
+	bool is_saturated = (utilization >= _SKIP_FRAMES_SATURATION_RATIO);
+
+	// A saturated thread still has to be missing the rate it is already set to. Falling
+	// short of a rate nobody asked for is not a bottleneck. No measurement yet is not
+	// evidence of one either, and skipping frames would not rescue a pipeline that is
+	// producing nothing at all.
+	bool is_missing_target = (actual_output_fps > 0.0) && (actual_output_fps < expected_output_fps * _SKIP_FRAMES_ENSURE_FPS_MARGIN_RATIO);
+
+	if (is_saturated == true && is_missing_target == true)
+	{
+		_skip_frames_bottleneck_count++;
+	}
+	else
+	{
+		_skip_frames_bottleneck_count = 0;
+
+		// The budget measured backpressure, not a shortage of capacity, so aim at no
+		// skipping and let the recovery branch walk down at its own rate. Stepping down
+		// needs its own evidence though: with the thread still close to capacity the level
+		// below would put it straight back over, which is how a marginal encoder turns into
+		// a slow oscillation. Hold until real headroom shows up.
+		next_skip_frames = (utilization < _SKIP_FRAMES_RECOVERY_BUSY_RATIO) ? FilterFps::SkipFramesMin : _skip_frames;
+	}
+
+	if (next_skip_frames > _skip_frames)
+	{
+		// One bad window is a hiccup - a stalled encoder reinit, a GPU spike. A bottleneck
+		// is still there on the next one.
+		if (_skip_frames_bottleneck_count < _SKIP_FRAMES_BOTTLENECK_HOLD_COUNT)
+		{
+			next_skip_frames = _skip_frames;
+		}
+		// Rise in single steps, so no single window can collapse the output rate.
+		else if (next_skip_frames > _skip_frames + _SKIP_FRAMES_MAX_INCREASE_PER_STEP)
+		{
+			next_skip_frames = _skip_frames + _SKIP_FRAMES_MAX_INCREASE_PER_STEP;
+		}
+	}
+
+	ov::String common_log = ov::String::FormatString("Possible FPS: %.2f/%.2f(ideal), Output FPS: %.2f/%.2f/%.2f, Frame Budget: %.2fus (Inproc: %.2fus + Handoff: %.2fus), Busy: %.1f%%",
 													 max_frames_per_second, ideal_frames_per_second,
 													 fixed_output_fps, expected_output_fps, actual_output_fps,
-													 frame_budget_us, _weighted_avg_frame_processing_time_us, _weighted_avg_frame_handoff_time_us);
+													 frame_budget_us, _weighted_avg_frame_processing_time_us, _weighted_avg_frame_handoff_time_us,
+													 utilization * 100.0);
 
 	// Increase skip frames immediately when bottleneck occurs.
 	if (_skip_frames < next_skip_frames)
@@ -329,13 +446,13 @@ void FilterVideoBase::UpdateSkipFrames()
 		}
 		else
 		{
-			logtt("[%s] Hold SkipFrames %d (Waiting for recovery). %s", GetLogPrefix().CStr(), _skip_frames, common_log.CStr());
+			logtd("[%s] Hold SkipFrames %d (Waiting for recovery). %s", GetLogPrefix().CStr(), _skip_frames, common_log.CStr());
 		}
 	}
 	// Keep skip frames unchanged when the system is stable.
 	else
 	{
-		logtt("[%s] Unchanged SkipFrames %d (Stable). %s", GetLogPrefix().CStr(), _skip_frames, common_log.CStr());
+		logtd("[%s] Unchanged SkipFrames %d (Stable). %s", GetLogPrefix().CStr(), _skip_frames, common_log.CStr());
 	}
 }
 #endif // _SKIP_FRAMES_ENABLED

--- a/src/transcoder/filter/filter_video_base.cpp
+++ b/src/transcoder/filter/filter_video_base.cpp
@@ -206,7 +206,9 @@ void FilterVideoBase::AddProcessingTime(const std::chrono::steady_clock::time_po
 
 void FilterVideoBase::ClearPendingTime()
 {
-	// Time spent on work that failed must not be pinned on a later frame.
+	// Called once the pending time has been charged to a completed frame, and on
+	// the failure paths, where time spent on work that will never complete must
+	// not be pinned on a later frame.
 	_pending_processing_time_us = 0;
 	_pending_handoff_time_us	= 0;
 }
@@ -290,15 +292,15 @@ void FilterVideoBase::UpdateSkipFrames()
 		next_skip_frames = FilterFps::SkipFramesMin;
 	}
 
-	ov::String common_log = ov::String::FormatString("Output FPS: %.2f (Conf: %.2f, Expect: %.2f), Frame Budget: %.2fus (Inproc: %.2fus + Handoff: %.2fus = Possible FPS: %.2f)",
-													 actual_output_fps, fixed_output_fps, expected_output_fps,
-													 frame_budget_us, _weighted_avg_frame_processing_time_us, _weighted_avg_frame_handoff_time_us,
-													ideal_frames_per_second);
+	ov::String common_log = ov::String::FormatString("Possible FPS: %.2f/%.2f(ideal), Output FPS: %.2f/%.2f/%.2f, Frame Budget: %.2fus (Inproc: %.2fus + Handoff: %.2fus)",
+													 max_frames_per_second, ideal_frames_per_second,
+													 fixed_output_fps, expected_output_fps, actual_output_fps,
+													 frame_budget_us, _weighted_avg_frame_processing_time_us, _weighted_avg_frame_handoff_time_us);
 
 	// Increase skip frames immediately when bottleneck occurs.
 	if (_skip_frames < next_skip_frames)
 	{
-		logtw("[%s] Changed SkipFrames() %d -> %d (Bottleneck). %s", GetLogPrefix().CStr(), _skip_frames, next_skip_frames, common_log.CStr());
+		logtw("[%s] Changed SkipFrames %d -> %d (Bottleneck). %s", GetLogPrefix().CStr(), _skip_frames, next_skip_frames, common_log.CStr());
 
 		_skip_frames = next_skip_frames;
 		_fps_filter.SetSkipFrames(_skip_frames);

--- a/src/transcoder/filter/filter_video_base.h
+++ b/src/transcoder/filter/filter_video_base.h
@@ -46,12 +46,20 @@ protected:
 #endif
 
 
-	int64_t ElapsedTimeInUs(const std::chrono::steady_clock::time_point &start_time) const;
-	void UpdateProcessingTimePerFrame(const std::chrono::steady_clock::time_point &start_time);
+public:
+	void AddHandoffTime(int64_t elapsed_us) override;
+protected:
+	void CommitPendingTime(const std::chrono::steady_clock::time_point &start_time);
+	void AddProcessingTime(const std::chrono::steady_clock::time_point &start_time);
+	void ClearPendingTime();
 
-	// Weighted average of frame processing time.
+	// Time spent inside this filter (FPS filter + rescaler graph).
 	double _weighted_avg_frame_processing_time_us = 0.0;
 
-	// Processing time that has not been charged to a completed frame yet.
+	// Time the thread sat blocked handing completed frames to the next stage.
+	double _weighted_avg_frame_handoff_time_us = 0.0;
+
+	// Time that no completed frame has taken over yet.
 	int64_t _pending_processing_time_us = 0;
+	int64_t _pending_handoff_time_us = 0;
 };

--- a/src/transcoder/filter/filter_video_base.h
+++ b/src/transcoder/filter/filter_video_base.h
@@ -27,6 +27,7 @@ public:
 	FilterResult PopCompletedFrameInternal() override;
 	std::vector<std::shared_ptr<MediaFrame>> FlushBuffered() override;
 	void InheritContinuity(const FilterBase *previous) override;
+	void AddHandoffTime(int64_t elapsed_us) override;
 
 protected:
 	bool InitializeFpsFilter();
@@ -45,21 +46,19 @@ protected:
 	int32_t _skip_frames				   = -1;
 #endif
 
-
-public:
-	void AddHandoffTime(int64_t elapsed_us) override;
-protected:
 	void CommitPendingTime(const std::chrono::steady_clock::time_point &start_time);
 	void AddProcessingTime(const std::chrono::steady_clock::time_point &start_time);
 	void ClearPendingTime();
 
-	// Time spent inside this filter (FPS filter + rescaler graph).
+	// Weighted average of the time spent inside this filter (FPS filter + rescaler graph).
 	double _weighted_avg_frame_processing_time_us = 0.0;
 
-	// Time the thread sat blocked handing completed frames to the next stage.
-	double _weighted_avg_frame_handoff_time_us = 0.0;
+	// Weighted average of the time the thread sat blocked handing completed frames to the next stage.
+	double _weighted_avg_frame_handoff_time_us	  = 0.0;
 
-	// Time that no completed frame has taken over yet.
-	int64_t _pending_processing_time_us = 0;
-	int64_t _pending_handoff_time_us = 0;
+	// Processing time that has not been charged to a completed frame yet.
+	int64_t _pending_processing_time_us			  = 0;
+
+	// Handoff time that has not been charged to a completed frame yet.
+	int64_t _pending_handoff_time_us			  = 0;
 };

--- a/src/transcoder/filter/filter_video_base.h
+++ b/src/transcoder/filter/filter_video_base.h
@@ -44,6 +44,10 @@ protected:
 	// Set initial Skip Frames
 	int32_t _skip_frames_conf			   = -1;
 	int32_t _skip_frames				   = -1;
+
+	// Consecutive evaluation windows that looked like a bottleneck. One bad window is a
+	// hiccup, so the skip level only rises once a window repeats the diagnosis.
+	int32_t _skip_frames_bottleneck_count  = 0;
 #endif
 
 	void CommitPendingTime(const std::chrono::steady_clock::time_point &start_time);
@@ -61,4 +65,10 @@ protected:
 
 	// Handoff time that has not been charged to a completed frame yet.
 	int64_t _pending_handoff_time_us			  = 0;
+
+	// Everything the thread was busy with during the current evaluation window, both
+	// filtering and handing frames off. Whatever is left of the window went to waiting
+	// for input, and that idle time is what tells a saturated thread apart from an
+	// overloaded one.
+	int64_t _window_busy_time_us				  = 0;
 };

--- a/src/transcoder/transcoder_filter.cpp
+++ b/src/transcoder/transcoder_filter.cpp
@@ -293,7 +293,13 @@ void TranscodeFilter::ThreadLoop()
 			auto recv = base->PopCompletedFrameInternal();
 			if (recv.result == TranscodeResult::DataReady)
 			{
+				// OnComplete() blocks here while the encoder queue is full, so the
+				// filter needs that wait to react to a backed-up encoder.
+				auto handoff_start = std::chrono::steady_clock::now();
+
 				OnComplete(recv.result, std::move(recv.frame));
+
+				base->AddHandoffTime(ov::Clock::GetElapsedMicroSecondsFromNow(handoff_start));
 
 				// Keep draining to check whether more frames are pending.
 				continue;


### PR DESCRIPTION
## Summary

`SkipFrames` sized itself from the time spent inside the filter graph alone. But the filter and the encoder are decoupled by a queue, so a saturated encoder grew that queue without ever touching the filter's own timing - the metric stayed flat at ~250us while input FPS collapsed from 30 to 10, and `SkipFrames` never left 0. The overload it exists to relieve went unhandled.

The filter thread does stall on the encoder. The encoder input queue has a threshold of 2 with exceed-wait enabled, so the handoff inside `OnComplete()` blocks until the encoder drains. That wait simply fell outside the measurement bracket, which closes as soon as `ReceiveFrame()` returns a frame.

## Changes

The load metric becomes a **per-frame budget** - the total time the filter thread is occupied per output frame:

```
frame_budget = filtering time + handoff wait
max_fps      = 1000000 / frame_budget
```

- The thread cannot outrun the sum of the two, so the budget is the real   throughput ceiling. A slow rescaler and a backed-up encoder now throttle   `SkipFrames` through one metric; previously only the former could.
- The skip formula, the 90% safety margin, the 1s evaluation interval and the 5s   recovery hold are unchanged - only the input to the formula got wider. 
- The two halves are averaged separately with the same EMA alpha so the log  attributes the bottleneck, but only the total drives the decision.
- Time measured on a round that produces no frame stays pending and is carried to  whichever frame completes next; on the error paths it is dropped rather than  pinned on an unrelated later frame.

## How to test

Inject lag into the encoder and watch the filter react. Each triggered frame sleeps 300ms inside the encoder, so a 20% rate on a 30fps stream pushes the encoder down to roughly 10fps.

**1.** Enable automatic `SkipFrames` on the video encode:

```xml
<Encodes>
    <Video>
        <SkipFrames>0</SkipFrames>  <!-- 0 = auto, -1 = disabled, 1~120 = fixed -->
        <Framerate>30</Framerate>
        ...
    </Video>
</Encodes>
```

**2.** Start a 30fps stream, then inject the fault
(`targetModule` is the encoder module: `default`, `nv`, `xma`, `nilogan`):

```bash
curl -u "$TOKEN:" -X POST \
  "http://<host>:8081/v2/internals/tests:setFaultInject" \
  -H 'Content-Type: application/json' \
  -d '{
        "transcoder": [
          {
            "targetComponent": "encoder",
            "targetModule": "nv",
            "targetDeviceId": 0,
            "faultType": "LAGGING",
            "faultRate": 20
          }
        ]
      }'
```

**3.** Watch the filter log. Before this change the budget stayed flat and
`SkipFrames` never moved:

```
SkipFrames evaluation. Input FPS: 10.66, Weighted Avg Time: 243.64us, MaxIeal: 3694.05
SkipFrames evaluation. Input FPS: 13.06, Weighted Avg Time: 254.15us, MaxIeal: 3541.27
```

Now the handoff wait dominates the budget and the skip count climbs:

```
Changed SkipFrames() 0 -> 1 (Bottleneck). Output FPS: ..., Frame Budget: 60000.00us (Inproc: 250.00us + Handoff: 59750.00us = Possible FPS: 15.00)
```

**4.** Clear the fault and confirm recovery - `SkipFrames` should decay back to 0
one step per 5s recovery hold:
