### PR TITLE
build: add .dockerignore for a cacheable build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Everything here is provably unread by the docker build; excluding it keeps
+# the COPY layer cache keyed to real build inputs. With .git excluded,
+# USE_LOCAL=true builds cannot run git describe; run
+# src/main/update_git_info.sh on the host first to keep the version stamp.
+.git
+.gitignore
+.dockerignore
+Dockerfile
+.github
+.gitbook.yaml
+docs
+dist
+api
+*.md
+docker-compose.yml
+ome_favicon.svg
+misc/install_*.sh
+misc/ome_docker_launcher.sh
+misc/oven_rtc_tester
+misc/generate_signed_policy.py
+misc/*signed_policy_url_generator.*
+misc/ovenmedia_policy_generator_golang
+src/.clang-format
+src/third_party/pugixml-1.9/docs
+src/third_party/pugixml-1.9/scripts
+src/third_party/expected-1.3.1/tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@
 #
 # 2. To build using the [local source code]
 #    $ docker build -t ovenmediaengine:dev -f Dockerfile --build-arg USE_LOCAL=true .
+#    (.dockerignore excludes .git; run src/main/update_git_info.sh first to keep
+#     the full version stamp in the binary)
 #
 # 3. To build with NVIDIA/CUDA support
 #    $ docker build -t ovenmediaengine:dev -f Dockerfile --build-arg USE_GPU=true .


### PR DESCRIPTION
The below is Claude-written but edited by naanlizard (as is the change).

### Problem

The Dockerfile copies the whole build context (`COPY . ${TEMP_LOCAL_DIR}`) before the
dependency install and the compile. Without a `.dockerignore` the context includes
`.git`, which changes on every commit and rebase, so both steps miss cache even when no
source file changed; documentation edits bust them the same way.

Beyond `.git`, a few other build-unused files are ignored. I can't claim it is
exhaustive but it is hopefully a good start.

### Reproduction

```sh
git clone https://github.com/OvenMediaLabs/OvenMediaEngine && cd OvenMediaEngine
docker build --build-arg USE_LOCAL=true -t ome:probe .   # full build
docker build --build-arg USE_LOCAL=true -t ome:probe .   # seconds, fully cached
git commit --allow-empty -m "cache probe"                # changes nothing but .git
docker build --build-arg USE_LOCAL=true -t ome:probe .   # COPY re-runs, then the whole
                                                         # dependency install and compile
                                                         # start over (Ctrl-C once visible)
```

The empty commit changes no file in the tree; the third build re-runs everything anyway,
purely from `.git` churn. With the `.dockerignore` in place, that build stays fully
cached (a couple of seconds), and edits to docs or markdown no longer trigger rebuilds
either.

### Version stamp with USE_LOCAL=true

With `.git` excluded, a `USE_LOCAL=true` build cannot run `git describe`: it keeps
whatever `git_info.h` is already in the context, or stamps `v0.21.0 ((From archive))` if
there is none. Running `src/main/update_git_info.sh` on the host before the build keeps
the stamp fresh. `USE_LOCAL=false` builds clone inside the stage and are unaffected. A
note to this effect is added to the Dockerfile header comment.

