### PR TITLE
build: parallelize the openh264 build

### DIFF
--- a/cmake/InstallPrerequisites.cmake
+++ b/cmake/InstallPrerequisites.cmake
@@ -469,7 +469,7 @@ set(_install_libopenh264 "
 mkdir -p ${TEMP_PATH}/openh264 && cd ${TEMP_PATH}/openh264 &&
 ome_fetch ${OPENH264_SOURCE_URL} &&
 sed -i -e 's|PREFIX=/usr/local|PREFIX=${PREFIX}|' Makefile &&
-make OS=linux && sudo make install && rm -rf ${TEMP_PATH}/openh264
+make ${_J} OS=linux && sudo make install && rm -rf ${TEMP_PATH}/openh264
 ")
 
 # ---- x264 (optional) ----


### PR DESCRIPTION
The below is Claude-written (as is the change).

`InstallPrerequisites.cmake` builds every dependency with the parallel job count except openh264, whose `make` runs serially. This adds `${_J}` there like the other recipes.

Measured on a 16-thread machine: the openh264 step drops from ~35-53 s to ~10-12 s, and a full `--no-cache` Docker build was ~30 s faster.
