### PR TITLE
fix(provider): apply only operator-set timeouts before a push channel publishes

### DIFF
--- a/src/base/provider/push_provider/provider.cpp
+++ b/src/base/provider/push_provider/provider.cpp
@@ -110,11 +110,12 @@ namespace pvd
 
 	bool PushProvider::OnChannelCreated(uint32_t channel_id, const std::shared_ptr<pvd::PushStream> &channel)
 	{
+		// This must leave the silence timeout alone.
+		// `WebRTCProvider` registers its channel after `JoinStream()` has applied the configured value,
+		// so a write here would discard it.
 		std::lock_guard<std::shared_mutex> lock(_channels_lock);
 
 		_channels.emplace(channel_id, channel);
-
-		channel->SetPacketSilenceTimeoutMs(DEFAULT_PUSH_CHANNEL_PACKET_SILENCE_TIMEOUT_MS);
 
 		return true;
 	}

--- a/src/base/provider/push_provider/provider.h
+++ b/src/base/provider/push_provider/provider.h
@@ -18,8 +18,6 @@
 
 namespace pvd
 {
-	static constexpr time_t DEFAULT_PUSH_CHANNEL_PACKET_SILENCE_TIMEOUT_MS = 3000;
-
     class PushProvider : public Provider
     {
     public:

--- a/src/base/provider/push_provider/stream.cpp
+++ b/src/base/provider/push_provider/stream.cpp
@@ -217,9 +217,9 @@ namespace pvd
 			return;
 		}
 
-		// Only a positive value the operator set applies here. A provider default filled in during
-		// config parsing (MPEG-TS gets `1500` ms) is not the operator's intent, and an explicit `0`
-		// leaves the channel-creation default in place instead of removing the timeout altogether.
+		// Only a positive value the operator set applies here.
+		// A provider default filled in during config parsing (MPEG-TS gets `1500` ms) is not that,
+		// and `0` is what the channel already carries.
 		bool is_configured	  = false;
 		const auto timeout_ms = application->GetConfiguredPacketSilenceTimeoutMs(provider->GetProviderType(), &is_configured);
 
@@ -299,13 +299,10 @@ namespace pvd
 			return;
 		}
 
+		// This wait is sized for a source that has not sent anything yet, so it must not survive the first frame.
 		// Only a positive value the operator set governs from here,
-		// and everything else falls back to the channel-creation timeout.
-		// This wait is sized for a source that has not sent anything yet,
-		// so it must not survive the first frame.
-		SetPacketSilenceTimeoutMs((is_configured && (configured_ms > 0))
-									  ? configured_ms
-									  : DEFAULT_PUSH_CHANNEL_PACKET_SILENCE_TIMEOUT_MS);
+		// and everything else leaves the channel with no timeout until it publishes.
+		SetPacketSilenceTimeoutMs((is_configured && (configured_ms > 0)) ? configured_ms : 0);
 	}
 
 	bool PushStream::PublishChannel(const info::VHostAppName &vhost_app_name)

--- a/src/base/provider/push_provider/stream.h
+++ b/src/base/provider/push_provider/stream.h
@@ -90,7 +90,7 @@ namespace pvd
 
 		// Applies the `PacketSilenceTimeoutMs` configured for the resolved application, which providers
 		// call as soon as that application is known.
-		// An option the operator did not set leaves the channel-creation default in place.
+		// An option the operator did not set leaves the channel with no timeout.
 		void ApplyConfiguredPacketSilenceTimeoutMs(const info::VHostAppName &vhost_app_name);
 
 		// Sizes the wait for an input's first coded frame and starts it, when the operator set
@@ -101,7 +101,7 @@ namespace pvd
 		// Ends that wait. A provider calls this for a message holding a coded frame, never for a codec
 		// description, which an encoder can send long before its first frame.
 		// The channel is still unpublished, so the timeout becomes a positive `PacketSilenceTimeoutMs`
-		// the operator set, or the channel-creation timeout otherwise.
+		// the operator set, and no timeout at all otherwise.
 		// `PushApplication::JoinStream()` applies the configured value, `0` included, at publish.
 		void EndFirstMediaWait(const info::VHostAppName &vhost_app_name);
 

--- a/src/base/provider/push_provider/stream_lifecycle_test.cpp
+++ b/src/base/provider/push_provider/stream_lifecycle_test.cpp
@@ -312,16 +312,13 @@ TEST(PushStreamLifecycle, AnUnpublishedChannelSurvivesSilenceThatFollowsItsFirst
 
 	ASSERT_TRUE(f.provider->OnDataReceived(Fixture::CHANNEL_ID, f.MakeData()));
 
-	// The first packet is what gives this channel a measurable elapsed time.
-	std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
 	const auto state = f.channel->GetSilenceState();
 
-	// The budget itself, not only the verdict:
-	// a channel carrying one would reach the same verdict this early,
-	// so without this the test says nothing about which budget it is carrying.
-	EXPECT_EQ(state.timeout_ms, 0);
+	// The first packet started the clock, so the runner now has an elapsed time it could judge.
+	// What stops it is the budget, and a channel carrying one would reach the same verdict this early,
+	// so without that second assertion the test says nothing about which budget it is carrying.
 	EXPECT_GE(state.elapsed_ms, 0);
+	EXPECT_EQ(state.timeout_ms, 0);
 	EXPECT_FALSE(state.IsSilentBeyondTimeout());
 }
 

--- a/src/base/provider/push_provider/stream_lifecycle_test.cpp
+++ b/src/base/provider/push_provider/stream_lifecycle_test.cpp
@@ -297,11 +297,56 @@ namespace
 	};
 }  // namespace
 
-TEST(PushStreamLifecycle, ChannelStartsWithTheCreationDefaultTimeout)
+TEST(PushStreamLifecycle, ChannelStartsWithNoSilenceTimeout)
 {
 	Fixture f;
 
-	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), pvd::DEFAULT_PUSH_CHANNEL_PACKET_SILENCE_TIMEOUT_MS);
+	// A budget here deletes an input that is still signalling,
+	// before anything has told the channel what the operator wants.
+	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), 0);
+}
+
+TEST(PushStreamLifecycle, AnUnpublishedChannelSurvivesSilenceThatFollowsItsFirstData)
+{
+	Fixture f;
+
+	ASSERT_TRUE(f.provider->OnDataReceived(Fixture::CHANNEL_ID, f.MakeData()));
+
+	// The first packet is what gives this channel a measurable elapsed time.
+	std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+	const auto state = f.channel->GetSilenceState();
+
+	// The budget itself, not only the verdict:
+	// a channel carrying one would reach the same verdict this early,
+	// so without this the test says nothing about which budget it is carrying.
+	EXPECT_EQ(state.timeout_ms, 0);
+	EXPECT_GE(state.elapsed_ms, 0);
+	EXPECT_FALSE(state.IsSilentBeyondTimeout());
+}
+
+TEST(PushStreamLifecycle, AConfiguredTimeoutStillGovernsAnUnpublishedChannel)
+{
+	Fixture f;
+
+	const auto vhost_app_name = f.CreateApplication("<PacketSilenceTimeoutMs>4000</PacketSilenceTimeoutMs>");
+	ASSERT_TRUE(vhost_app_name.IsValid());
+
+	f.channel->ApplyConfiguredPacketSilenceTimeoutMs(vhost_app_name);
+
+	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), 4000);
+}
+
+TEST(PushStreamLifecycle, AnAbsentTimeoutOptionLeavesAnUnpublishedChannelUnguarded)
+{
+	Fixture f;
+
+	const auto vhost_app_name = f.CreateApplication("");
+	ASSERT_TRUE(vhost_app_name.IsValid());
+
+	f.channel->ApplyConfiguredPacketSilenceTimeoutMs(vhost_app_name);
+
+	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), 0);
 }
 
 TEST(PushStreamLifecycle, ChannelWithoutDataIsNeverSilentBeyondItsTimeout)
@@ -443,7 +488,8 @@ TEST(PushStreamLifecycle, EndingTheFirstMediaWaitKeepsTheTimeoutWhenTheApplicati
 
 	// A name that resolves to nothing, which is also what a channel sees
 	// when its application is deleted while it waits.
-	// Losing the budget here would leave the channel with no guard at all.
+	// A lookup that failed has learned nothing about what should govern from here,
+	// so it must leave the wait exactly as it found it.
 	f.channel->EndFirstMediaWait(info::VHostAppName::InvalidVHostAppName());
 
 	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), 8000);
@@ -451,7 +497,7 @@ TEST(PushStreamLifecycle, EndingTheFirstMediaWaitKeepsTheTimeoutWhenTheApplicati
 	// The failed lookup must not have spent the wait either, so the next packet still ends it.
 	f.channel->EndFirstMediaWait(vhost_app_name);
 
-	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), pvd::DEFAULT_PUSH_CHANNEL_PACKET_SILENCE_TIMEOUT_MS);
+	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), 0);
 }
 
 TEST(PushStreamLifecycle, AnAbsentFirstMediaWaitOptionChangesNothing)
@@ -461,14 +507,14 @@ TEST(PushStreamLifecycle, AnAbsentFirstMediaWaitOptionChangesNothing)
 	const auto vhost_app_name = f.CreateApplication("");
 	ASSERT_TRUE(vhost_app_name.IsValid());
 
-	// With the option off, this leaves the channel on the timeout it was created with, and never starts
-	// the wait, so the first media packet has nothing to end.
+	// With the option off this applies `PacketSilenceTimeoutMs`, which this application does not set,
+	// and it never starts the wait, so the first media packet has nothing to end.
 	f.channel->ApplyConfiguredFirstMediaWaitTimeoutMs(vhost_app_name);
-	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), pvd::DEFAULT_PUSH_CHANNEL_PACKET_SILENCE_TIMEOUT_MS);
+	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), 0);
 
 	f.channel->EndFirstMediaWait(vhost_app_name);
 
-	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), pvd::DEFAULT_PUSH_CHANNEL_PACKET_SILENCE_TIMEOUT_MS);
+	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), 0);
 }
 
 TEST(PushStreamLifecycle, AnAbsentFirstMediaWaitOptionStillHonorsPacketSilenceTimeoutMs)
@@ -484,7 +530,7 @@ TEST(PushStreamLifecycle, AnAbsentFirstMediaWaitOptionStillHonorsPacketSilenceTi
 	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), 4000);
 }
 
-TEST(PushStreamLifecycle, FirstMediaEndsTheWaitOnTheUnpublishedFallbackWhenTheTimeoutIsExplicitlyZero)
+TEST(PushStreamLifecycle, FirstMediaLeavesTheChannelUnguardedWhenTheTimeoutIsExplicitlyZero)
 {
 	Fixture f;
 
@@ -494,10 +540,9 @@ TEST(PushStreamLifecycle, FirstMediaEndsTheWaitOnTheUnpublishedFallbackWhenTheTi
 	f.channel->ApplyConfiguredFirstMediaWaitTimeoutMs(vhost_app_name);
 	f.channel->EndFirstMediaWait(vhost_app_name);
 
-	// An explicit `0` disables the timeout for a published stream.
-	// Honoring it here would leave an unpublished channel with no guard at all,
-	// so it holds its connection for as long as it likes.
-	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), pvd::DEFAULT_PUSH_CHANNEL_PACKET_SILENCE_TIMEOUT_MS);
+	// The wait was sized for a source that had sent nothing, and the first frame has now arrived,
+	// so it must not survive. Nothing the operator did not ask for may take its place either.
+	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), 0);
 }
 
 TEST(PushStreamLifecycle, FirstMediaEndsTheWaitOnAnOperatorConfiguredTimeout)
@@ -525,7 +570,7 @@ TEST(PushStreamLifecycle, MediaThatArrivesBeforeTheWaitIsSizedDoesNotConsumeIt)
 	// A message dispatcher hands media to a channel whether or not it has asked to publish yet,
 	// so this can run before the provider sized the wait.
 	f.channel->EndFirstMediaWait(vhost_app_name);
-	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), pvd::DEFAULT_PUSH_CHANNEL_PACKET_SILENCE_TIMEOUT_MS);
+	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), 0);
 
 	f.channel->ApplyConfiguredFirstMediaWaitTimeoutMs(vhost_app_name);
 	EXPECT_EQ(f.channel->GetPacketSilenceTimeoutMs(), 8000);

--- a/src/providers/webrtc/webrtc_provider.cpp
+++ b/src/providers/webrtc/webrtc_provider.cpp
@@ -597,15 +597,13 @@ namespace pvd
 			return false;
 		}
 
+		// This provider calls `PublishChannel()` before this,
+		// and channel creation leaves the silence timeout alone,
+		// so the value `JoinStream()` applied is the one this channel runs on.
 		if (OnChannelCreated(stream->GetId(), stream) == false)
 		{
 			return false;
 		}
-
-		// This provider calls `PublishChannel()` before `OnChannelCreated()`, so the value
-		// `JoinStream()` applied has just been overwritten with the channel-creation default.
-		// Re-apply the configured one.
-		stream->ApplyConfiguredPacketSilenceTimeoutMs(final_vhost_app_name);
 
 		RegisterStreamToSessionKeyStreamMap(stream);
 
@@ -896,15 +894,13 @@ namespace pvd
 			return {http::StatusCode::InternalServerError, "Could not publish stream"};
 		}
 
+		// This provider calls `PublishChannel()` before this,
+		// and channel creation leaves the silence timeout alone,
+		// so the value `JoinStream()` applied is the one this channel runs on.
 		if (OnChannelCreated(stream->GetId(), stream) == false)
 		{
 			return {http::StatusCode::InternalServerError, "Could not publish stream"};
 		}
-
-		// This provider calls `PublishChannel()` before `OnChannelCreated()`, so the value
-		// `JoinStream()` applied has just been overwritten with the channel-creation default.
-		// Re-apply the configured one.
-		stream->ApplyConfiguredPacketSilenceTimeoutMs(final_vhost_app_name);
 
 		RegisterStreamToSessionKeyStreamMap(stream);
 


### PR DESCRIPTION
## Summary

`PushProvider::OnChannelCreated()` seeded every channel with a hard-coded 3000 ms
`PacketSilenceTimeoutMs`. That write was inert until `fbff83737`: the silence timer was an
`ov::StopWatch` started only by `PushStream::PublishChannel()`, so `Elapsed()` returned `-1` before
publish and `ChannelTaskRunner()` could never act on it. Replacing the stop watch with an atomic
timestamp removed the notion of "started" and brought the default to life across the whole pre-publish
window, deleting live inputs three seconds into a window nobody had configured.

This PR removes the default. Before publish a channel is governed only by what the operator set, a
positive `PacketSilenceTimeoutMs` or a `FirstMediaWaitTimeoutMs`; with neither it carries no timeout.
The value `JoinStream()` applies at publish, an explicit `0` and provider config defaults included, is
unchanged. This is v0.20.5's pre-publish behaviour with the opt-ins added since left intact.

## Changes

- Removed `DEFAULT_PUSH_CHANNEL_PACKET_SILENCE_TIMEOUT_MS` and the `SetPacketSilenceTimeoutMs()` call it
  fed in `PushProvider::OnChannelCreated()`. A comment there records that leaving the timeout alone is a
  contract the WebRTC provider depends on.
- `PushStream::EndFirstMediaWait()` falls back to `0` instead of that default.
- Dropped the re-apply workaround from `WebRTCProvider::OnAddRemoteDescription()` and `OnSdpOffer()`
  (WHIP). That provider registers its channel after `JoinStream()` has applied the configured value, so
  the creation-time write used to discard it. There is nothing left to undo.
- `stream_lifecycle_test.cpp`: four new cases, plus five existing expectations moved from the
  creation-time default to `0`.

## Behaviour

`unset` means the application declares no `PacketSilenceTimeoutMs` for that provider.

| Provider | Window | Before | After |
| --- | --- | --- | --- |
| RTMP | accept until `publish` resolves the application | 3000 ms | none |
| RTMP | first coded frame until publish, `unset` | 3000 ms | none |
| MPEG-TS, SRT | application known until publish, `unset` | 3000 ms | none |
| WebRTC, WHIP | whole channel life, `unset` | 3000 ms | none, `<WebRTC><Timeout>` still applies |
| all | a positive value set, or after publish | unchanged | unchanged |

## Configuration

No config element changes, and the value applied at publish is the same as before. What changes is the
effective value while a channel is still unpublished.

```xml
<Application>
    <Providers>
        <RTMP>
            <!-- Takes effect once the `publish` command resolves the application, and stays in effect
                 after publish. Unset leaves the window before publish unbounded.
                 When `FirstMediaWaitTimeoutMs` is set, it governs until the first coded frame instead. -->
            <PacketSilenceTimeoutMs>4000</PacketSilenceTimeoutMs>
        </RTMP>
    </Providers>
</Application>
```

Two pre-existing details this makes visible:

- Only a value the operator wrote counts before publish. MPEG-TS gets `1500` filled in during config
  parsing and `ApplyConfiguredPacketSilenceTimeoutMs()` skips it, so writing that same `1500` explicitly
  behaves differently from relying on the default.
- RTMP cannot apply the value until the `publish` command resolves the application, since vhost/app is
  unknown at TCP accept. The handshake and `connect` phase is unbounded either way.

## Known residual

An MPEG-TS/UDP channel that receives bytes but never reaches `Publish()`, say a sender whose PAT/PMT
never completes, stays in the pre-publish window and with no explicit `PacketSilenceTimeoutMs` is never
reaped, since UDP has no disconnect notification either. This matches v0.20.5, the port keeps working
because the next sender reuses the channel, and one config line bounds it. Tracked separately.

## Testing

### Unit tests

```bash
cmake -B build/Debug -S . -DCMAKE_BUILD_TYPE=Debug -DOME_BUILD_TESTS=ON -G Ninja
cmake --build build/Debug --target ome_test_base
ctest --test-dir build/Debug -L base -R 'PushStreamLifecycle'
```

32 tests pass. `ChannelStartsWithNoSilenceTimeout`,
`AnUnpublishedChannelSurvivesSilenceThatFollowsItsFirstData`,
`AConfiguredTimeoutStillGovernsAnUnpublishedChannel`,
`AnAbsentTimeoutOptionLeavesAnUnpublishedChannelUnguarded` and
`FirstMediaLeavesTheChannelUnguardedWhenTheTimeoutIsExplicitlyZero` pin this change.

### Manual verification

Two applications, one without the option and one with it, so the same input can be run against both:

```xml
<Application>
    <Name>app</Name>
    <Providers>
        <RTMP />
        <WebRTC />
        <MPEGTS>
            <StreamMap><Stream><Name>ts_default</Name><Port>4000</Port></Stream></StreamMap>
        </MPEGTS>
    </Providers>
</Application>
<Application>
    <Name>app_cfg</Name>
    <Providers>
        <RTMP><PacketSilenceTimeoutMs>2000</PacketSilenceTimeoutMs></RTMP>
        <WebRTC><PacketSilenceTimeoutMs>2000</PacketSilenceTimeoutMs></WebRTC>
        <MPEGTS>
            <PacketSilenceTimeoutMs>2000</PacketSilenceTimeoutMs>
            <StreamMap><Stream><Name>ts_cfg</Name><Port>4001</Port></Stream></StreamMap>
        </MPEGTS>
    </Providers>
</Application>
```

Every case is read off the one line `ChannelTaskRunner()` logs when it deletes a channel. The thread name
identifies the reaper, which matters when another layer could also be responsible:

```
Channel <id> is timed out, <elapsed> ms elapsed since last received, deleting it
```

**1. RTMP stalling after the handshake is no longer reaped.** Handshake, then go silent without sending
`connect`, so the application is never resolved:

```python
import os, socket, time

s = socket.create_connection(('127.0.0.1', 1935))
s.sendall(bytes([3]) + b'\x00' * 8 + os.urandom(1528))   # C0 + C1
buf = b''
while len(buf) < 3073:                                    # S0 + S1 + S2
    buf += s.recv(4096)
s.sendall(buf[1:1537])                                    # C2
time.sleep(12)
```

Nothing is logged; the channel goes away only when the socket closes. Before this change it was deleted
about 3 s after the last handshake byte.

**2. MPEG-TS/UDP that never reaches `Publish()`.** Send TS packets whose PID is neither a PAT nor a PMT:

```python
import socket, time

pkt = bytes([0x47, 0x01, 0x00, 0x10]) + bytes(184)        # sync byte, PID 0x100
s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
for _ in range(20):
    s.sendto(pkt * 7, ('127.0.0.1', 4000))
    time.sleep(0.05)
```

Port 4000 (`app`) logs nothing. Port 4001 (`app_cfg`) logs a deletion at about 2000 ms, the configured
value taking effect before publish.

**3. A published stream is unaffected.**

```bash
ffmpeg -re -i src.mp4 -c copy -f mpegts udp://127.0.0.1:4000
```

Deletion at about 1500 ms after the sender stops, the MPEG-TS config default `JoinStream()` applies.

**4. WebRTC and WHIP.** Publish, then let the peer connection die. `app` logs nothing and the session is
torn down by `<WebRTC><Timeout>` at 30 s. `app_cfg` logs a deletion at about 2000 ms. That 2000 rather
than 3000 is what shows the value `JoinStream()` applied survives channel registration, which is why the
re-apply workaround could go.

The clock is refreshed by every non-STUN packet, RTCP included, so stopping the outgoing tracks alone
does not trigger it; the peer has to stop responding. FFmpeg's `whip` muxer cannot drive this because it
offers `a=setup:passive`, which OME rejects. A browser `RTCPeerConnection` posting to
`http://<host>:3333/<app>/<stream>?direction=whip` works, and headless Chrome with
`--use-fake-device-for-media-stream --use-fake-ui-for-media-stream` is enough.

**5. SRT.**

```bash
ffmpeg -re -i src.mp4 -c copy -f mpegts "srt://127.0.0.1:9999?streamid=srt://127.0.0.1:9999/app/srt_test"
```

Removed by the SRT socket layer on disconnect, not by `ChannelTaskRunner()`. The deleting thread name
tells them apart: `SPSRT-s9999` rather than `PTimer-SRT`.

### Not covered by the manual steps

The fallback in `PushStream::EndFirstMediaWait()` is covered by unit tests only; holding a channel in
that window from outside needs an RTMP client that sends `publish` and then a media message with
incomplete codec information, since in practice ending the wait and publishing happen on the same
message. Behaviour before this change was not re-measured against a `master` build, but steps 1 and 2
show an unconfigured channel is not reaped and steps 2 and 4 show a configured one is, which exercises
both sides of the decision.
