### PR TITLE
refactor(transcoder): restructure SkipFrames control and improve its accuracy

### DIFF
--- a/src/base/ovlibrary/clock.h
+++ b/src/base/ovlibrary/clock.h
@@ -61,10 +61,16 @@ namespace ov
 			lsw = (uint32_t)((double)(now.tv_nsec/1000)*(double)(((uint64_t)1)<<32)*1.0e-6);
 		}
 
-		static uint64_t GetElapsedMiliSecondsFromNow(std::chrono::steady_clock::time_point time)
+		static int64_t GetElapsedMiliSecondsFromNow(std::chrono::steady_clock::time_point time)
 		{
 			auto current = std::chrono::steady_clock::now();
 			return std::chrono::duration_cast<std::chrono::milliseconds>(current - time).count();
+		}
+
+		static int64_t GetElapsedMicroSecondsFromNow(std::chrono::steady_clock::time_point time)
+		{
+			auto current = std::chrono::steady_clock::now();
+			return std::chrono::duration_cast<std::chrono::microseconds>(current - time).count();
 		}
 	};
 }

--- a/src/transcoder/filter/filter_base.h
+++ b/src/transcoder/filter/filter_base.h
@@ -74,6 +74,13 @@ public:
 		(void)previous;
 	}
 
+	// How long the handoff of a completed frame blocked the filter thread. A full
+	// queue on the far side throttles the filter as much as slow filtering does.
+	virtual void AddHandoffTime(int64_t elapsed_us)
+	{
+		(void)elapsed_us;
+	}
+
 	int32_t GetInputWidth() const
 	{
 		return _src_width;

--- a/src/transcoder/filter/filter_lavfi_rescaler.cpp
+++ b/src/transcoder/filter/filter_lavfi_rescaler.cpp
@@ -219,8 +219,7 @@ bool FilterLavfiRescaler::Initialize()
 
 #if _SKIP_FRAMES_ENABLED
 	// Set initial Skip Frames
-	_skip_frames_conf = _output_track->GetSkipFramesByConfig();
-	_skip_frames	  = _skip_frames_conf;
+	_skip_frames_controller.Configure(_output_track->GetSkipFramesByConfig());
 #endif
 
 	SetState(State::STARTED);

--- a/src/transcoder/filter/filter_lavfi_rescaler.cpp
+++ b/src/transcoder/filter/filter_lavfi_rescaler.cpp
@@ -217,11 +217,6 @@ bool FilterLavfiRescaler::Initialize()
 		return false;
 	}
 
-#if _SKIP_FRAMES_ENABLED
-	// Set initial Skip Frames
-	_skip_frames_controller.Configure(_output_track->GetSkipFramesByConfig());
-#endif
-
 	SetState(State::STARTED);
 
 	return true;

--- a/src/transcoder/filter/filter_skipframes_controller.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller.cpp
@@ -176,7 +176,9 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 	{
 		next_skip_frames = static_cast<int32_t>(std::floor(observation.max_output_fps - 1));
 	}
-	else if (next_skip_frames < FilterFps::SkipFramesMin)
+
+	// Prevent the level from going below the minimum, which is also the disabled value.
+	if (next_skip_frames < FilterFps::SkipFramesMin)
 	{
 		next_skip_frames = FilterFps::SkipFramesMin;
 	}

--- a/src/transcoder/filter/filter_skipframes_controller.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller.cpp
@@ -133,22 +133,22 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 
 	// A slow rescaler and a backed-up encoder both throttle the thread, and it cannot outrun
 	// their sum, so the decision uses the total.
-	double frame_budget_us = _weighted_avg_frame_processing_time_us + _weighted_avg_frame_handoff_time_us;
+	double frame_cost_us = _weighted_avg_frame_processing_time_us + _weighted_avg_frame_handoff_time_us;
 
-	if (frame_budget_us <= 0.0 || observation.cadence_fps <= 0.0)
+	if (frame_cost_us <= 0.0 || observation.max_output_fps <= 0.0)
 	{
 		return std::nullopt;
 	}
 
-	// The most frames per second the budget allows, less a safety margin.
-	double peak_fps		   = (1000000.0 / frame_budget_us);
+	// The most frames per second the cost allows, less a safety margin.
+	double peak_fps		   = (1000000.0 / frame_cost_us);
 	double sustainable_fps = peak_fps * kSafetyMarginRatio;
 
-	// How far the cadence has to be divided down to land on the sustainable rate.
-	auto next_skip_frames = static_cast<int32_t>(std::ceil(observation.cadence_fps / sustainable_fps - 1.0));
-	if (next_skip_frames > observation.cadence_fps - 1)
+	// How far the output ceiling has to be divided down to land on the sustainable rate.
+	auto next_skip_frames = static_cast<int32_t>(std::ceil(observation.max_output_fps / sustainable_fps - 1.0));
+	if (next_skip_frames > observation.max_output_fps - 1)
 	{
-		next_skip_frames = static_cast<int32_t>(std::floor(observation.cadence_fps - 1));
+		next_skip_frames = static_cast<int32_t>(std::floor(observation.max_output_fps - 1));
 	}
 	else if (next_skip_frames < FilterFps::SkipFramesMin)
 	{
@@ -157,19 +157,19 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 
 	// Busy is not the same as overloaded. The encoder queue is only two frames deep, so the
 	// handoff blocks even on a chain that keeps up. Idle time is what tells the two apart.
-	bool is_saturated = (utilization >= kSaturationRatio);
+	bool is_fully_busy = (utilization >= kSaturationRatio);
 
-	// A saturated thread also has to be losing ground. Zero means the FPS filter has not
+	// A fully busy thread also has to be losing input. Zero means the FPS filter has not
 	// measured a second yet, not that nothing was consumed.
-	bool is_falling_behind = (observation.expected_input_fps > 0.0) &&
-							 (observation.actual_input_fps > 0.0) &&
-							 (observation.actual_input_fps < observation.expected_input_fps * kInputKeepUpRatio);
+	bool is_losing_input = (observation.expected_input_fps > 0.0) &&
+						   (observation.actual_input_fps > 0.0) &&
+						   (observation.actual_input_fps < observation.expected_input_fps * kInputKeepUpRatio);
 
-	if (is_saturated == true && is_falling_behind == true)
+	if (is_fully_busy == true && is_losing_input == true)
 	{
 		_bottleneck_count++;
 
-		// The budget decays between stalls, so without this the recovery branch below could
+		// The cost decays between stalls, so without this the recovery branch below could
 		// walk the level down while the bottleneck is still there.
 		next_skip_frames = std::max(next_skip_frames, _skip_frames);
 	}
@@ -181,9 +181,13 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 		// busy; gating on utilization alone would pin a level reached during a spike
 		// forever. The hold interval makes this a probe - if the level below cannot hold,
 		// the next window says so and puts it back.
-		bool has_headroom = (utilization < kRecoveryMaxBusyRatio) || (is_falling_behind == false);
+		bool may_step_down = (utilization < kRecoveryMaxBusyRatio) || (is_losing_input == false);
 
-		next_skip_frames = has_headroom ? FilterFps::SkipFramesMin : _skip_frames;
+		// The step down lands where the cost allows, not at nothing.
+		if (may_step_down == false)
+		{
+			next_skip_frames = _skip_frames;
+		}
 	}
 
 	if (next_skip_frames > _skip_frames)
@@ -203,16 +207,23 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 	// Every value labelled, every pair actual/target, times in ms - readable on its own.
 	Result result;
 	result.skip_frames = _skip_frames;
-	result.metrics	   = ov::String::FormatString("Input: %.1f/%.1ffps, Busy: %.1f%%, Budget: %.2fms (proc %.2f + handoff %.2f), Capacity: %.1ffps, Output: %.1f/%.1ffps (cadence %.1f)",
+	result.metrics	   = ov::String::FormatString("Input: %.1f/%.1ffps, Busy: %.1f%%, Cost: %.2fms (proc %.2f + handoff %.2f), Capacity: %.1ffps, Output: %.1f/%.1ffps (max %.1f)",
 												  observation.actual_input_fps, observation.expected_input_fps,
 												  utilization * 100.0,
-												  frame_budget_us / 1000.0, _weighted_avg_frame_processing_time_us / 1000.0, _weighted_avg_frame_handoff_time_us / 1000.0,
+												  frame_cost_us / 1000.0, _weighted_avg_frame_processing_time_us / 1000.0, _weighted_avg_frame_handoff_time_us / 1000.0,
 												  sustainable_fps,
-												  observation.actual_output_fps, observation.expected_output_fps, observation.cadence_fps);
+												  observation.actual_output_fps, observation.expected_output_fps, observation.max_output_fps);
 
 	// Increase skip frames immediately when bottleneck occurs.
 	if (_skip_frames < next_skip_frames)
 	{
+		// The step down could not hold. Wait longer before trying the next one.
+		if (_probe_origin_level > 0)
+		{
+			_recovery_hold_ms	= std::min(_recovery_hold_ms * 2, kRecoveryHoldMaxMs);
+			_probe_origin_level = 0;
+		}
+
 		result.decision	   = Decision::Bottleneck;
 		result.skip_frames = next_skip_frames;
 
@@ -222,8 +233,15 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 	// Decrease skip frames slowly when the system is recovering.
 	else if (_skip_frames > next_skip_frames)
 	{
-		if (elapsed_since_change_ms > kRecoveryHoldIntervalMs)
+		if (elapsed_since_change_ms > _recovery_hold_ms)
 		{
+			// The last step down stood. Back to the base interval.
+			if (_probe_origin_level > 0)
+			{
+				_recovery_hold_ms = kRecoveryHoldIntervalMs;
+			}
+			_probe_origin_level = _skip_frames;
+
 			// Come down 20% at a time, never in one jump.
 			int32_t rate_limited_next = _skip_frames - std::max(1, _skip_frames / 5);
 			next_skip_frames		  = std::max(rate_limited_next, next_skip_frames);
@@ -254,12 +272,16 @@ void SkipFramesController::InheritFrom(const SkipFramesController &previous)
 	_weighted_avg_frame_processing_time_us = previous._weighted_avg_frame_processing_time_us;
 	_weighted_avg_frame_handoff_time_us	   = previous._weighted_avg_frame_handoff_time_us;
 
-	// The level counts frames within a cadence, so it only transfers between two automatic
+	// The level is a divisor of the output rate, so it only transfers between two automatic
 	// controllers. A configured level was already applied by Configure().
 	if (IsAutomatic() == true && previous.IsAutomatic() == true)
 	{
 		_skip_frames	  = previous._skip_frames;
 		_bottleneck_count = previous._bottleneck_count;
+
+		// What the probes learned describes the pipeline, not the filter measuring it.
+		_recovery_hold_ms	= previous._recovery_hold_ms;
+		_probe_origin_level = previous._probe_origin_level;
 
 		// Both carry, or neither does: Evaluate() re-seeds the pair whenever either is zero,
 		// which would restart the recovery hold at every replacement.

--- a/src/transcoder/filter/filter_skipframes_controller.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller.cpp
@@ -35,6 +35,9 @@ namespace
 	// steps the level may rise in one window
 	constexpr int32_t MAX_INCREASE_PER_WINDOW	= 1;
 
+	// how long a step down must stand before it counts
+	constexpr int64_t PROBE_SETTLE_INTERVAL_MS = EVALUATION_INTERVAL_MS * (BOTTLENECK_CONFIRM_COUNT + 1);
+
 	// Weight given to the newest sample in the per-frame time averages.
 	constexpr double FRAME_TIME_EMA_ALPHA = 0.1;
 }  // namespace
@@ -211,7 +214,9 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 		// busy; gating on utilization alone would pin a level reached during a spike
 		// forever. The hold interval makes this a probe - if the level below cannot hold,
 		// the next window says so and puts it back.
-		bool may_step_down = (utilization < RECOVERY_MAX_BUSY_RATIO) || (is_losing_input == false);
+		bool is_recoverable_busy = (utilization < RECOVERY_MAX_BUSY_RATIO);
+
+		bool may_step_down = (is_recoverable_busy == true) || (is_losing_input == false);
 
 		// The step down lands where the cost allows, not at nothing.
 		if (may_step_down == false)
@@ -222,12 +227,13 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 
 	if (next_skip_frames > _skip_frames)
 	{
-		// One bad window is a hiccup; a bottleneck is still there on the next one.
+		// Check for a second window of agreement before rising
 		if (_bottleneck_count < BOTTLENECK_CONFIRM_COUNT)
 		{
 			next_skip_frames = _skip_frames;
 		}
-		// Rise in single steps, so no single window can collapse the output rate.
+		
+		// The level may only rise one step per window, to avoid overshooting the target.
 		else if (next_skip_frames > _skip_frames + MAX_INCREASE_PER_WINDOW)
 		{
 			next_skip_frames = _skip_frames + MAX_INCREASE_PER_WINDOW;
@@ -244,14 +250,28 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 												  sustainable_fps,
 												  observation.actual_output_fps, observation.expected_output_fps, observation.max_output_fps);
 
-	// Increase skip frames immediately when bottleneck occurs.
+	// The step down stood. Judged here, not at the next one - that never comes at the minimum.
+	if (_probe_deadline_ms > 0 && curr_time_ms > _probe_deadline_ms)
+	{
+		// Only a step at or below the one that failed proves the pipeline gained room.
+		if (_skip_frames <= _known_bad_skip_frames)
+		{
+			_known_bad_skip_frames = -1;
+			_recovery_hold_ms	   = RECOVERY_HOLD_INTERVAL_MS;
+		}
+
+		_probe_deadline_ms = 0;
+	}
+
+	// [Bottleneck] Increase skip frames immediately when bottleneck occurs.
 	if (_skip_frames < next_skip_frames)
 	{
-		// The step down could not hold. Wait longer before trying the next one.
-		if (_probe_origin_level > 0)
+		// The step down could not hold. Remember where, and wait longer next time.
+		if (_probe_deadline_ms > 0)
 		{
-			_recovery_hold_ms	= std::min(_recovery_hold_ms * 2, RECOVERY_HOLD_MAX_MS);
-			_probe_origin_level = 0;
+			_known_bad_skip_frames = std::max(_known_bad_skip_frames, _skip_frames);
+			_recovery_hold_ms	   = std::min(_recovery_hold_ms * 2, RECOVERY_HOLD_MAX_MS);
+			_probe_deadline_ms	   = 0;
 		}
 
 		result.decision	   = Decision::Bottleneck;
@@ -260,17 +280,12 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 		_skip_frames		  = next_skip_frames;
 		_last_changed_time_ms = curr_time_ms;
 	}
-	// Decrease skip frames slowly when the system is recovering.
+	// [Recovery & HoldRecovery] Decrease skip frames slowly when the system is recovering.
 	else if (_skip_frames > next_skip_frames)
 	{
 		if (elapsed_since_change_ms > _recovery_hold_ms)
 		{
-			// The last step down stood. Back to the base interval.
-			if (_probe_origin_level > 0)
-			{
-				_recovery_hold_ms = RECOVERY_HOLD_INTERVAL_MS;
-			}
-			_probe_origin_level = _skip_frames;
+			_probe_deadline_ms = curr_time_ms + PROBE_SETTLE_INTERVAL_MS;
 
 			// Come down 20% at a time, never in one jump.
 			int32_t rate_limited_next = _skip_frames - std::max(1, _skip_frames / 5);
@@ -287,7 +302,7 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 			result.decision = Decision::HoldRecovery;
 		}
 	}
-	// Keep skip frames unchanged when the system is stable.
+	// [Unchanged] Keep skip frames unchanged when the system is stable.
 	else
 	{
 		result.decision = Decision::Unchanged;
@@ -310,8 +325,9 @@ void SkipFramesController::InheritFrom(const SkipFramesController &previous)
 		_bottleneck_count = previous._bottleneck_count;
 
 		// What the probes learned describes the pipeline, not the filter measuring it.
-		_recovery_hold_ms	= previous._recovery_hold_ms;
-		_probe_origin_level = previous._probe_origin_level;
+		_recovery_hold_ms	   = previous._recovery_hold_ms;
+		_probe_deadline_ms	   = previous._probe_deadline_ms;
+		_known_bad_skip_frames = previous._known_bad_skip_frames;
 
 		// Both carry, or neither does: Evaluate() re-seeds the pair whenever either is zero,
 		// which would restart the recovery hold at every replacement.

--- a/src/transcoder/filter/filter_skipframes_controller.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller.cpp
@@ -36,7 +36,7 @@ namespace
 	constexpr int32_t MAX_INCREASE_PER_WINDOW	= 1;
 
 	// how long a step down must stand before it counts
-	constexpr int64_t PROBE_SETTLE_INTERVAL_MS = EVALUATION_INTERVAL_MS * (BOTTLENECK_CONFIRM_COUNT + 1);
+	constexpr int64_t PROBE_SETTLE_INTERVAL_MS = RECOVERY_HOLD_INTERVAL_MS;
 
 	// Weight given to the newest sample in the per-frame time averages.
 	constexpr double FRAME_TIME_EMA_ALPHA = 0.1;

--- a/src/transcoder/filter/filter_skipframes_controller.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller.cpp
@@ -155,16 +155,18 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 		next_skip_frames = FilterFps::SkipFramesMin;
 	}
 
+	if (observation.expected_input_fps <= 0.0 || observation.actual_input_fps <= 0.0)
+	{
+		return std::nullopt;
+	}
+
 	// Busy is not the same as overloaded. The encoder queue is only two frames deep, so the
 	// handoff blocks even on a chain that keeps up. Idle time is what tells the two apart.
 	bool is_fully_busy = (utilization >= kSaturationRatio);
 
-	// A fully busy thread also has to be losing input. Zero means the FPS filter has not
-	// measured a second yet, not that nothing was consumed.
-	bool is_losing_input = (observation.expected_input_fps > 0.0) &&
-						   (observation.actual_input_fps > 0.0) &&
-						   (observation.actual_input_fps < observation.expected_input_fps * kInputKeepUpRatio);
+	bool is_losing_input = (observation.actual_input_fps < observation.expected_input_fps * kInputKeepUpRatio);
 
+	// A fully busy thread also has to be losing input.
 	if (is_fully_busy == true && is_losing_input == true)
 	{
 		_bottleneck_count++;
@@ -287,5 +289,7 @@ void SkipFramesController::InheritFrom(const SkipFramesController &previous)
 		// which would restart the recovery hold at every replacement.
 		_last_check_time_ms	  = previous._last_check_time_ms;
 		_last_changed_time_ms = previous._last_changed_time_ms;
+
+		_window_busy_time_us = previous._window_busy_time_us;
 	}
 }

--- a/src/transcoder/filter/filter_skipframes_controller.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller.cpp
@@ -14,18 +14,6 @@
 
 #include "filter_fps.h"
 
-#define _SKIP_FRAMES_EVALUATION_INTERVAL_MS 	1000	// how often the level is reconsidered
-#define _SKIP_FRAMES_RECOVERY_HOLD_INTERVAL_MS 	5000	// how long a level must stand before it may drop
-#define _SKIP_FRAMES_SAFETY_MARGIN_RATIO 		0.9f	// aim at 90% of what the budget allows
-#define _SKIP_FRAMES_SATURATION_RATIO 			0.95f	// busy this much of a window counts as saturated
-#define _SKIP_FRAMES_RECOVERY_MAX_BUSY_RATIO 	0.80f	// below this the thread has room to try one level down
-#define _SKIP_FRAMES_INPUT_KEEP_UP_RATIO 		0.95f	// share of the input rate the thread must consume
-#define _SKIP_FRAMES_BOTTLENECK_CONFIRM_COUNT 	2		// windows that must agree before the level rises
-#define _SKIP_FRAMES_MAX_INCREASE_PER_WINDOW 	1		// steps the level may rise in one window
-
-// Weight given to the newest sample in the per-frame time averages.
-static constexpr double kFrameTimeEmaAlpha = 0.1;
-
 void SkipFramesController::Configure(int32_t skip_frames_conf)
 {
 	_skip_frames_conf = skip_frames_conf;
@@ -131,7 +119,7 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 	auto elapsed_since_check_ms	 = curr_time_ms - _last_check_time_ms;
 	auto elapsed_since_change_ms = curr_time_ms - _last_changed_time_ms;
 
-	if (elapsed_since_check_ms <= _SKIP_FRAMES_EVALUATION_INTERVAL_MS)
+	if (elapsed_since_check_ms <= kEvaluationIntervalMs)
 	{
 		return std::nullopt;
 	}
@@ -154,7 +142,7 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 
 	// The most frames per second the budget allows, less a safety margin.
 	double peak_fps		   = (1000000.0 / frame_budget_us);
-	double sustainable_fps = peak_fps * _SKIP_FRAMES_SAFETY_MARGIN_RATIO;
+	double sustainable_fps = peak_fps * kSafetyMarginRatio;
 
 	// How far the cadence has to be divided down to land on the sustainable rate.
 	auto next_skip_frames = static_cast<int32_t>(std::ceil(observation.cadence_fps / sustainable_fps - 1.0));
@@ -169,13 +157,13 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 
 	// Busy is not the same as overloaded. The encoder queue is only two frames deep, so the
 	// handoff blocks even on a chain that keeps up. Idle time is what tells the two apart.
-	bool is_saturated = (utilization >= _SKIP_FRAMES_SATURATION_RATIO);
+	bool is_saturated = (utilization >= kSaturationRatio);
 
 	// A saturated thread also has to be losing ground. Zero means the FPS filter has not
 	// measured a second yet, not that nothing was consumed.
 	bool is_falling_behind = (observation.expected_input_fps > 0.0) &&
 							 (observation.actual_input_fps > 0.0) &&
-							 (observation.actual_input_fps < observation.expected_input_fps * _SKIP_FRAMES_INPUT_KEEP_UP_RATIO);
+							 (observation.actual_input_fps < observation.expected_input_fps * kInputKeepUpRatio);
 
 	if (is_saturated == true && is_falling_behind == true)
 	{
@@ -193,7 +181,7 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 		// busy; gating on utilization alone would pin a level reached during a spike
 		// forever. The hold interval makes this a probe - if the level below cannot hold,
 		// the next window says so and puts it back.
-		bool has_headroom = (utilization < _SKIP_FRAMES_RECOVERY_MAX_BUSY_RATIO) || (is_falling_behind == false);
+		bool has_headroom = (utilization < kRecoveryMaxBusyRatio) || (is_falling_behind == false);
 
 		next_skip_frames = has_headroom ? FilterFps::SkipFramesMin : _skip_frames;
 	}
@@ -201,14 +189,14 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 	if (next_skip_frames > _skip_frames)
 	{
 		// One bad window is a hiccup; a bottleneck is still there on the next one.
-		if (_bottleneck_count < _SKIP_FRAMES_BOTTLENECK_CONFIRM_COUNT)
+		if (_bottleneck_count < kBottleneckConfirmCount)
 		{
 			next_skip_frames = _skip_frames;
 		}
 		// Rise in single steps, so no single window can collapse the output rate.
-		else if (next_skip_frames > _skip_frames + _SKIP_FRAMES_MAX_INCREASE_PER_WINDOW)
+		else if (next_skip_frames > _skip_frames + kMaxIncreasePerWindow)
 		{
-			next_skip_frames = _skip_frames + _SKIP_FRAMES_MAX_INCREASE_PER_WINDOW;
+			next_skip_frames = _skip_frames + kMaxIncreasePerWindow;
 		}
 	}
 
@@ -234,7 +222,7 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 	// Decrease skip frames slowly when the system is recovering.
 	else if (_skip_frames > next_skip_frames)
 	{
-		if (elapsed_since_change_ms > _SKIP_FRAMES_RECOVERY_HOLD_INTERVAL_MS)
+		if (elapsed_since_change_ms > kRecoveryHoldIntervalMs)
 		{
 			// Come down 20% at a time, never in one jump.
 			int32_t rate_limited_next = _skip_frames - std::max(1, _skip_frames / 5);

--- a/src/transcoder/filter/filter_skipframes_controller.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller.cpp
@@ -1,0 +1,281 @@
+//==============================================================================
+//
+//  Transcode
+//
+//  Created by Kwon Keuk Han
+//  Copyright (c) 2018 AirenSoft. All rights reserved.
+//
+//==============================================================================
+
+#include "filter_skipframes_controller.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "filter_fps.h"
+
+#define _SKIP_FRAMES_EVALUATION_INTERVAL_MS 	1000	// how often the level is reconsidered
+#define _SKIP_FRAMES_RECOVERY_HOLD_INTERVAL_MS 	5000	// how long a level must stand before it may drop
+#define _SKIP_FRAMES_SAFETY_MARGIN_RATIO 		0.9f	// aim at 90% of what the budget allows
+#define _SKIP_FRAMES_SATURATION_RATIO 			0.95f	// busy this much of a window counts as saturated
+#define _SKIP_FRAMES_RECOVERY_MAX_BUSY_RATIO 	0.80f	// below this the thread has room to try one level down
+#define _SKIP_FRAMES_INPUT_KEEP_UP_RATIO 		0.95f	// share of the input rate the thread must consume
+#define _SKIP_FRAMES_BOTTLENECK_CONFIRM_COUNT 	2		// windows that must agree before the level rises
+#define _SKIP_FRAMES_MAX_INCREASE_PER_WINDOW 	1		// steps the level may rise in one window
+
+// Weight given to the newest sample in the per-frame time averages.
+static constexpr double kFrameTimeEmaAlpha = 0.1;
+
+void SkipFramesController::Configure(int32_t skip_frames_conf)
+{
+	_skip_frames_conf = skip_frames_conf;
+	_skip_frames	  = skip_frames_conf;
+}
+
+int32_t SkipFramesController::GetConfiguredSkipFrames() const
+{
+	return _skip_frames_conf;
+}
+
+bool SkipFramesController::IsEnabled() const
+{
+	return (_skip_frames_conf >= FilterFps::SkipFramesMin);
+}
+
+bool SkipFramesController::IsAutomatic() const
+{
+	return (_skip_frames_conf == FilterFps::SkipFramesMin);
+}
+
+int32_t SkipFramesController::GetSkipFrames() const
+{
+	return _skip_frames;
+}
+
+void SkipFramesController::AddProcessingTime(int64_t elapsed_us)
+{
+	// Only the automatic level reads any of this; otherwise the window never closes.
+	if (IsAutomatic() == false)
+	{
+		return;
+	}
+
+	_pending_processing_time_us += elapsed_us;
+	_window_busy_time_us += elapsed_us;
+}
+
+void SkipFramesController::AddBusyTime(int64_t elapsed_us)
+{
+	if (IsAutomatic() == false)
+	{
+		return;
+	}
+
+	_window_busy_time_us += elapsed_us;
+}
+
+void SkipFramesController::AddHandoffTime(int64_t elapsed_us)
+{
+	if (IsAutomatic() == false)
+	{
+		return;
+	}
+
+	// Charged whole: capping a sample would also cap the level the controller can reach.
+	// One-off stalls are filtered later, when the decision is made.
+	_window_busy_time_us += elapsed_us;
+	_pending_handoff_time_us += elapsed_us;
+}
+
+void SkipFramesController::CommitFrame(int64_t elapsed_us)
+{
+	if (IsAutomatic() == false)
+	{
+		return;
+	}
+
+	auto processing_time_us = _pending_processing_time_us + elapsed_us;
+	auto handoff_time_us	= _pending_handoff_time_us;
+
+	// Only this round: the earlier ones went into the window when they were measured.
+	_window_busy_time_us += elapsed_us;
+
+	DiscardPending();
+
+	_weighted_avg_frame_processing_time_us	= (_weighted_avg_frame_processing_time_us * (1.0 - kFrameTimeEmaAlpha)) + (processing_time_us * kFrameTimeEmaAlpha);
+	_weighted_avg_frame_handoff_time_us		= (_weighted_avg_frame_handoff_time_us * (1.0 - kFrameTimeEmaAlpha)) + (handoff_time_us * kFrameTimeEmaAlpha);
+}
+
+void SkipFramesController::DiscardPending()
+{
+	_pending_processing_time_us = 0;
+	_pending_handoff_time_us	= 0;
+}
+
+std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64_t curr_time_ms, const Observation &observation)
+{
+	if (IsAutomatic() == false)
+	{
+		return std::nullopt;
+	}
+
+	if (_last_check_time_ms == 0 || _last_changed_time_ms == 0)
+	{
+		_last_check_time_ms	  = curr_time_ms;
+		_last_changed_time_ms = curr_time_ms;
+
+		// Session startup was measured before any window opened; it belongs to none.
+		_window_busy_time_us = 0;
+	}
+
+	auto elapsed_since_check_ms	 = curr_time_ms - _last_check_time_ms;
+	auto elapsed_since_change_ms = curr_time_ms - _last_changed_time_ms;
+
+	if (elapsed_since_check_ms <= _SKIP_FRAMES_EVALUATION_INTERVAL_MS)
+	{
+		return std::nullopt;
+	}
+	_last_check_time_ms = curr_time_ms;
+
+	// Closed here, before the early returns below can skip the reset.
+	double window_us   = static_cast<double>(elapsed_since_check_ms) * 1000.0;
+	double utilization = static_cast<double>(_window_busy_time_us) / window_us;
+
+	_window_busy_time_us = 0;
+
+	// A slow rescaler and a backed-up encoder both throttle the thread, and it cannot outrun
+	// their sum, so the decision uses the total.
+	double frame_budget_us = _weighted_avg_frame_processing_time_us + _weighted_avg_frame_handoff_time_us;
+
+	if (frame_budget_us <= 0.0 || observation.cadence_fps <= 0.0)
+	{
+		return std::nullopt;
+	}
+
+	// The most frames per second the budget allows, less a safety margin.
+	double peak_fps		   = (1000000.0 / frame_budget_us);
+	double sustainable_fps = peak_fps * _SKIP_FRAMES_SAFETY_MARGIN_RATIO;
+
+	// How far the cadence has to be divided down to land on the sustainable rate.
+	auto next_skip_frames = static_cast<int32_t>(std::ceil(observation.cadence_fps / sustainable_fps - 1.0));
+	if (next_skip_frames > observation.cadence_fps - 1)
+	{
+		next_skip_frames = static_cast<int32_t>(std::floor(observation.cadence_fps - 1));
+	}
+	else if (next_skip_frames < FilterFps::SkipFramesMin)
+	{
+		next_skip_frames = FilterFps::SkipFramesMin;
+	}
+
+	// Busy is not the same as overloaded. The encoder queue is only two frames deep, so the
+	// handoff blocks even on a chain that keeps up. Idle time is what tells the two apart.
+	bool is_saturated = (utilization >= _SKIP_FRAMES_SATURATION_RATIO);
+
+	// A saturated thread also has to be losing ground. Zero means the FPS filter has not
+	// measured a second yet, not that nothing was consumed.
+	bool is_falling_behind = (observation.expected_input_fps > 0.0) &&
+							 (observation.actual_input_fps > 0.0) &&
+							 (observation.actual_input_fps < observation.expected_input_fps * _SKIP_FRAMES_INPUT_KEEP_UP_RATIO);
+
+	if (is_saturated == true && is_falling_behind == true)
+	{
+		_bottleneck_count++;
+
+		// The budget decays between stalls, so without this the recovery branch below could
+		// walk the level down while the bottleneck is still there.
+		next_skip_frames = std::max(next_skip_frames, _skip_frames);
+	}
+	else
+	{
+		_bottleneck_count = 0;
+
+		// A thread keeping up with its input has earned a step down even while it looks
+		// busy; gating on utilization alone would pin a level reached during a spike
+		// forever. The hold interval makes this a probe - if the level below cannot hold,
+		// the next window says so and puts it back.
+		bool has_headroom = (utilization < _SKIP_FRAMES_RECOVERY_MAX_BUSY_RATIO) || (is_falling_behind == false);
+
+		next_skip_frames = has_headroom ? FilterFps::SkipFramesMin : _skip_frames;
+	}
+
+	if (next_skip_frames > _skip_frames)
+	{
+		// One bad window is a hiccup; a bottleneck is still there on the next one.
+		if (_bottleneck_count < _SKIP_FRAMES_BOTTLENECK_CONFIRM_COUNT)
+		{
+			next_skip_frames = _skip_frames;
+		}
+		// Rise in single steps, so no single window can collapse the output rate.
+		else if (next_skip_frames > _skip_frames + _SKIP_FRAMES_MAX_INCREASE_PER_WINDOW)
+		{
+			next_skip_frames = _skip_frames + _SKIP_FRAMES_MAX_INCREASE_PER_WINDOW;
+		}
+	}
+
+	// Every value labelled, every pair actual/target, times in ms - readable on its own.
+	Result result;
+	result.skip_frames = _skip_frames;
+	result.metrics	   = ov::String::FormatString("Input: %.1f/%.1ffps, Busy: %.1f%%, Budget: %.2fms (proc %.2f + handoff %.2f), Capacity: %.1ffps, Output: %.1f/%.1ffps (cadence %.1f)",
+												  observation.actual_input_fps, observation.expected_input_fps,
+												  utilization * 100.0,
+												  frame_budget_us / 1000.0, _weighted_avg_frame_processing_time_us / 1000.0, _weighted_avg_frame_handoff_time_us / 1000.0,
+												  sustainable_fps,
+												  observation.actual_output_fps, observation.expected_output_fps, observation.cadence_fps);
+
+	// Increase skip frames immediately when bottleneck occurs.
+	if (_skip_frames < next_skip_frames)
+	{
+		result.decision	   = Decision::Bottleneck;
+		result.skip_frames = next_skip_frames;
+
+		_skip_frames		  = next_skip_frames;
+		_last_changed_time_ms = curr_time_ms;
+	}
+	// Decrease skip frames slowly when the system is recovering.
+	else if (_skip_frames > next_skip_frames)
+	{
+		if (elapsed_since_change_ms > _SKIP_FRAMES_RECOVERY_HOLD_INTERVAL_MS)
+		{
+			// Come down 20% at a time, never in one jump.
+			int32_t rate_limited_next = _skip_frames - std::max(1, _skip_frames / 5);
+			next_skip_frames		  = std::max(rate_limited_next, next_skip_frames);
+
+			result.decision	   = Decision::Recovery;
+			result.skip_frames = next_skip_frames;
+
+			_skip_frames		  = next_skip_frames;
+			_last_changed_time_ms = curr_time_ms;
+		}
+		else
+		{
+			result.decision = Decision::HoldRecovery;
+		}
+	}
+	// Keep skip frames unchanged when the system is stable.
+	else
+	{
+		result.decision = Decision::Unchanged;
+	}
+
+	return result;
+}
+
+void SkipFramesController::InheritFrom(const SkipFramesController &previous)
+{
+	// The load the outgoing controller measured still describes the pipeline.
+	_weighted_avg_frame_processing_time_us = previous._weighted_avg_frame_processing_time_us;
+	_weighted_avg_frame_handoff_time_us	   = previous._weighted_avg_frame_handoff_time_us;
+
+	// The level counts frames within a cadence, so it only transfers between two automatic
+	// controllers. A configured level was already applied by Configure().
+	if (IsAutomatic() == true && previous.IsAutomatic() == true)
+	{
+		_skip_frames	  = previous._skip_frames;
+		_bottleneck_count = previous._bottleneck_count;
+
+		// Both carry, or neither does: Evaluate() re-seeds the pair whenever either is zero,
+		// which would restart the recovery hold at every replacement.
+		_last_check_time_ms	  = previous._last_check_time_ms;
+		_last_changed_time_ms = previous._last_changed_time_ms;
+	}
+}

--- a/src/transcoder/filter/filter_skipframes_controller.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller.cpp
@@ -21,7 +21,7 @@ namespace
 	// how long a level must stand before it may drop
 	constexpr int64_t RECOVERY_HOLD_INTERVAL_MS	= 5000;
 	// ceiling the hold backs off to while probes keep failing
-	constexpr int64_t RECOVERY_HOLD_MAX_MS		= 30000;
+	constexpr int64_t RECOVERY_HOLD_MAX_MS		= 60000;
 	// aim at 90% of what the frame cost allows
 	constexpr double SAFETY_MARGIN_RATIO		= 0.9;
 	// busy this much of a window counts as saturated

--- a/src/transcoder/filter/filter_skipframes_controller.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller.cpp
@@ -14,10 +14,36 @@
 
 #include "filter_fps.h"
 
+namespace
+{
+	// how often the level is reconsidered
+	constexpr int64_t EVALUATION_INTERVAL_MS	= 1000;
+	// how long a level must stand before it may drop
+	constexpr int64_t RECOVERY_HOLD_INTERVAL_MS	= 5000;
+	// ceiling the hold backs off to while probes keep failing
+	constexpr int64_t RECOVERY_HOLD_MAX_MS		= 30000;
+	// aim at 90% of what the frame cost allows
+	constexpr double SAFETY_MARGIN_RATIO		= 0.9;
+	// busy this much of a window counts as saturated
+	constexpr double SATURATION_RATIO			= 0.95;
+	// below this the thread has room to try one level down
+	constexpr double RECOVERY_MAX_BUSY_RATIO	= 0.80;
+	// share of the input rate the thread must consume
+	constexpr double INPUT_KEEP_UP_RATIO		= 0.95;
+	// windows that must agree before the level rises
+	constexpr int32_t BOTTLENECK_CONFIRM_COUNT	= 2;
+	// steps the level may rise in one window
+	constexpr int32_t MAX_INCREASE_PER_WINDOW	= 1;
+
+	// Weight given to the newest sample in the per-frame time averages.
+	constexpr double FRAME_TIME_EMA_ALPHA = 0.1;
+}  // namespace
+
 void SkipFramesController::Configure(int32_t skip_frames_conf)
 {
 	_skip_frames_conf = skip_frames_conf;
 	_skip_frames	  = skip_frames_conf;
+	_recovery_hold_ms = RECOVERY_HOLD_INTERVAL_MS;
 }
 
 int32_t SkipFramesController::GetConfiguredSkipFrames() const
@@ -90,8 +116,8 @@ void SkipFramesController::CommitFrame(int64_t elapsed_us)
 
 	DiscardPending();
 
-	_weighted_avg_frame_processing_time_us	= (_weighted_avg_frame_processing_time_us * (1.0 - kFrameTimeEmaAlpha)) + (processing_time_us * kFrameTimeEmaAlpha);
-	_weighted_avg_frame_handoff_time_us		= (_weighted_avg_frame_handoff_time_us * (1.0 - kFrameTimeEmaAlpha)) + (handoff_time_us * kFrameTimeEmaAlpha);
+	_weighted_avg_frame_processing_time_us	= (_weighted_avg_frame_processing_time_us * (1.0 - FRAME_TIME_EMA_ALPHA)) + (processing_time_us * FRAME_TIME_EMA_ALPHA);
+	_weighted_avg_frame_handoff_time_us		= (_weighted_avg_frame_handoff_time_us * (1.0 - FRAME_TIME_EMA_ALPHA)) + (handoff_time_us * FRAME_TIME_EMA_ALPHA);
 }
 
 void SkipFramesController::DiscardPending()
@@ -119,7 +145,7 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 	auto elapsed_since_check_ms	 = curr_time_ms - _last_check_time_ms;
 	auto elapsed_since_change_ms = curr_time_ms - _last_changed_time_ms;
 
-	if (elapsed_since_check_ms <= kEvaluationIntervalMs)
+	if (elapsed_since_check_ms <= EVALUATION_INTERVAL_MS)
 	{
 		return std::nullopt;
 	}
@@ -142,7 +168,7 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 
 	// The most frames per second the cost allows, less a safety margin.
 	double peak_fps		   = (1000000.0 / frame_cost_us);
-	double sustainable_fps = peak_fps * kSafetyMarginRatio;
+	double sustainable_fps = peak_fps * SAFETY_MARGIN_RATIO;
 
 	// How far the output ceiling has to be divided down to land on the sustainable rate.
 	auto next_skip_frames = static_cast<int32_t>(std::ceil(observation.max_output_fps / sustainable_fps - 1.0));
@@ -162,9 +188,9 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 
 	// Busy is not the same as overloaded. The encoder queue is only two frames deep, so the
 	// handoff blocks even on a chain that keeps up. Idle time is what tells the two apart.
-	bool is_fully_busy = (utilization >= kSaturationRatio);
+	bool is_fully_busy = (utilization >= SATURATION_RATIO);
 
-	bool is_losing_input = (observation.actual_input_fps < observation.expected_input_fps * kInputKeepUpRatio);
+	bool is_losing_input = (observation.actual_input_fps < observation.expected_input_fps * INPUT_KEEP_UP_RATIO);
 
 	// A fully busy thread also has to be losing input.
 	if (is_fully_busy == true && is_losing_input == true)
@@ -183,7 +209,7 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 		// busy; gating on utilization alone would pin a level reached during a spike
 		// forever. The hold interval makes this a probe - if the level below cannot hold,
 		// the next window says so and puts it back.
-		bool may_step_down = (utilization < kRecoveryMaxBusyRatio) || (is_losing_input == false);
+		bool may_step_down = (utilization < RECOVERY_MAX_BUSY_RATIO) || (is_losing_input == false);
 
 		// The step down lands where the cost allows, not at nothing.
 		if (may_step_down == false)
@@ -195,14 +221,14 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 	if (next_skip_frames > _skip_frames)
 	{
 		// One bad window is a hiccup; a bottleneck is still there on the next one.
-		if (_bottleneck_count < kBottleneckConfirmCount)
+		if (_bottleneck_count < BOTTLENECK_CONFIRM_COUNT)
 		{
 			next_skip_frames = _skip_frames;
 		}
 		// Rise in single steps, so no single window can collapse the output rate.
-		else if (next_skip_frames > _skip_frames + kMaxIncreasePerWindow)
+		else if (next_skip_frames > _skip_frames + MAX_INCREASE_PER_WINDOW)
 		{
-			next_skip_frames = _skip_frames + kMaxIncreasePerWindow;
+			next_skip_frames = _skip_frames + MAX_INCREASE_PER_WINDOW;
 		}
 	}
 
@@ -222,7 +248,7 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 		// The step down could not hold. Wait longer before trying the next one.
 		if (_probe_origin_level > 0)
 		{
-			_recovery_hold_ms	= std::min(_recovery_hold_ms * 2, kRecoveryHoldMaxMs);
+			_recovery_hold_ms	= std::min(_recovery_hold_ms * 2, RECOVERY_HOLD_MAX_MS);
 			_probe_origin_level = 0;
 		}
 
@@ -240,7 +266,7 @@ std::optional<SkipFramesController::Result> SkipFramesController::Evaluate(int64
 			// The last step down stood. Back to the base interval.
 			if (_probe_origin_level > 0)
 			{
-				_recovery_hold_ms = kRecoveryHoldIntervalMs;
+				_recovery_hold_ms = RECOVERY_HOLD_INTERVAL_MS;
 			}
 			_probe_origin_level = _skip_frames;
 

--- a/src/transcoder/filter/filter_skipframes_controller.h
+++ b/src/transcoder/filter/filter_skipframes_controller.h
@@ -45,28 +45,6 @@
 class SkipFramesController
 {
 public:
-	// how often the level is reconsidered
-	static constexpr int64_t kEvaluationIntervalMs	 = 1000;
-	// how long a level must stand before it may drop
-	static constexpr int64_t kRecoveryHoldIntervalMs = 5000;
-	// ceiling the hold backs off to while probes keep failing
-	static constexpr int64_t kRecoveryHoldMaxMs		 = 30000;
-	// aim at 90% of what the frame cost allows
-	static constexpr double kSafetyMarginRatio		 = 0.9;
-	// busy this much of a window counts as saturated
-	static constexpr double kSaturationRatio		 = 0.95;
-	// below this the thread has room to try one level down
-	static constexpr double kRecoveryMaxBusyRatio	 = 0.80;
-	// share of the input rate the thread must consume
-	static constexpr double kInputKeepUpRatio		 = 0.95;
-	// windows that must agree before the level rises
-	static constexpr int32_t kBottleneckConfirmCount = 2;
-	// steps the level may rise in one window
-	static constexpr int32_t kMaxIncreasePerWindow	 = 1;
-
-	// Weight given to the newest sample in the per-frame time averages.
-	static constexpr double kFrameTimeEmaAlpha = 0.1;
-
 	enum class Decision
 	{
 		Unchanged,
@@ -139,7 +117,7 @@ private:
 	int32_t _bottleneck_count = 0;
 
 	// Grows while probes keep failing, back to the base interval as soon as one stands.
-	int64_t _recovery_hold_ms = kRecoveryHoldIntervalMs;
+	int64_t _recovery_hold_ms = 0;
 
 	// The level the outstanding step down was taken from, or 0 when there is none.
 	int32_t _probe_origin_level = 0;

--- a/src/transcoder/filter/filter_skipframes_controller.h
+++ b/src/transcoder/filter/filter_skipframes_controller.h
@@ -1,0 +1,125 @@
+//==============================================================================
+//
+//  Transcode
+//
+//  Created by Kwon Keuk Han
+//  Copyright (c) 2018 AirenSoft. All rights reserved.
+//
+//==============================================================================
+
+#pragma once
+
+#include <optional>
+
+#include <base/ovlibrary/ovlibrary.h>
+
+// Decides how many frames the FPS filter should skip so a video filter stays within the
+// capacity of the pipeline behind it.
+//
+// Measured over one evaluation window (1s):
+//
+//   budget        per frame, the time spent processing plus the time blocked handing it off
+//   utilization   the share of the window the thread was busy rather than waiting for input
+//
+// Decided from the two together:
+//
+//   raise    saturated AND not consuming the full input rate. The budget sets the target
+//            level; the rise is one step per window, and only after a second window agrees
+//   lower    anything else, once the recovery hold passes - 20% at a time
+//
+// Two traps this is shaped around:
+//
+//   * Judge against the INPUT rate, never the output rate the level aims at. Skipping
+//     lowers that output target, so the filter would keep meeting a bar it just lowered
+//     while the upstream queue grew.
+//   * Busy is not overloaded. The encoder queue is two frames deep, so the handoff blocks
+//     even on a chain that keeps up. Idle time in the window is what tells them apart.
+//
+// Computation only: no clock, no logging, no FPS filter. The caller supplies the time and
+// applies the result, which is what makes the tuning ratios testable.
+class SkipFramesController
+{
+public:
+	enum class Decision
+	{
+		Unchanged,
+		Bottleneck,
+		Recovery,
+		// Wants to come down, but the hold interval has not elapsed.
+		HoldRecovery,
+	};
+
+	struct Observation
+	{
+		// The gap between these two is the pipeline backing up.
+		double expected_input_fps = 0.0;
+		double actual_input_fps	  = 0.0;
+
+		// The cadence to divide down; the skip count is how far.
+		double cadence_fps = 0.0;
+
+		// Log-only - see the note above on why the output rate is not judged against.
+		double expected_output_fps = 0.0;
+		double actual_output_fps   = 0.0;
+	};
+
+	struct Result
+	{
+		Decision decision = Decision::Unchanged;
+		// Equal to the current level except on Bottleneck and Recovery.
+		int32_t skip_frames = 0;
+		// Everything measured this window, for the caller's log line.
+		ov::String metrics;
+	};
+
+	// From the output profile: < 0 disabled, 0 automatic, > 0 fixed level.
+	void Configure(int32_t skip_frames_conf);
+	int32_t GetConfiguredSkipFrames() const;
+
+	bool IsEnabled() const;
+	bool IsAutomatic() const;
+
+	// The level currently being asked for. Meaningful once Configure() has run.
+	int32_t GetSkipFrames() const;
+
+	// Measurement. All of these run on the filter thread, so none of them synchronize.
+
+	// A round that produced no frame; the time waits for one that does.
+	void AddProcessingTime(int64_t elapsed_us);
+	// Busy time belonging to no particular frame. Counts toward the window, not the budget.
+	void AddBusyTime(int64_t elapsed_us);
+	// Measurable only after the frame leaves, so it lands one frame late in the average.
+	void AddHandoffTime(int64_t elapsed_us);
+	// A frame completed: fold everything pending into the averages.
+	void CommitFrame(int64_t elapsed_us);
+	// Work that will never complete. The busy window is kept - the thread was busy anyway.
+	void DiscardPending();
+
+	// Nothing until the interval elapses and there is enough measurement to decide on.
+	std::optional<Result> Evaluate(int64_t curr_time_ms, const Observation &observation);
+
+	// Carries the measured load across a filter replacement - the pipeline behind it does
+	// not empty out because the filter was replaced.
+	void InheritFrom(const SkipFramesController &previous);
+
+private:
+	int32_t _skip_frames_conf = -1;
+	int32_t _skip_frames	  = -1;
+
+	int64_t _last_check_time_ms	  = 0;
+	int64_t _last_changed_time_ms = 0;
+
+	// One bad window is a hiccup, so the level only rises once the diagnosis repeats.
+	int32_t _bottleneck_count = 0;
+
+	// The per-frame budget, split so the log can name the bottleneck.
+	double _weighted_avg_frame_processing_time_us = 0.0;
+	double _weighted_avg_frame_handoff_time_us	  = 0.0;
+
+	// Time that has not been charged to a completed frame yet.
+	int64_t _pending_processing_time_us = 0;
+	int64_t _pending_handoff_time_us	= 0;
+
+	// Busy time this window. Whatever is left of the window was spent waiting for input.
+	int64_t _window_busy_time_us = 0;
+};

--- a/src/transcoder/filter/filter_skipframes_controller.h
+++ b/src/transcoder/filter/filter_skipframes_controller.h
@@ -40,6 +40,26 @@
 class SkipFramesController
 {
 public:
+	// how often the level is reconsidered
+	static constexpr int64_t kEvaluationIntervalMs	 = 1000;
+	// how long a level must stand before it may drop
+	static constexpr int64_t kRecoveryHoldIntervalMs = 5000;
+	// aim at 90% of what the budget allows
+	static constexpr double kSafetyMarginRatio		 = 0.9;
+	// busy this much of a window counts as saturated
+	static constexpr double kSaturationRatio		 = 0.95;
+	// below this the thread has room to try one level down
+	static constexpr double kRecoveryMaxBusyRatio	 = 0.80;
+	// share of the input rate the thread must consume
+	static constexpr double kInputKeepUpRatio		 = 0.95;
+	// windows that must agree before the level rises
+	static constexpr int32_t kBottleneckConfirmCount = 2;
+	// steps the level may rise in one window
+	static constexpr int32_t kMaxIncreasePerWindow	 = 1;
+
+	// Weight given to the newest sample in the per-frame time averages.
+	static constexpr double kFrameTimeEmaAlpha = 0.1;
+
 	enum class Decision
 	{
 		Unchanged,

--- a/src/transcoder/filter/filter_skipframes_controller.h
+++ b/src/transcoder/filter/filter_skipframes_controller.h
@@ -119,8 +119,11 @@ private:
 	// Grows while probes keep failing, back to the base interval as soon as one stands.
 	int64_t _recovery_hold_ms = 0;
 
-	// The level the outstanding step down was taken from, or 0 when there is none.
-	int32_t _probe_origin_level = 0;
+	// When the outstanding step down gets judged, or 0 when there is none.
+	int64_t _probe_deadline_ms = 0;
+
+	// The highest skip frames a step down failed at, or -1 when none has.
+	int32_t _known_bad_skip_frames = -1;
 
 	// The per-frame cost, split so the log can name the bottleneck.
 	double _weighted_avg_frame_processing_time_us = 0.0;

--- a/src/transcoder/filter/filter_skipframes_controller.h
+++ b/src/transcoder/filter/filter_skipframes_controller.h
@@ -18,22 +18,27 @@
 //
 // Measured over one evaluation window (1s):
 //
-//   budget        per frame, the time spent processing plus the time blocked handing it off
+//   frame cost    what one frame takes: the time spent processing plus the time blocked
+//                 handing it off
 //   utilization   the share of the window the thread was busy rather than waiting for input
 //
 // Decided from the two together:
 //
-//   raise    saturated AND not consuming the full input rate. The budget sets the target
+//   raise    fully busy AND losing input. The frame cost sets the target
 //            level; the rise is one step per window, and only after a second window agrees
-//   lower    anything else, once the recovery hold passes - 20% at a time
+//   lower    anything else, once the recovery hold passes - 20% at a time, down to what
+//            the frame cost allows rather than straight off
 //
-// Two traps this is shaped around:
+// Three traps this is shaped around:
 //
 //   * Judge against the INPUT rate, never the output rate the level aims at. Skipping
 //     lowers that output target, so the filter would keep meeting a bar it just lowered
 //     while the upstream queue grew.
 //   * Busy is not overloaded. The encoder queue is two frames deep, so the handoff blocks
 //     even on a chain that keeps up. Idle time in the window is what tells them apart.
+//   * A level that works erases its own evidence. Handoff time falls to zero once the
+//     level is right, so a step down is measured where the filter is the bottleneck and
+//     probed where the encoder is, with the hold backing off while probes keep failing.
 //
 // Computation only: no clock, no logging, no FPS filter. The caller supplies the time and
 // applies the result, which is what makes the tuning ratios testable.
@@ -44,7 +49,9 @@ public:
 	static constexpr int64_t kEvaluationIntervalMs	 = 1000;
 	// how long a level must stand before it may drop
 	static constexpr int64_t kRecoveryHoldIntervalMs = 5000;
-	// aim at 90% of what the budget allows
+	// ceiling the hold backs off to while probes keep failing
+	static constexpr int64_t kRecoveryHoldMaxMs		 = 30000;
+	// aim at 90% of what the frame cost allows
 	static constexpr double kSafetyMarginRatio		 = 0.9;
 	// busy this much of a window counts as saturated
 	static constexpr double kSaturationRatio		 = 0.95;
@@ -75,8 +82,7 @@ public:
 		double expected_input_fps = 0.0;
 		double actual_input_fps	  = 0.0;
 
-		// The cadence to divide down; the skip count is how far.
-		double cadence_fps = 0.0;
+		double max_output_fps = 0.0;
 
 		// Log-only - see the note above on why the output rate is not judged against.
 		double expected_output_fps = 0.0;
@@ -106,7 +112,7 @@ public:
 
 	// A round that produced no frame; the time waits for one that does.
 	void AddProcessingTime(int64_t elapsed_us);
-	// Busy time belonging to no particular frame. Counts toward the window, not the budget.
+	// Busy time belonging to no particular frame. Counts toward the window, not the frame cost.
 	void AddBusyTime(int64_t elapsed_us);
 	// Measurable only after the frame leaves, so it lands one frame late in the average.
 	void AddHandoffTime(int64_t elapsed_us);
@@ -132,7 +138,13 @@ private:
 	// One bad window is a hiccup, so the level only rises once the diagnosis repeats.
 	int32_t _bottleneck_count = 0;
 
-	// The per-frame budget, split so the log can name the bottleneck.
+	// Grows while probes keep failing, back to the base interval as soon as one stands.
+	int64_t _recovery_hold_ms = kRecoveryHoldIntervalMs;
+
+	// The level the outstanding step down was taken from, or 0 when there is none.
+	int32_t _probe_origin_level = 0;
+
+	// The per-frame cost, split so the log can name the bottleneck.
 	double _weighted_avg_frame_processing_time_us = 0.0;
 	double _weighted_avg_frame_handoff_time_us	  = 0.0;
 

--- a/src/transcoder/filter/filter_skipframes_controller_test.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller_test.cpp
@@ -697,3 +697,93 @@ TEST(SkipFramesControllerTest, NeverFallsBelowSkipFramesMin)
 	EXPECT_GE(result->skip_frames, skip_frames_min);
 	EXPECT_GE(controller.GetSkipFrames(), skip_frames_min);
 }
+
+namespace
+{
+	// A closed loop, so the cost average ramps the way it does in production. FeedFrames()
+	// drives it straight to a target, which hides how many windows a step down needs before
+	// the level it left is detected as insufficient again.
+	constexpr double  kLoopInputFps	  = 30.0;
+	constexpr int64_t kLoopProcessUs  = 5000;  // a cheap rescale
+	constexpr double  kLoopEncoderFps = 6.5;   // 30/(4+1)=6.0 fits, 30/(3+1)=7.5 does not
+	constexpr int32_t kLoopFitLevel	  = 4;
+
+	// One second of an encoder-bound pipeline at whatever level the controller is asking for.
+	std::optional<SkipFramesController::Result> RunEncoderBoundWindow(SkipFramesController &controller, int64_t &now)
+	{
+		int32_t skip_frames = controller.GetSkipFrames();
+		double	output_fps	= kLoopInputFps / static_cast<double>(skip_frames + 1);
+
+		// Handing off faster than the encoder drains fills its queue and blocks the thread
+		// at the encoder's pace; at or below it the queue never fills and the blocking - the
+		// only evidence of the encoder's limit - disappears.
+		bool   is_throttled	   = (output_fps > kLoopEncoderFps);
+		double actual_output   = is_throttled ? kLoopEncoderFps : output_fps;
+		double actual_input	   = std::min(kLoopInputFps, actual_output * static_cast<double>(skip_frames + 1));
+		int64_t handoff_us	   = is_throttled ? static_cast<int64_t>(1000000.0 / kLoopEncoderFps) - kLoopProcessUs : 0;
+
+		for (int32_t frame = 0; frame < static_cast<int32_t>(std::lround(actual_output)); frame++)
+		{
+			controller.AddHandoffTime(handoff_us);
+			controller.CommitFrame(kLoopProcessUs);
+		}
+
+		now += kWindowMs;
+
+		SkipFramesController::Observation observation;
+		observation.expected_input_fps	= kLoopInputFps;
+		observation.actual_input_fps	= actual_input;
+		observation.max_output_fps		= kLoopInputFps;
+		observation.expected_output_fps	= actual_output;
+		observation.actual_output_fps	= actual_output;
+
+		return controller.Evaluate(now, observation);
+	}
+}  // namespace
+
+// The step down has to stand for longer than it takes to notice it failed. Re-detection
+// waits for the cost average to climb back before the target exceeds the level again, and
+// only then for the confirming windows - if the settle interval expires first, the failure
+// is read as a success and the interval never grows.
+TEST(SkipFramesControllerTest, BacksOffWhenReDetectionNeedsSeveralWindows)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(RunEncoderBoundWindow(controller, now).has_value());
+
+	int64_t last_recovery_at_ms = 0;
+	int64_t first_gap_ms		= 0;
+	int64_t last_gap_ms			= 0;
+	int32_t below_target		= 0;
+
+	for (int32_t window = 0; window < 300; window++)
+	{
+		auto result = RunEncoderBoundWindow(controller, now);
+
+		if (result.has_value() && result->decision == Decision::Recovery)
+		{
+			if (last_recovery_at_ms > 0)
+			{
+				last_gap_ms = now - last_recovery_at_ms;
+				if (first_gap_ms == 0)
+				{
+					first_gap_ms = last_gap_ms;
+				}
+			}
+			last_recovery_at_ms = now;
+		}
+
+		if (controller.GetSkipFrames() < kLoopFitLevel)
+		{
+			below_target++;
+		}
+	}
+
+	// The pipeline never recovers, so the attempts have to spread out rather than repeat at
+	// the base interval for as long as the overload lasts.
+	ASSERT_GT(first_gap_ms, 0);
+	EXPECT_GT(last_gap_ms, first_gap_ms * 2) << "the attempts never spread out";
+	EXPECT_LT(below_target, 45) << below_target << "/300 windows below the level that fits";
+}

--- a/src/transcoder/filter/filter_skipframes_controller_test.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller_test.cpp
@@ -25,24 +25,24 @@ namespace
 
 	constexpr int64_t kWindowMs	  = 1001;  // one tick past the 1s evaluation interval
 	constexpr int32_t kEmaFrames  = 80;	   // enough commits for the average to reach the target
-	constexpr double  kCadenceFps = 30.0;
+	constexpr double  kMaxOutputFps = 30.0;
 
-	// Budgets chosen to land clear of an integer boundary, so rounding cannot flip the level.
+	// Costs chosen to land clear of an integer boundary, so rounding cannot flip the level.
 	//   138ms -> 6.52fps sustainable -> skip 4
 	//   316ms -> 2.85fps sustainable -> skip 10
-	constexpr int64_t kBudgetForLevel4Us  = 138000;
-	constexpr int64_t kBudgetForLevel10Us = 316000;
-	constexpr int64_t kCheapBudgetUs	  = 200;
+	constexpr int64_t kCostForLevel4Us	= 138000;
+	constexpr int64_t kCostForLevel10Us	= 316000;
+	constexpr int64_t kCheapCostUs		= 200;
 
 	SkipFramesController::Observation MakeObservation(double actual_input_fps)
 	{
 		SkipFramesController::Observation observation;
 
-		observation.expected_input_fps	= kCadenceFps;
+		observation.expected_input_fps	= kMaxOutputFps;
 		observation.actual_input_fps	= actual_input_fps;
-		observation.cadence_fps			= kCadenceFps;
-		observation.expected_output_fps	= kCadenceFps;
-		observation.actual_output_fps	= kCadenceFps;
+		observation.max_output_fps		= kMaxOutputFps;
+		observation.expected_output_fps	= kMaxOutputFps;
+		observation.actual_output_fps	= kMaxOutputFps;
 
 		return observation;
 	}
@@ -50,12 +50,12 @@ namespace
 	// The threshold is 95% of the expected input rate.
 	SkipFramesController::Observation KeepingUp()
 	{
-		return MakeObservation(kCadenceFps);
+		return MakeObservation(kMaxOutputFps);
 	}
 
 	SkipFramesController::Observation FallingBehind()
 	{
-		return MakeObservation(kCadenceFps * 0.5);
+		return MakeObservation(kMaxOutputFps * 0.5);
 	}
 
 	// Drives the per-frame average to processing_us + handoff_us.
@@ -125,7 +125,7 @@ TEST(SkipFramesControllerTest, WaitsForTheEvaluationInterval)
 {
 	SkipFramesController controller;
 	controller.Configure(0);
-	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+	FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
 
 	int64_t now = 1000;
 	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
@@ -139,12 +139,12 @@ TEST(SkipFramesControllerTest, RaisesOnlyAfterASecondWindowAgrees)
 {
 	SkipFramesController controller;
 	controller.Configure(0);
-	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+	FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
 
 	int64_t now = 1000;
 	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
 
-	// The budget asks for 4, but one window is a hiccup.
+	// The frame cost asks for 4, but one window is a hiccup.
 	auto first = RunOverloadedWindow(controller, now);
 	ASSERT_TRUE(first.has_value());
 	EXPECT_EQ(first->decision, Decision::Unchanged);
@@ -158,11 +158,11 @@ TEST(SkipFramesControllerTest, RaisesOnlyAfterASecondWindowAgrees)
 	EXPECT_EQ(controller.GetSkipFrames(), 1);
 }
 
-TEST(SkipFramesControllerTest, ClimbsOneStepPerWindowAndStopsAtTheBudget)
+TEST(SkipFramesControllerTest, ClimbsOneStepPerWindowAndStopsAtTheFrameCost)
 {
 	SkipFramesController controller;
 	controller.Configure(0);
-	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+	FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
 
 	int64_t now = 1000;
 	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
@@ -176,7 +176,7 @@ TEST(SkipFramesControllerTest, ClimbsOneStepPerWindowAndStopsAtTheBudget)
 		EXPECT_EQ(controller.GetSkipFrames(), expected);
 	}
 
-	// The budget wanted 4, so it stops there however long the overload lasts.
+	// The frame cost wanted 4, so it stops there however long the overload lasts.
 	auto settled = RunOverloadedWindow(controller, now);
 	ASSERT_TRUE(settled.has_value());
 	EXPECT_EQ(settled->decision, Decision::Unchanged);
@@ -187,7 +187,7 @@ TEST(SkipFramesControllerTest, DoesNotRaiseBeforeTheInputRateIsMeasured)
 {
 	SkipFramesController controller;
 	controller.Configure(0);
-	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+	FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
 
 	// A zero input rate means the FPS filter has not measured a second yet. Raising on it
 	// would act on a sample that does not exist.
@@ -213,12 +213,12 @@ TEST(SkipFramesControllerTest, DoesNotRaiseWhenTheThreadHasIdleTime)
 {
 	SkipFramesController controller;
 	controller.Configure(0);
-	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+	FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
 
 	int64_t now = 1000;
 	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
 
-	// The budget looks expensive, but the thread is only half busy - the handoff was waiting
+	// The frame cost looks expensive, but the thread is only half busy - the handoff was waiting
 	// on a shallow queue, not running out of capacity.
 	for (int32_t i = 0; i < 3; i++)
 	{
@@ -237,14 +237,14 @@ TEST(SkipFramesControllerTest, DoesNotStepDownWhileTheBottleneckStands)
 {
 	SkipFramesController controller;
 	controller.Configure(0);
-	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+	FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
 
 	int64_t now = 1000;
 	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
 	ClimbTo(controller, 2, now);
 
-	// The budget decays between stalls, so on its own it now asks for no skipping at all.
-	FeedFrames(controller, kCheapBudgetUs, 0);
+	// The cost decays between stalls, so on its own it now asks for no skipping at all.
+	FeedFrames(controller, kCheapCostUs, 0);
 
 	// The thread is still saturated and still losing input, and the recovery hold has long
 	// passed - the level must not come down on a window that was just counted as overloaded.
@@ -261,13 +261,13 @@ TEST(SkipFramesControllerTest, HoldsRecoveryUntilTheIntervalPasses)
 {
 	SkipFramesController controller;
 	controller.Configure(0);
-	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+	FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
 
 	int64_t now = 1000;
 	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
 	ClimbTo(controller, 1, now);
 
-	FeedFrames(controller, kCheapBudgetUs, 0);
+	FeedFrames(controller, kCheapCostUs, 0);
 
 	// Capacity is back, but the level has only just changed.
 	controller.AddBusyTime(BusyUsFor(0.10));
@@ -293,15 +293,17 @@ TEST(SkipFramesControllerTest, StepsDownWhileBusyIfTheInputIsKeptUp)
 {
 	SkipFramesController controller;
 	controller.Configure(0);
-	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+	FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
 
 	int64_t now = 1000;
 	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
 	ClimbTo(controller, 1, now);
 
-	// Still 99% busy, but the filter is taking in everything that arrives. Utilization alone
-	// cannot tell real work from waiting on a two-frame queue, so a level reached during a
-	// spike has to be allowed back down.
+	FeedFrames(controller, kCheapCostUs, 0);
+
+	// Still 99% busy, but the filter is taking in everything that arrives and the cost no
+	// longer asks for a level. Utilization alone cannot tell real work from waiting on a
+	// two-frame queue, so a level reached during a spike has to be allowed back down.
 	controller.AddBusyTime(BusyUsFor(0.99, 6000));
 	now += 6000;
 
@@ -315,13 +317,13 @@ TEST(SkipFramesControllerTest, RecoveryComesDownTwentyPercentAtATime)
 {
 	SkipFramesController controller;
 	controller.Configure(0);
-	FeedFrames(controller, 1000, kBudgetForLevel10Us - 1000);
+	FeedFrames(controller, 1000, kCostForLevel10Us - 1000);
 
 	int64_t now = 1000;
 	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
 	ClimbTo(controller, 10, now);
 
-	FeedFrames(controller, kCheapBudgetUs, 0);
+	FeedFrames(controller, kCheapCostUs, 0);
 
 	// 10 - max(1, 10/5) = 8, not straight to 0.
 	controller.AddBusyTime(BusyUsFor(0.10, 6000));
@@ -346,11 +348,13 @@ TEST(SkipFramesControllerTest, InheritKeepsTheLevelAndTheRecoveryHold)
 {
 	SkipFramesController previous;
 	previous.Configure(0);
-	FeedFrames(previous, 1000, kBudgetForLevel4Us - 1000);
+	FeedFrames(previous, 1000, kCostForLevel4Us - 1000);
 
 	int64_t now = 1000;
 	ASSERT_FALSE(previous.Evaluate(now, FallingBehind()).has_value());
 	ClimbTo(previous, 1, now);
+
+	FeedFrames(previous, kCheapCostUs, 0);
 
 	SkipFramesController replacement;
 	replacement.Configure(0);
@@ -374,17 +378,137 @@ TEST(SkipFramesControllerTest, InheritDoesNotCarryTheLevelToAFixedConfig)
 {
 	SkipFramesController previous;
 	previous.Configure(0);
-	FeedFrames(previous, 1000, kBudgetForLevel4Us - 1000);
+	FeedFrames(previous, 1000, kCostForLevel4Us - 1000);
 
 	int64_t now = 1000;
 	ASSERT_FALSE(previous.Evaluate(now, FallingBehind()).has_value());
 	ClimbTo(previous, 1, now);
 
-	// The level counts frames within a cadence, so it only transfers between two automatic
+	// The level is a divisor of the output rate, so it only transfers between two automatic
 	// controllers. A configured level was already applied by Configure().
 	SkipFramesController replacement;
 	replacement.Configure(3);
 	replacement.InheritFrom(previous);
 
 	EXPECT_EQ(replacement.GetSkipFrames(), 3);
+}
+
+// A filter that is itself the bottleneck costs the same per frame at every level, so the
+// level has no reason to move.
+TEST(SkipFramesControllerTest, HoldsTheLevelTheFrameCostStillDemands)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+	FeedFrames(controller, kCostForLevel4Us, 0);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
+	ClimbTo(controller, 4, now);
+
+	// Far longer than the recovery hold. The thread now keeps up with its input - which is
+	// what level 4 bought - and nothing may read that as grounds to hand the level back.
+	for (int32_t i = 0; i < 30; i++)
+	{
+		controller.AddBusyTime(BusyUsFor(0.99));
+		now += kWindowMs;
+
+		auto result = controller.Evaluate(now, KeepingUp());
+		ASSERT_TRUE(result.has_value());
+		ASSERT_EQ(result->decision, Decision::Unchanged) << "window " << i;
+	}
+
+	EXPECT_EQ(controller.GetSkipFrames(), 4);
+}
+
+namespace
+{
+	// Takes the step down the way an encoder-bound pipeline gets one: the level is holding
+	// the backpressure off, so the cost no longer asks for anything.
+	std::optional<SkipFramesController::Result> ProbeAfter(SkipFramesController &controller, int64_t wait_ms, int64_t &now)
+	{
+		FeedFrames(controller, kCheapCostUs, 0);
+
+		controller.AddBusyTime(BusyUsFor(0.99, wait_ms));
+		now += wait_ms;
+
+		return controller.Evaluate(now, KeepingUp());
+	}
+
+	// The level below could not hold: the backpressure is back in the cost, and with it
+	// the level.
+	void FailTheProbe(SkipFramesController &controller, int32_t back_to, int64_t &now)
+	{
+		FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
+
+		for (int32_t guard = 0; guard < 8 && controller.GetSkipFrames() < back_to; guard++)
+		{
+			RunOverloadedWindow(controller, now);
+		}
+
+		ASSERT_EQ(controller.GetSkipFrames(), back_to);
+	}
+}  // namespace
+
+// When the encoder is the bottleneck, stepping down is a blind probe. One that keeps
+// failing has to get rarer.
+TEST(SkipFramesControllerTest, BacksOffTheProbeWhileItKeepsFailing)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+	FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
+	ClimbTo(controller, 4, now);
+
+	// The base hold buys the first probe.
+	auto first = ProbeAfter(controller, 6000, now);
+	ASSERT_TRUE(first.has_value());
+	ASSERT_EQ(first->decision, Decision::Recovery);
+	ASSERT_EQ(controller.GetSkipFrames(), 3);
+
+	FailTheProbe(controller, 4, now);
+
+	// The same wait no longer does.
+	auto second = ProbeAfter(controller, 6000, now);
+	ASSERT_TRUE(second.has_value());
+	EXPECT_EQ(second->decision, Decision::HoldRecovery);
+	EXPECT_EQ(controller.GetSkipFrames(), 4);
+}
+
+// The backoff is not a ratchet: the first step down that stands puts the interval back.
+TEST(SkipFramesControllerTest, ReturnsToTheBaseHoldOnceAProbeStands)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+	FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
+	ClimbTo(controller, 4, now);
+
+	ASSERT_EQ(ProbeAfter(controller, 6000, now)->decision, Decision::Recovery);
+	ASSERT_EQ(controller.GetSkipFrames(), 3);
+
+	FailTheProbe(controller, 4, now);
+
+	// Backed off, so this one has to wait longer than the base interval.
+	ASSERT_EQ(ProbeAfter(controller, 6000, now)->decision, Decision::HoldRecovery);
+
+	auto taken = ProbeAfter(controller, 11000, now);
+	ASSERT_TRUE(taken.has_value());
+	ASSERT_EQ(taken->decision, Decision::Recovery);
+	ASSERT_EQ(controller.GetSkipFrames(), 3);
+
+	// This one is not taken back. Reaching the next step down proves it stood for a whole
+	// hold, so the interval goes back to where it started.
+	auto stood = ProbeAfter(controller, 11000, now);
+	ASSERT_TRUE(stood.has_value());
+	ASSERT_EQ(stood->decision, Decision::Recovery);
+	ASSERT_EQ(controller.GetSkipFrames(), 2);
+
+	auto at_base_again = ProbeAfter(controller, 6000, now);
+	ASSERT_TRUE(at_base_again.has_value());
+	EXPECT_EQ(at_base_again->decision, Decision::Recovery);
+	EXPECT_EQ(controller.GetSkipFrames(), 1);
 }

--- a/src/transcoder/filter/filter_skipframes_controller_test.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller_test.cpp
@@ -34,6 +34,10 @@ namespace
 	constexpr int64_t kCostForLevel10Us	= 316000;
 	constexpr int64_t kCheapCostUs		= 200;
 
+	// Just past the base recovery hold: a wait under this came at the base interval, a
+	// wait over it means the backoff engaged.
+	constexpr int64_t kBaseHoldCeilingMs = 7000;
+
 	SkipFramesController::Observation MakeObservation(double actual_input_fps)
 	{
 		SkipFramesController::Observation observation;
@@ -567,6 +571,101 @@ TEST(SkipFramesControllerTest, InheritKeepsTheBusyTimeMeasuredInTheWindow)
 	ASSERT_TRUE(result.has_value());
 	EXPECT_EQ(result->decision, Decision::Unchanged);
 	EXPECT_EQ(replacement.GetSkipFrames(), 4);
+}
+
+namespace
+{
+	// Cheap, keeping-up windows until the level steps down. Returns the wait in ms, or -1.
+	int64_t WaitForRecovery(SkipFramesController &controller, int64_t &now, int32_t max_windows = 80)
+	{
+		int64_t started_at = now;
+
+		for (int32_t guard = 0; guard < max_windows; guard++)
+		{
+			FeedFrames(controller, kCheapCostUs, 0);
+			controller.AddBusyTime(BusyUsFor(0.99));
+			now += kWindowMs;
+
+			auto result = controller.Evaluate(now, KeepingUp());
+			if (result.has_value() && result->decision == Decision::Recovery)
+			{
+				return now - started_at;
+			}
+		}
+
+		return -1;
+	}
+}  // namespace
+
+// A step down that stood must stop counting as outstanding, or the next unrelated overload
+// is charged as a failed probe and the interval ratchets up for a pipeline that is fine.
+TEST(SkipFramesControllerTest, UnrelatedOverloadDoesNotBackOffTheProbe)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
+
+	// Three separate episodes of the same overload arriving and clearing again. Level 1
+	// cannot produce a step down of its own, so nothing but this can clear the flag.
+	for (int32_t episode = 0; episode < 3; episode++)
+	{
+		FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
+		ClimbTo(controller, 1, now);
+
+		int64_t wait_ms = WaitForRecovery(controller, now);
+		ASSERT_GT(wait_ms, 0) << "episode " << episode;
+		EXPECT_LT(wait_ms, kBaseHoldCeilingMs) << "episode " << episode;
+
+		ASSERT_EQ(controller.GetSkipFrames(), 0) << "episode " << episode;
+
+		// The step down settles: the next episode is a new overload, not this one failing.
+		for (int32_t guard = 0; guard < 5; guard++)
+		{
+			FeedFrames(controller, kCheapCostUs, 0);
+			controller.AddBusyTime(BusyUsFor(0.99));
+			now += kWindowMs;
+			controller.Evaluate(now, KeepingUp());
+		}
+	}
+}
+
+// A descent of several steps must not treat an early step as proof the pipeline recovered.
+// The level that actually fails is further down, and the interval has to keep growing for it
+// across cycles rather than being handed back every time the harmless step succeeds.
+TEST(SkipFramesControllerTest, BacksOffWhenTheFailingLevelIsSeveralStepsDown)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
+	FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
+	ClimbTo(controller, 4, now);
+
+	int64_t previous_wait_ms = 0;
+
+	for (int32_t cycle = 0; cycle < 3; cycle++)
+	{
+		// 4 -> 3 always holds; it is the step after it that cannot.
+		int64_t wait_ms = WaitForRecovery(controller, now);
+		ASSERT_GT(wait_ms, 0) << "cycle " << cycle;
+		ASSERT_EQ(controller.GetSkipFrames(), 3) << "cycle " << cycle;
+
+		if (cycle > 0)
+		{
+			EXPECT_GT(wait_ms, previous_wait_ms) << "cycle " << cycle << " waited no longer than the one before it";
+		}
+		previous_wait_ms = wait_ms;
+
+		ASSERT_GT(WaitForRecovery(controller, now), 0) << "cycle " << cycle;
+		ASSERT_EQ(controller.GetSkipFrames(), 2) << "cycle " << cycle;
+
+		// Level 2 cannot hold: the load is back.
+		FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
+		ClimbTo(controller, 4, now);
+	}
 }
 
 // An output ceiling under 1fps drives the ceiling clamp negative, and -1 is not a level -

--- a/src/transcoder/filter/filter_skipframes_controller_test.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller_test.cpp
@@ -189,8 +189,8 @@ TEST(SkipFramesControllerTest, DoesNotRaiseBeforeTheInputRateIsMeasured)
 	controller.Configure(0);
 	FeedFrames(controller, 1000, kCostForLevel4Us - 1000);
 
-	// A zero input rate means the FPS filter has not measured a second yet. Raising on it
-	// would act on a sample that does not exist.
+	// A zero input rate means the FPS filter has not measured a second yet. Deciding on it
+	// would act on a sample that does not exist, so no window closes on one.
 	auto no_sample_yet = MakeObservation(0.0);
 
 	int64_t now = 1000;
@@ -201,9 +201,7 @@ TEST(SkipFramesControllerTest, DoesNotRaiseBeforeTheInputRateIsMeasured)
 		controller.AddBusyTime(BusyUsFor(0.99));
 		now += kWindowMs;
 
-		auto result = controller.Evaluate(now, no_sample_yet);
-		ASSERT_TRUE(result.has_value());
-		EXPECT_EQ(result->decision, Decision::Unchanged);
+		EXPECT_FALSE(controller.Evaluate(now, no_sample_yet).has_value());
 	}
 
 	EXPECT_EQ(controller.GetSkipFrames(), 0);
@@ -511,4 +509,62 @@ TEST(SkipFramesControllerTest, ReturnsToTheBaseHoldOnceAProbeStands)
 	ASSERT_TRUE(at_base_again.has_value());
 	EXPECT_EQ(at_base_again->decision, Decision::Recovery);
 	EXPECT_EQ(controller.GetSkipFrames(), 1);
+}
+
+// A replacement filter reports no input rate until it has measured a second of its own.
+// That is a missing sample, not a thread that is keeping up.
+TEST(SkipFramesControllerTest, DoesNotStepDownBeforeTheInputRateIsMeasured)
+{
+	SkipFramesController previous;
+	previous.Configure(0);
+	FeedFrames(previous, 1000, kCostForLevel4Us - 1000);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(previous.Evaluate(now, FallingBehind()).has_value());
+	ClimbTo(previous, 4, now);
+
+	FeedFrames(previous, kCheapCostUs, 0);
+
+	SkipFramesController replacement;
+	replacement.Configure(0);
+	replacement.InheritFrom(previous);
+
+	// Saturated, and the recovery hold carried over has already expired.
+	replacement.AddBusyTime(BusyUsFor(0.995, 6000));
+	now += 6000;
+
+	EXPECT_FALSE(replacement.Evaluate(now, MakeObservation(0.0)).has_value());
+	EXPECT_EQ(replacement.GetSkipFrames(), 4);
+}
+
+// The window start carries across a replacement, so the busy time measured in it has to
+// carry too - otherwise a partial window reads as idle.
+TEST(SkipFramesControllerTest, InheritKeepsTheBusyTimeMeasuredInTheWindow)
+{
+	SkipFramesController previous;
+	previous.Configure(0);
+	FeedFrames(previous, 1000, kCostForLevel4Us - 1000);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(previous.Evaluate(now, FallingBehind()).has_value());
+	ClimbTo(previous, 4, now);
+
+	FeedFrames(previous, kCheapCostUs, 0);
+
+	// Six seconds of the window are spent busy, then the filter is replaced.
+	previous.AddBusyTime(BusyUsFor(0.99, 6000));
+	now += 6000;
+
+	SkipFramesController replacement;
+	replacement.Configure(0);
+	replacement.InheritFrom(previous);
+
+	// The remainder is busy as well, so the window closes saturated rather than idle.
+	replacement.AddBusyTime(BusyUsFor(0.99, 1000));
+	now += 1000;
+
+	auto result = replacement.Evaluate(now, FallingBehind());
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->decision, Decision::Unchanged);
+	EXPECT_EQ(replacement.GetSkipFrames(), 4);
 }

--- a/src/transcoder/filter/filter_skipframes_controller_test.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller_test.cpp
@@ -1,0 +1,390 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include "filter_fps.h"
+#include "filter_skipframes_controller.h"
+
+// The controller reads no clock and touches nothing outside itself, so a test can hand it
+// synthetic time and rates and assert the decision directly.
+//
+// Two things about the measurement API matter when reading these tests:
+//   * Every Add*/Commit call also counts toward the busy window, so a test that cares about
+//     utilization either feeds before the window it measures or keeps the values small.
+//   * The very first Evaluate() only seeds the timestamps and clears the window. Every test
+//     therefore starts with one throwaway call.
+
+namespace
+{
+	using Decision = SkipFramesController::Decision;
+
+	constexpr int64_t kWindowMs	  = 1001;  // one tick past the 1s evaluation interval
+	constexpr int32_t kEmaFrames  = 80;	   // enough commits for the average to reach the target
+	constexpr double  kCadenceFps = 30.0;
+
+	// Budgets chosen to land clear of an integer boundary, so rounding cannot flip the level.
+	//   138ms -> 6.52fps sustainable -> skip 4
+	//   316ms -> 2.85fps sustainable -> skip 10
+	constexpr int64_t kBudgetForLevel4Us  = 138000;
+	constexpr int64_t kBudgetForLevel10Us = 316000;
+	constexpr int64_t kCheapBudgetUs	  = 200;
+
+	SkipFramesController::Observation MakeObservation(double actual_input_fps)
+	{
+		SkipFramesController::Observation observation;
+
+		observation.expected_input_fps	= kCadenceFps;
+		observation.actual_input_fps	= actual_input_fps;
+		observation.cadence_fps			= kCadenceFps;
+		observation.expected_output_fps	= kCadenceFps;
+		observation.actual_output_fps	= kCadenceFps;
+
+		return observation;
+	}
+
+	// The threshold is 95% of the expected input rate.
+	SkipFramesController::Observation KeepingUp()
+	{
+		return MakeObservation(kCadenceFps);
+	}
+
+	SkipFramesController::Observation FallingBehind()
+	{
+		return MakeObservation(kCadenceFps * 0.5);
+	}
+
+	// Drives the per-frame average to processing_us + handoff_us.
+	void FeedFrames(SkipFramesController &controller, int64_t processing_us, int64_t handoff_us)
+	{
+		for (int32_t i = 0; i < kEmaFrames; i++)
+		{
+			controller.AddHandoffTime(handoff_us);
+			controller.CommitFrame(processing_us);
+		}
+	}
+
+	int64_t BusyUsFor(double utilization, int64_t window_ms = kWindowMs)
+	{
+		return static_cast<int64_t>(utilization * static_cast<double>(window_ms) * 1000.0);
+	}
+
+	// One saturated window that is also losing input.
+	std::optional<SkipFramesController::Result> RunOverloadedWindow(SkipFramesController &controller, int64_t &now)
+	{
+		controller.AddBusyTime(BusyUsFor(0.99));
+		now += kWindowMs;
+
+		return controller.Evaluate(now, FallingBehind());
+	}
+
+	// Repeats overloaded windows until the level reaches the target.
+	void ClimbTo(SkipFramesController &controller, int32_t target, int64_t &now)
+	{
+		for (int32_t guard = 0; guard < 64 && controller.GetSkipFrames() < target; guard++)
+		{
+			RunOverloadedWindow(controller, now);
+		}
+
+		ASSERT_EQ(controller.GetSkipFrames(), target);
+	}
+}  // namespace
+
+TEST(SkipFramesControllerTest, DisabledConfigNeverDecides)
+{
+	SkipFramesController controller;
+	controller.Configure(-1);
+
+	EXPECT_FALSE(controller.IsEnabled());
+	EXPECT_FALSE(controller.IsAutomatic());
+
+	EXPECT_FALSE(controller.Evaluate(1000, KeepingUp()).has_value());
+	EXPECT_FALSE(controller.Evaluate(1000 + kWindowMs, KeepingUp()).has_value());
+}
+
+TEST(SkipFramesControllerTest, FixedConfigNeverDecides)
+{
+	SkipFramesController controller;
+	controller.Configure(3);
+
+	EXPECT_TRUE(controller.IsEnabled());
+	EXPECT_FALSE(controller.IsAutomatic());
+	EXPECT_EQ(controller.GetSkipFrames(), 3);
+	EXPECT_EQ(controller.GetConfiguredSkipFrames(), 3);
+
+	EXPECT_FALSE(controller.Evaluate(1000, FallingBehind()).has_value());
+	EXPECT_FALSE(controller.Evaluate(1000 + kWindowMs, FallingBehind()).has_value());
+	EXPECT_EQ(controller.GetSkipFrames(), 3);
+}
+
+TEST(SkipFramesControllerTest, WaitsForTheEvaluationInterval)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
+
+	controller.AddBusyTime(BusyUsFor(0.99));
+	EXPECT_FALSE(controller.Evaluate(now + 999, FallingBehind()).has_value());
+	EXPECT_TRUE(controller.Evaluate(now + kWindowMs, FallingBehind()).has_value());
+}
+
+TEST(SkipFramesControllerTest, RaisesOnlyAfterASecondWindowAgrees)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
+
+	// The budget asks for 4, but one window is a hiccup.
+	auto first = RunOverloadedWindow(controller, now);
+	ASSERT_TRUE(first.has_value());
+	EXPECT_EQ(first->decision, Decision::Unchanged);
+	EXPECT_EQ(controller.GetSkipFrames(), 0);
+
+	// The second window agrees, and the level rises by one step - not straight to 4.
+	auto second = RunOverloadedWindow(controller, now);
+	ASSERT_TRUE(second.has_value());
+	EXPECT_EQ(second->decision, Decision::Bottleneck);
+	EXPECT_EQ(second->skip_frames, 1);
+	EXPECT_EQ(controller.GetSkipFrames(), 1);
+}
+
+TEST(SkipFramesControllerTest, ClimbsOneStepPerWindowAndStopsAtTheBudget)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
+
+	RunOverloadedWindow(controller, now);  // confirmation window
+	for (int32_t expected = 1; expected <= 4; expected++)
+	{
+		auto result = RunOverloadedWindow(controller, now);
+		ASSERT_TRUE(result.has_value());
+		EXPECT_EQ(result->decision, Decision::Bottleneck);
+		EXPECT_EQ(controller.GetSkipFrames(), expected);
+	}
+
+	// The budget wanted 4, so it stops there however long the overload lasts.
+	auto settled = RunOverloadedWindow(controller, now);
+	ASSERT_TRUE(settled.has_value());
+	EXPECT_EQ(settled->decision, Decision::Unchanged);
+	EXPECT_EQ(controller.GetSkipFrames(), 4);
+}
+
+TEST(SkipFramesControllerTest, DoesNotRaiseBeforeTheInputRateIsMeasured)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+
+	// A zero input rate means the FPS filter has not measured a second yet. Raising on it
+	// would act on a sample that does not exist.
+	auto no_sample_yet = MakeObservation(0.0);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, no_sample_yet).has_value());
+
+	for (int32_t i = 0; i < 3; i++)
+	{
+		controller.AddBusyTime(BusyUsFor(0.99));
+		now += kWindowMs;
+
+		auto result = controller.Evaluate(now, no_sample_yet);
+		ASSERT_TRUE(result.has_value());
+		EXPECT_EQ(result->decision, Decision::Unchanged);
+	}
+
+	EXPECT_EQ(controller.GetSkipFrames(), 0);
+}
+
+TEST(SkipFramesControllerTest, DoesNotRaiseWhenTheThreadHasIdleTime)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
+
+	// The budget looks expensive, but the thread is only half busy - the handoff was waiting
+	// on a shallow queue, not running out of capacity.
+	for (int32_t i = 0; i < 3; i++)
+	{
+		controller.AddBusyTime(BusyUsFor(0.50));
+		now += kWindowMs;
+
+		auto result = controller.Evaluate(now, FallingBehind());
+		ASSERT_TRUE(result.has_value());
+		EXPECT_EQ(result->decision, Decision::Unchanged);
+	}
+
+	EXPECT_EQ(controller.GetSkipFrames(), 0);
+}
+
+TEST(SkipFramesControllerTest, DoesNotStepDownWhileTheBottleneckStands)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
+	ClimbTo(controller, 2, now);
+
+	// The budget decays between stalls, so on its own it now asks for no skipping at all.
+	FeedFrames(controller, kCheapBudgetUs, 0);
+
+	// The thread is still saturated and still losing input, and the recovery hold has long
+	// passed - the level must not come down on a window that was just counted as overloaded.
+	controller.AddBusyTime(BusyUsFor(0.99, 6000));
+	now += 6000;
+
+	auto result = controller.Evaluate(now, FallingBehind());
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->decision, Decision::Unchanged);
+	EXPECT_EQ(controller.GetSkipFrames(), 2);
+}
+
+TEST(SkipFramesControllerTest, HoldsRecoveryUntilTheIntervalPasses)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
+	ClimbTo(controller, 1, now);
+
+	FeedFrames(controller, kCheapBudgetUs, 0);
+
+	// Capacity is back, but the level has only just changed.
+	controller.AddBusyTime(BusyUsFor(0.10));
+	now += kWindowMs;
+
+	auto held = controller.Evaluate(now, KeepingUp());
+	ASSERT_TRUE(held.has_value());
+	EXPECT_EQ(held->decision, Decision::HoldRecovery);
+	EXPECT_EQ(controller.GetSkipFrames(), 1);
+
+	// Once the hold passes it comes down.
+	controller.AddBusyTime(BusyUsFor(0.10, 6000));
+	now += 6000;
+
+	auto recovered = controller.Evaluate(now, KeepingUp());
+	ASSERT_TRUE(recovered.has_value());
+	EXPECT_EQ(recovered->decision, Decision::Recovery);
+	EXPECT_EQ(recovered->skip_frames, 0);
+	EXPECT_EQ(controller.GetSkipFrames(), 0);
+}
+
+TEST(SkipFramesControllerTest, StepsDownWhileBusyIfTheInputIsKeptUp)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+	FeedFrames(controller, 1000, kBudgetForLevel4Us - 1000);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
+	ClimbTo(controller, 1, now);
+
+	// Still 99% busy, but the filter is taking in everything that arrives. Utilization alone
+	// cannot tell real work from waiting on a two-frame queue, so a level reached during a
+	// spike has to be allowed back down.
+	controller.AddBusyTime(BusyUsFor(0.99, 6000));
+	now += 6000;
+
+	auto result = controller.Evaluate(now, KeepingUp());
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->decision, Decision::Recovery);
+	EXPECT_EQ(controller.GetSkipFrames(), 0);
+}
+
+TEST(SkipFramesControllerTest, RecoveryComesDownTwentyPercentAtATime)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+	FeedFrames(controller, 1000, kBudgetForLevel10Us - 1000);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, FallingBehind()).has_value());
+	ClimbTo(controller, 10, now);
+
+	FeedFrames(controller, kCheapBudgetUs, 0);
+
+	// 10 - max(1, 10/5) = 8, not straight to 0.
+	controller.AddBusyTime(BusyUsFor(0.10, 6000));
+	now += 6000;
+
+	auto first = controller.Evaluate(now, KeepingUp());
+	ASSERT_TRUE(first.has_value());
+	EXPECT_EQ(first->decision, Decision::Recovery);
+	EXPECT_EQ(controller.GetSkipFrames(), 8);
+
+	// 8 - max(1, 8/5) = 7
+	controller.AddBusyTime(BusyUsFor(0.10, 6000));
+	now += 6000;
+
+	auto second = controller.Evaluate(now, KeepingUp());
+	ASSERT_TRUE(second.has_value());
+	EXPECT_EQ(second->decision, Decision::Recovery);
+	EXPECT_EQ(controller.GetSkipFrames(), 7);
+}
+
+TEST(SkipFramesControllerTest, InheritKeepsTheLevelAndTheRecoveryHold)
+{
+	SkipFramesController previous;
+	previous.Configure(0);
+	FeedFrames(previous, 1000, kBudgetForLevel4Us - 1000);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(previous.Evaluate(now, FallingBehind()).has_value());
+	ClimbTo(previous, 1, now);
+
+	SkipFramesController replacement;
+	replacement.Configure(0);
+	replacement.InheritFrom(previous);
+
+	EXPECT_EQ(replacement.GetSkipFrames(), 1);
+
+	// The hold carries too. Evaluate() re-seeds the timestamps whenever either is still
+	// zero, so inheriting only one of the pair would silently restart the interval and the
+	// level could never come down on a stream that reconfigures often.
+	replacement.AddBusyTime(BusyUsFor(0.10, 6000));
+	now += 6000;
+
+	auto result = replacement.Evaluate(now, KeepingUp());
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->decision, Decision::Recovery);
+	EXPECT_EQ(replacement.GetSkipFrames(), 0);
+}
+
+TEST(SkipFramesControllerTest, InheritDoesNotCarryTheLevelToAFixedConfig)
+{
+	SkipFramesController previous;
+	previous.Configure(0);
+	FeedFrames(previous, 1000, kBudgetForLevel4Us - 1000);
+
+	int64_t now = 1000;
+	ASSERT_FALSE(previous.Evaluate(now, FallingBehind()).has_value());
+	ClimbTo(previous, 1, now);
+
+	// The level counts frames within a cadence, so it only transfers between two automatic
+	// controllers. A configured level was already applied by Configure().
+	SkipFramesController replacement;
+	replacement.Configure(3);
+	replacement.InheritFrom(previous);
+
+	EXPECT_EQ(replacement.GetSkipFrames(), 3);
+}

--- a/src/transcoder/filter/filter_skipframes_controller_test.cpp
+++ b/src/transcoder/filter/filter_skipframes_controller_test.cpp
@@ -568,3 +568,33 @@ TEST(SkipFramesControllerTest, InheritKeepsTheBusyTimeMeasuredInTheWindow)
 	EXPECT_EQ(result->decision, Decision::Unchanged);
 	EXPECT_EQ(replacement.GetSkipFrames(), 4);
 }
+
+// An output ceiling under 1fps drives the ceiling clamp negative, and -1 is not a level -
+// it is SkipFramesDisabled.
+TEST(SkipFramesControllerTest, NeverFallsBelowSkipFramesMin)
+{
+	SkipFramesController controller;
+	controller.Configure(0);
+
+	SkipFramesController::Observation slow;
+	slow.expected_input_fps	 = 0.5;
+	slow.actual_input_fps	 = 0.5;
+	slow.max_output_fps		 = 0.5;
+	slow.expected_output_fps = 0.5;
+	slow.actual_output_fps	 = 0.5;
+
+	int64_t now = 1000;
+	ASSERT_FALSE(controller.Evaluate(now, slow).has_value());
+	FeedFrames(controller, kCostForLevel4Us, 0);
+
+	// Keeping up and past the hold, so the step down is free to act on the clamped value.
+	controller.AddBusyTime(BusyUsFor(0.99, 6000));
+	now += 6000;
+
+	auto result = controller.Evaluate(now, slow);
+	ASSERT_TRUE(result.has_value());
+
+	const int32_t skip_frames_min = FilterFps::SkipFramesMin;
+	EXPECT_GE(result->skip_frames, skip_frames_min);
+	EXPECT_GE(controller.GetSkipFrames(), skip_frames_min);
+}

--- a/src/transcoder/filter/filter_video_base.cpp
+++ b/src/transcoder/filter/filter_video_base.cpp
@@ -236,7 +236,7 @@ void FilterVideoBase::UpdateSkipFrames()
 	SkipFramesController::Observation observation;
 	observation.expected_input_fps	= _fps_filter.GetInputFrameRate();
 	observation.actual_input_fps	= _fps_filter.GetInputFramesPerSecond();
-	observation.cadence_fps	= _fps_filter.GetOutputFrameRate();
+	observation.max_output_fps		= _fps_filter.GetOutputFrameRate();
 	observation.expected_output_fps	= _fps_filter.GetExpectedOutputFramesPerSecond();
 	observation.actual_output_fps	= _fps_filter.GetOutputFramesPerSecond();
 

--- a/src/transcoder/filter/filter_video_base.cpp
+++ b/src/transcoder/filter/filter_video_base.cpp
@@ -23,6 +23,8 @@ bool FilterVideoBase::InitializeFpsFilter()
 	// Configure skip frames
 #if _SKIP_FRAMES_ENABLED
 	int32_t skip_frames_config = _output_track->GetSkipFramesByConfig();
+	_skip_frames_controller.Configure(skip_frames_config);
+
 	int32_t skip_frames = (skip_frames_config >= FilterFps::SkipFramesMin) ? skip_frames_config : FilterFps::SkipFramesDisabled;
 	_fps_filter.SetSkipFrames(skip_frames);
 

--- a/src/transcoder/filter/filter_video_base.cpp
+++ b/src/transcoder/filter/filter_video_base.cpp
@@ -21,8 +21,8 @@ bool FilterVideoBase::InitializeFpsFilter()
 	_fps_filter.SetInputFrameRate(_input_track->GetFrameRate());
 
 	// Configure skip frames
-	int32_t skip_frames_config = _output_track->GetSkipFramesByConfig();
 #if _SKIP_FRAMES_ENABLED
+	int32_t skip_frames_config = _output_track->GetSkipFramesByConfig();
 	int32_t skip_frames = (skip_frames_config >= FilterFps::SkipFramesMin) ? skip_frames_config : FilterFps::SkipFramesDisabled;
 	_fps_filter.SetSkipFrames(skip_frames);
 
@@ -66,10 +66,20 @@ FilterResult FilterVideoBase::ProcessFrameInternal(const std::shared_ptr<MediaFr
 		return FilterResult::Error("Received frame is null");
 	}
 
+#if _SKIP_FRAMES_ENABLED
+	auto start_time = std::chrono::steady_clock::now();
+#endif
+
 	if (_fps_filter.Push(media_frame) == false)
 	{
 		logtw("[%s] Dropped a frame because the FPS filter is full.", GetLogPrefix().CStr());
 	}
+
+#if _SKIP_FRAMES_ENABLED
+	// The push runs on the filter thread like everything else, so it counts toward how
+	// busy the thread was this window.
+	_skip_frames_controller.AddBusyTime(ov::Clock::GetElapsedMicroSecondsFromNow(start_time));
+#endif
 
 	return FilterResult::NoOutput();
 }
@@ -78,27 +88,34 @@ FilterResult FilterVideoBase::PopCompletedFrameInternal()
 {
 	if (GetState() == FilterBase::State::ERROR)
 	{
-		_pending_processing_time_us = 0;
+#if _SKIP_FRAMES_ENABLED
+		_skip_frames_controller.DiscardPending();
+#endif
 
 		return FilterResult::Error("The filter is in the error state");
 	}
 
+#if _SKIP_FRAMES_ENABLED
 	auto start_time = std::chrono::steady_clock::now();
+#endif
 
 	while (true)
 	{
 		auto completed_frame = ReceiveFrame();
 		if (completed_frame != nullptr)
 		{
-			UpdateProcessingTimePerFrame(start_time);
+#if _SKIP_FRAMES_ENABLED
+			_skip_frames_controller.CommitFrame(ov::Clock::GetElapsedMicroSecondsFromNow(start_time));
+#endif
 
 			return FilterResult::Ready(std::move(completed_frame));
 		}
 
 		if (GetState() == FilterBase::State::ERROR)
 		{
-			// The measured time belongs to work that will never complete.
-			_pending_processing_time_us = 0;
+#if _SKIP_FRAMES_ENABLED
+			_skip_frames_controller.DiscardPending();
+#endif
 
 			return FilterResult::Error("The backend rescaler has failed");
 		}
@@ -107,10 +124,9 @@ FilterResult FilterVideoBase::PopCompletedFrameInternal()
 		auto frame = _fps_filter.Pop();
 		if (frame == nullptr)
 		{
-			// No completed frame available yet. Update pending processing time
-			_pending_processing_time_us += ElapsedTimeInUs(start_time);
-
 #if _SKIP_FRAMES_ENABLED
+			_skip_frames_controller.AddProcessingTime(ov::Clock::GetElapsedMicroSecondsFromNow(start_time));
+
 			// Update skip frames based on the current processing time and framerate.
 			UpdateSkipFrames();
 #endif
@@ -168,7 +184,6 @@ void FilterVideoBase::InheritContinuity(const FilterBase *previous)
 	{
 		return;
 	}
-
 	// The slot position only transfers within the same output cadence
 	if (_fps_filter.GetOutputFrameRate() != previous_video->_fps_filter.GetOutputFrameRate())
 	{
@@ -179,153 +194,86 @@ void FilterVideoBase::InheritContinuity(const FilterBase *previous)
 	// change) leaves a slot hole no instance can see on its own; carrying the
 	// slot position lets the new filter refill it
 	_fps_filter.SetContinuationPts(previous_video->_fps_filter.GetNextPts());
-}
 
-int64_t FilterVideoBase::ElapsedTimeInUs(const std::chrono::steady_clock::time_point &start_time) const
-{
-	return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start_time).count();
-}
+#if _SKIP_FRAMES_ENABLED
+	// The encoder does not empty out because this filter was replaced, so the load the
+	// outgoing controller measured still describes the pipeline.
+	_skip_frames_controller.InheritFrom(previous_video->_skip_frames_controller);
 
-void FilterVideoBase::UpdateProcessingTimePerFrame(const std::chrono::steady_clock::time_point &start_time)
-{
-	static constexpr double kProcessingTimeEmaAlpha = 0.1;
-
-	auto elapsed_time_us = _pending_processing_time_us + ElapsedTimeInUs(start_time);
-
-	_pending_processing_time_us				= 0;
-	_weighted_avg_frame_processing_time_us	= (_weighted_avg_frame_processing_time_us * (1.0 - kProcessingTimeEmaAlpha)) + (elapsed_time_us * kProcessingTimeEmaAlpha);
+	_fps_filter.SetSkipFrames(_skip_frames_controller.GetSkipFrames());
+#endif
 }
 
 #if _SKIP_FRAMES_ENABLED
-#define _SKIP_FRAMES_EVALUATION_INTERVAL_MS 	1000	// 1s
-#define _SKIP_FRAMES_RECOVERY_HOLD_INTERVAL_MS 	5000	// 5s
-#define _SKIP_FRAMES_ENSURE_FPS_MARGIN_RATIO 	0.9f	// 90%
+void FilterVideoBase::AddHandoffTime(int64_t elapsed_us)
+{
+	// Called on the filter thread, so no synchronization is needed.
+	_skip_frames_controller.AddHandoffTime(elapsed_us);
+}
 
 void FilterVideoBase::UpdateSkipFrames()
 {
 	// Skip frame is disabled.
-	if (_skip_frames_conf < 0)
+	if (_skip_frames_controller.IsEnabled() == false)
 	{
 		return;
 	}
 
 	// Static skip frames set by the user.
-	if (_skip_frames_conf > 0)
+	if (_skip_frames_controller.IsAutomatic() == false)
 	{
-		if (_fps_filter.GetSkipFrames() != _skip_frames_conf)
+		auto configured = _skip_frames_controller.GetConfiguredSkipFrames();
+		if (_fps_filter.GetSkipFrames() != configured)
 		{
-			_fps_filter.SetSkipFrames(_skip_frames_conf);
-			logti("[%s] Changed skip frames to user config value: %d", GetLogPrefix().CStr(), _fps_filter.GetSkipFrames());
+			_fps_filter.SetSkipFrames(configured);
+			logti("[%s] SkipFrames %d, fixed by config.", GetLogPrefix().CStr(), _fps_filter.GetSkipFrames());
 		}
 		return;
 	}
 
-	// Automatic skip frame adjustment.
+	// Automatic skip frame adjustment. The controller owns the decision; this applies it
+	// and reports it, because the log prefix and the FPS filter live here.
+	SkipFramesController::Observation observation;
+	observation.expected_input_fps	= _fps_filter.GetInputFrameRate();
+	observation.actual_input_fps	= _fps_filter.GetInputFramesPerSecond();
+	observation.cadence_fps	= _fps_filter.GetOutputFrameRate();
+	observation.expected_output_fps	= _fps_filter.GetExpectedOutputFramesPerSecond();
+	observation.actual_output_fps	= _fps_filter.GetOutputFramesPerSecond();
 
-	auto curr_time = ov::Time::GetTimestampInMs();
-
-	if (_skip_frames_last_check_time == 0 || _skip_frames_last_changed_time == 0)
-	{
-		_skip_frames_last_check_time   = curr_time;
-		_skip_frames_last_changed_time = curr_time;
-	}
-
-	auto elapsed_check_time = curr_time - _skip_frames_last_check_time;
-	auto elapsed_stable_time = curr_time - _skip_frames_last_changed_time;
-
-	// Checking every 1 second is sufficient for skip frame adjustment
-	if (elapsed_check_time <= _SKIP_FRAMES_EVALUATION_INTERVAL_MS)
-	{
-		return;
-	}
-	_skip_frames_last_check_time = curr_time;
-
-	// Remain for debugging and future improvement for queue-based skip frame adjustment
-	// -----------------------------------------------------------------------------
-	// double actual_input_fps			   = _fps_filter.GetInputFramesPerSecond();
-	// double expected_input_fps		   = _fps_filter.GetInputFrameRate();
-
-	// double expected_output_fps		   = _fps_filter.GetExpectedOutputFramesPerSecond();
-
-	// int64_t queue_waiting_deviation_us = _input_buffer.GetWaitingTimeInUs();
-	// double expected_frame_interval_us  = (expected_input_fps > 0.0) ? (1000000.0 / expected_input_fps) : 0.0;
-	// bool is_queue_overload			   = (expected_frame_interval_us > 0.0) &&
-	// 						 (queue_waiting_deviation_us > expected_frame_interval_us * _SKIP_FRAMES_QUEUE_BACKLOG_RATIO);
-	// bool is_queue_stable = (expected_frame_interval_us > 0.0) &&
-	// 					   (queue_waiting_deviation_us < expected_frame_interval_us * _SKIP_FRAMES_QUEUE_RECOVERY_RATIO);
-
-	double fixed_output_fps			   = _fps_filter.GetOutputFrameRate();
-	double expected_output_fps		   = _fps_filter.GetExpectedOutputFramesPerSecond();
-	double actual_output_fps		   = _fps_filter.GetOutputFramesPerSecond();
-
-	if (_weighted_avg_frame_processing_time_us <= 0.0 || fixed_output_fps <= 0.0)
+	// Monotonic, not wall clock: the busy time this is divided against comes from
+	// steady_clock, and a system clock step would make the two disagree - stalling the
+	// evaluation while busy time piles up, then charging all of it to one window.
+	auto result = _skip_frames_controller.Evaluate(ov::Time::GetMonotonicTimestamp(), observation);
+	if (result.has_value() == false)
 	{
 		return;
 	}
 
-	// Calculate the maximum possible frames per second.
-	double max_frames_per_second = (1000000.0 / _weighted_avg_frame_processing_time_us);
-	// To ensure stability, set a margin and use OO% of the calculated maximum FPS.
-	double ideal_frames_per_second = max_frames_per_second * _SKIP_FRAMES_ENSURE_FPS_MARGIN_RATIO;
+	auto previous_skip_frames = _fps_filter.GetSkipFrames();
 
-	if (ideal_frames_per_second <= 0.0)
+	// All four lines lead with "SkipFrames <level>" so one grep follows a track through
+	// every state. Warn only where output actually degrades.
+	switch (result->decision)
 	{
-		// If the ideal FPS is not a positive value, skip frame cannot be performed.
-		return;
-	}
+		case SkipFramesController::Decision::Bottleneck:
+			logtw("[%s] SkipFrames %d -> %d, pipeline cannot keep up. %s", GetLogPrefix().CStr(), previous_skip_frames, result->skip_frames, result->metrics.CStr());
+			_fps_filter.SetSkipFrames(result->skip_frames);
+			break;
 
-	// Calculate number of skip frames value to match the ideal FPS.
-	auto next_skip_frames = static_cast<int32_t>(std::ceil(fixed_output_fps / ideal_frames_per_second - 1.0));
-	if (next_skip_frames > fixed_output_fps - 1)
-	{
-		next_skip_frames = static_cast<int32_t>(std::floor(fixed_output_fps - 1));
-	}
-	else if (next_skip_frames < FilterFps::SkipFramesMin)
-	{
-		next_skip_frames = FilterFps::SkipFramesMin;
-	}
+		case SkipFramesController::Decision::Recovery:
+			logti("[%s] SkipFrames %d -> %d, capacity came back. %s", GetLogPrefix().CStr(), previous_skip_frames, result->skip_frames, result->metrics.CStr());
+			_fps_filter.SetSkipFrames(result->skip_frames);
+			break;
 
-	ov::String common_log = ov::String::FormatString("Possible FPS: %.2f/%.2f(ideal), Output FPS: %.2f/%.2f/%.2f", max_frames_per_second, ideal_frames_per_second, fixed_output_fps, expected_output_fps, actual_output_fps);
+		// Both no-ops, and they fire once per second per track. Trace, so a debug-level
+		// deployment is not buried under a line per track per second.
+		case SkipFramesController::Decision::HoldRecovery:
+			logtt("[%s] SkipFrames %d, waiting out the recovery hold. %s", GetLogPrefix().CStr(), result->skip_frames, result->metrics.CStr());
+			break;
 
-	// Increase skip frames immediately when bottleneck occurs.
-	if (_skip_frames < next_skip_frames)
-	{
-		logtw("[%s] Changed SkipFrames %d -> %d (Bottleneck). %s", GetLogPrefix().CStr(), _skip_frames, next_skip_frames, common_log.CStr());
-
-		_skip_frames = next_skip_frames;
-		_fps_filter.SetSkipFrames(_skip_frames);
-
-		_skip_frames_last_changed_time = curr_time;
-	}
-	// Decrease skip frames slowly when the system is recovering.
-	else if ((_skip_frames > next_skip_frames))
-	{
-		if (elapsed_stable_time > _SKIP_FRAMES_RECOVERY_HOLD_INTERVAL_MS)
-		{
-			// Decay 20% per step (rate-limited)
-			int32_t rate_limited_next = _skip_frames - std::max(1, _skip_frames / 5);
-			next_skip_frames = std::max(rate_limited_next, next_skip_frames);
-			if (next_skip_frames < FilterFps::SkipFramesMin)
-			{
-				next_skip_frames = FilterFps::SkipFramesMin;
-			}
-
-			logti("[%s] Changed SkipFrames %d -> %d (Recovery). %s", GetLogPrefix().CStr(), _skip_frames, next_skip_frames, common_log.CStr());
-
-			_skip_frames = next_skip_frames;
-			_fps_filter.SetSkipFrames(_skip_frames);
-
-			_skip_frames_last_changed_time = curr_time;
-		}
-		else
-		{
-			logtt("[%s] Hold SkipFrames %d (Waiting for recovery). %s", GetLogPrefix().CStr(), _skip_frames, common_log.CStr());
-		}
-	}
-	// Keep skip frames unchanged when the system is stable.
-	else
-	{
-		logtt("[%s] Unchanged SkipFrames %d (Stable). %s", GetLogPrefix().CStr(), _skip_frames, common_log.CStr());
+		case SkipFramesController::Decision::Unchanged:
+			logtt("[%s] SkipFrames %d, steady. %s", GetLogPrefix().CStr(), result->skip_frames, result->metrics.CStr());
+			break;
 	}
 }
 #endif // _SKIP_FRAMES_ENABLED

--- a/src/transcoder/filter/filter_video_base.h
+++ b/src/transcoder/filter/filter_video_base.h
@@ -16,6 +16,7 @@
 #include "base/mediarouter/media_type.h"
 #include "filter_base.h"
 #include "filter_fps.h"
+#include "filter_skipframes_controller.h"
 
 #define _SKIP_FRAMES_ENABLED 1
 #define _SIMULATE_PROCESSING_DELAY_ENABLED 0
@@ -27,6 +28,9 @@ public:
 	FilterResult PopCompletedFrameInternal() override;
 	std::vector<std::shared_ptr<MediaFrame>> FlushBuffered() override;
 	void InheritContinuity(const FilterBase *previous) override;
+#if _SKIP_FRAMES_ENABLED
+	void AddHandoffTime(int64_t elapsed_us) override;
+#endif
 
 protected:
 	bool InitializeFpsFilter();
@@ -35,23 +39,10 @@ protected:
 	FilterFps _fps_filter;
 
 #if _SKIP_FRAMES_ENABLED
+	// Decides the skip level from the load this filter measures. Fed by the timing calls
+	// in PopCompletedFrameInternal(); applied to _fps_filter by UpdateSkipFrames().
+	SkipFramesController _skip_frames_controller;
+
 	void UpdateSkipFrames();
-
-	int64_t _skip_frames_last_check_time   = 0;
-	int64_t _skip_frames_last_changed_time = 0;
-
-	// Set initial Skip Frames
-	int32_t _skip_frames_conf			   = -1;
-	int32_t _skip_frames				   = -1;
 #endif
-
-
-	int64_t ElapsedTimeInUs(const std::chrono::steady_clock::time_point &start_time) const;
-	void UpdateProcessingTimePerFrame(const std::chrono::steady_clock::time_point &start_time);
-
-	// Weighted average of frame processing time.
-	double _weighted_avg_frame_processing_time_us = 0.0;
-
-	// Processing time that has not been charged to a completed frame yet.
-	int64_t _pending_processing_time_us = 0;
 };

--- a/src/transcoder/transcoder_filter.cpp
+++ b/src/transcoder/transcoder_filter.cpp
@@ -537,6 +537,7 @@ void TranscodeFilter::SetCompleteHandler(CompleteHandler complete_handler)
 
 void TranscodeFilter::OnComplete(TranscodeResult result, std::shared_ptr<MediaFrame> frame)
 {
+	auto handoff_start = std::chrono::steady_clock::now();
 
 	// Fault Injection for testing
 	if (TranscodeFaultInjector::GetInstance()->IsEnabled())
@@ -572,6 +573,12 @@ void TranscodeFilter::OnComplete(TranscodeResult result, std::shared_ptr<MediaFr
 	if (_complete_handler)
 	{
 		_complete_handler(result, _id, frame);
+	}
+
+	auto handoff_time_us = ov::Clock::GetElapsedMicroSecondsFromNow(handoff_start);
+	if (auto base = GetBaseFilter(); base != nullptr)
+	{
+		base->AddHandoffTime(handoff_time_us);
 	}
 }
 


### PR DESCRIPTION
## Summary

SkipFrames did not react when the encoder was the bottleneck: it only measured the filter's own work, so the level stayed at 0 while frames piled up in the decoder queue.
It now measures the wait on the encoder too, and checks itself against the input rate instead of the output rate it aims at.
The decision logic moves into its own file.

## Changes

**Load is measured as a per-frame budget.**

```
budget  = time filtering + time waiting on the handoff
max fps = 1000000 / budget
```

The filter thread blocks on the handoff when the encoder queue is full, so a slow encoder and a slow rescaler now throttle SkipFrames through the same number.

**The level is checked against the input rate.**
Skipping lowers the output target, so checking against that let the filter keep meeting a bar it had just lowered while the queue grew.

**Busy alone does not raise the level.**
The encoder queue is only two frames deep, so the handoff blocks even when the chain keeps up.
The level rises only when the thread is busy *and* losing input, and only after a second window agrees.

**Recovery is a probe.**
After 5s at one level it steps down 20%.
If that does not hold, the next window puts it back.

## Testing

Slow the encoder down and watch the filter react.
Each triggered frame sleeps 300ms, so 20% on a 30fps stream drops the encoder to about 10fps.

**1.** Turn on automatic SkipFrames:

```xml
<Encodes>
    <Video>
        <SkipFrames>0</SkipFrames>  <!-- 0 = auto, -1 = off, 1~120 = fixed -->
        <Framerate>30</Framerate>
    </Video>
</Encodes>
```

**2.** Start a 30fps stream, then inject the fault:

```bash
curl -u "$TOKEN:" -X POST \
  "http://<host>:8081/v2/internals/tests:setFaultInject" \
  -H 'Content-Type: application/json' \
  -d '{"transcoder":[{"targetComponent":"encoder","targetModule":"nv",
                      "targetDeviceId":0,"faultType":"LAGGING","faultRate":20}]}'
```

**3.** Watch the filter log. It should climb until the thread keeps up:

```
SkipFrames 0 -> 1, pipeline cannot keep up. Input: 10.7/30.0fps, Busy: 99.5%, Budget: 60.00ms (proc 0.25 + handoff 59.75), Capacity: 15.0fps, ...
SkipFrames 1 -> 2, ...
SkipFrames 2, steady. Input: 29.8/30.0fps, Busy: 90.1%, ...
```

Two things to check: `Input` returns to ~30/30fps, and the `dec_H264_t0` queue stops reporting `Exceeded`.

**4.** Clear the fault. SkipFrames should walk back to 0, one step per 5s:

```bash
curl -u "$TOKEN:" -X POST \
  "http://<host>:8081/v2/internals/tests:setFaultInject" \
  -H 'Content-Type: application/json' -d '{"transcoder":[]}'
```
