### PR TITLE
fix(build): link the split ggml archives with static whisper

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -378,8 +378,17 @@ endif()
 
 # Whisper GGML
 if(PKG_WHISPER_FOUND)
+    # Static whisper splits ggml into ggml + ggml-base + ggml-cpu; all three
+    # must follow libwhisper.a on the link line (test binaries surface the
+    # miss; the main binary only survived by link order).
+    find_library(GGML_LIB       ggml            HINTS ${OME_DEP_PREFIX}/lib ${OME_DEP_PREFIX}/lib64)
+    find_library(GGML_BASE_LIB  ggml-base       HINTS ${OME_DEP_PREFIX}/lib ${OME_DEP_PREFIX}/lib64)
     find_library(GGML_CPU_LIB   ggml-cpu        HINTS ${OME_DEP_PREFIX}/lib ${OME_DEP_PREFIX}/lib64)
-    set_property(TARGET PkgConfig::PKG_WHISPER APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${GGML_CPU_LIB}")
+    foreach(_ggml_lib IN ITEMS "${GGML_LIB}" "${GGML_CPU_LIB}" "${GGML_BASE_LIB}")
+        if(_ggml_lib)
+            set_property(TARGET PkgConfig::PKG_WHISPER APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${_ggml_lib}")
+        endif()
+    endforeach()
     set_property(TARGET PkgConfig::PKG_WHISPER APPEND PROPERTY INTERFACE_LINK_LIBRARIES gomp)
     
     if(OME_HWACCEL_NVIDIA)  
@@ -410,6 +419,8 @@ if(PKG_WHISPER_FOUND)
         endif()      
     endif()  
     
+    unset(GGML_LIB CACHE)
+    unset(GGML_BASE_LIB CACHE)
     unset(GGML_CPU_LIB CACHE)    
     unset(NV_CUBLAS_LIB CACHE)
     unset(NV_CUBLASLT_LIB CACHE)


### PR DESCRIPTION
The below is Claude-written (as is the change). Manually tested/reproduced by me

### Reproduction

On current master, in a fresh build directory:

```
cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DOME_BUILD_TESTS=ON
cmake --build build
```

The test binaries fail to link (excerpt):

```
/usr/bin/ld: /opt/ovenmediaengine/lib/libwhisper.a(whisper.cpp.o): in function `whisper_full_with_state':
whisper.cpp:(.text+0x293f3): undefined reference to `ggml_backend_buffer_free'
/usr/bin/ld: whisper.cpp:(.text+0x299bc): undefined reference to `ggml_time_us'
/usr/bin/ld: /opt/ovenmediaengine/lib/libwhisper.a(whisper.cpp.o): in function `whisper_log_set':
whisper.cpp:(.text+0x102d1): undefined reference to `ggml_log_set'
/usr/bin/ld: /opt/ovenmediaengine/lib/libwhisper.a(whisper.cpp.o): in function `whisper_vad_init_with_params::{lambda(vad_tensor, ggml_tensor*)#2}::operator()(vad_tensor, ggml_tensor*) const [clone .cold]':
whisper.cpp:(.text.unlikely+0x81e): undefined reference to `ggml_free'
clang: error: linker command failed with exit code 1
```

### Cause

Release builds use static whisper (`OME_WHISPER_STATIC` defaults to ON for Release), and whisper.cpp ships ggml as three static archives: `libggml.a`, `libggml-base.a`, `libggml-cpu.a`. The build only tells the linker about `ggml-cpu`. The other two do appear on the link line (via `whisper.pc`), but before `libwhisper.a`. A static archive placed before the code that uses it does not resolve anything.

The main `OvenMediaEngine` binary links anyway, by luck: `third_parties.cpp` calls two ggml functions directly, which makes the linker pull in the right archives early. Any other binary that links whisper, such as the test binaries, fails.

### Fix

Add all three ggml archives to the link line again, after `libwhisper.a`, where the linker can actually use them. Shared-whisper builds are unaffected.
