### PR TITLE
build: require Clang 21 or newer for OME_THREAD_SAFETY

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -108,7 +108,24 @@ endif()
 # The flag is only meaningful on Clang; GCC and MSVC ignore the
 # annotations entirely (they expand to nothing),
 # so we gate the option on the active compiler instead of erroring out.
+# Too old a Clang is the one case that does error: the annotations are active
+# there but the compiler rejects them, so the build cannot proceed either way.
 # ------------------------------------------------------------------------------
+# ov::ScopedLock annotates a variadic constructor. Clang accepts a pack
+# expansion inside a capability attribute only from 21 onwards, and the
+# rejection lands in a header nearly every file includes.
+set(OME_TSA_MIN_CLANG_VERSION 21)
+if(OME_THREAD_SAFETY AND CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+        AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${OME_TSA_MIN_CLANG_VERSION})
+    message(FATAL_ERROR
+        "[OME] OME_THREAD_SAFETY=ON requires Clang ${OME_TSA_MIN_CLANG_VERSION} "
+        "or newer; this is ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}. "
+        "Install a newer Clang (apt.llvm.org) and select it with "
+        "-DOME_USE_CLANG=OFF -DCMAKE_C_COMPILER=clang-${OME_TSA_MIN_CLANG_VERSION} "
+        "-DCMAKE_CXX_COMPILER=clang++-${OME_TSA_MIN_CLANG_VERSION}, or configure "
+        "with -DOME_THREAD_SAFETY=OFF.")
+endif()
+
 if(OME_THREAD_SAFETY AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wthread-safety)
     add_compile_definitions(OME_THREAD_SAFETY)

--- a/src/base/ovlibrary/tsa/README.md
+++ b/src/base/ovlibrary/tsa/README.md
@@ -80,7 +80,7 @@ OME has a single set of `ov::` wrapper classes, and the CMake option `OME_THREAD
 The two modes have identical `sizeof` / `alignof` / method signatures (tests guard this with `static_assert`). So you write the source once and build with `ON` only when you need the analysis.
 
 > [!IMPORTANT]
-> Even with `OME_THREAD_SAFETY=ON`, no analysis happens unless the compiler is actually Clang. OME defaults to `OME_USE_CLANG=ON`, but that falls back to the system compiler (GCC) when `clang`/`clang++` are not installed, so make sure Clang is available. If TSA ends up off, CMake prints a `NO EFFECT` warning at configure time (not during the build); look for `[OME] Clang thread-safety analysis: ENABLED` in the configure log to confirm it is on (`cmake/CompilerOptions.cmake`).
+> Even with `OME_THREAD_SAFETY=ON`, no analysis happens unless the compiler is actually Clang. OME defaults to `OME_USE_CLANG=ON`, but that falls back to the system compiler (GCC) when `clang`/`clang++` are not installed, so make sure Clang is available, and specifically Clang 21 or newer (see [2.3](#23-verifying-with-tsa-analysis)); on an older Clang, configuring with the option on stops with an error naming the requirement. If TSA ends up off, CMake prints a `NO EFFECT` warning at configure time (not during the build); look for `[OME] Clang thread-safety analysis: ENABLED` in the configure log to confirm it is on (`cmake/CompilerOptions.cmake`).
 
 ---
 
@@ -152,7 +152,7 @@ After writing new code, always build in `ON` mode (Clang) to check for violation
 
 | Option              | Default | Role                                                                                      |
 | ------------------- | ------- | ----------------------------------------------------------------------------------------- |
-| `OME_THREAD_SAFETY` | `OFF`   | When `ON` (Clang only), defines the `OME_THREAD_SAFETY` macro + enables `-Wthread-safety` |
+| `OME_THREAD_SAFETY` | `OFF`   | When `ON` (Clang 21+ only), defines `OME_THREAD_SAFETY` + enables `-Wthread-safety`       |
 | `OME_USE_CLANG`     | `ON`    | Use Clang as the compiler (required for TSA analysis)                                     |
 | `OME_BUILD_TESTS`   | `OFF`   | When `ON`, the TSA regression test is built/registered                                    |
 
@@ -165,6 +165,9 @@ cmake -B <build-dir> -G Ninja -DOME_THREAD_SAFETY=ON -DOME_BUILD_TESTS=ON
 # Build (TSA violations surface as -Wthread-safety warnings)
 cmake --build <build-dir>
 ```
+
+> [!IMPORTANT]
+> TSA needs **Clang 21 or newer**. `ov::ScopedLock` annotates a variadic constructor, and support for pack expansion in thread-safety attributes arrived in Clang 21; older Clang rejects the annotation in `tsa/mutex.h` (Clang 14 as a parse error, later versions as `attribute 'acquire_capability' does not support argument pack expansion`). Configuring with `OME_THREAD_SAFETY=ON` on an older Clang stops with an error saying so. Note that the `clang` package on Ubuntu 22.04 is Clang 14 and on Ubuntu 24.04 is Clang 18, so a newer Clang has to come from apt.llvm.org or an equivalent source. Select it explicitly, and turn `OME_USE_CLANG` off while you do, because with it on the build overwrites the compiler you pass: `-DOME_USE_CLANG=OFF -DCMAKE_C_COMPILER=clang-21 -DCMAKE_CXX_COMPILER=clang++-21`.
 
 > [!IMPORTANT]
 > TSA violations surface as compiler **warnings** (`-Wthread-safety`). OME does not use `-Werror`, so these warnings alone do not stop the build. After a change, check the build log yourself for any `warning: ... requires holding mutex ...` warnings.
@@ -601,7 +604,7 @@ Most of these fall under the limitations in [Section 7](#7-limitations-of-tsa).
 For the TSA regression test (`tsa_negative_verify`) to be registered/run, all of the following must hold:
 
 - `OME_THREAD_SAFETY=ON`
-- the compiler is Clang
+- the compiler is Clang 21 or newer
 - `OME_BUILD_TESTS=ON`
 
 If any is missing, the test is not registered. The non-Clang case is not silent: with `OME_THREAD_SAFETY=ON` on a non-Clang compiler, CMake's `NO EFFECT` configure warning explicitly states the negative-verify test is skipped. With all three enabled, the check runs automatically as part of the build.


### PR DESCRIPTION
The below is Claude-written (as is the change). Edited by me.

### Problem

`OME_THREAD_SAFETY=ON` needs Clang 21 or newer. Nothing in the project says so, and the
Clang the project installs for you is older than that, so turning the option on fails with
what looks like a broken header.

`tsa/mutex.h:605` expands a parameter pack inside a thread-safety attribute. Clang only
accepts that from version 21 (llvm/llvm-project#137477). Older Clang cannot parse the line
and stops there, which is what you see below.

### Reproduction

The reproduction here uses the Dockerfile for convenience, but we ran into this bug building locally
first. We build master from source with `OME_BUILD_TESTS=ON` while validating the patches we send
upstream, which is how we hit the static-whisper link failure in #2296; turning the analysis on over
that same tree is what surfaced this one. 

```sh
mkdir -p ~/ome-tsa-repro && cd ~/ome-tsa-repro
git clone https://github.com/OvenMediaLabs/OvenMediaEngine.git
cd OvenMediaEngine

docker build --target build -t ome-tsa .

docker run --rm --entrypoint bash ome-tsa -c '
  cd /tmp/ome
  clang --version | head -1
  cmake -B /tmp/tsa -G Ninja -DOME_THREAD_SAFETY=ON
  cmake --build /tmp/tsa'
```

The image builds fine. The configure inside it does not:

```
Ubuntu clang version 14.0.0-1ubuntu1.1
-- The C compiler identification is Clang 14.0.0
-- The CXX compiler identification is Clang 14.0.0
...
-- Build type: Debug
-- Options:
--   OME_USE_CLANG: ON
...
--   OME_THREAD_SAFETY: ON
...
-- [OME] Clang thread-safety analysis: ENABLED
...
[7/563] Building CXX object src/base/ovlibrary/CMakeFiles/ovlibrary.dir/bps_calculator.cpp.o
FAILED: src/base/ovlibrary/CMakeFiles/ovlibrary.dir/bps_calculator.cpp.o
In file included from /tmp/ome/src/base/ovlibrary/bps_calculator.cpp:9:
In file included from /tmp/ome/src/base/ovlibrary/bps_calculator.h:15:
/tmp/ome/src/base/ovlibrary/tsa/mutex.h:605:51: fatal error: expected ')'
                explicit ScopedLock(Tmutex &...ms) OV_ACQUIRE(ms...)
                                                                ^
1 error generated.
...
ninja: build stopped: subcommand failed.
```

### Change

Stop at configure time with the requirement, and say it in the TSA guide. Nothing changes
for `OME_THREAD_SAFETY=OFF`, and non-Clang compilers keep their existing `NO EFFECT`
warning.

```
CMake Error at cmake/CompilerOptions.cmake:120 (message):
  [OME] OME_THREAD_SAFETY=ON requires Clang 21 or newer; this is Clang
  14.0.0.  Install a newer Clang (apt.llvm.org) and select it with
  -DOME_USE_CLANG=OFF -DCMAKE_C_COMPILER=clang-21
  -DCMAKE_CXX_COMPILER=clang++-21, or configure with -DOME_THREAD_SAFETY=OFF.
```

`OME_USE_CLANG=OFF` is in that message because the default overwrites an explicit
`-DCMAKE_CXX_COMPILER`; the route shown is verified on current master.
