### PR TITLE
fix(build): stop the compiler override from wiping the CMake cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,12 @@ if(OME_USE_CLANG)
     find_program(_OME_CLANG   NAMES clang)
     find_program(_OME_CLANGXX NAMES clang++)
     if(_OME_CLANG AND _OME_CLANGXX)
-        set(CMAKE_C_COMPILER   "${_OME_CLANG}"   CACHE STRING "C compiler"   FORCE)
-        set(CMAKE_CXX_COMPILER "${_OME_CLANGXX}" CACHE STRING "C++ compiler" FORCE)
+        # Deliberately not FORCE: changing a cached compiler on a re-configure makes
+        # CMake wipe the cache, discarding every other -D setting with it.
+        set(CMAKE_C_COMPILER   "${_OME_CLANG}"   CACHE STRING "C compiler")
+        set(CMAKE_CXX_COMPILER "${_OME_CLANGXX}" CACHE STRING "C++ compiler")
     else()
-        message(WARNING "[OME] OME_USE_CLANG=ON but clang/clang++ not found - falling back to default compiler")
+        message(WARNING "[OME] OME_USE_CLANG=ON but clang/clang++ not found - falling back to the default compiler. This build directory keeps it even after clang is installed; use a fresh build directory to switch.")
     endif()
 endif()
 


### PR DESCRIPTION
The below is Claude-written (as is the change) and edited by me.

### Reproduction

This repository's own Dockerfile is enough, because its build stage already performs the
first configure, at a point where clang is not installed yet. Build it, then configure once
more inside it asking for Release again, and look at the same two settings before and
after:

```sh
mkdir -p ~/ome-cache-repro && cd ~/ome-cache-repro
git clone https://github.com/OvenMediaLabs/OvenMediaEngine.git
cd OvenMediaEngine

docker build --target build -t ome-repro .

docker run --rm --entrypoint bash ome-repro -c '
  cd /tmp/ome
  grep -E "CMAKE_(BUILD_TYPE|C_COMPILER):" build/Release/CMakeCache.txt
  cmake -B build/Release -G Ninja -DCMAKE_BUILD_TYPE=Release
  grep -E "CMAKE_(BUILD_TYPE|C_COMPILER):" build/Release/CMakeCache.txt'
```

The first `grep` shows the image built as Release with the system compiler:

```
CMAKE_BUILD_TYPE:STRING=Release
CMAKE_C_COMPILER:FILEPATH=/usr/bin/cc
```

The configure prints its build type twice, before and after CMake discards the cache:

```
-- Build type: Release
...
You have changed variables that require your cache to be deleted.
Configure will be re-run and you may have to reset some variables.
The following variables have changed:
CMAKE_C_COMPILER= /usr/bin/clang
CMAKE_CXX_COMPILER= /usr/bin/clang++
...
-- Build type: Debug
```

And the second `grep` shows what the build directory is now set to, after a command that
asked for Release:

```
CMAKE_BUILD_TYPE:STRING=Debug
CMAKE_C_COMPILER:STRING=/usr/bin/clang
```

The build type is not the only casualty. In the same output `OME_ENABLE_JEMALLOC` and
`OME_WHISPER_STATIC` both go from ON to OFF, since each defaults off outside Release, and
the second configure stops checking for jemalloc at all. No extra flags are needed to see
that; it happens on the command above.

The same thing happens outside Docker in any environment where clang is absent for the
first configure, which is the normal state of a fresh machine. Other options are lost the
same way. With `-DOME_BUILD_TESTS=ON` on both configures, measured with clang hidden for
the first and restored for the second:

| after the second configure | master | with this patch |
|---|---|---|
| cache deletions | 1 | 0 |
| CMAKE_C_COMPILER | /usr/bin/clang | /usr/bin/cc (unchanged) |
| CMAKE_BUILD_TYPE | Debug | Release |
| OME_BUILD_TESTS | OFF | ON |
| test targets generated | 0 | 634 |

Both configures exit 0, so nothing signals that the build being produced is not the one
that was asked for. A toolchain file naming another compiler is overridden the same way
from the second configure onward.

### How we hit it

- A Release build came out Debug after an otherwise routine reconfigure. That is what first drew attention to this.
- Re-running configure on an existing build directory with `-DOME_BUILD_TESTS=ON` produced a build with tests off, which made a genuine link bug look unreproducible.
- Installing a newer Clang for `OME_THREAD_SAFETY` did not take: `CXX=clang++-21` and `-DCMAKE_CXX_COMPILER=clang++-21` were both discarded and configure kept reporting Clang 14.

### Cause

`OME_USE_CLANG` defaults to ON, so the first configure looks for clang. In a fresh
environment there is none yet, the warning fires, and CMake caches the system compiler.
That same configure then has `InstallPrerequisites.cmake` apt-install clang and lld.

From then on, every configure finds clang and re-writes `CMAKE_C_COMPILER` and
`CMAKE_CXX_COMPILER` with `FORCE`. CMake sees a compiler change and does what it always
does in that situation: deletes the cache and configures again from scratch. Options given
on the command line live in that deleted cache and are not reapplied.

### Fix

Drop `FORCE`, so an entry already in the cache is left alone. That is the whole change.

An explicit `-DCMAKE_C_COMPILER` or `-DCMAKE_CXX_COMPILER` now takes effect, which the
forced write used to discard. That supersedes the workaround #2297 has to document: on
master, pointing the build at a newer Clang also needs `-DOME_USE_CLANG=OFF`, while on this
branch `-DCMAKE_CXX_COMPILER=clang++-21` alone configures as `Clang 21.1.8`. The default
path is unchanged: with no compiler given, configure still selects the clang it finds.

