### PR TITLE
chore(rtp_rtcp): remove unused member variables

### DIFF
--- a/src/modules/rtp_rtcp/rtp_rtcp.h
+++ b/src/modules/rtp_rtcp/rtp_rtcp.h
@@ -158,10 +158,6 @@ private:
 
 	void ConnectSsrcToTrack(uint32_t ssrc, uint32_t track_id);
 
-    time_t _first_receiver_report_time = 0; // 0 - not received RR packet
-    time_t _last_sender_report_time = 0;
-    uint64_t _send_packet_sequence_number = 0;
-
 	// Lifecycle gate: data path (send/receive) takes it shared, Stop/setup exclusive
 	std::shared_mutex _state_lock;
 	std::shared_ptr<RtpRtcpInterface> _observer;


### PR DESCRIPTION
## Summary
Remove unused member variables from `RtpRtcp` to fix unused-variable build warnings.

## Changes
- Removed `_first_receiver_report_time`, `_last_sender_report_time`, and `_send_packet_sequence_number` from `rtp_rtcp.h`