### PR TITLE
fix(config): unify `webRtcAutoAbr` JSON key casing with a deprecated input alias

### DIFF
--- a/api/ome.yml
+++ b/api/ome.yml
@@ -639,8 +639,13 @@ components:
     Options:
       type: object
       properties:
+        webrtcAutoAbr:
+          type: boolean
+        # Deprecated alias of webrtcAutoAbr. It is still accepted on requests for backward compatibility
+        # but is no longer included in responses, and will be removed in a future release.
         webRtcAutoAbr:
           type: boolean
+          deprecated: true
         hlsChunklistPathDepth:
           type: integer
           format: int32

--- a/api/ome.yml
+++ b/api/ome.yml
@@ -644,6 +644,7 @@ components:
         webRtcAutoAbr:
           type: boolean
           deprecated: true
+          writeOnly: true
           description: Deprecated alias of webrtcAutoAbr. It is still accepted on requests for backward compatibility (ignored when webrtcAutoAbr is also present) but is no longer included in responses, and will be removed in a future release.
         hlsChunklistPathDepth:
           type: integer

--- a/api/ome.yml
+++ b/api/ome.yml
@@ -644,8 +644,7 @@ components:
         webRtcAutoAbr:
           type: boolean
           deprecated: true
-          writeOnly: true
-          description: Deprecated alias of webrtcAutoAbr. It is still accepted on requests for backward compatibility (ignored when webrtcAutoAbr is also present) but is no longer included in responses, and will be removed in a future release.
+          description: Deprecated alias of webrtcAutoAbr. During the deprecation window it is accepted on requests (a request that sends both keys with different values is rejected) and included in responses alongside webrtcAutoAbr, and will be removed in a future release.
         hlsChunklistPathDepth:
           type: integer
           format: int32

--- a/api/ome.yml
+++ b/api/ome.yml
@@ -644,7 +644,7 @@ components:
         webRtcAutoAbr:
           type: boolean
           deprecated: true
-          description: Deprecated alias of webrtcAutoAbr. It is still accepted on requests for backward compatibility but is no longer included in responses, and will be removed in a future release.
+          description: Deprecated alias of webrtcAutoAbr. It is still accepted on requests for backward compatibility (ignored when webrtcAutoAbr is also present) but is no longer included in responses, and will be removed in a future release.
         hlsChunklistPathDepth:
           type: integer
           format: int32

--- a/api/ome.yml
+++ b/api/ome.yml
@@ -641,11 +641,10 @@ components:
       properties:
         webrtcAutoAbr:
           type: boolean
-        # Deprecated alias of webrtcAutoAbr. It is still accepted on requests for backward compatibility
-        # but is no longer included in responses, and will be removed in a future release.
         webRtcAutoAbr:
           type: boolean
           deprecated: true
+          description: Deprecated alias of webrtcAutoAbr. It is still accepted on requests for backward compatibility but is no longer included in responses, and will be removed in a future release.
         hlsChunklistPathDepth:
           type: integer
           format: int32

--- a/docs/transcoding/transcodewebhook.md
+++ b/docs/transcoding/transcodewebhook.md
@@ -249,7 +249,7 @@ The `outputProfiles` section in the JSON structure mirrors the configuration in 
           "name": "abr",
           "options": {
             "enableTsPackaging": true,
-            "webRtcAutoAbr": true,
+            "webrtcAutoAbr": true,
             "hlsChunklistPathDepth": -1
           },
           "renditions": [
@@ -280,6 +280,8 @@ The `outputProfiles` section in the JSON structure mirrors the configuration in 
   ]
 }
 ```
+
+> **Note**: `webRtcAutoAbr` is a deprecated alias of `webrtcAutoAbr`. It is still accepted for backward compatibility, and will be removed in a future release.
 
 #### tracksets (optional)
 

--- a/docs/transcoding/transcodewebhook.md
+++ b/docs/transcoding/transcodewebhook.md
@@ -281,7 +281,7 @@ The `outputProfiles` section in the JSON structure mirrors the configuration in 
 }
 ```
 
-> **Note**: `webRtcAutoAbr` is a deprecated alias of `webrtcAutoAbr`. It is still accepted for backward compatibility, and will be removed in a future release.
+> **Note**: `webRtcAutoAbr` is a deprecated alias of `webrtcAutoAbr`. It is still accepted for backward compatibility (ignored when `webrtcAutoAbr` is also present), and will be removed in a future release.
 
 #### tracksets (optional)
 

--- a/docs/transcoding/transcodewebhook.md
+++ b/docs/transcoding/transcodewebhook.md
@@ -281,7 +281,7 @@ The `outputProfiles` section in the JSON structure mirrors the configuration in 
 }
 ```
 
-> **Note**: `webRtcAutoAbr` is a deprecated alias of `webrtcAutoAbr`. It is still accepted for backward compatibility (ignored when `webrtcAutoAbr` is also present), and will be removed in a future release.
+> **Note**: `webRtcAutoAbr` is a deprecated alias of `webrtcAutoAbr`. During the deprecation window it is accepted for backward compatibility (a response that contains both keys with different values is rejected), and will be removed in a future release.
 
 #### tracksets (optional)
 

--- a/src/config/engine/child.cpp
+++ b/src/config/engine/child.cpp
@@ -112,11 +112,7 @@ namespace cfg
 		auto value		= data_source.GetValue(GetType(), item_name, ResolvePath(), OmitJsonName(), &original_value, item_path);
 		auto name		= item_name.GetName(DataType::Json);
 
-		auto child_path = ov::String::FormatString(
-			"%s%s%s",
-			item_path.CStr(),
-			item_path.IsEmpty() ? "" : ".",
-			name.CStr());
+		auto child_path = MakeChildPath(item_path, name);
 
 		if (value.HasValue() == false)
 		{

--- a/src/config/engine/child.cpp
+++ b/src/config/engine/child.cpp
@@ -109,10 +109,10 @@ namespace cfg
 		auto &item_name = GetItemName();
 
 		Json::Value original_value;
-		auto value			  = data_source.GetValue(GetType(), item_name, ResolvePath(), OmitJsonName(), &original_value);
-		auto name			  = item_name.GetName(DataType::Json);
+		auto value		= data_source.GetValue(GetType(), item_name, ResolvePath(), OmitJsonName(), &original_value, item_path);
+		auto name		= item_name.GetName(DataType::Json);
 
-		ov::String child_path = ov::String::FormatString(
+		auto child_path = ov::String::FormatString(
 			"%s%s%s",
 			item_path.CStr(),
 			item_path.IsEmpty() ? "" : ".",

--- a/src/config/engine/data_source.cpp
+++ b/src/config/engine/data_source.cpp
@@ -698,8 +698,34 @@ namespace cfg
 			case DataType::Xml:
 				return GetValueFromXml(value_type, name.GetName(_type), true, resolve_path, original_value);
 
-			case DataType::Json:
-				return GetValueFromJson(value_type, name.GetName(_type), true, resolve_path, omit_json, original_value);
+			case DataType::Json: {
+				const auto &json_name = name.GetName(_type);
+
+				if (
+					// This item has a deprecated alias
+					(name.deprecated_json_name.IsEmpty() == false) &&
+					// `isMember()` below is only valid on an object
+					_json.isObject())
+				{
+					if (_json.isMember(json_name.CStr()))
+					{
+						// The current name is present, so use it as-is.
+						// Warn if the deprecated key is also present, because it is ignored.
+						if (_json.isMember(name.deprecated_json_name.CStr()))
+						{
+							logtw("The deprecated JSON key \"%s\" is ignored because \"%s\" is also present", name.deprecated_json_name.CStr(), json_name.CStr());
+						}
+					}
+					else if (_json.isMember(name.deprecated_json_name.CStr()))
+					{
+						// The current name is absent - fall back to the deprecated JSON name
+						logtw("The JSON key \"%s\" is deprecated. Use \"%s\" instead", name.deprecated_json_name.CStr(), json_name.CStr());
+						return GetValueFromJson(value_type, name.deprecated_json_name, true, resolve_path, omit_json, original_value);
+					}
+				}
+
+				return GetValueFromJson(value_type, json_name, true, resolve_path, omit_json, original_value);
+			}
 		}
 
 		OV_ASSERT2(false);

--- a/src/config/engine/data_source.cpp
+++ b/src/config/engine/data_source.cpp
@@ -704,37 +704,35 @@ namespace cfg
 				if (
 					// This item has a deprecated alias
 					(name.deprecated_json_name.IsEmpty() == false) &&
-					// `isMember()` below is only valid on an object
+					// `isMember()` below asserts on non-object values other than null
 					_json.isObject())
 				{
-					// Full path of the deprecated key for the warnings below, such as "playlists.options.webRtcAutoAbr in Server.json"
-					auto deprecated_key_location = [&]() -> ov::String {
-						ov::String location = ov::String::FormatString(
+					// Full path of the deprecated key for the warnings below, such as "playlists.options.webRtcAutoAbr"
+					auto deprecated_key_path = [&]() -> ov::String {
+						return ov::String::FormatString(
 							"%s%s%s",
 							item_path.CStr(), item_path.IsEmpty() ? "" : ".", name.deprecated_json_name.CStr());
-
+					};
+					// " in <file>" when the JSON comes from a file, empty otherwise
+					auto file_suffix = [&]() -> ov::String {
 						auto file_name = GetFileName();
-						if (file_name.IsEmpty() == false)
-						{
-							location.AppendFormat(" in %s", file_name.CStr());
-						}
-
-						return location;
+						return file_name.IsEmpty() ? ov::String() : ov::String::FormatString(" in %s", file_name.CStr());
 					};
 
 					if (_json.isMember(json_name.CStr()))
 					{
-						// The current name is present, so use it as-is.
+						// The current name is present, so use it as-is. Key presence decides, not the value:
+						// an explicit null under the current name still wins over the deprecated key.
 						// Warn if the deprecated key is also present, because it is ignored.
 						if (_json.isMember(name.deprecated_json_name.CStr()))
 						{
-							logtw("The deprecated JSON key \"%s\" is ignored because \"%s\" is also present", deprecated_key_location().CStr(), json_name.CStr());
+							logtw("The deprecated JSON key \"%s\" is ignored because \"%s\" is also present%s", deprecated_key_path().CStr(), json_name.CStr(), file_suffix().CStr());
 						}
 					}
 					else if (_json.isMember(name.deprecated_json_name.CStr()))
 					{
 						// The current name is absent - fall back to the deprecated JSON name
-						logtw("The JSON key \"%s\" is deprecated. Use \"%s\" instead", deprecated_key_location().CStr(), json_name.CStr());
+						logtw("The JSON key \"%s\" is deprecated. Use \"%s\" instead%s", deprecated_key_path().CStr(), json_name.CStr(), file_suffix().CStr());
 						return GetValueFromJson(value_type, name.deprecated_json_name, true, resolve_path, omit_json, original_value);
 					}
 				}

--- a/src/config/engine/data_source.cpp
+++ b/src/config/engine/data_source.cpp
@@ -691,7 +691,7 @@ namespace cfg
 		return {};
 	}
 
-	Variant DataSource::GetValue(ValueType value_type, const ItemName &name, bool resolve_path, bool omit_json, Json::Value *original_value) const
+	Variant DataSource::GetValue(ValueType value_type, const ItemName &name, bool resolve_path, bool omit_json, Json::Value *original_value, const ov::String &item_path) const
 	{
 		switch (_type)
 		{
@@ -707,19 +707,34 @@ namespace cfg
 					// `isMember()` below is only valid on an object
 					_json.isObject())
 				{
+					// Full path of the deprecated key for the warnings below, such as "playlists.options.webRtcAutoAbr in Server.json"
+					auto deprecated_key_location = [&]() -> ov::String {
+						ov::String location = ov::String::FormatString(
+							"%s%s%s",
+							item_path.CStr(), item_path.IsEmpty() ? "" : ".", name.deprecated_json_name.CStr());
+
+						auto file_name = GetFileName();
+						if (file_name.IsEmpty() == false)
+						{
+							location.AppendFormat(" in %s", file_name.CStr());
+						}
+
+						return location;
+					};
+
 					if (_json.isMember(json_name.CStr()))
 					{
 						// The current name is present, so use it as-is.
 						// Warn if the deprecated key is also present, because it is ignored.
 						if (_json.isMember(name.deprecated_json_name.CStr()))
 						{
-							logtw("The deprecated JSON key \"%s\" is ignored because \"%s\" is also present", name.deprecated_json_name.CStr(), json_name.CStr());
+							logtw("The deprecated JSON key \"%s\" is ignored because \"%s\" is also present", deprecated_key_location().CStr(), json_name.CStr());
 						}
 					}
 					else if (_json.isMember(name.deprecated_json_name.CStr()))
 					{
 						// The current name is absent - fall back to the deprecated JSON name
-						logtw("The JSON key \"%s\" is deprecated. Use \"%s\" instead", name.deprecated_json_name.CStr(), json_name.CStr());
+						logtw("The JSON key \"%s\" is deprecated. Use \"%s\" instead", deprecated_key_location().CStr(), json_name.CStr());
 						return GetValueFromJson(value_type, name.deprecated_json_name, true, resolve_path, omit_json, original_value);
 					}
 				}
@@ -799,7 +814,7 @@ namespace cfg
 	bool DataSource::GetIncludeFileList(ov::String *pattern, std::vector<ov::String> *include_file_list) const
 	{
 		Json::Value dummy_value;
-		auto include_file_pattern = GetValue(ValueType::Attribute, "include", false, false, &dummy_value);
+		auto include_file_pattern = GetValue(ValueType::Attribute, "include", false, false, &dummy_value, "");
 
 		if (include_file_pattern.HasValue())
 		{

--- a/src/config/engine/data_source.cpp
+++ b/src/config/engine/data_source.cpp
@@ -372,6 +372,12 @@ namespace cfg
 		return Json::nullValue;
 	}
 
+	// `isMember()` asserts on non-object values other than null, so the guard lives here
+	bool HasJsonMember(const Json::Value &value, const ov::String &name)
+	{
+		return value.isObject() && value.isMember(name.CStr());
+	}
+
 	Json::Value GetJsonAttribute(const Json::Value &value, const ov::String &attribute_name)
 	{
 		if (value.isObject() && value.isMember("$"))
@@ -701,17 +707,12 @@ namespace cfg
 			case DataType::Json: {
 				const auto &json_name = name.GetName(_type);
 
-				if (
-					// This item has a deprecated alias
-					(name.deprecated_json_name.IsEmpty() == false) &&
-					// `isMember()` below asserts on non-object values other than null
-					_json.isObject())
+				// This item has a deprecated alias
+				if (name.deprecated_json_name.IsEmpty() == false)
 				{
-					// Full path of the deprecated key for the warnings below, such as "playlists.options.webRtcAutoAbr"
+					// Full path of the deprecated key for the diagnostics below, such as "playlists.options.webRtcAutoAbr"
 					auto deprecated_key_path = [&]() -> ov::String {
-						return ov::String::FormatString(
-							"%s%s%s",
-							item_path.CStr(), item_path.IsEmpty() ? "" : ".", name.deprecated_json_name.CStr());
+						return MakeChildPath(item_path, name.deprecated_json_name);
 					};
 					// " in <file>" when the JSON comes from a file, empty otherwise
 					auto file_suffix = [&]() -> ov::String {
@@ -719,17 +720,20 @@ namespace cfg
 						return file_name.IsEmpty() ? ov::String() : ov::String::FormatString(" in %s", file_name.CStr());
 					};
 
-					if (_json.isMember(json_name.CStr()))
+					const bool has_current	  = HasJsonMember(_json, json_name);
+					const bool has_deprecated = HasJsonMember(_json, name.deprecated_json_name);
+
+					if (has_current && has_deprecated)
 					{
-						// The current name is present, so use it as-is. Key presence decides, not the value:
-						// an explicit null under the current name still wins over the deprecated key.
-						// Warn if the deprecated key is also present, because it is ignored.
-						if (_json.isMember(name.deprecated_json_name.CStr()))
+						// The two values must match. ToJson emits both keys during the deprecation window,
+						// so an equal pair is a normal echo of our own output and passes silently,
+						// while different values (an explicit null counts as a value) mean the request contradicts itself.
+						if (_json[json_name.CStr()] != _json[name.deprecated_json_name.CStr()])
 						{
-							logtw("The deprecated JSON key \"%s\"%s is ignored because \"%s\" is also present", deprecated_key_path().CStr(), file_suffix().CStr(), json_name.CStr());
+							throw CreateConfigError("The deprecated JSON key \"%s\"%s conflicts with \"%s\": the two values differ", deprecated_key_path().CStr(), file_suffix().CStr(), json_name.CStr());
 						}
 					}
-					else if (_json.isMember(name.deprecated_json_name.CStr()))
+					else if (has_deprecated)
 					{
 						// The current name is absent - fall back to the deprecated JSON name
 						logtw("The JSON key \"%s\"%s is deprecated. Use \"%s\" instead", deprecated_key_path().CStr(), file_suffix().CStr(), json_name.CStr());

--- a/src/config/engine/data_source.cpp
+++ b/src/config/engine/data_source.cpp
@@ -726,13 +726,13 @@ namespace cfg
 						// Warn if the deprecated key is also present, because it is ignored.
 						if (_json.isMember(name.deprecated_json_name.CStr()))
 						{
-							logtw("The deprecated JSON key \"%s\" is ignored because \"%s\" is also present%s", deprecated_key_path().CStr(), json_name.CStr(), file_suffix().CStr());
+							logtw("The deprecated JSON key \"%s\"%s is ignored because \"%s\" is also present", deprecated_key_path().CStr(), file_suffix().CStr(), json_name.CStr());
 						}
 					}
 					else if (_json.isMember(name.deprecated_json_name.CStr()))
 					{
 						// The current name is absent - fall back to the deprecated JSON name
-						logtw("The JSON key \"%s\" is deprecated. Use \"%s\" instead%s", deprecated_key_path().CStr(), json_name.CStr(), file_suffix().CStr());
+						logtw("The JSON key \"%s\"%s is deprecated. Use \"%s\" instead", deprecated_key_path().CStr(), file_suffix().CStr(), json_name.CStr());
 						return GetValueFromJson(value_type, name.deprecated_json_name, true, resolve_path, omit_json, original_value);
 					}
 				}

--- a/src/config/engine/data_source.h
+++ b/src/config/engine/data_source.h
@@ -68,7 +68,8 @@ namespace cfg
 		MAY_THROWS(cfg::ConfigError)
 		Variant GetRootValue(ValueType value_type, bool resolve_path, bool omit_json, Json::Value *original_value) const;
 		MAY_THROWS(cfg::ConfigError)
-		Variant GetValue(ValueType value_type, const ItemName &name, bool resolve_path, bool omit_json, Json::Value *original_value) const;
+		// item_path is used only to locate the item in diagnostics such as the deprecated-key warnings
+		Variant GetValue(ValueType value_type, const ItemName &name, bool resolve_path, bool omit_json, Json::Value *original_value, const ov::String &item_path) const;
 
 		// Create a data source from this context
 		DataSource NewDataSource(const ov::String &file_name, const ItemName &root_name) const

--- a/src/config/engine/declare_utilities.h
+++ b/src/config/engine/declare_utilities.h
@@ -10,6 +10,7 @@
 
 // auto &GetInt() { return int_value; }
 #define CFG_DECLARE_REF_GETTER_OF(getter_name, variable_name) \
+	MAY_THROWS(cfg::ConfigError)                              \
 	auto &getter_name(bool *is_configured = nullptr)          \
 	{                                                         \
 		if (is_configured != nullptr)                         \
@@ -22,6 +23,7 @@
 
 // const auto &GetInt() const { return int_value; }
 #define CFG_DECLARE_CONST_REF_GETTER_OF(getter_name, variable_name) \
+	MAY_THROWS(cfg::ConfigError)                                    \
 	const auto &getter_name(bool *is_configured = nullptr) const    \
 	{                                                               \
 		if (is_configured != nullptr)                               \
@@ -34,6 +36,7 @@
 
 // virtual decltype(variable_name) GetInt() { return int_value; }
 #define CFG_DECLARE_VIRTUAL_REF_GETTER_OF(getter_name, variable_name)           \
+	MAY_THROWS(cfg::ConfigError)                                                \
 	virtual decltype(variable_name) &getter_name(bool *is_configured = nullptr) \
 	{                                                                           \
 		if (is_configured != nullptr)                                           \
@@ -46,6 +49,7 @@
 
 // virtual const decltype(variable_name) GetInt() const { return int_value; }
 #define CFG_DECLARE_VIRTUAL_CONST_REF_GETTER_OF(getter_name, variable_name)                 \
+	MAY_THROWS(cfg::ConfigError)                                                            \
 	virtual const decltype(variable_name) &getter_name(bool *is_configured = nullptr) const \
 	{                                                                                       \
 		if (is_configured != nullptr)                                                       \
@@ -58,6 +62,7 @@
 
 // auto GetInt() override { return int_value; }
 #define CFG_DECLARE_OVERRIDED_GETTER_OF(getter_name, variable_name) \
+	MAY_THROWS(cfg::ConfigError)                                    \
 	auto getter_name(bool *is_configured = nullptr) override        \
 	{                                                               \
 		if (is_configured != nullptr)                               \
@@ -70,6 +75,7 @@
 
 // auto GetInt() const override { return int_value; }
 #define CFG_DECLARE_OVERRIDED_CONST_GETTER_OF(getter_name, variable_name) \
+	MAY_THROWS(cfg::ConfigError)                                          \
 	auto getter_name(bool *is_configured = nullptr) const override        \
 	{                                                                     \
 		if (is_configured != nullptr)                                     \

--- a/src/config/engine/item.cpp
+++ b/src/config/engine/item.cpp
@@ -201,21 +201,13 @@ namespace cfg
 		{
 			logat("[%s] Rebuilding a list of children (last: %p, current: %p)", _item_name.ToString().CStr(), _last_target, this);
 
-			_last_target = this;
+			MakeList();
 
-			try
-			{
-				MakeList();
-			}
-			catch (...)
-			{
-				// This does not roll back the partial mutations `MakeList()` made before throwing.
-				// Resetting the guard only makes the next call rerun `MakeList()` from scratch
-				// (deterministically re-registering, or re-throwing at, every child)
-				// instead of treating the partially built child list as complete.
-				_last_target = nullptr;
-				throw;
-			}
+			// Commit the guard only after `MakeList()` succeeds, so a throw leaves the guard untouched
+			// and the next call reruns the rebuild from scratch instead of treating the partially built
+			// child list as complete. (`MakeList()` implementations must not re-enter
+			// `RebuildListIfNeeded()` on the same item - they only call `Register()`.)
+			_last_target = this;
 		}
 	}
 
@@ -246,19 +238,13 @@ namespace cfg
 			// and `IsSourceOf()` silently drops every element,
 			// and an Item child is rejected as well because no use case needs that path and it is untested.
 			const auto type = child->GetType();
-			const bool supported =
-				(type == ValueType::String) ||
-				(type == ValueType::Integer) ||
-				(type == ValueType::Long) ||
-				(type == ValueType::Boolean) ||
-				(type == ValueType::Double) ||
-				(type == ValueType::Text);
 
-			if (supported == false)
+			if (IsScalarValueType(type) == false)
 			{
-				// Fail loudly in every build. The startup schema validation (ValidateOmitJsonNameRules)
-				// rebuilds every item type, so an invalid registration refuses server startup
-				// instead of silently dropping the deprecated key at runtime.
+				// Fail loudly in every build.
+				// `ValidateOmitJsonNameRules()` at startup rebuilds every item type reachable from cfg::Server,
+				// so an invalid registration in that tree refuses server startup;
+				// a standalone-loaded item root would fail lazily at its first rebuild instead.
 				throw CreateConfigError("The deprecated JSON alias \"%s\" of %s is not supported for this value type: %s", name.deprecated_json_name.CStr(), name.ToString().CStr(), StringFromValueType(type));
 			}
 
@@ -280,17 +266,18 @@ namespace cfg
 			}
 		}
 
+		// The iterator is reused for the insert below; the dedup loop only touches _children,
+		// so it stays valid
+		auto existing_json_entry = _children_for_json.find(name.json_name);
+
+		// A canonical name must not displace another child's deprecated alias:
+		// the same JSON key would then feed two children (one directly, one via the alias fallback)
+		// with no diagnostic anywhere
+		if ((existing_json_entry != _children_for_json.end()) &&
+			((existing_json_entry->second->GetItemName() == name) == false) &&
+			(existing_json_entry->second->GetItemName().deprecated_json_name == name.json_name))
 		{
-			// A canonical name must not displace another child's deprecated alias:
-			// the same JSON key would then feed two children (one directly, one via the alias fallback)
-			// with no diagnostic anywhere
-			auto existing = _children_for_json.find(name.json_name);
-			if ((existing != _children_for_json.end()) &&
-				((existing->second->GetItemName() == name) == false) &&
-				(existing->second->GetItemName().deprecated_json_name == name.json_name))
-			{
-				throw CreateConfigError("The JSON name \"%s\" of %s conflicts with the deprecated alias of %s", name.json_name.CStr(), name.ToString().CStr(), existing->second->GetItemName().ToString().CStr());
-			}
+			throw CreateConfigError("The JSON name \"%s\" of %s conflicts with the deprecated alias of %s", name.json_name.CStr(), name.ToString().CStr(), existing_json_entry->second->GetItemName().ToString().CStr());
 		}
 
 		for (auto child_iterator = _children.begin(); child_iterator != _children.end(); ++child_iterator)
@@ -305,7 +292,15 @@ namespace cfg
 		}
 
 		_children_for_xml.insert_or_assign(name.xml_name, child);
-		_children_for_json.insert_or_assign(name.json_name, child);
+
+		if (existing_json_entry != _children_for_json.end())
+		{
+			existing_json_entry->second = child;
+		}
+		else
+		{
+			_children_for_json.emplace(name.json_name, child);
+		}
 
 		if (name.deprecated_json_name.IsEmpty() == false)
 		{
@@ -435,7 +430,7 @@ namespace cfg
 	{
 		RebuildListIfNeeded();
 
-		auto child_path = item_path.IsEmpty() ? name : ov::String::FormatString("%s.%s", item_path.CStr(), name.CStr());
+		auto child_path = MakeChildPath(item_path, name);
 
 		// Check omit rule for children
 		for (const auto &child : _children)
@@ -722,7 +717,7 @@ namespace cfg
 						[[fallthrough]];
 					case ValueType::Attribute:
 						[[fallthrough]];
-					case ValueType::Text:
+					case ValueType::Text: {
 						if (original_value)
 						{
 							SetOriginalJsonValue(value_type, value, child_name, child->GetOriginalValue());
@@ -731,7 +726,23 @@ namespace cfg
 						{
 							SetCurrentJsonValue(value_type, value, child_name, child->GetMemberPointer());
 						}
+
+						auto &deprecated_json_name = child->GetItemName().deprecated_json_name;
+						if (deprecated_json_name.IsEmpty() == false)
+						{
+							// Emit the deprecated key with the same value during the deprecation window,
+							// so response-only readers keep working until the key is removed
+							if (original_value)
+							{
+								SetOriginalJsonValue(value_type, value, deprecated_json_name, child->GetOriginalValue());
+							}
+							else
+							{
+								SetCurrentJsonValue(value_type, value, deprecated_json_name, child->GetMemberPointer());
+							}
+						}
 						break;
+					}
 
 					case ValueType::Item: {
 						Item *child_item = nullptr;

--- a/src/config/engine/item.cpp
+++ b/src/config/engine/item.cpp
@@ -244,6 +244,7 @@ namespace cfg
 			// an Attribute value lives under "$" so the alias lookup never matches it,
 			// and for a List child the alias name propagates into the element DataSources
 			// and `IsSourceOf()` silently drops every element.
+#ifdef DEBUG
 			auto type = child->GetType();
 
 			OV_ASSERT2(
@@ -253,6 +254,7 @@ namespace cfg
 				(type == ValueType::Boolean) ||
 				(type == ValueType::Double) ||
 				(type == ValueType::Text));
+#endif	// DEBUG
 
 			// Register the deprecated JSON name as well so that the unknown item check accepts it
 			_children_for_json.insert_or_assign(name.deprecated_json_name, child);

--- a/src/config/engine/item.cpp
+++ b/src/config/engine/item.cpp
@@ -209,7 +209,10 @@ namespace cfg
 			}
 			catch (...)
 			{
-				// Reset the guard so the next call rebuilds the list again instead of leaving a partially built child list behind
+				// This does not roll back the partial mutations MakeList() made before throwing.
+				// Resetting the guard only makes the next call rerun MakeList() from scratch
+				// (deterministically re-registering, or re-throwing at, every child)
+				// instead of treating the partially built child list as complete.
 				_last_target = nullptr;
 				throw;
 			}
@@ -233,12 +236,15 @@ namespace cfg
 		std::shared_ptr<const Child> prev_child;
 		auto name = child->GetItemName();
 
+		// All validations run before any mutation, so a throw never leaves the maps
+		// and _children inconsistent with each other
 		if (name.deprecated_json_name.IsEmpty() == false)
 		{
-			// The deprecated JSON alias works only for scalar leaf values:
+			// The deprecated JSON alias is restricted to scalar leaf values:
 			// an Attribute value lives under "$" so the alias lookup never matches it,
-			// and for a List child the alias name propagates into the element DataSources
-			// and `IsSourceOf()` silently drops every element.
+			// a List child propagates the alias name into the element DataSources
+			// and `IsSourceOf()` silently drops every element,
+			// and an Item child is rejected as well because no use case needs that path and it is untested.
 			const auto type = child->GetType();
 			const bool supported =
 				(type == ValueType::String) ||
@@ -250,10 +256,40 @@ namespace cfg
 
 			if (supported == false)
 			{
-				// Validate before mutating any state, and fail loudly in every build.
-				// The startup schema validation (ValidateOmitJsonNameRules) rebuilds every item type,
-				// so an invalid registration refuses server startup instead of silently dropping the deprecated key at runtime.
-				throw CreateConfigError("The deprecated JSON alias \"%s\" is not supported for this value type: %s", name.deprecated_json_name.CStr(), name.ToString().CStr());
+				// Fail loudly in every build. The startup schema validation (ValidateOmitJsonNameRules)
+				// rebuilds every item type, so an invalid registration refuses server startup
+				// instead of silently dropping the deprecated key at runtime.
+				throw CreateConfigError("The deprecated JSON alias \"%s\" of %s is not supported for this value type: %s", name.deprecated_json_name.CStr(), name.ToString().CStr(), StringFromValueType(type));
+			}
+
+			if (name.deprecated_json_name == name.json_name)
+			{
+				// An alias identical to the canonical name would make every legitimate use of the key
+				// log a bogus "deprecated key is ignored" warning
+				throw CreateConfigError("The deprecated JSON alias of %s must differ from its JSON name \"%s\"", name.ToString().CStr(), name.json_name.CStr());
+			}
+
+			// A deprecated alias must not collide with a JSON key that another child already uses,
+			// whether as its canonical name or as its own alias. Compare by ItemName, not by pointer,
+			// because MakeList() reruns re-register the same logical child with a fresh instance.
+			auto existing = _children_for_json.find(name.deprecated_json_name);
+			if ((existing != _children_for_json.end()) &&
+				((existing->second->GetItemName() == name) == false))
+			{
+				throw CreateConfigError("The deprecated JSON alias \"%s\" of %s conflicts with a JSON key already used by %s", name.deprecated_json_name.CStr(), name.ToString().CStr(), existing->second->GetItemName().ToString().CStr());
+			}
+		}
+
+		{
+			// A canonical name must not displace another child's deprecated alias:
+			// the same JSON key would then feed two children (one directly, one via the alias fallback)
+			// with no diagnostic anywhere
+			auto existing = _children_for_json.find(name.json_name);
+			if ((existing != _children_for_json.end()) &&
+				((existing->second->GetItemName() == name) == false) &&
+				(existing->second->GetItemName().deprecated_json_name == name.json_name))
+			{
+				throw CreateConfigError("The JSON name \"%s\" of %s conflicts with the deprecated alias of %s", name.json_name.CStr(), name.ToString().CStr(), existing->second->GetItemName().ToString().CStr());
 			}
 		}
 
@@ -269,33 +305,10 @@ namespace cfg
 		}
 
 		_children_for_xml.insert_or_assign(name.xml_name, child);
-
-		{
-			// A canonical name must not displace another child's deprecated alias:
-			// the same JSON key would then feed two children (one directly, one via the alias fallback)
-			// with no diagnostic anywhere. Compare by ItemName, not by pointer,
-			// because MakeList() reruns re-register the same logical child with a fresh instance.
-			auto existing = _children_for_json.find(name.json_name);
-			if ((existing != _children_for_json.end()) &&
-				((existing->second->GetItemName() == name) == false) &&
-				(existing->second->GetItemName().deprecated_json_name == name.json_name))
-			{
-				throw CreateConfigError("The JSON name \"%s\" of %s conflicts with the deprecated alias of %s", name.json_name.CStr(), name.ToString().CStr(), existing->second->GetItemName().ToString().CStr());
-			}
-		}
 		_children_for_json.insert_or_assign(name.json_name, child);
 
 		if (name.deprecated_json_name.IsEmpty() == false)
 		{
-			// A deprecated alias must not collide with a JSON key that another child already uses,
-			// whether as its canonical name or as its own alias
-			auto existing = _children_for_json.find(name.deprecated_json_name);
-			if ((existing != _children_for_json.end()) &&
-				((existing->second->GetItemName() == name) == false))
-			{
-				throw CreateConfigError("The deprecated JSON alias \"%s\" of %s conflicts with the JSON name of %s", name.deprecated_json_name.CStr(), name.ToString().CStr(), existing->second->GetItemName().ToString().CStr());
-			}
-
 			// Register the deprecated JSON name as well so that the unknown item check accepts it
 			_children_for_json.insert_or_assign(name.deprecated_json_name, child);
 		}

--- a/src/config/engine/item.cpp
+++ b/src/config/engine/item.cpp
@@ -237,6 +237,13 @@ namespace cfg
 
 		_children_for_xml.insert_or_assign(name.xml_name, child);
 		_children_for_json.insert_or_assign(name.json_name, child);
+
+		if (name.deprecated_json_name.IsEmpty() == false)
+		{
+			// Register the deprecated JSON name as well so that the unknown item check accepts it
+			_children_for_json.insert_or_assign(name.deprecated_json_name, child);
+		}
+
 		_children.push_back(child);
 
 		if (prev_child != nullptr)

--- a/src/config/engine/item.cpp
+++ b/src/config/engine/item.cpp
@@ -203,7 +203,16 @@ namespace cfg
 
 			_last_target = this;
 
-			MakeList();
+			try
+			{
+				MakeList();
+			}
+			catch (...)
+			{
+				// Reset the guard so the next call rebuilds the list again instead of leaving a partially built child list behind
+				_last_target = nullptr;
+				throw;
+			}
 		}
 	}
 
@@ -224,6 +233,30 @@ namespace cfg
 		std::shared_ptr<const Child> prev_child;
 		auto name = child->GetItemName();
 
+		if (name.deprecated_json_name.IsEmpty() == false)
+		{
+			// The deprecated JSON alias works only for scalar leaf values:
+			// an Attribute value lives under "$" so the alias lookup never matches it,
+			// and for a List child the alias name propagates into the element DataSources
+			// and `IsSourceOf()` silently drops every element.
+			const auto type = child->GetType();
+			const bool supported =
+				(type == ValueType::String) ||
+				(type == ValueType::Integer) ||
+				(type == ValueType::Long) ||
+				(type == ValueType::Boolean) ||
+				(type == ValueType::Double) ||
+				(type == ValueType::Text);
+
+			if (supported == false)
+			{
+				// Validate before mutating any state, and fail loudly in every build.
+				// The startup schema validation (ValidateOmitJsonNameRules) rebuilds every item type,
+				// so an invalid registration refuses server startup instead of silently dropping the deprecated key at runtime.
+				throw CreateConfigError("The deprecated JSON alias \"%s\" is not supported for this value type: %s", name.deprecated_json_name.CStr(), name.ToString().CStr());
+			}
+		}
+
 		for (auto child_iterator = _children.begin(); child_iterator != _children.end(); ++child_iterator)
 		{
 			auto &child = *child_iterator;
@@ -240,22 +273,6 @@ namespace cfg
 
 		if (name.deprecated_json_name.IsEmpty() == false)
 		{
-			// The deprecated JSON alias works only for scalar leaf values:
-			// an Attribute value lives under "$" so the alias lookup never matches it,
-			// and for a List child the alias name propagates into the element DataSources
-			// and `IsSourceOf()` silently drops every element.
-#ifdef DEBUG
-			auto type = child->GetType();
-
-			OV_ASSERT2(
-				(type == ValueType::String) ||
-				(type == ValueType::Integer) ||
-				(type == ValueType::Long) ||
-				(type == ValueType::Boolean) ||
-				(type == ValueType::Double) ||
-				(type == ValueType::Text));
-#endif	// DEBUG
-
 			// Register the deprecated JSON name as well so that the unknown item check accepts it
 			_children_for_json.insert_or_assign(name.deprecated_json_name, child);
 		}

--- a/src/config/engine/item.cpp
+++ b/src/config/engine/item.cpp
@@ -209,8 +209,8 @@ namespace cfg
 			}
 			catch (...)
 			{
-				// This does not roll back the partial mutations MakeList() made before throwing.
-				// Resetting the guard only makes the next call rerun MakeList() from scratch
+				// This does not roll back the partial mutations `MakeList()` made before throwing.
+				// Resetting the guard only makes the next call rerun `MakeList()` from scratch
 				// (deterministically re-registering, or re-throwing at, every child)
 				// instead of treating the partially built child list as complete.
 				_last_target = nullptr;

--- a/src/config/engine/item.cpp
+++ b/src/config/engine/item.cpp
@@ -269,10 +269,33 @@ namespace cfg
 		}
 
 		_children_for_xml.insert_or_assign(name.xml_name, child);
+
+		{
+			// A canonical name must not displace another child's deprecated alias:
+			// the same JSON key would then feed two children (one directly, one via the alias fallback)
+			// with no diagnostic anywhere. Compare by ItemName, not by pointer,
+			// because MakeList() reruns re-register the same logical child with a fresh instance.
+			auto existing = _children_for_json.find(name.json_name);
+			if ((existing != _children_for_json.end()) &&
+				((existing->second->GetItemName() == name) == false) &&
+				(existing->second->GetItemName().deprecated_json_name == name.json_name))
+			{
+				throw CreateConfigError("The JSON name \"%s\" of %s conflicts with the deprecated alias of %s", name.json_name.CStr(), name.ToString().CStr(), existing->second->GetItemName().ToString().CStr());
+			}
+		}
 		_children_for_json.insert_or_assign(name.json_name, child);
 
 		if (name.deprecated_json_name.IsEmpty() == false)
 		{
+			// A deprecated alias must not collide with a JSON key that another child already uses,
+			// whether as its canonical name or as its own alias
+			auto existing = _children_for_json.find(name.deprecated_json_name);
+			if ((existing != _children_for_json.end()) &&
+				((existing->second->GetItemName() == name) == false))
+			{
+				throw CreateConfigError("The deprecated JSON alias \"%s\" of %s conflicts with the JSON name of %s", name.deprecated_json_name.CStr(), name.ToString().CStr(), existing->second->GetItemName().ToString().CStr());
+			}
+
 			// Register the deprecated JSON name as well so that the unknown item check accepts it
 			_children_for_json.insert_or_assign(name.deprecated_json_name, child);
 		}

--- a/src/config/engine/item.cpp
+++ b/src/config/engine/item.cpp
@@ -240,6 +240,20 @@ namespace cfg
 
 		if (name.deprecated_json_name.IsEmpty() == false)
 		{
+			// The deprecated JSON alias works only for scalar leaf values:
+			// an Attribute value lives under "$" so the alias lookup never matches it,
+			// and for a List child the alias name propagates into the element DataSources
+			// and `IsSourceOf()` silently drops every element.
+			auto type = child->GetType();
+
+			OV_ASSERT2(
+				(type == ValueType::String) ||
+				(type == ValueType::Integer) ||
+				(type == ValueType::Long) ||
+				(type == ValueType::Boolean) ||
+				(type == ValueType::Double) ||
+				(type == ValueType::Text));
+
 			// Register the deprecated JSON name as well so that the unknown item check accepts it
 			_children_for_json.insert_or_assign(name.deprecated_json_name, child);
 		}

--- a/src/config/engine/item.h
+++ b/src/config/engine/item.h
@@ -36,6 +36,7 @@ namespace cfg
 	class Item
 	{
 	protected:
+		MAY_THROWS(cfg::ConfigError)
 		static ov::String ChildToString(int indent_count, const std::shared_ptr<const Child> &child, size_t index, size_t child_count);
 
 		friend class SetValueHelper;
@@ -57,6 +58,7 @@ namespace cfg
 		MAY_THROWS(cfg::ConfigError)
 		void FromJson(const Json::Value &value, bool allow_optional = false);
 
+		MAY_THROWS(cfg::ConfigError)
 		Item &operator=(const Item &item);
 
 		const ItemName &GetItemName() const
@@ -79,6 +81,7 @@ namespace cfg
 			_is_parsed = is_parsed;
 		}
 
+		MAY_THROWS(cfg::ConfigError)
 		void EnsureBuilt() const
 		{
 			RebuildListIfNeeded();
@@ -94,6 +97,7 @@ namespace cfg
 			_is_read_only = is_read_only;
 		}
 
+		MAY_THROWS(cfg::ConfigError)
 		template <typename Ttype = Child>
 		std::shared_ptr<Ttype> GetMember(const void *member_pointer)
 		{
@@ -110,12 +114,14 @@ namespace cfg
 			return nullptr;
 		}
 
+		MAY_THROWS(cfg::ConfigError)
 		template <typename Ttype>
 		std::shared_ptr<List<Ttype>> GetListMember(const std::vector<Ttype> *member_pointer)
 		{
 			return GetMember<List<Ttype>>(member_pointer);
 		}
 
+		MAY_THROWS(cfg::ConfigError)
 		void SetValue(const void *member_pointer, const Variant &value, bool is_parent_optional)
 		{
 			RebuildListIfNeeded();
@@ -136,11 +142,13 @@ namespace cfg
 		MAY_THROWS(cfg::ConfigError)
 		void ValidateOmitJsonNameRules() const;
 
+		MAY_THROWS(cfg::ConfigError)
 		virtual ov::String ToString() const
 		{
 			return ToString(0);
 		}
 
+		MAY_THROWS(cfg::ConfigError)
 		virtual ov::String ToString(int indent_count) const;
 
 		// Add `original_value` to `object[child_name]` based on `value_type`.
@@ -217,19 +225,25 @@ namespace cfg
 		MAY_THROWS(cfg::ConfigError)
 		void ValidateOmitJsonNameRule(const ov::String &item_path, const ov::String &name) const;
 
+		MAY_THROWS(cfg::ConfigError)
 		void RebuildListIfNeeded() const;
+		MAY_THROWS(cfg::ConfigError)
 		void RebuildListIfNeeded();
 
+		MAY_THROWS(cfg::ConfigError)
 		virtual void MakeList() = 0;
 
+		MAY_THROWS(cfg::ConfigError)
 		void AddChild(const ItemName &name, ValueType type, const ov::String &type_name,
 					  Optional is_optional, cfg::ResolvePath resolve_path, cfg::OmitJsonName omit_json_name,
 					  OptionalCallback optional_callback, ValidationCallback validation_callback,
 					  void *member_raw_pointer, std::any member_pointer);
 
+		MAY_THROWS(cfg::ConfigError)
 		void AddChild(const std::shared_ptr<Child> &child);
 
 		// For primitive types
+		MAY_THROWS(cfg::ConfigError)
 		template <
 			typename Tannot1 = void, typename Tannot2 = void, typename Tannot3 = void,
 			typename Ttype, std::enable_if_t<!std::is_base_of_v<Item, Ttype> && !std::is_base_of_v<Text, Ttype>, int> = 0>
@@ -244,6 +258,7 @@ namespace cfg
 		}
 
 		// For Text
+		MAY_THROWS(cfg::ConfigError)
 		template <
 			typename Tannot1 = void, typename Tannot2 = void, typename Tannot3 = void,
 			typename Ttype, std::enable_if_t<std::is_base_of_v<Text, Ttype>, int> = 0>
@@ -258,6 +273,7 @@ namespace cfg
 		}
 
 		// For Item
+		MAY_THROWS(cfg::ConfigError)
 		template <
 			typename Tannot1 = void, typename Tannot2 = void, typename Tannot3 = void,
 			typename Ttype, std::enable_if_t<std::is_base_of_v<Item, Ttype>, int> = 0>
@@ -274,6 +290,7 @@ namespace cfg
 		}
 
 		// For std::vector<Ttype>
+		MAY_THROWS(cfg::ConfigError)
 		template <
 			typename Tannot1 = void, typename Tannot2 = void, typename Tannot3 = void,
 			typename Ttype>

--- a/src/config/engine/item_name.cpp
+++ b/src/config/engine/item_name.cpp
@@ -28,6 +28,13 @@ namespace cfg
 	{
 	}
 
+	ItemName::ItemName(const char *xml_name, const char *json_name, const char *deprecated_json_name)
+		: xml_name(xml_name),
+		  json_name(json_name),
+		  deprecated_json_name(deprecated_json_name)
+	{
+	}
+
 	ov::String ItemName::ToString() const
 	{
 		ov::String name = xml_name.CStr();

--- a/src/config/engine/item_name.h
+++ b/src/config/engine/item_name.h
@@ -34,6 +34,7 @@ namespace cfg
 		ItemName(const char *xml_name, const char *json_name);
 		// deprecated_json_name is an old JSON name kept for backward compatibility.
 		// It is still accepted on input (never emitted on output), and will be removed in a future release.
+		// Supported only for scalar leaf values; see the assertion in `Item::AddChild()`.
 		ItemName(const char *xml_name, const char *json_name, const char *deprecated_json_name);
 
 		ov::String ToString() const;

--- a/src/config/engine/item_name.h
+++ b/src/config/engine/item_name.h
@@ -33,7 +33,8 @@ namespace cfg
 		ItemName(const char *xml_name);
 		ItemName(const char *xml_name, const char *json_name);
 		// deprecated_json_name is an old JSON name kept for backward compatibility.
-		// It is still accepted on input (never emitted on output), and will be removed in a future release.
+		// During the deprecation window it is accepted on input and emitted on output alongside the current name,
+		// and will be removed in a future release.
 		// Supported only for scalar leaf values; `Item::AddChild()` throws a ConfigError otherwise.
 		ItemName(const char *xml_name, const char *json_name, const char *deprecated_json_name);
 
@@ -69,4 +70,12 @@ namespace cfg
 
 		bool _created_from_xml_name = false;
 	};
+
+	// Joins an item path and a child name into a dotted path, such as "playlists.options"
+	inline ov::String MakeChildPath(const ov::String &parent_path, const ov::String &child_name)
+	{
+		return parent_path.IsEmpty()
+				   ? child_name
+				   : ov::String::FormatString("%s.%s", parent_path.CStr(), child_name.CStr());
+	}
 }  // namespace cfg

--- a/src/config/engine/item_name.h
+++ b/src/config/engine/item_name.h
@@ -34,7 +34,7 @@ namespace cfg
 		ItemName(const char *xml_name, const char *json_name);
 		// deprecated_json_name is an old JSON name kept for backward compatibility.
 		// It is still accepted on input (never emitted on output), and will be removed in a future release.
-		// Supported only for scalar leaf values; see the assertion in `Item::AddChild()`.
+		// Supported only for scalar leaf values; `Item::AddChild()` throws a ConfigError otherwise.
 		ItemName(const char *xml_name, const char *json_name, const char *deprecated_json_name);
 
 		ov::String ToString() const;

--- a/src/config/engine/item_name.h
+++ b/src/config/engine/item_name.h
@@ -32,6 +32,9 @@ namespace cfg
 	public:
 		ItemName(const char *xml_name);
 		ItemName(const char *xml_name, const char *json_name);
+		// deprecated_json_name is an old JSON name kept for backward compatibility.
+		// It is still accepted on input (never emitted on output), and will be removed in a future release.
+		ItemName(const char *xml_name, const char *json_name, const char *deprecated_json_name);
 
 		ov::String ToString() const;
 
@@ -51,11 +54,14 @@ namespace cfg
 
 		bool operator==(const ItemName &name) const
 		{
-			return (xml_name == name.xml_name) && (json_name == name.json_name);
+			return (xml_name == name.xml_name) &&
+				   (json_name == name.json_name) &&
+				   (deprecated_json_name == name.deprecated_json_name);
 		}
 
 		ov::String xml_name;
 		ov::String json_name;
+		ov::String deprecated_json_name;
 
 	protected:
 		ItemName()					= default;

--- a/src/config/engine/list_interface.h
+++ b/src/config/engine/list_interface.h
@@ -31,6 +31,7 @@ namespace cfg
 					  OptionalCallback optional_callback, ValidationCallback validation_callback,
 					  void *member_raw_pointer, std::any member_pointer, ValueType list_item_type);
 
+		MAY_THROWS(cfg::ConfigError)
 		void AddChildValueList(const std::vector<DataSource> &data_source_list);
 
 		virtual void CopyFrom(const std::shared_ptr<const ListInterface> &another_list);
@@ -42,6 +43,7 @@ namespace cfg
 		// virtual void AddChildrenToJson(Json::Value &object, ValueType value_type, OmitRule omit_name, const ov::String &child_name, const std::any &child_target, const Json::Value &original_value, bool include_default_values) const = 0;
 		virtual void CopyToJsonValue(Json::Value &object, bool original_value, bool include_default_values) const = 0;
 
+		MAY_THROWS(cfg::ConfigError)
 		virtual ov::String ToString(int indent_count, const std::shared_ptr<const Child> &child) const			  = 0;
 
 		virtual size_t GetCount() const																			  = 0;

--- a/src/config/engine/value_type.h
+++ b/src/config/engine/value_type.h
@@ -58,6 +58,17 @@ namespace cfg
 	};
 
 	const char *StringFromValueType(ValueType type);
+
+	// Scalar leaf values - the types whose JSON value is read directly by `DataSource::GetValue()`
+	inline bool IsScalarValueType(ValueType type)
+	{
+		return (type == ValueType::String) ||
+			   (type == ValueType::Integer) ||
+			   (type == ValueType::Long) ||
+			   (type == ValueType::Boolean) ||
+			   (type == ValueType::Double) ||
+			   (type == ValueType::Text);
+	}
 	//--------------------------------------------------------------------
 
 	enum class CheckUnknownItems

--- a/src/config/items/virtual_hosts/applications/output_profiles/playlist/options.h
+++ b/src/config/items/virtual_hosts/applications/output_profiles/playlist/options.h
@@ -41,8 +41,8 @@ namespace cfg
 					void MakeList() override
 					{
 						// The JSON name "webrtcAutoAbr" is specified explicitly to follow the all-lowercase "webrtc" convention.
-						// Deprecated: the auto-derived old name "webRtcAutoAbr" is still accepted on input for backward compatibility,
-						// and will be removed in a future release.
+						// Deprecated: during the deprecation window the auto-derived old name "webRtcAutoAbr" is accepted
+						// on input and emitted on output alongside the new name, and will be removed in a future release.
 						Register<Optional>({"WebRtcAutoAbr", "webrtcAutoAbr", "webRtcAutoAbr"}, &_webrtc_auto_abr);
 						Register<Optional>({"HLSChunklistPathDepth", "hlsChunklistPathDepth"}, &_hls_chunklist_path_depth);
 						Register<Optional>("EnableTsPackaging", &_enable_ts_packaging);

--- a/src/config/items/virtual_hosts/applications/output_profiles/playlist/options.h
+++ b/src/config/items/virtual_hosts/applications/output_profiles/playlist/options.h
@@ -40,7 +40,10 @@ namespace cfg
 				protected:
 					void MakeList() override
 					{
-						Register<Optional>("WebRtcAutoAbr", &_webrtc_auto_abr);
+						// The JSON name "webrtcAutoAbr" is specified explicitly to follow the all-lowercase "webrtc" convention.
+						// Deprecated: the auto-derived old name "webRtcAutoAbr" is still accepted on input for backward compatibility,
+						// and will be removed in a future release.
+						Register<Optional>({"WebRtcAutoAbr", "webrtcAutoAbr", "webRtcAutoAbr"}, &_webrtc_auto_abr);
 						Register<Optional>({"HLSChunklistPathDepth", "hlsChunklistPathDepth"}, &_hls_chunklist_path_depth);
 						Register<Optional>("EnableTsPackaging", &_enable_ts_packaging);
 						Register<Optional>("EnableSubtitles", &_enable_subtitles);

--- a/src/modules/json_serdes/application.h
+++ b/src/modules/json_serdes/application.h
@@ -13,6 +13,7 @@
 
 namespace serdes
 {
+	MAY_THROWS(cfg::ConfigError)
 	Json::Value JsonFromOutputProfile(const cfg::vhost::app::oprf::OutputProfile &output_profile);
 
 	MAY_THROWS(cfg::ConfigError)

--- a/src/modules/ovt_packetizer/ovt_signaling.h
+++ b/src/modules/ovt_packetizer/ovt_signaling.h
@@ -13,9 +13,9 @@
 			{
 				"name" : "for llhls",
 				"fileName" : "llhls_abr.oven",
-				"options" :	// Required - the receiver rejects a playlist whose options is not an object
+				"options" :	// Required - the receiver rejects the entire describe payload if options is not an object
 				{
-					"webrtcAutoAbr" : true // default false
+					"webrtcAutoAbr" : true // the receiver assumes false when this key is omitted
 				},
 				"renditions":
 				[

--- a/src/modules/ovt_packetizer/ovt_signaling.h
+++ b/src/modules/ovt_packetizer/ovt_signaling.h
@@ -15,7 +15,7 @@
 				"fileName" : "llhls_abr.oven",
 				"options" :	// Optional
 				{
-					"webrtcAutoAbr" : true // default true
+					"webrtcAutoAbr" : true // default false
 				},
 				"renditions":
 				[

--- a/src/modules/ovt_packetizer/ovt_signaling.h
+++ b/src/modules/ovt_packetizer/ovt_signaling.h
@@ -13,7 +13,7 @@
 			{
 				"name" : "for llhls",
 				"fileName" : "llhls_abr.oven",
-				"options" :	// Optional
+				"options" :	// Required - the receiver rejects a playlist whose options is not an object
 				{
 					"webrtcAutoAbr" : true // default false
 				},


### PR DESCRIPTION
## Summary
The playlist option `WebRtcAutoAbr` was exposed with two different JSON key casings: the configuration API auto-derived `webRtcAutoAbr` from the XML name, while the handwritten serializers (stream query response, multiplex channel API, OVT signaling) use `webrtcAutoAbr`.
This PR unifies the JSON key on `webrtcAutoAbr`, which follows the all-lowercase `webrtc` convention used by every other WebRTC-related JSON key.
During the deprecation window the old key is accepted on requests and emitted in responses alongside the new key, and it will be removed in a future release.
XML configuration (`<WebRtcAutoAbr>`) is unchanged.

## Changes
- Add a deprecated JSON alias to the config engine: `ItemName` gains a `deprecated_json_name` and a 3-argument constructor, and the unknown-item check accepts the alias
- Input rules: when only the deprecated key is present, `DataSource::GetValue()` falls back to it and logs a deprecation warning with the item path and file name; when both keys are present with different values (an explicit null counts as a value), the request is rejected with a ConfigError so a stale value can never silently win over the client's intent; an equal pair passes silently since responses emit both keys and an echo is expected
- Output rule: `Item::ToJson()` emits the deprecated key with the same value alongside the canonical key during the deprecation window, so response-only readers keep working
- Registration safety: the alias is restricted to scalar leaf values and must not collide with its own canonical name or a JSON key another child already uses; violations throw a ConfigError, which fails server startup deterministically because the startup schema validation rebuilds every item type reachable from cfg::Server
- Engine cleanups from review: commit the rebuild guard only after `MakeList()` succeeds, and extract the `MakeChildPath()`, `IsScalarValueType()`, and `HasJsonMember()` helpers
- Annotate the propagation path of the new throw with MAY_THROWS, in separate commits
- Update the `Options` schema in `api/ome.yml` (`webrtcAutoAbr` plus the deprecated alias with a description of the window behavior) and the transcode webhook docs
- Correct stale comments in `ovt_signaling.h`: the receiver requires the `options` object and assumes `false` when `webrtcAutoAbr` is omitted

## Configuration
`Server.xml` is not affected; `<WebRtcAutoAbr>` works as before.
Only the JSON key of the REST API (and the transcode webhook response) changes.

Requests accept both spellings; a request that sends both keys with different values is rejected with 400:

```json
"options": { "webrtcAutoAbr": true }
```

```json
"options": { "webRtcAutoAbr": true }
```

Responses contain both keys with the same value during the deprecation window:

```json
"options": { "webrtcAutoAbr": true, "webRtcAutoAbr": true, "hlsChunklistPathDepth": -1, "enableTsPackaging": false }
```

## Testing
Tested with a debug build, using only curl and ffmpeg.

1. Start OME with the API server enabled and create a vhost/app via the API.
2. `POST /v1/vhosts/{vh}/apps/{app}/outputProfiles` with a playlist option in each form:
   - `{"webrtcAutoAbr": true}` -> 200, no warning
   - `{"webRtcAutoAbr": false}` -> 200, the value is applied, and the server logs `The JSON key "playlists.options.webRtcAutoAbr" is deprecated. Use "webrtcAutoAbr" instead`
   - `{"webrtcAutoAbr": true, "webRtcAutoAbr": true}` -> 200 with no warning (echo case)
   - `{"webrtcAutoAbr": true, "webRtcAutoAbr": false}` -> 400 (conflicting values)
   - `{"webrtcAutoAbr": null, "webRtcAutoAbr": false}` -> 400 (null counts as a value)
   - a typo key such as `{"webrtcautoabr": true}` -> still rejected with 400 `Unknown item found: playlists.options.webrtcautoabr`
3. `GET` the profile and the app: every response contains both keys with the same value.
4. XML regression: OME starts normally with `<WebRtcAutoAbr>true</WebRtcAutoAbr>` in `Server.xml`.
5. TranscodeWebhook: with an ffmpeg RTMP input and a local webhook server, a response whose `outputProfiles` uses either spelling creates the stream successfully.
6. Regressions on the handwritten paths: the stream query response key, the multiplex channel API (`.mux` file content and channel query response), and OVT pull propagation of the flag are unchanged.
