### PR TITLE
feat: add transport connection info to ingress stream alerts and REST API

### DIFF
--- a/src/base/info/stream.cpp
+++ b/src/base/info/stream.cpp
@@ -190,6 +190,15 @@ namespace info
 		_stats->SetMediaSource(url);
 	}
 
+	std::shared_ptr<const ConnectionInfo> Stream::GetConnectionInfo() const
+	{
+		return _stats->GetConnectionInfo();
+	}
+	bool Stream::SetConnectionInfo(const std::shared_ptr<const ConnectionInfo> &connection_info)
+	{
+		return _stats->SetConnectionInfo(connection_info);
+	}
+
 	void Stream::SetOutputProfileName(ov::String name)
 	{
 		_output_profile_name = std::move(name);

--- a/src/base/info/stream.h
+++ b/src/base/info/stream.h
@@ -49,6 +49,9 @@ namespace info
 		ov::String GetMediaSource() const;
 		void SetMediaSource(ov::String url);
 
+		std::shared_ptr<const ConnectionInfo> GetConnectionInfo() const;
+		bool SetConnectionInfo(const std::shared_ptr<const ConnectionInfo> &connection_info);
+
 		void SetOutputProfileName(ov::String name);
 		ov::String GetOutputProfileName() const;
 

--- a/src/base/info/stream_stats.cpp
+++ b/src/base/info/stream_stats.cpp
@@ -57,7 +57,7 @@ namespace info
 
 		if (local_port.has_value())
 		{
-			result.AppendFormat("%s:%u", local_address.CStr(), local_port.value());
+			result.AppendFormat("%s:%" PRIu16, local_address.CStr(), local_port.value());
 		}
 		else
 		{
@@ -68,7 +68,7 @@ namespace info
 
 		if (remote_port.has_value())
 		{
-			result.AppendFormat("%s:%u", remote_address.CStr(), remote_port.value());
+			result.AppendFormat("%s:%" PRIu16, remote_address.CStr(), remote_port.value());
 		}
 		else
 		{

--- a/src/base/info/stream_stats.cpp
+++ b/src/base/info/stream_stats.cpp
@@ -10,6 +10,76 @@
 
 namespace info
 {
+	std::shared_ptr<const ConnectionInfo> ConnectionInfo::From(const ov::SocketAddress *local_address, const ov::SocketAddress *remote_address, ov::SocketType socket_type, const char *transport, uint64_t version)
+	{
+		auto connection_info	   = std::make_shared<ConnectionInfo>();
+
+		auto protocol			   = ov::StringFromSocketType(socket_type);
+
+		connection_info->protocol  = protocol;
+		connection_info->transport = (transport != nullptr) ? transport : protocol;
+
+		if ((local_address != nullptr) && local_address->IsValid())
+		{
+			connection_info->local_address = local_address->GetIpAddress();
+			connection_info->local_port	   = local_address->Port();
+		}
+		if ((remote_address != nullptr) && remote_address->IsValid())
+		{
+			connection_info->remote_address = remote_address->GetIpAddress();
+			connection_info->remote_port	= remote_address->Port();
+		}
+		connection_info->version = version;
+
+		return connection_info;
+	}
+
+	std::shared_ptr<const ConnectionInfo> ConnectionInfo::From(const ov::SocketAddressPair &address_pair, ov::SocketType socket_type, const char *transport, uint64_t version)
+	{
+		return From(&(address_pair.GetLocalAddress()), &(address_pair.GetRemoteAddress()), socket_type, transport, version);
+	}
+
+	std::shared_ptr<const ConnectionInfo> ConnectionInfo::From(const std::shared_ptr<ov::Socket> &socket, const char *transport, uint64_t version)
+	{
+		if (socket == nullptr)
+		{
+			return nullptr;
+		}
+
+		return From(socket->GetLocalAddress().get(), socket->GetRemoteAddress().get(), socket->GetType(), transport, version);
+	}
+
+	ov::String ConnectionInfo::ToString() const
+	{
+		auto result = ov::String::FormatString(
+			"%s (%s, local: ",
+			transport.CStr(), protocol.CStr());
+
+		if (local_port.has_value())
+		{
+			result.AppendFormat("%s:%u", local_address.CStr(), local_port.value());
+		}
+		else
+		{
+			result.Append("N/A");
+		}
+
+		result.Append(", remote: ");
+
+		if (remote_port.has_value())
+		{
+			result.AppendFormat("%s:%u", remote_address.CStr(), remote_port.value());
+		}
+		else
+		{
+			result.Append("N/A");
+		}
+
+		result.Append(")");
+
+		return result;
+	}
+
 	StreamStats::StreamStats()
 		: _created_time(std::chrono::system_clock::now())
 	{
@@ -97,5 +167,26 @@ namespace info
 	{
 		ov::LockGuard lock(_media_source_mutex);
 		return _media_source;
+	}
+
+	bool StreamStats::SetConnectionInfo(const std::shared_ptr<const ConnectionInfo> &connection_info)
+	{
+		ov::LockGuard lock(_connection_info_mutex);
+
+		// Equal or lower versions are stale/duplicate publications from a racing thread
+		if ((_connection_info != nullptr) && (connection_info != nullptr) &&
+			(connection_info->version != 0) && (connection_info->version <= _connection_info->version))
+		{
+			return false;
+		}
+
+		_connection_info = connection_info;
+		return true;
+	}
+
+	std::shared_ptr<const ConnectionInfo> StreamStats::GetConnectionInfo() const
+	{
+		ov::LockGuard lock(_connection_info_mutex);
+		return _connection_info;
 	}
 }  // namespace info

--- a/src/base/info/stream_stats.h
+++ b/src/base/info/stream_stats.h
@@ -10,12 +10,42 @@
 
 #include <atomic>
 #include <chrono>
+#include <optional>
 
 #include "base/ovlibrary/ovlibrary.h"
 #include "base/ovlibrary/tsa/mutex.h"
+#include "base/ovsocket/ovsocket.h"
 
 namespace info
 {
+	// Transport-level details of the connection the stream's media travels on.
+	// Immutable once published: writers build a new instance and swap the pointer.
+	struct ConnectionInfo
+	{
+		// Final path type as the client experiences it: "UDP"/"TCP"/"SRT"/"TURN"
+		ov::String transport;
+		// Socket protocol ("UDP"/"TCP"/"SRT"); differs from `transport` only for TURN
+		ov::String protocol;
+		// Filled only when the corresponding address was valid at snapshot time
+		ov::String local_address;
+		std::optional<uint16_t> local_port;
+		ov::String remote_address;
+		std::optional<uint16_t> remote_port;
+
+		// Selection order of this snapshot; `0` means "unversioned" (always accepted)
+		uint64_t version = 0;
+
+		// Build an immutable snapshot.
+		// A null (or invalid) address side is left unfilled.
+		// `transport` defaults to the socket protocol; `version` orders racing publications.
+		static std::shared_ptr<const ConnectionInfo> From(const ov::SocketAddress *local_address, const ov::SocketAddress *remote_address, ov::SocketType socket_type, const char *transport = nullptr, uint64_t version = 0);
+		static std::shared_ptr<const ConnectionInfo> From(const ov::SocketAddressPair &address_pair, ov::SocketType socket_type, const char *transport = nullptr, uint64_t version = 0);
+		// Fills whichever addresses the socket knows; null only for a null socket
+		static std::shared_ptr<const ConnectionInfo> From(const std::shared_ptr<ov::Socket> &socket, const char *transport = nullptr, uint64_t version = 0);
+
+		ov::String ToString() const;
+	};
+
 	// Runtime state of one stream instance.
 	// This is the deliberately shared mutable state between modules: every copy of a
 	// stream shares the same StreamStats instance, while the stream description travels
@@ -53,6 +83,11 @@ namespace info
 		void SetMediaSource(const ov::String &url);
 		ov::String GetMediaSource() const;
 
+		// The currently selected transport path; `nullptr` until one is selected.
+		// A versioned snapshot is stored only when newer; `false` means dropped as stale.
+		bool SetConnectionInfo(const std::shared_ptr<const ConnectionInfo> &connection_info);
+		std::shared_ptr<const ConnectionInfo> GetConnectionInfo() const;
+
 	private:
 		const std::chrono::system_clock::time_point _created_time;
 
@@ -66,5 +101,8 @@ namespace info
 
 		mutable ov::Mutex _media_source_mutex;
 		ov::String _media_source OV_GUARDED_BY(_media_source_mutex);
+
+		mutable ov::Mutex _connection_info_mutex;
+		std::shared_ptr<const ConnectionInfo> _connection_info OV_GUARDED_BY(_connection_info_mutex);
 	};
 }  // namespace info

--- a/src/base/info/stream_stats_test.cpp
+++ b/src/base/info/stream_stats_test.cpp
@@ -1,0 +1,75 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+#include "stream_stats.h"
+
+#include <gtest/gtest.h>
+
+static ov::SocketAddressPair Pair(const char *local_ip, uint16_t local_port, const char *remote_ip, uint16_t remote_port)
+{
+	return ov::SocketAddressPair(
+		ov::SocketAddress::CreateAndGetFirst(local_ip, local_port),
+		ov::SocketAddress::CreateAndGetFirst(remote_ip, remote_port));
+}
+
+// From() maps socket-level facts to the reported transport/protocol
+TEST(ConnectionInfo, FromClassification)
+{
+	auto pair		= Pair("10.0.0.5", 10200, "1.2.3.4", 51234);
+
+	auto direct_udp = info::ConnectionInfo::From(pair, ov::SocketType::Udp, nullptr, 1);
+	EXPECT_STREQ(direct_udp->transport.CStr(), "UDP");
+	EXPECT_STREQ(direct_udp->protocol.CStr(), "UDP");
+	EXPECT_STREQ(direct_udp->local_address.CStr(), "10.0.0.5");
+	EXPECT_EQ(direct_udp->local_port, 10200u);
+	EXPECT_STREQ(direct_udp->remote_address.CStr(), "1.2.3.4");
+	EXPECT_EQ(direct_udp->remote_port, 51234u);
+	EXPECT_EQ(direct_udp->version, 1u);
+
+	auto direct_tcp = info::ConnectionInfo::From(pair, ov::SocketType::Tcp);
+	EXPECT_STREQ(direct_tcp->transport.CStr(), "TCP");
+	EXPECT_STREQ(direct_tcp->protocol.CStr(), "TCP");
+
+	auto turn_over_tcp = info::ConnectionInfo::From(pair, ov::SocketType::Tcp, "TURN");
+	EXPECT_STREQ(turn_over_tcp->transport.CStr(), "TURN");
+	EXPECT_STREQ(turn_over_tcp->protocol.CStr(), "TCP");
+
+	EXPECT_STREQ(direct_udp->ToString().CStr(), "UDP (UDP, local: 10.0.0.5:10200, remote: 1.2.3.4:51234)");
+}
+
+// SetConnectionInfo() must keep only the newest versioned snapshot;
+// unversioned snapshots always win
+TEST(StreamStats, ConnectionInfoVersionGate)
+{
+	info::StreamStats stats;
+	auto pair_a = Pair("10.0.0.5", 10200, "1.2.3.4", 50001);
+	auto pair_b = Pair("10.0.0.5", 13478, "1.2.3.4", 50002);
+
+	EXPECT_EQ(stats.GetConnectionInfo(), nullptr);
+
+	auto v1 = info::ConnectionInfo::From(pair_a, ov::SocketType::Udp, nullptr, 1);
+	auto v2 = info::ConnectionInfo::From(pair_b, ov::SocketType::Tcp, "TURN", 2);
+
+	EXPECT_TRUE(stats.SetConnectionInfo(v1));
+	EXPECT_TRUE(stats.SetConnectionInfo(v2));
+	EXPECT_EQ(stats.GetConnectionInfo(), v2);
+
+	// The straggler publication of the older selection is dropped
+	EXPECT_FALSE(stats.SetConnectionInfo(v1));
+	EXPECT_EQ(stats.GetConnectionInfo(), v2);
+
+	// A duplicate publication of the same selection is dropped too
+	auto v2_dup = info::ConnectionInfo::From(pair_b, ov::SocketType::Tcp, "TURN", 2);
+	EXPECT_FALSE(stats.SetConnectionInfo(v2_dup));
+	EXPECT_EQ(stats.GetConnectionInfo(), v2);
+
+	// An unversioned snapshot is always accepted (a provider without racing publishers)
+	auto unversioned = info::ConnectionInfo::From(pair_a, ov::SocketType::Tcp);
+	EXPECT_TRUE(stats.SetConnectionInfo(unversioned));
+	EXPECT_EQ(stats.GetConnectionInfo(), unversioned);
+}

--- a/src/modules/ice/ice_candidate_pair.cpp
+++ b/src/modules/ice/ice_candidate_pair.cpp
@@ -77,16 +77,21 @@ void IceCandidatePair::SetTurnDataChannel(uint16_t channel_number)
 
 void IceCandidatePair::SetTurnSendIndication(const ov::SocketAddress &turn_peer_address)
 {
-    {
-        ov::LockGuard<ov::Mutex> lock(_turn_peer_address_mutex);
-        _turn_peer_address = turn_peer_address;
-    }
-    _transport_type.store(TransportType::TurnSendIndication);
+	{
+		ov::LockGuard<ov::Mutex> lock(_turn_peer_address_mutex);
+		_turn_peer_address = turn_peer_address;
+	}
+	_transport_type.store(TransportType::TurnSendIndication);
 }
 
 IceCandidatePair::TransportType IceCandidatePair::GetTransportType() const
 {
-    return _transport_type.load();
+	return _transport_type.load();
+}
+
+const char *IceCandidatePair::GetReportedTransport() const
+{
+	return (GetTransportType() != TransportType::Direct) ? "TURN" : nullptr;
 }
 
 uint16_t IceCandidatePair::GetTurnChannelNumber() const

--- a/src/modules/ice/ice_candidate_pair.h
+++ b/src/modules/ice/ice_candidate_pair.h
@@ -46,14 +46,17 @@ public:
     void OnReceivedBindingRequest();
     void OnReceivedBindingResponse();
 
-    // Valid candidate pair
-    bool IsConnectable() const;
+	// Valid candidate pair
+	bool IsConnectable() const;
 
 	// Outgoing framing for this pair. Set when TURN ChannelData / Send
 	// Indication is received on this pair; defaults to Direct.
 	void SetTurnDataChannel(uint16_t channel_number);
 	void SetTurnSendIndication(const ov::SocketAddress &turn_peer_address);
 	TransportType GetTransportType() const;
+	// The transport label to report for this pair: nullptr means "use the socket protocol",
+	// "TURN" means OME's built-in TURN server relays it
+	const char *GetReportedTransport() const;
 	uint16_t GetTurnChannelNumber() const;
 	ov::SocketAddress GetTurnPeerAddress() const;
 

--- a/src/modules/ice/ice_port.cpp
+++ b/src/modules/ice/ice_port.cpp
@@ -783,7 +783,9 @@ void IcePort::OnApplicationPacketReceived(const std::shared_ptr<ov::Socket> &rem
 	if (ice_session->IsActive(address_pair) == false)
 	{
 		auto old_state = ice_session->GetState();
-		if (ice_session->SelectActiveCandidatePair(address_pair) == false)
+		std::shared_ptr<IceCandidatePair> selected_pair;
+		uint64_t selected_version = 0;
+		if (ice_session->SelectActiveCandidatePair(address_pair, &selected_pair, &selected_version) == false)
 		{
 			// Not a STUN-validated pair, so not a trusted path
 			logtw("Received application packet from invalid peer(%s). Dropping...", address_pair.ToString().CStr());
@@ -793,6 +795,32 @@ void IcePort::OnApplicationPacketReceived(const std::shared_ptr<ov::Socket> &rem
 		if (old_state != ice_session->GetState())
 		{
 			NotifyIceSessionStateChanged(ice_session);
+		}
+
+		// Report the pair this thread selected; the version lets the consumer
+		// drop deliveries that raced out of selection order.
+		auto observer = ice_session->GetObserver();
+		if (observer != nullptr)
+		{
+#if DEBUG
+			// Catch a blocking observer during development (it runs on the packet processing thread)
+			constexpr int64_t OBSERVER_WARNING_THRESHOLD_MS = 100;
+			ov::StopWatch stop_watch;
+
+			stop_watch.Start();
+#endif	// DEBUG
+			observer->OnIceCandidatePairSelected(*this, ice_session->GetSessionID(), selected_pair, selected_version, ice_session->GetUserData());
+#if DEBUG
+			const auto elapsed_us = stop_watch.ElapsedUs();
+			if (elapsed_us >= (OBSERVER_WARNING_THRESHOLD_MS * 1000))
+			{
+				logte(
+					"[DEBUG ONLY] OnIceCandidatePairSelected() of the observer took too long: %.1fms "
+					"(threshold: %" PRId64 "ms). It blocks the packet processing thread, so it must return immediately",
+					elapsed_us / 1000.0,
+					OBSERVER_WARNING_THRESHOLD_MS);
+			}
+#endif	// DEBUG
 		}
 	}
 

--- a/src/modules/ice/ice_port_observer.h
+++ b/src/modules/ice/ice_port_observer.h
@@ -17,6 +17,7 @@
 #include "ice_types.h"
 
 class IcePort;
+class IceCandidatePair;
 
 class IcePortObserver : public ov::EnableSharedFromThis<IcePortObserver>
 {
@@ -46,6 +47,13 @@ public:
 	// delivered as the same transport state as ordinary disconnects, but Enterprise
 	// ingress alerts must classify them as PolicyExpired instead of NetworkError.
 	virtual void OnStateChanged(IcePort &port, uint32_t session_id, IceConnectionState state, bool is_expired, std::any user_data)
+	{
+		// dummy function
+	}
+	// Notifies the observer of the newly active candidate pair, on the first selection
+	// and on every switch. Called on the packet processing thread: do not block.
+	// Deliveries may race out of order; keep only the highest `selected_version`.
+	virtual void OnIceCandidatePairSelected(IcePort &port, uint32_t session_id, const std::shared_ptr<const IceCandidatePair> &candidate_pair, uint64_t selected_version, std::any user_data)
 	{
 		// dummy function
 	}

--- a/src/modules/ice/ice_port_test.cpp
+++ b/src/modules/ice/ice_port_test.cpp
@@ -275,3 +275,19 @@ TEST_F(IcePortTest, ApplicationPacketReportsSelectedPair)
 	EXPECT_EQ(observer->selected_pairs.size(), 2u);
 	EXPECT_TRUE(s->GetActiveCandidatePair()->GetAddressPair() == pair_b);
 }
+
+// The reported transport label follows the pair's TURN framing:
+// Direct -> nullptr (socket protocol), relayed -> "TURN"
+TEST_F(IcePortTest, ReportedTransportFollowsTurnFraming)
+{
+	IceCandidatePair direct_pair(Pair(10200, 20000), nullptr);
+	EXPECT_EQ(direct_pair.GetReportedTransport(), nullptr);
+
+	IceCandidatePair channel_pair(Pair(13478, 20001), nullptr);
+	channel_pair.SetTurnDataChannel(0x4000);
+	EXPECT_STREQ(channel_pair.GetReportedTransport(), "TURN");
+
+	IceCandidatePair indication_pair(Pair(13478, 20002), nullptr);
+	indication_pair.SetTurnSendIndication(ov::SocketAddress::CreateAndGetFirst("127.0.0.1", 30000));
+	EXPECT_STREQ(indication_pair.GetReportedTransport(), "TURN");
+}

--- a/src/modules/ice/ice_port_test.cpp
+++ b/src/modules/ice/ice_port_test.cpp
@@ -7,12 +7,13 @@
 //  address pair registered for a session (not just the active one).
 //
 //==============================================================================
-#include <gtest/gtest.h>
+#include "ice_port.h"
 
 #include <base/ovsocket/ovsocket.h>
+#include <gtest/gtest.h>
 #include <modules/sdp/session_description.h>
 
-#include "ice_port.h"
+#include "ice_candidate_pair.h"
 #include "ice_session.h"
 
 // Fixture is friended by IcePort, so its (protected) helpers may touch the
@@ -36,13 +37,31 @@ protected:
 			id, IceSession::Role::CONTROLLED, sdp, sdp, 600000, 0, std::any{}, nullptr);
 	}
 
-	bool AddId(IcePort &p, session_id_t id, const std::shared_ptr<IceSession> &s) { return p.AddIceSession(id, s); }
-	bool AddUfrag(IcePort &p, const ov::String &u, const std::shared_ptr<IceSession> &s) { return p.AddIceSession(u, s); }
-	bool AddPair(IcePort &p, const ov::SocketAddressPair &ap, const std::shared_ptr<IceSession> &s) { return p.AddIceSession(ap, s); }
+	bool AddId(IcePort &p, session_id_t id, const std::shared_ptr<IceSession> &s)
+	{
+		return p.AddIceSession(id, s);
+	}
+	bool AddUfrag(IcePort &p, const ov::String &u, const std::shared_ptr<IceSession> &s)
+	{
+		return p.AddIceSession(u, s);
+	}
+	bool AddPair(IcePort &p, const ov::SocketAddressPair &ap, const std::shared_ptr<IceSession> &s)
+	{
+		return p.AddIceSession(ap, s);
+	}
 
-	std::shared_ptr<IceSession> FindId(IcePort &p, session_id_t id) { return p.FindIceSession(id); }
-	std::shared_ptr<IceSession> FindUfrag(IcePort &p, const ov::String &u) { return p.FindIceSession(u); }
-	std::shared_ptr<IceSession> FindPair(IcePort &p, const ov::SocketAddressPair &ap) { return p.FindIceSession(ap); }
+	std::shared_ptr<IceSession> FindId(IcePort &p, session_id_t id)
+	{
+		return p.FindIceSession(id);
+	}
+	std::shared_ptr<IceSession> FindUfrag(IcePort &p, const ov::String &u)
+	{
+		return p.FindIceSession(u);
+	}
+	std::shared_ptr<IceSession> FindPair(IcePort &p, const ov::SocketAddressPair &ap)
+	{
+		return p.FindIceSession(ap);
+	}
 
 	bool MarkNom(IcePort &p, const std::shared_ptr<IceSession> &s, const ov::SocketAddressPair &ap)
 	{
@@ -52,7 +71,46 @@ protected:
 	// Stop the background sweeper so these registry tests are deterministic and
 	// free of a data race between CheckTimedOut() and the helpers below. The
 	// idempotent ~IcePort() Stop() afterwards is a harmless no-op.
-	void StopSweeper(IcePort &p) { p._timer.Stop(); }
+	void StopSweeper(IcePort &p)
+	{
+		p._timer.Stop();
+	}
+
+	static std::shared_ptr<IceSession> MakeObservedSession(session_id_t id, const ov::String &ufrag, const std::shared_ptr<IcePortObserver> &observer)
+	{
+		auto sdp = std::make_shared<SessionDescription>(SessionDescription::SdpType::Offer);
+		sdp->SetIceUfrag(ufrag);
+		return std::make_shared<IceSession>(
+			id, IceSession::Role::CONTROLLED, sdp, sdp, 600000, 0, std::any{}, observer);
+	}
+
+	// Feed an application packet into the (private) demux entry point
+	void InjectAppPacket(IcePort &p, const ov::SocketAddressPair &ap)
+	{
+		IcePort::GateInfo gate_info;
+		gate_info.packet_type = IcePacketIdentifier::PacketType::RTP_RTCP;
+		p.OnApplicationPacketReceived(nullptr, ap, gate_info, std::make_shared<ov::Data>());
+	}
+};
+
+// Records every OnIceCandidatePairSelected() delivery for assertions
+class PairRecordingObserver : public IcePortObserver
+{
+public:
+	void OnDataReceived(IcePort &port, uint32_t session_id, std::shared_ptr<const ov::Data> data, std::any user_data) override
+	{
+	}
+
+	void OnIceCandidatePairSelected(IcePort &port, uint32_t session_id, const std::shared_ptr<const IceCandidatePair> &candidate_pair, uint64_t selected_version, std::any user_data) override
+	{
+		last_session_id = session_id;
+		selected_pairs.push_back(candidate_pair);
+		selected_versions.push_back(selected_version);
+	}
+
+	uint32_t last_session_id = 0;
+	std::vector<std::shared_ptr<const IceCandidatePair>> selected_pairs;
+	std::vector<uint64_t> selected_versions;
 };
 
 // Add / Find across the three indices, including idempotent inserts.
@@ -167,4 +225,53 @@ TEST_F(IcePortTest, MarkNominatedRegistersPair)
 	// A pair the session never validated cannot be nominated/registered
 	EXPECT_FALSE(MarkNom(port, s, other));
 	EXPECT_EQ(FindPair(port, other), nullptr);
+}
+
+// The observer is notified once per selection/switch,
+// never for a packet arriving on the already-active pair (the hot path).
+TEST_F(IcePortTest, ApplicationPacketReportsSelectedPair)
+{
+	IcePort port;
+	StopSweeper(port);
+
+	auto observer = std::make_shared<PairRecordingObserver>();
+	auto s		  = MakeObservedSession(7, "ufragA", observer);
+	auto pair_a	  = Pair(13478, 20000);
+	auto pair_b	  = Pair(13478, 20001);
+
+	// Validate both pairs on the session and register them in the port's index
+	s->OnReceivedStunBindingRequest(pair_a, nullptr);
+	s->OnReceivedStunBindingRequest(pair_b, nullptr);
+	ASSERT_TRUE(MarkNom(port, s, pair_a));
+	ASSERT_TRUE(MarkNom(port, s, pair_b));
+
+	// First application packet selects pair_a and reports it
+	InjectAppPacket(port, pair_a);
+	ASSERT_EQ(observer->selected_pairs.size(), 1u);
+	EXPECT_EQ(observer->last_session_id, 7u);
+	EXPECT_TRUE(observer->selected_pairs[0]->GetAddressPair() == pair_a);
+	EXPECT_EQ(observer->selected_versions[0], 1u);
+
+	// A packet on the already-active pair must not report again
+	InjectAppPacket(port, pair_a);
+	EXPECT_EQ(observer->selected_pairs.size(), 1u);
+
+	// The peer moves to pair_b: the switch is reported with the new pair
+	// and a higher selection version
+	InjectAppPacket(port, pair_b);
+	ASSERT_EQ(observer->selected_pairs.size(), 2u);
+	EXPECT_TRUE(observer->selected_pairs[1]->GetAddressPair() == pair_b);
+	EXPECT_EQ(observer->selected_versions[1], 2u);
+
+	// A packet on an unknown pair is dropped and reports nothing
+	InjectAppPacket(port, Pair(13478, 20002));
+	EXPECT_EQ(observer->selected_pairs.size(), 2u);
+
+	// A pair the port knows but the session never STUN-validated is rejected:
+	// no callback, and the active pair stays pair_b
+	auto unvalidated = Pair(13478, 20003);
+	ASSERT_TRUE(AddPair(port, unvalidated, s));
+	InjectAppPacket(port, unvalidated);
+	EXPECT_EQ(observer->selected_pairs.size(), 2u);
+	EXPECT_TRUE(s->GetActiveCandidatePair()->GetAddressPair() == pair_b);
 }

--- a/src/modules/ice/ice_session.cpp
+++ b/src/modules/ice/ice_session.cpp
@@ -317,13 +317,23 @@ bool IceSession::MarkNominated(const ov::SocketAddressPair& address_pair)
 // Make a nominated pair the active pair (the one we send on). Called when the
 // peer sends application data on it, so OME follows the pair the peer chose
 // and switches if the peer moves.
-bool IceSession::SelectActiveCandidatePair(const ov::SocketAddressPair& address_pair)
+bool IceSession::SelectActiveCandidatePair(const ov::SocketAddressPair &address_pair,
+										   std::shared_ptr<IceCandidatePair> *selected_pair,
+										   uint64_t *selected_version)
 {
 	ov::ScopedLock lock(_active_candidate_pair_mutex);
 
 	if (_active_candidate_pair != nullptr && _active_candidate_pair->GetAddressPair() == address_pair)
 	{
-		// Already the active pair
+		// Already the active pair: report the current selection, without a new version
+		if (selected_pair != nullptr)
+		{
+			*selected_pair = _active_candidate_pair;
+		}
+		if (selected_version != nullptr)
+		{
+			*selected_version = _active_pair_version;
+		}
 		return true;
 	}
 
@@ -338,7 +348,17 @@ bool IceSession::SelectActiveCandidatePair(const ov::SocketAddressPair& address_
 	auto previous = _active_candidate_pair;
 
 	_active_candidate_pair = candidate_pair;
+	_active_pair_version++;
 	SetState(IceConnectionState::Connected);
+
+	if (selected_pair != nullptr)
+	{
+		*selected_pair = candidate_pair;
+	}
+	if (selected_version != nullptr)
+	{
+		*selected_version = _active_pair_version;
+	}
 
 	// ToString() includes the socket (TCP/UDP + addresses), useful for tracing
 	// which path the peer moved to.

--- a/src/modules/ice/ice_session.h
+++ b/src/modules/ice/ice_session.h
@@ -81,7 +81,11 @@ public:
 
 	// Make a STUN-validated pair the active pair (the one we send on).
 	// False if the pair is unknown or has failed its STUN check.
-	bool SelectActiveCandidatePair(const ov::SocketAddressPair& address_pair);
+	// The out-params receive the selected pair and its selection version
+	// (increases per switch), so racing consumers can drop a stale selection.
+	bool SelectActiveCandidatePair(const ov::SocketAddressPair &address_pair,
+								   std::shared_ptr<IceCandidatePair> *selected_pair = nullptr,
+								   uint64_t *selected_version						= nullptr);
 
 	// Active candidate pair (the single pair we send on)
 	std::shared_ptr<IceCandidatePair> GetActiveCandidatePair() const;
@@ -108,6 +112,8 @@ private:
     // Candidate pairs
 	mutable ov::SharedMutex _active_candidate_pair_mutex;
     std::shared_ptr<IceCandidatePair> _active_candidate_pair OV_GUARDED_BY(_active_candidate_pair_mutex);
+	// Increases on every active-pair switch; see SelectActiveCandidatePair()
+	uint64_t _active_pair_version OV_GUARDED_BY(_active_candidate_pair_mutex) = 0;
 
 	mutable ov::SharedMutex _candidate_pairs_mutex;
     std::map<ov::SocketAddressPair, std::shared_ptr<IceCandidatePair>> _candidate_pairs OV_GUARDED_BY(_candidate_pairs_mutex);

--- a/src/modules/json_serdes/common.h
+++ b/src/modules/json_serdes/common.h
@@ -10,6 +10,8 @@
 
 #include <base/ovlibrary/ovlibrary.h>
 
+#include <optional>
+
 #include "./converter_private.h"
 
 #define CONVERTER_RETURN_IF(condition, default_value)          \
@@ -68,5 +70,38 @@ namespace serdes
 	inline void SetBool(Json::Value &parent_object, const char *key, bool value)
 	{
 		parent_object[key] = value;
+	}
+
+	// std::optional overloads: the key is emitted only when the value is present
+	inline void SetInt(Json::Value &parent_object, const char *key, const std::optional<int32_t> &value)
+	{
+		if (value.has_value())
+		{
+			SetInt(parent_object, key, value.value());
+		}
+	}
+
+	inline void SetInt64(Json::Value &parent_object, const char *key, const std::optional<int64_t> &value)
+	{
+		if (value.has_value())
+		{
+			SetInt64(parent_object, key, value.value());
+		}
+	}
+
+	inline void SetFloat(Json::Value &parent_object, const char *key, const std::optional<float> &value)
+	{
+		if (value.has_value())
+		{
+			SetFloat(parent_object, key, value.value());
+		}
+	}
+
+	inline void SetBool(Json::Value &parent_object, const char *key, const std::optional<bool> &value)
+	{
+		if (value.has_value())
+		{
+			SetBool(parent_object, key, value.value());
+		}
 	}
 }  // namespace serdes

--- a/src/modules/json_serdes/stream.cpp
+++ b/src/modules/json_serdes/stream.cpp
@@ -11,8 +11,16 @@
 
 namespace serdes
 {
-	static void SetConnection(Json::Value &parent_object, const char *key, const void *temp, Optional optional)
+	static void SetConnection(Json::Value &parent_object, const char *key, const std::shared_ptr<const info::ConnectionInfo> &connection_info, Optional optional)
 	{
+		CONVERTER_RETURN_IF(connection_info == nullptr, Json::objectValue);
+
+		SetString(object, "transport", connection_info->transport, Optional::False);
+		SetString(object, "protocol", connection_info->protocol, Optional::True);
+		SetString(object, "localAddress", connection_info->local_address, Optional::True);
+		SetInt(object, "localPort", connection_info->local_port);
+		SetString(object, "remoteAddress", connection_info->remote_address, Optional::True);
+		SetInt(object, "remotePort", connection_info->remote_port);
 	}
 
 	static void SetTimebase(Json::Value &parent_object, const char *key, const cmn::Timebase &timebase, Optional optional)
@@ -257,8 +265,7 @@ namespace serdes
 
 		SetString(object, "sourceType", ::StringFromStreamSourceType(stream->GetSourceType()), Optional::False);
 		SetString(object, "sourceUrl", stream->GetMediaSource(), Optional::True);
-		// TODO(dimiden): Complete this function
-		SetConnection(object, "connection", stream.get(), Optional::True);
+		SetConnection(object, "connection", stream->GetConnectionInfo(), Optional::True);
 		SetTracks(object, "tracks", *stream, Optional::False);
 		SetTimestamp(object, "createdTime", common_metrics->GetCreatedTime());
 	}

--- a/src/providers/mpegts/mpegts_provider.cpp
+++ b/src/providers/mpegts/mpegts_provider.cpp
@@ -339,13 +339,13 @@ namespace pvd
 			return;
 		}
 
-		OnConnected(remote, *remote->GetRemoteAddress());
+		OnConnected(remote, ov::SocketAddressPair(*remote->GetLocalAddress(), *remote->GetRemoteAddress()));
 	}
 
-	bool MpegTsProvider::OnConnected(const std::shared_ptr<ov::Socket> &remote, const ov::SocketAddress &remote_address)
+	bool MpegTsProvider::OnConnected(const std::shared_ptr<ov::Socket> &remote, const ov::SocketAddressPair &address_pair)
 	{
-		auto local_port = remote->GetLocalAddress()->Port();
-		auto channel_id = remote->GetNativeHandle();
+		auto local_port		  = remote->GetLocalAddress()->Port();
+		auto channel_id		  = remote->GetNativeHandle();
 
 		auto stream_port_item = GetStreamPortItem(local_port);
 		if (stream_port_item == nullptr || stream_port_item->IsAttached() == false)
@@ -353,7 +353,11 @@ namespace pvd
 			return false;
 		}
 
-		auto stream = MpegTsStream::Create(StreamSourceType::Mpegts, channel_id, stream_port_item->GetVhostAppName(), stream_port_item->GetOutputStreamName(), remote, remote_address, 0, GetSharedPtrAs<PushProvider>());
+		auto stream = MpegTsStream::Create(
+			StreamSourceType::Mpegts, channel_id,
+			stream_port_item->GetVhostAppName(), stream_port_item->GetOutputStreamName(),
+			remote, address_pair, 0, GetSharedPtrAs<PushProvider>());
+
 		if (PushProvider::OnChannelCreated(remote->GetNativeHandle(), stream) == true)
 		{
 			logti("A MPEG-TS client has connected");  // %s", remote->ToString().CStr());
@@ -384,7 +388,7 @@ namespace pvd
 		// UDP
 		if (stream_port_item->IsClientConnected() == false)
 		{
-			if (OnConnected(remote, address_pair.GetRemoteAddress()) == false)
+			if (OnConnected(remote, address_pair) == false)
 			{
 				return;
 			}

--- a/src/providers/mpegts/mpegts_provider.h
+++ b/src/providers/mpegts/mpegts_provider.h
@@ -184,7 +184,7 @@ namespace pvd
 		// Implementation of PhysicalPortObserver
 		//--------------------------------------------------------------------
 		void OnConnected(const std::shared_ptr<ov::Socket> &remote) override;
-		bool OnConnected(const std::shared_ptr<ov::Socket> &remote, const ov::SocketAddress &address);
+		bool OnConnected(const std::shared_ptr<ov::Socket> &remote, const ov::SocketAddressPair &address_pair);
 
 		void OnDatagramReceived(const std::shared_ptr<ov::Socket> &remote,
 								const ov::SocketAddressPair &address_pair,

--- a/src/providers/mpegts/mpegts_stream.cpp
+++ b/src/providers/mpegts/mpegts_stream.cpp
@@ -43,6 +43,9 @@ namespace pvd
 		SetName(stream_name);
 		_remote = client_socket;
 		SetMediaSource(ov::String::FormatString("%s://%s", ov::StringFromSocketType(client_socket->GetType()), remote_address.ToString(false).CStr()));
+
+		// The shared UDP listener socket knows no remote address; use the packet source instead
+		SetConnectionInfo(info::ConnectionInfo::From(client_socket->GetLocalAddress().get(), &remote_address, client_socket->GetType()));
 		_lifetime_epoch_msec = lifetime_epoch_msec;
 	}
 

--- a/src/providers/mpegts/mpegts_stream.cpp
+++ b/src/providers/mpegts/mpegts_stream.cpp
@@ -25,9 +25,13 @@
 
 namespace pvd
 {
-	std::shared_ptr<MpegTsStream> MpegTsStream::Create(StreamSourceType source_type, uint32_t client_id, const info::VHostAppName &vhost_app_name, const ov::String &stream_name, const std::shared_ptr<ov::Socket> &client_socket, const ov::SocketAddress &remote_address, uint64_t lifetime_epoch_msec, const std::shared_ptr<PushProvider> &provider)
+	std::shared_ptr<MpegTsStream> MpegTsStream::Create(
+		StreamSourceType source_type, uint32_t client_id,
+		const info::VHostAppName &vhost_app_name, const ov::String &stream_name,
+		const std::shared_ptr<ov::Socket> &client_socket, const ov::SocketAddressPair &address_pair,
+		uint64_t lifetime_epoch_msec, const std::shared_ptr<PushProvider> &provider)
 	{
-		auto stream = std::make_shared<MpegTsStream>(source_type, client_id, vhost_app_name, stream_name, client_socket, remote_address, lifetime_epoch_msec, provider);
+		auto stream = std::make_shared<MpegTsStream>(source_type, client_id, vhost_app_name, stream_name, client_socket, address_pair, lifetime_epoch_msec, provider);
 		if (stream != nullptr)
 		{
 			stream->Start();
@@ -35,17 +39,27 @@ namespace pvd
 		return stream;
 	}
 
-	MpegTsStream::MpegTsStream(StreamSourceType source_type, uint32_t client_id, const info::VHostAppName &vhost_app_name, const ov::String &stream_name, std::shared_ptr<ov::Socket> client_socket, const ov::SocketAddress &remote_address, uint64_t lifetime_epoch_msec, const std::shared_ptr<PushProvider> &provider)
+	MpegTsStream::MpegTsStream(
+		StreamSourceType source_type, uint32_t client_id,
+		const info::VHostAppName &vhost_app_name, const ov::String &stream_name,
+		std::shared_ptr<ov::Socket> client_socket, const ov::SocketAddressPair &address_pair,
+		uint64_t lifetime_epoch_msec, const std::shared_ptr<PushProvider> &provider)
 		: PushStream(source_type, client_id, provider),
 
 		  _vhost_app_name(vhost_app_name)
 	{
 		SetName(stream_name);
 		_remote = client_socket;
-		SetMediaSource(ov::String::FormatString("%s://%s", ov::StringFromSocketType(client_socket->GetType()), remote_address.ToString(false).CStr()));
+		SetMediaSource(ov::String::FormatString("%s://%s", ov::StringFromSocketType(client_socket->GetType()), address_pair.GetRemoteAddress().ToString(false).CStr()));
 
-		// The shared UDP listener socket knows no remote address; use the packet source instead
-		SetConnectionInfo(info::ConnectionInfo::From(client_socket->GetLocalAddress().get(), &remote_address, client_socket->GetType()));
+		// The pair's local side is the per-datagram destination (pktinfo) for the shared UDP
+		// listener; fall back to the bind address when it is unavailable.
+		// The shared_ptr keeps the fallback alive across the statements below.
+		auto bind_address		  = client_socket->GetLocalAddress();
+		const auto *local_address = address_pair.GetLocalAddress().IsValid()
+										? &address_pair.GetLocalAddress()
+										: bind_address.get();
+		SetConnectionInfo(info::ConnectionInfo::From(local_address, &address_pair.GetRemoteAddress(), client_socket->GetType()));
 		_lifetime_epoch_msec = lifetime_epoch_msec;
 	}
 

--- a/src/providers/mpegts/mpegts_stream.h
+++ b/src/providers/mpegts/mpegts_stream.h
@@ -17,9 +17,17 @@ namespace pvd
 	class MpegTsStream final : public PushStream
 	{
 	public:
-		static std::shared_ptr<MpegTsStream> Create(StreamSourceType source_type, uint32_t channel_id, const info::VHostAppName &vhost_app_name, const ov::String &stream_name, const std::shared_ptr<ov::Socket> &client_socket, const ov::SocketAddress &remote_address, uint64_t lifetime_epoch_msec, const std::shared_ptr<PushProvider> &provider);
-		
-		explicit MpegTsStream(StreamSourceType source_type, uint32_t channel_id, const info::VHostAppName &vhost_app_name, const ov::String &stream_name, std::shared_ptr<ov::Socket> client_socket, const ov::SocketAddress &remote_address, uint64_t lifetime_epoch_msec, const std::shared_ptr<PushProvider> &provider);
+		static std::shared_ptr<MpegTsStream> Create(
+			StreamSourceType source_type, uint32_t channel_id,
+			const info::VHostAppName &vhost_app_name, const ov::String &stream_name,
+			const std::shared_ptr<ov::Socket> &client_socket, const ov::SocketAddressPair &address_pair,
+			uint64_t lifetime_epoch_msec, const std::shared_ptr<PushProvider> &provider);
+
+		explicit MpegTsStream(
+			StreamSourceType source_type, uint32_t channel_id,
+			const info::VHostAppName &vhost_app_name, const ov::String &stream_name,
+			std::shared_ptr<ov::Socket> client_socket, const ov::SocketAddressPair &address_pair,
+			uint64_t lifetime_epoch_msec, const std::shared_ptr<PushProvider> &provider);
 		~MpegTsStream() final;
 
 		bool Stop() override;

--- a/src/providers/rtmp/rtmp_stream.cpp
+++ b/src/providers/rtmp/rtmp_stream.cpp
@@ -98,6 +98,7 @@ namespace pvd
 
 		_remote = client_socket;
 		SetMediaSource(_remote->GetRemoteAddressAsUrl());
+		SetConnectionInfo(info::ConnectionInfo::From(_remote));
 
 		_import_chunk	   = std::make_shared<RtmpChunkParser>(RTMP_DEFAULT_CHUNK_SIZE);
 		_export_chunk	   = std::make_shared<RtmpExportChunk>(false, RTMP_DEFAULT_CHUNK_SIZE);

--- a/src/providers/rtmp/rtmp_stream_v2.cpp
+++ b/src/providers/rtmp/rtmp_stream_v2.cpp
@@ -43,6 +43,7 @@ namespace pvd::rtmp
 		logat("Stream has been created");
 
 		SetMediaSource(_remote->GetRemoteAddressAsUrl());
+		SetConnectionInfo(info::ConnectionInfo::From(_remote));
 	}
 
 	RtmpStreamV2::~RtmpStreamV2()

--- a/src/providers/srt/srt_provider.cpp
+++ b/src/providers/srt/srt_provider.cpp
@@ -299,7 +299,17 @@ namespace pvd
 			return;
 		}
 
-		auto stream = MpegTsStream::Create(StreamSourceType::Srt, channel_id, vhost_app_name, stream_name, remote, *remote->GetRemoteAddress(), life_time, GetSharedPtrAs<pvd::PushProvider>());
+		// An accepted SRT socket can miss its local address when `srt_getsockname()` failed
+		ov::SocketAddressPair address_pair(
+			(remote->GetLocalAddress() != nullptr) ? *remote->GetLocalAddress() : ov::SocketAddress(),
+			*remote->GetRemoteAddress());
+
+		auto stream = MpegTsStream::Create(
+			StreamSourceType::Srt, channel_id,
+			vhost_app_name, stream_name,
+			remote, address_pair,
+			life_time, GetSharedPtrAs<pvd::PushProvider>());
+
 		stream->SetRequestedUrl(requested_url);
 		stream->SetFinalUrl(final_url);
 

--- a/src/providers/webrtc/webrtc_provider.cpp
+++ b/src/providers/webrtc/webrtc_provider.cpp
@@ -737,11 +737,10 @@ namespace pvd
 			return;
 		}
 
-		// A non-direct pair goes through the built-in TURN server regardless of the socket protocol
 		auto connection_info = info::ConnectionInfo::From(
 			candidate_pair->GetAddressPair(),
 			socket->GetType(),
-			(candidate_pair->GetTransportType() != IceCandidatePair::TransportType::Direct) ? "TURN" : nullptr,
+			candidate_pair->GetReportedTransport(),
 			selected_version);
 
 		if (stream->SetConnectionInfo(connection_info) == false)

--- a/src/providers/webrtc/webrtc_provider.cpp
+++ b/src/providers/webrtc/webrtc_provider.cpp
@@ -711,6 +711,49 @@ namespace pvd
 		}
 	}
 
+	void WebRTCProvider::OnIceCandidatePairSelected(IcePort &port, uint32_t session_id, const std::shared_ptr<const IceCandidatePair> &candidate_pair, uint64_t selected_version, std::any user_data)
+	{
+		std::shared_ptr<WebRTCStream> stream;
+
+		try
+		{
+			stream = std::any_cast<std::shared_ptr<WebRTCStream>>(user_data);
+		}
+		catch (const std::bad_any_cast &e)
+		{
+			logtc("[INTERNAL ERROR] could not convert user_data to WebRTCStream");
+			OV_ASSERT2(false);
+			return;
+		}
+
+		if (candidate_pair == nullptr)
+		{
+			return;
+		}
+
+		auto socket = candidate_pair->GetSocket();
+		if (socket == nullptr)
+		{
+			return;
+		}
+
+		// A non-direct pair goes through the built-in TURN server regardless of the socket protocol
+		auto connection_info = info::ConnectionInfo::From(
+			candidate_pair->GetAddressPair(),
+			socket->GetType(),
+			(candidate_pair->GetTransportType() != IceCandidatePair::TransportType::Direct) ? "TURN" : nullptr,
+			selected_version);
+
+		if (stream->SetConnectionInfo(connection_info) == false)
+		{
+			// A racing thread already published a newer selection
+			return;
+		}
+
+		logti("Transport selected for stream(%s/%s) : %s",
+			  stream->GetApplicationName(), stream->GetName().CStr(), connection_info->ToString().CStr());
+	}
+
 	// WHIP API
 	WhipObserver::Answer WebRTCProvider::OnSdpOffer(const std::shared_ptr<const http::svr::HttpRequest> &request,
 													const std::shared_ptr<const SessionDescription> &offer_sdp)

--- a/src/providers/webrtc/webrtc_provider.h
+++ b/src/providers/webrtc/webrtc_provider.h
@@ -56,6 +56,7 @@ namespace pvd
 		// IcePortObserver Implementation
 		//--------------------------------------------------------------------
 		void OnStateChanged(IcePort &port, uint32_t session_id, IceConnectionState state, bool is_expired, std::any user_data) override;
+		void OnIceCandidatePairSelected(IcePort &port, uint32_t session_id, const std::shared_ptr<const IceCandidatePair> &candidate_pair, uint64_t selected_version, std::any user_data) override;
 		void OnDataReceived(IcePort &port, uint32_t session_id, std::shared_ptr<const ov::Data> data, std::any user_data) override;
 		//--------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds a `connection` object (transport, protocol, local/remote address and port) to ingress stream alerts (`sourceInfo`) and the REST API stream response (`input`).
For WebRTC it reports the ICE-selected path: with `?transport=all` there was previously no way to tell whether a stream ended up on UDP, direct TCP, or the TURN relay.
RTMP/SRT/MPEG-TS streams report their socket connection as well.

## Changes

- `info::ConnectionInfo` snapshot stored in `StreamStats`; publication is version-gated so a stale selection racing a newer one on another socket thread cannot overwrite it.
- New `IcePortObserver::OnIceCandidatePairSelected()` (default no-op) fires on the first selection and every switch of the active candidate pair; the WebRTC provider classifies the pair as UDP/TCP/TURN and records it (WHIP and WebSocket signalling).
- RTMP/MPEG-TS (SRT) record their connection at stream creation, so it is available from `INGRESS_STREAM_CREATED`; WebRTC from `INGRESS_STREAM_PREPARED` (after ICE completes).
- serdes: implement the `SetConnection()` stub; add `std::optional` setter overloads.
- Unit tests for callback/version ordering, transport classification, and the version gate.

## Testing

Publish via WHIP with `?transport=udp|tcp|relay|all` and via RTMP, then check the `INGRESS_STREAM_PREPARED` alert (`sourceInfo.connection`) and `GET /v1/vhosts/{vhost}/apps/{app}/streams/{stream}` (`input.connection`), e.g.:

```json
{"transport": "TURN", "protocol": "TCP", "localAddress": "10.0.0.5", "localPort": 3478, "remoteAddress": "1.2.3.4", "remotePort": 51234}
```
