### PR TITLE
refactor(transcoder): rename the NETINT hardware module from nilogan to ni

### DIFF
--- a/src/base/mediarouter/media_type.h
+++ b/src/base/mediarouter/media_type.h
@@ -130,7 +130,7 @@ namespace cmn
 		X264,	   // SW
 		NVENC,	   // HW
 		XMA,	   // HW
-		NILOGAN,   // HW
+		NETINT,	   // HW
 		LIBVPX,	   // SW
 		LIBAOM,	   // SW
 		FDKAAC,	   // SW
@@ -148,7 +148,7 @@ namespace cmn
 			OV_CASE_RETURN_ENUM_STRING(MediaCodecModuleId, X264);
 			OV_CASE_RETURN_ENUM_STRING(MediaCodecModuleId, NVENC);
 			OV_CASE_RETURN_ENUM_STRING(MediaCodecModuleId, XMA);
-			OV_CASE_RETURN_ENUM_STRING(MediaCodecModuleId, NILOGAN);
+			OV_CASE_RETURN_ENUM_STRING(MediaCodecModuleId, NETINT);
 			OV_CASE_RETURN_ENUM_STRING(MediaCodecModuleId, LIBVPX);
 			OV_CASE_RETURN_ENUM_STRING(MediaCodecModuleId, LIBAOM);
 			OV_CASE_RETURN_ENUM_STRING(MediaCodecModuleId, FDKAAC);
@@ -505,9 +505,9 @@ namespace cmn
 		{
 			return cmn::MediaCodecModuleId::NVENC;
 		}
-		else if (name.HasSuffix("_NILOGAN") || name.HasSuffix("NILOGAN"))
+		else if (name.HasSuffix("_NI") || name.HasSuffix("NI"))
 		{
-			return cmn::MediaCodecModuleId::NILOGAN;
+			return cmn::MediaCodecModuleId::NETINT;
 		}
 		else if (name.HasSuffix("_XMA") || name.HasSuffix("XMA"))
 		{
@@ -544,7 +544,7 @@ namespace cmn
 			OV_CASE_RETURN(MediaCodecModuleId::DEFAULT, "default");
 			OV_CASE_RETURN(MediaCodecModuleId::OPENH264, "openh264");
 			OV_CASE_RETURN(MediaCodecModuleId::NVENC, "nv");
-			OV_CASE_RETURN(MediaCodecModuleId::NILOGAN, "nilogan");
+			OV_CASE_RETURN(MediaCodecModuleId::NETINT, "ni");
 			OV_CASE_RETURN(MediaCodecModuleId::XMA, "xma");
 			OV_CASE_RETURN(MediaCodecModuleId::LIBVPX, "libvpx");
 			OV_CASE_RETURN(MediaCodecModuleId::LIBAOM, "libaom");
@@ -566,7 +566,7 @@ namespace cmn
 		{
 			case cmn::MediaCodecModuleId::NVENC:
 			case cmn::MediaCodecModuleId::XMA:
-			case cmn::MediaCodecModuleId::NILOGAN:
+			case cmn::MediaCodecModuleId::NETINT:
 				return true;
 			default:
 				break;

--- a/src/base/mediarouter/media_type.h
+++ b/src/base/mediarouter/media_type.h
@@ -505,7 +505,7 @@ namespace cmn
 		{
 			return cmn::MediaCodecModuleId::NVENC;
 		}
-		else if (name.HasSuffix("_NI") || name.HasSuffix("NI"))
+		else if (name.HasSuffix("_NI") || name.HasSuffix("NI") || name.HasSuffix("_NETINT") || name.HasSuffix("NETINT"))
 		{
 			return cmn::MediaCodecModuleId::NETINT;
 		}

--- a/src/transcoder/filter/filter_lavfi_rescaler.cpp
+++ b/src/transcoder/filter/filter_lavfi_rescaler.cpp
@@ -57,7 +57,7 @@ bool FilterLavfiRescaler::BuildDescription(ov::String &desc)
 			desc.Clear();
 		}
 		break;
-		case cmn::MediaCodecModuleId::NILOGAN:	
+		case cmn::MediaCodecModuleId::NETINT:	
 		default: {
 			logtw("Unsupported input module: %s", cmn::GetCodecModuleIdString(input_module_id));
 			desc.Clear();

--- a/src/transcoder/transcoder_decoder.cpp
+++ b/src/transcoder/transcoder_decoder.cpp
@@ -56,7 +56,7 @@ std::shared_ptr<std::vector<std::shared_ptr<info::CodecCandidate>>> TranscodeDec
 		{
 			desire_modules.push_back(ov::String::FormatString("%s:%d", "XMA", ALL_GPU_ID));
 			desire_modules.push_back(ov::String::FormatString("%s:%d", "NV", ALL_GPU_ID));
-			desire_modules.push_back(ov::String::FormatString("%s:%d", "NILOGAN", ALL_GPU_ID));
+			desire_modules.push_back(ov::String::FormatString("%s:%d", "NI", ALL_GPU_ID));
 		}
 
 		desire_modules.push_back(ov::String::FormatString("%s:%d", DEFAULT_MODULE_NAME, ALL_GPU_ID));

--- a/src/transcoder/transcoder_encoder.cpp
+++ b/src/transcoder/transcoder_encoder.cpp
@@ -74,7 +74,7 @@ std::shared_ptr<std::vector<std::shared_ptr<info::CodecCandidate>>> TranscodeEnc
 		{
 			desire_modules.push_back(ov::String::FormatString("%s:%d", "XMA", ALL_GPU_ID));
 			desire_modules.push_back(ov::String::FormatString("%s:%d", "NV", ALL_GPU_ID));
-			desire_modules.push_back(ov::String::FormatString("%s:%d", "NILOGAN", ALL_GPU_ID));
+			desire_modules.push_back(ov::String::FormatString("%s:%d", "NI", ALL_GPU_ID));
 		}
 
 		desire_modules.push_back(ov::String::FormatString("%s:%d", DEFAULT_MODULE_NAME, ALL_GPU_ID));

--- a/src/transcoder/transcoder_gpu.cpp
+++ b/src/transcoder/transcoder_gpu.cpp
@@ -31,7 +31,7 @@ TranscodeGPU::TranscodeGPU()
 {
 	for (int i = 0; i < MAX_DEVICE_COUNT; i++)
 	{
-		_device_context_nilogan[i].reset();
+		_device_context_ni[i].reset();
 		_device_context_nv[i].reset();
 	}
 	_initialized = false;
@@ -69,10 +69,10 @@ bool TranscodeGPU::Initialize()
 		logtd("No supported Xilinx Media accelerator");
 	}
 
-	// NILOGAN
-	if (CheckSupportedNILOGAN() == true)
+	// NI
+	if (CheckSupportedNI() == true)
 	{
-		logti("Supported Netint VPU accelerator. Number of devices(%d)", GetDeviceCount(cmn::MediaCodecModuleId::NILOGAN));
+		logti("Supported Netint VPU accelerator. Number of devices(%d)", GetDeviceCount(cmn::MediaCodecModuleId::NETINT));
 	}
 	else
 	{
@@ -96,7 +96,7 @@ bool TranscodeGPU::Uninitialize()
 	for (int i = 0; i < MAX_DEVICE_COUNT; i++)
 	{
 		_device_context_nv[i].reset();
-		_device_context_nilogan[i].reset();
+		_device_context_ni[i].reset();
 	}
 
 	_supported_devices.clear();
@@ -112,8 +112,8 @@ bool TranscodeGPU::IsSupported(cmn::MediaCodecModuleId id, cmn::DeviceId gpu_id)
 {
 	switch (id)
 	{
-		case cmn::MediaCodecModuleId::NILOGAN:
-			return IsSupportedNILOGAN(gpu_id);
+		case cmn::MediaCodecModuleId::NETINT:
+			return IsSupportedNI(gpu_id);
 		case cmn::MediaCodecModuleId::NVENC:
 			return IsSupportedNV(gpu_id);
 		case cmn::MediaCodecModuleId::XMA:
@@ -129,8 +129,8 @@ int32_t TranscodeGPU::GetDeviceCount(cmn::MediaCodecModuleId id)
 {
 	switch (id)
 	{
-		case cmn::MediaCodecModuleId::NILOGAN:
-			return GetDeviceCountNILOGAN();
+		case cmn::MediaCodecModuleId::NETINT:
+			return GetDeviceCountNI();
 		case cmn::MediaCodecModuleId::NVENC:
 			return GetDeviceCountNV();
 		case cmn::MediaCodecModuleId::XMA:
@@ -146,8 +146,8 @@ std::shared_ptr<HwDeviceContext> TranscodeGPU::GetDeviceContext(cmn::MediaCodecM
 {
 	switch (id)
 	{
-		case cmn::MediaCodecModuleId::NILOGAN:
-			return GetDeviceContextNILOGAN(gpu_id);
+		case cmn::MediaCodecModuleId::NETINT:
+			return GetDeviceContextNI(gpu_id);
 		case cmn::MediaCodecModuleId::NVENC:
 			return GetDeviceContextNV(gpu_id);
 		case cmn::MediaCodecModuleId::XMA:
@@ -179,8 +179,8 @@ ov::String TranscodeGPU::GetDeviceDisplayName(cmn::MediaCodecModuleId id, cmn::D
 
 	switch (id)
 	{
-		case cmn::MediaCodecModuleId::NILOGAN:
-			return _device_display_name_nilogan[gpu_id];
+		case cmn::MediaCodecModuleId::NETINT:
+			return _device_display_name_ni[gpu_id];
 		case cmn::MediaCodecModuleId::NVENC:
 			return _device_display_name_nv[gpu_id];
 		case cmn::MediaCodecModuleId::XMA:
@@ -211,9 +211,9 @@ ov::String TranscodeGPU::GetDeviceBusId(cmn::MediaCodecModuleId id, cmn::DeviceI
 	return "Unknown";
 }
 
-int32_t TranscodeGPU::GetDeviceCountNILOGAN()
+int32_t TranscodeGPU::GetDeviceCountNI()
 {
-	return _device_count_nilogan;
+	return _device_count_ni;
 }
 
 int32_t TranscodeGPU::GetDeviceCountNV()
@@ -434,21 +434,21 @@ bool TranscodeGPU::CheckSupportedXMA()
 #endif
 }
 
-bool TranscodeGPU::CheckSupportedNILOGAN()
+bool TranscodeGPU::CheckSupportedNI()
 {
-	_device_count_nilogan = 0;
+	_device_count_ni = 0;
 
 	return false;
 }
 
-std::shared_ptr<HwDeviceContext> TranscodeGPU::GetDeviceContextNILOGAN(cmn::DeviceId gpu_id)
+std::shared_ptr<HwDeviceContext> TranscodeGPU::GetDeviceContextNI(cmn::DeviceId gpu_id)
 {
 	if (gpu_id >= MAX_DEVICE_COUNT)
 	{
 		return nullptr;
 	}
 
-	return _device_context_nilogan[gpu_id];
+	return _device_context_ni[gpu_id];
 }
 
 std::shared_ptr<HwDeviceContext> TranscodeGPU::GetDeviceContextNV(cmn::DeviceId gpu_id)
@@ -473,9 +473,9 @@ int32_t TranscodeGPU::GetDeviceIdNV(cmn::DeviceId gpu_id)
 	return _device_cuda_id_nv[gpu_id];
 }
 
-bool TranscodeGPU::IsSupportedNILOGAN(cmn::DeviceId gpu_id)
+bool TranscodeGPU::IsSupportedNI(cmn::DeviceId gpu_id)
 {
-	if (_device_count_nilogan == 0 || gpu_id >= _device_count_nilogan)
+	if (_device_count_ni == 0 || gpu_id >= _device_count_ni)
 	{
 		return false;
 	}

--- a/src/transcoder/transcoder_gpu.h
+++ b/src/transcoder/transcoder_gpu.h
@@ -38,18 +38,18 @@ public:
 	ov::String GetDeviceBusId(cmn::MediaCodecModuleId id, cmn::DeviceId gpu_id = 0);
 
 protected:
-	bool CheckSupportedNILOGAN();
+	bool CheckSupportedNI();
 	bool CheckSupportedNV();
 	bool CheckSupportedXMA();
 
-	std::shared_ptr<HwDeviceContext> GetDeviceContextNILOGAN(cmn::DeviceId gpu_id = 0);
+	std::shared_ptr<HwDeviceContext> GetDeviceContextNI(cmn::DeviceId gpu_id = 0);
 	std::shared_ptr<HwDeviceContext> GetDeviceContextNV(cmn::DeviceId gpu_id = 0);
 
-	bool IsSupportedNILOGAN(cmn::DeviceId gpu_id = 0);
+	bool IsSupportedNI(cmn::DeviceId gpu_id = 0);
 	bool IsSupportedNV(cmn::DeviceId gpu_id = 0);
 	bool IsSupportedXMA(cmn::DeviceId gpu_id = 0);
 
-	int32_t GetDeviceCountNILOGAN();
+	int32_t GetDeviceCountNI();
 	int32_t GetDeviceCountNV();
 	int32_t GetDeviceCountXMA();
 
@@ -63,9 +63,9 @@ protected:
 	ov::String _device_display_name_xma[MAX_DEVICE_COUNT];
 	ov::String _device_bus_id_xma[MAX_DEVICE_COUNT];
 	
-	std::shared_ptr<HwDeviceContext> _device_context_nilogan[MAX_DEVICE_COUNT];
-	ov::String _device_display_name_nilogan[MAX_DEVICE_COUNT];
-	int32_t _device_count_nilogan;
+	std::shared_ptr<HwDeviceContext> _device_context_ni[MAX_DEVICE_COUNT];
+	ov::String _device_display_name_ni[MAX_DEVICE_COUNT];
+	int32_t _device_count_ni;
 
 	std::shared_ptr<HwDeviceContext> _device_context_nv[MAX_DEVICE_COUNT];
 	ov::String _device_display_name_nv[MAX_DEVICE_COUNT];


### PR DESCRIPTION
## Summary

The NETINT module was named after `nilogan`, the vendor's legacy Logan SDK. It is renamed to
`ni`, matching the short names the other accelerators use (`nv`, `xma`).

This is a breaking configuration change. `nilogan` is no longer accepted.

## Changes

- Configuration name: `nilogan` → `ni` (`<Modules>ni:0</Modules>`, `<Codec>h264_ni</Codec>`)
- Enum constant: `MediaCodecModuleId::NILOGAN` → `MediaCodecModuleId::NETINT` (position unchanged)
- `TranscodeGPU` members: `*NILOGAN()` → `*NI()`, `_*_nilogan` → `_*_ni`, following `nv` / `xma`
- API `codecModule` / `module` values now report `ni`

## Testing

None.