### PR TITLE
build(deps): update libsrt to 1.5.6

### DIFF
--- a/LICENSE-3RD-PARTY
+++ b/LICENSE-3RD-PARTY
@@ -1054,7 +1054,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-* libsrt 1.5.2 (https://github.com/Haivision/srt/blob/master/LICENSE)
+* libsrt 1.5.6 (https://github.com/Haivision/srt/blob/master/LICENSE)
 Mozilla Public License Version 2.0
 ==================================
 

--- a/cmake/InstallPrerequisites.cmake
+++ b/cmake/InstallPrerequisites.cmake
@@ -417,7 +417,7 @@ make ${_J} shared_library && sudo make install && rm -rf ${TEMP_PATH}/srtp
 set(_install_libsrt "
 mkdir -p ${TEMP_PATH}/srt && cd ${TEMP_PATH}/srt &&
 ome_fetch ${SRT_SOURCE_URL} &&
-cmake -S . -B build -DCMAKE_INSTALL_PREFIX=${PREFIX} -DENABLE_SHARED=1 -DENABLE_STATIC=0 -DCMAKE_POLICY_VERSION_MINIMUM=3.5 &&
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX=${PREFIX} -DENABLE_SHARED=1 -DENABLE_STATIC=0 -DENABLE_ENCRYPTION=ON -DOPENSSL_ROOT_DIR=${PREFIX} -DCMAKE_POLICY_VERSION_MINIMUM=3.5 &&
 cmake --build build ${_J} &&
 sudo cmake --install build --prefix ${PREFIX} && rm -rf ${TEMP_PATH}/srt
 ")

--- a/cmake/Versions.cmake
+++ b/cmake/Versions.cmake
@@ -30,7 +30,7 @@
 #     OME_VER_WEBP
 set(OME_VER_OPENSSL         3.0.7)
 set(OME_VER_SRTP            2.4.2)
-set(OME_VER_SRT             1.5.2)
+set(OME_VER_SRT             1.5.6)
 set(OME_VER_OPUS            1.3.1)
 set(OME_VER_VPX             1.11.0)
 set(OME_VER_AOM             3.12.0)

--- a/docs/live-source/srt.md
+++ b/docs/live-source/srt.md
@@ -145,4 +145,4 @@ You can configure SRT's socket options of the OvenMediaEngine server using `<Opt
 </Providers>
 ```
 
-For more information on SRT socket options, please refer to [https://github.com/Haivision/srt/blob/v1.5.2/docs/API/API-socket-options.md#list-of-options](https://github.com/Haivision/srt/blob/v1.5.2/docs/API/API-socket-options.md#list-of-options).
+For more information on SRT socket options, please refer to [https://github.com/Haivision/srt/blob/v1.5.6/docs/API/API-socket-options.md#list-of-options](https://github.com/Haivision/srt/blob/v1.5.6/docs/API/API-socket-options.md#list-of-options).

--- a/docs/streaming/srt.md
+++ b/docs/streaming/srt.md
@@ -273,4 +273,4 @@ You can configure SRT's socket options of the OvenMediaEngine server using `<Opt
 ...
 ```
 
-For more information on SRT socket options, please refer to [https://github.com/Haivision/srt/blob/v1.5.2/docs/API/API-socket-options.md#list-of-options](https://github.com/Haivision/srt/blob/v1.5.2/docs/API/API-socket-options.md#list-of-options).
+For more information on SRT socket options, please refer to [https://github.com/Haivision/srt/blob/v1.5.6/docs/API/API-socket-options.md#list-of-options](https://github.com/Haivision/srt/blob/v1.5.6/docs/API/API-socket-options.md#list-of-options).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -79,7 +79,7 @@ rm -rf ${DIR}
 
 ```bash title="Install SRT"
 PREFIX=/opt/ovenmediaengine && \
-SRT_VERSION=1.5.2 && \
+SRT_VERSION=1.5.6 && \
 DIR=/tmp/srt && \
 mkdir -p ${DIR} && \
 cd ${DIR} && \

--- a/src/base/ovsocket/socket_test.cpp
+++ b/src/base/ovsocket/socket_test.cpp
@@ -375,7 +375,10 @@ namespace
 			}
 			for (auto s : list)
 			{
-				::srt_close(s);
+				if (s != SRT_INVALID_SOCK)
+				{
+					::srt_close(s);
+				}
 			}
 		}
 
@@ -1206,6 +1209,7 @@ protected:
 		events->Attach(client);
 		if (client->MakeNonBlocking(events) == false)
 		{
+			client->Close();
 			return nullptr;
 		}
 
@@ -1620,6 +1624,7 @@ protected:
 		events->Attach(client);
 		if (client->MakeNonBlocking(events) == false)
 		{
+			client->Close();
 			return nullptr;
 		}
 		if (Connected(client, client->Connect(LoopbackAddress(peer.Port()), LOOPBACK_TIMEOUT_MSEC)) == false)

--- a/src/base/ovsocket/socket_test.cpp
+++ b/src/base/ovsocket/socket_test.cpp
@@ -250,7 +250,9 @@ namespace
 	};
 
 	// A libsrt peer (listener) that the OME SRT socket under test connects to, so
-	// the test can drive SRT message delivery and peer shutdown directly.
+	// the test can drive SRT message delivery and peer shutdown directly. One
+	// listener can accept several connections (`AcceptAsync(count)`); the
+	// index-less accessors operate on the first accepted connection.
 	class SrtPeer
 	{
 	public:
@@ -263,7 +265,7 @@ namespace
 			}
 		}
 
-		bool Listen()
+		bool Listen(int backlog = 1)
 		{
 			_listener = ::srt_create_socket();
 			if (_listener == SRT_INVALID_SOCK)
@@ -281,7 +283,7 @@ namespace
 			{
 				return false;
 			}
-			if (::srt_listen(_listener, 1) == SRT_ERROR)
+			if (::srt_listen(_listener, backlog) == SRT_ERROR)
 			{
 				return false;
 			}
@@ -295,22 +297,26 @@ namespace
 			return true;
 		}
 
-		// Accepts in a background thread so the OME blocking `Connect()` and this
-		// accept can proceed concurrently. The listener is non-blocking and the
-		// accept is polled up to a timeout, so a failed client connect cannot hang
-		// `WaitAccepted()`.
-		void AcceptAsync()
+		// Accepts `count` connections in a background thread so the OME blocking
+		// `Connect()` and this accept can proceed concurrently. The listener is
+		// non-blocking and each accept is polled up to a timeout, so a failed
+		// client connect cannot hang `WaitAccepted()`.
+		void AcceptAsync(int count = 1)
 		{
-			_accept_thread = std::thread([this]() {
-				for (int waited = 0; waited < LOOPBACK_TIMEOUT_MSEC; waited += 5)
+			_accept_thread = std::thread([this, count]() {
+				int waited = 0;
+				while ((ConnectionCount() < count) && (waited < LOOPBACK_TIMEOUT_MSEC))
 				{
 					SRTSOCKET accepted = ::srt_accept(_listener, nullptr, nullptr);
 					if (accepted != SRT_INVALID_SOCK)
 					{
-						_accepted = accepted;
-						return;
+						std::lock_guard<std::mutex> lock(_accepted_mutex);
+						_accepted_list.push_back(accepted);
+						waited = 0;
+						continue;
 					}
 					std::this_thread::sleep_for(std::chrono::milliseconds(5));
+					waited += 5;
 				}
 			});
 		}
@@ -327,30 +333,83 @@ namespace
 		{
 			return _port;
 		}
+		SRTSOCKET ListenerHandle() const
+		{
+			return _listener;
+		}
 		bool IsConnected() const
 		{
-			return _accepted != SRT_INVALID_SOCK;
+			return ConnectionCount() > 0;
+		}
+		int ConnectionCount() const
+		{
+			std::lock_guard<std::mutex> lock(_accepted_mutex);
+			return static_cast<int>(_accepted_list.size());
 		}
 
 		int Send(const void *data, size_t length)
 		{
-			return ::srt_sendmsg2(_accepted, reinterpret_cast<const char *>(data), static_cast<int>(length), nullptr);
+			return Send(0, data, length);
+		}
+		int Send(int index, const void *data, size_t length)
+		{
+			SRTSOCKET s = Accepted(index);
+			if (s == SRT_INVALID_SOCK)
+			{
+				return SRT_ERROR;
+			}
+			return ::srt_sendmsg2(s, reinterpret_cast<const char *>(data), static_cast<int>(length), nullptr);
 		}
 
+		// Closes every accepted connection (after the accept thread has finished).
 		void CloseConnection()
 		{
 			if (_accept_thread.joinable())
 			{
 				_accept_thread.join();
 			}
-			if (_accepted != SRT_INVALID_SOCK)
+			std::vector<SRTSOCKET> list;
 			{
-				::srt_close(_accepted);
-				_accepted = SRT_INVALID_SOCK;
+				std::lock_guard<std::mutex> lock(_accepted_mutex);
+				list.swap(_accepted_list);
+			}
+			for (auto s : list)
+			{
+				::srt_close(s);
+			}
+		}
+
+		// Closes one accepted connection; safe to call from several threads with
+		// distinct indexes. The slot is invalidated first so a later
+		// `CloseConnection()` does not close it twice.
+		void CloseConnection(int index)
+		{
+			SRTSOCKET s = SRT_INVALID_SOCK;
+			{
+				std::lock_guard<std::mutex> lock(_accepted_mutex);
+				if ((index >= 0) && (index < static_cast<int>(_accepted_list.size())))
+				{
+					s					  = _accepted_list[index];
+					_accepted_list[index] = SRT_INVALID_SOCK;
+				}
+			}
+			if (s != SRT_INVALID_SOCK)
+			{
+				::srt_close(s);
 			}
 		}
 
 	private:
+		SRTSOCKET Accepted(int index) const
+		{
+			std::lock_guard<std::mutex> lock(_accepted_mutex);
+			if ((index >= 0) && (index < static_cast<int>(_accepted_list.size())))
+			{
+				return _accepted_list[index];
+			}
+			return SRT_INVALID_SOCK;
+		}
+
 		// Match OME's SRT configuration (live transtype + message API) so the
 		// handshake succeeds. The listener uses non-blocking accept (so a failed
 		// connect cannot hang the accept thread) and blocking send.
@@ -367,10 +426,323 @@ namespace
 		}
 
 		SRTSOCKET _listener = SRT_INVALID_SOCK;
-		std::atomic<SRTSOCKET> _accepted{SRT_INVALID_SOCK};
+		mutable std::mutex _accepted_mutex;
+		std::vector<SRTSOCKET> _accepted_list;
 		uint16_t _port = 0;
 		std::thread _accept_thread;
 	};
+
+	// Relays UDP datagrams between one OME SRT client and an `SrtPeer` so the test can
+	// cut the link without any SRT shutdown handshake (`StopForwarding()`), which is
+	// the only way to drive libsrt into `SRTS_BROKEN` on loopback.
+	class UdpRelay
+	{
+	public:
+		~UdpRelay()
+		{
+			Stop();
+		}
+
+		bool Start(uint16_t peer_port)
+		{
+			_front = ::socket(AF_INET, SOCK_DGRAM, 0);
+			_back  = ::socket(AF_INET, SOCK_DGRAM, 0);
+			if ((_front < 0) || (_back < 0))
+			{
+				return false;
+			}
+
+			// Short receive timeouts so the relay threads notice `Stop()` promptly.
+			timeval tv = {0, 50 * 1000};
+			::setsockopt(_front, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+			::setsockopt(_back, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+			sockaddr_in sa{};
+			sa.sin_family	   = AF_INET;
+			sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+			sa.sin_port		   = 0;	 // ephemeral
+			if (::bind(_front, reinterpret_cast<sockaddr *>(&sa), sizeof(sa)) != 0)
+			{
+				return false;
+			}
+			socklen_t len = sizeof(sa);
+			if (::getsockname(_front, reinterpret_cast<sockaddr *>(&sa), &len) != 0)
+			{
+				return false;
+			}
+			_port = ntohs(sa.sin_port);
+
+			sa.sin_port = htons(peer_port);
+			if (::connect(_back, reinterpret_cast<sockaddr *>(&sa), sizeof(sa)) != 0)
+			{
+				return false;
+			}
+
+			_running = true;
+			_front_thread = std::thread([this]() { FrontLoop(); });
+			_back_thread  = std::thread([this]() { BackLoop(); });
+			return true;
+		}
+
+		uint16_t Port() const
+		{
+			return _port;
+		}
+
+		// Silently drops every datagram in both directions from now on.
+		void StopForwarding()
+		{
+			_forwarding = false;
+		}
+
+		void Stop()
+		{
+			_running = false;
+			if (_front_thread.joinable())
+			{
+				_front_thread.join();
+			}
+			if (_back_thread.joinable())
+			{
+				_back_thread.join();
+			}
+			if (_front >= 0)
+			{
+				::close(_front);
+				_front = -1;
+			}
+			if (_back >= 0)
+			{
+				::close(_back);
+				_back = -1;
+			}
+		}
+
+	private:
+		// Client -> peer. Remembers the client's address so replies can be routed back.
+		void FrontLoop()
+		{
+			char buffer[2048];
+			while (_running)
+			{
+				sockaddr_in from{};
+				socklen_t from_len = sizeof(from);
+				ssize_t n = ::recvfrom(_front, buffer, sizeof(buffer), 0, reinterpret_cast<sockaddr *>(&from), &from_len);
+				if (n < 0)
+				{
+					continue;
+				}
+				{
+					std::lock_guard<std::mutex> lock(_client_mutex);
+					_client	   = from;
+					_has_client = true;
+				}
+				if (_forwarding)
+				{
+					::send(_back, buffer, n, MSG_NOSIGNAL);
+				}
+			}
+		}
+
+		// Peer -> client.
+		void BackLoop()
+		{
+			char buffer[2048];
+			while (_running)
+			{
+				ssize_t n = ::recv(_back, buffer, sizeof(buffer), 0);
+				if (n < 0)
+				{
+					continue;
+				}
+				sockaddr_in to{};
+				{
+					std::lock_guard<std::mutex> lock(_client_mutex);
+					if (_has_client == false)
+					{
+						continue;
+					}
+					to = _client;
+				}
+				if (_forwarding)
+				{
+					::sendto(_front, buffer, n, MSG_NOSIGNAL, reinterpret_cast<sockaddr *>(&to), sizeof(to));
+				}
+			}
+		}
+
+		int _front	   = -1;
+		int _back	   = -1;
+		uint16_t _port = 0;
+		std::atomic<bool> _running{false};
+		std::atomic<bool> _forwarding{true};
+		std::mutex _client_mutex;
+		sockaddr_in _client{};
+		bool _has_client = false;
+		std::thread _front_thread;
+		std::thread _back_thread;
+	};
+
+	// Counts the async socket events of a non-blocking OME socket and drains every
+	// readable message, so a test can observe the worker-driven close path
+	// (`EPOLLHUP` -> `OnClosed()`) and the bytes delivered before it.
+	class SrtAsyncEvents : public ov::SocketAsyncInterface
+	{
+	public:
+		void Attach(const std::shared_ptr<ov::Socket> &socket)
+		{
+			_socket = socket;
+		}
+
+		void OnConnected(const std::shared_ptr<const ov::SocketError> &error) override
+		{
+			if (error == nullptr)
+			{
+				_connected.fetch_add(1);
+			}
+			else
+			{
+				_connect_failed.fetch_add(1);
+			}
+		}
+
+		void OnReadable() override
+		{
+			auto socket = _socket.lock();
+			if (socket == nullptr)
+			{
+				return;
+			}
+			char buffer[1500];
+			while (true)
+			{
+				auto result = socket->Recv(buffer, sizeof(buffer));
+				if ((result.has_value() == false) || (result.value() == 0))
+				{
+					break;
+				}
+				_received_bytes.fetch_add(result.value());
+			}
+		}
+
+		void OnClosed() override
+		{
+			_closed.fetch_add(1);
+		}
+
+		int Connected() const
+		{
+			return _connected.load();
+		}
+		int ConnectFailed() const
+		{
+			return _connect_failed.load();
+		}
+		size_t ReceivedBytes() const
+		{
+			return _received_bytes.load();
+		}
+		int Closed() const
+		{
+			return _closed.load();
+		}
+
+	private:
+		std::weak_ptr<ov::Socket> _socket;
+		std::atomic<int> _connected{0};
+		std::atomic<int> _connect_failed{0};
+		std::atomic<size_t> _received_bytes{0};
+		std::atomic<int> _closed{0};
+	};
+
+	// Polls `predicate` every millisecond until it holds or `timeout` elapses.
+	template <typename Tpredicate>
+	bool WaitUntil(Tpredicate predicate, std::chrono::milliseconds timeout = std::chrono::milliseconds(LOOPBACK_TIMEOUT_MSEC))
+	{
+		auto deadline = std::chrono::steady_clock::now() + timeout;
+		while (predicate() == false)
+		{
+			if (std::chrono::steady_clock::now() >= deadline)
+			{
+				return false;
+			}
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		}
+		return true;
+	}
+
+	// An asynchronous `srt_connect()` returns before the handshake completes; this
+	// waits for libsrt to report the socket connected. Only `SRTS_CONNECTED` ends
+	// the wait early: while `postConnect()` runs, `srt_getsockstate()` briefly
+	// reports `SRTS_BROKEN` (neither connecting nor connected yet), and under
+	// global-lock contention that window lasts tens of milliseconds.
+	bool WaitSrtConnected(const std::shared_ptr<ov::Socket> &socket)
+	{
+		return WaitUntil([&]() { return ::srt_getsockstate(socket->GetNativeHandle()) == SRTS_CONNECTED; });
+	}
+
+	// Waits until libsrt reports the socket readable (a message has reached its
+	// TSBPD play time), without consuming it. Uses a private SRT epoll because a
+	// blocking-mode OME socket is not registered in any worker epoll.
+	bool WaitSrtReadable(const std::shared_ptr<ov::Socket> &socket, int timeout_msec = LOOPBACK_TIMEOUT_MSEC)
+	{
+		int eid = ::srt_epoll_create();
+		if (eid < 0)
+		{
+			return false;
+		}
+		int events = SRT_EPOLL_IN;
+		bool ready = false;
+		if (::srt_epoll_add_usock(eid, socket->GetNativeHandle(), &events) != SRT_ERROR)
+		{
+			SRT_EPOLL_EVENT out{};
+			ready = (::srt_epoll_uwait(eid, &out, 1, timeout_msec) > 0) && OV_CHECK_FLAG(out.events, SRT_EPOLL_IN);
+			::srt_epoll_remove_usock(eid, socket->GetNativeHandle());
+		}
+		::srt_epoll_release(eid);
+		return ready;
+	}
+
+	// Receives one SRT message on an async (`SRTO_RCVSYN=false`) blocking-mode
+	// socket: `SRT_EASYNCRCV` surfaces as a `0`-byte success, so retry until a
+	// message arrives, the socket fails, or `timeout` elapses (returns `false`).
+	bool RecvSrtMessage(const std::shared_ptr<ov::Socket> &socket, void *out, size_t capacity, size_t *received,
+						std::chrono::milliseconds timeout = std::chrono::milliseconds(LOOPBACK_TIMEOUT_MSEC))
+	{
+		auto deadline = std::chrono::steady_clock::now() + timeout;
+		while (true)
+		{
+			auto result = socket->Recv(out, capacity);
+			if (result.has_value() == false)
+			{
+				return false;
+			}
+			if (result.value() > 0)
+			{
+				*received = result.value();
+				return true;
+			}
+			if (std::chrono::steady_clock::now() >= deadline)
+			{
+				return false;
+			}
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		}
+	}
+
+	// Keeps calling `Recv()` until it reports failure (the async no-data retries in
+	// between are expected). Returns `false` if it is still succeeding at `timeout`.
+	bool RecvUntilFailure(const std::shared_ptr<ov::Socket> &socket,
+						  std::chrono::milliseconds timeout = std::chrono::milliseconds(LOOPBACK_TIMEOUT_MSEC))
+	{
+		char buffer[1500];
+		size_t received = 0;
+		while (RecvSrtMessage(socket, buffer, sizeof(buffer), &received, timeout))
+		{
+			// Late data before the shutdown is processed; keep draining.
+		}
+		return socket->Recv(buffer, sizeof(buffer)).has_value() == false;
+	}
 
 	// Aborts the process if not disarmed within the deadline. A deadlock in the
 	// code under test would otherwise hang the whole binary forever; this turns
@@ -412,6 +784,30 @@ namespace
 		bool _done = false;
 		std::string _label;
 		std::thread _thread;
+	};
+
+	// Closes every still-connected socket in `sockets` on scope exit, so an early
+	// `ASSERT` failure does not trip the `~Socket` "not closed" assertion.
+	class CloseOnExit
+	{
+	public:
+		explicit CloseOnExit(std::vector<std::shared_ptr<ov::Socket>> &sockets)
+			: _sockets(sockets)
+		{
+		}
+		~CloseOnExit()
+		{
+			for (auto &socket : _sockets)
+			{
+				if (socket->GetState() == ov::SocketState::Connected)
+				{
+					socket->Close();
+				}
+			}
+		}
+
+	private:
+		std::vector<std::shared_ptr<ov::Socket>> &_sockets;
 	};
 }  // namespace
 
@@ -740,8 +1136,12 @@ TEST_F(SocketRecvUdpTest, StaysUsableAfterZeroLengthDatagram)
 //
 // Pins the `SRT_EASYNCRCV` -> retry (`0`) contract. `srt_recvmsg2()` ignores a
 // per-call `non_block` flag, so async recv (`SRTO_RCVSYN=false`) is what surfaces
-// `SRT_EASYNCRCV`; the client connects in blocking mode first (deterministic
-// handshake) and is then switched to async.
+// `SRT_EASYNCRCV`. The option is set before `Connect()` on purpose: a synchronous
+// `srt_connect()` completes the handshake on the caller thread, and libsrt's
+// receive worker only registers the socket on its next loop iteration, so a data
+// packet that arrives in that window is stored for the (finished) connect and
+// never delivered. The asynchronous handshake registers the socket on the worker
+// itself, which makes the first message deterministic.
 // ===========================================================================
 class SocketRecvSrtTest : public SocketTestBase
 {
@@ -758,9 +1158,15 @@ protected:
 		::srt_cleanup();
 	}
 
-	// Returns an OME SRT client connected (blocking handshake) to `peer`, then
-	// switched to async recv so a no-data read yields `SRT_EASYNCRCV`.
+	// Returns a blocking-mode OME SRT client connected to `peer` with async recv,
+	// so a no-data read yields `SRT_EASYNCRCV` instead of blocking.
 	std::shared_ptr<ov::Socket> ConnectClient(SrtPeer &peer)
+	{
+		return ConnectClientVia(peer, peer.Port());
+	}
+
+	// Same as `ConnectClient()`, but connects to `port` (a `UdpRelay` in front of `peer`).
+	std::shared_ptr<ov::Socket> ConnectClientVia(SrtPeer &peer, uint16_t port)
 	{
 		auto client = _pool->AllocSocket(ov::SocketFamily::Inet);
 		if (client == nullptr)
@@ -769,23 +1175,75 @@ protected:
 		}
 
 		client->MakeBlocking();
+		// Async recv (and thereby an async handshake, see the fixture comment):
+		// no data -> `SRT_EASYNCRCV`, broken link -> `SRT_ECONNLOST`.
+		client->SetSockOpt<bool>(SRTO_RCVSYN, false);
 
 		peer.AcceptAsync();
-		auto error = client->Connect(LoopbackAddress(peer.Port()), LOOPBACK_TIMEOUT_MSEC);
+		auto error = client->Connect(LoopbackAddress(port), LOOPBACK_TIMEOUT_MSEC);
 		peer.WaitAccepted();
 
-		if (error != nullptr || peer.IsConnected() == false)
+		if (error != nullptr || peer.IsConnected() == false || WaitSrtConnected(client) == false)
+		{
+			client->Close();
+			return nullptr;
+		}
+
+		_client = client;
+		return client;
+	}
+
+	// Returns a non-blocking OME SRT client (driven by the pool worker, events
+	// delivered to `events`) connected to `port`.
+	std::shared_ptr<ov::Socket> ConnectAsyncClientVia(SrtPeer &peer, uint16_t port, const std::shared_ptr<SrtAsyncEvents> &events)
+	{
+		auto client = _pool->AllocSocket(ov::SocketFamily::Inet);
+		if (client == nullptr)
 		{
 			return nullptr;
 		}
 
-		// Switch to async recv: no data -> `SRT_EASYNCRCV`, broken link -> `SRT_ECONNLOST`.
-		client->SetSockOpt<bool>(SRTO_RCVSYN, false);
+		events->Attach(client);
+		if (client->MakeNonBlocking(events) == false)
+		{
+			return nullptr;
+		}
+
+		peer.AcceptAsync();
+		auto error = client->Connect(LoopbackAddress(port), LOOPBACK_TIMEOUT_MSEC);
+		peer.WaitAccepted();
+
+		if (error != nullptr || peer.IsConnected() == false || WaitSrtConnected(client) == false)
+		{
+			client->Close();
+			return nullptr;
+		}
 
 		_client = client;
 		return client;
 	}
 };
+
+// `srt_startup()` / `srt_cleanup()` must be reference counted: a library user such
+// as FFmpeg's libsrt protocol pairs them per connection, and an unbalanced count
+// tears the whole library down (every listener included) on the first close.
+// libsrt 1.5.4 returned early from `srt_startup()` while the GC was already
+// running, so OME's own startup was cancelled by the first FFmpeg SRT close.
+TEST_F(SocketRecvSrtTest, StartupCleanupIsRefCounted)
+{
+	SrtPeer peer;
+	ASSERT_TRUE(peer.Listen());
+
+	// A nested user: startup once more and clean up once, like one FFmpeg open/close.
+	ASSERT_NE(::srt_startup(), -1);
+	ASSERT_EQ(::srt_cleanup(), 0);
+
+	// The fixture's own startup must still be in effect: the listener is alive and accepts.
+	EXPECT_EQ(::srt_getsockstate(peer.ListenerHandle()), SRTS_LISTENING);
+	auto client = ConnectClient(peer);
+	ASSERT_NE(client, nullptr);
+	EXPECT_EQ(client->GetState(), ov::SocketState::Connected);
+}
 
 // On an async SRT socket with no data, `SRT_EASYNCRCV` is a retry-later success
 // (`0` bytes), not an error and not a disconnect.
@@ -802,6 +1260,139 @@ TEST_F(SocketRecvSrtTest, NoDataReportsRetry)
 	ASSERT_TRUE(result.has_value());
 	EXPECT_EQ(result.value(), 0u);
 	EXPECT_EQ(client->GetState(), ov::SocketState::Connected);
+}
+
+// After the peer delivers data and calls `srt_close()`, the data must be read
+// intact, the following reads must converge on a failure, and a failed socket
+// must never report a spurious success afterwards.
+//
+// The failure is `Disconnected` (`SRT_ECONNLOST`) when `Recv()` observes the
+// broken socket before libsrt's GC, and `Error` (`SRT_EINVSOCK`) when the GC,
+// which every `srt_close()` in the process wakes, has already moved the
+// drained socket to `SRTS_CLOSED`. The order is decided by thread scheduling,
+// so both are accepted and the outcome is recorded.
+//
+// Two messages are sent and the second is left unread until after the peer
+// closes: the GC leaves a broken socket alone while unread packets remain, which
+// keeps the second message readable through the close. Packets still inside
+// the TSBPD latency window when the shutdown arrives are dropped by libsrt, so
+// the second message is confirmed playable before the peer closes.
+TEST_F(SocketRecvSrtTest, GracefulPeerCloseReportsFailure)
+{
+	Watchdog watchdog(std::chrono::seconds(15), "GracefulPeerCloseReportsFailure");
+
+	SrtPeer peer;
+	ASSERT_TRUE(peer.Listen());
+	auto client = ConnectClient(peer);
+	ASSERT_NE(client, nullptr);
+
+	const char first[]	= "srt-graceful-eof-1";
+	const char second[] = "srt-graceful-eof-2";
+	ASSERT_EQ(peer.Send(first, sizeof(first)), static_cast<int>(sizeof(first)));
+	ASSERT_EQ(peer.Send(second, sizeof(second)), static_cast<int>(sizeof(second)));
+
+	char buffer[1500] = {0};
+	size_t received	  = 0;
+	ASSERT_TRUE(RecvSrtMessage(client, buffer, sizeof(buffer), &received));
+	ASSERT_EQ(received, sizeof(first));
+	EXPECT_EQ(::memcmp(buffer, first, sizeof(first)), 0);
+	ASSERT_TRUE(WaitSrtReadable(client));
+
+	peer.CloseConnection();
+
+	ASSERT_TRUE(RecvSrtMessage(client, buffer, sizeof(buffer), &received));
+	ASSERT_EQ(received, sizeof(second));
+	EXPECT_EQ(::memcmp(buffer, second, sizeof(second)), 0);
+
+	EXPECT_TRUE(RecvUntilFailure(client));
+	auto state = client->GetState();
+	EXPECT_TRUE((state == ov::SocketState::Disconnected) || (state == ov::SocketState::Error))
+		<< ov::StringFromSocketState(state);
+	RecordProperty("state", ov::StringFromSocketState(state));
+	EXPECT_FALSE(client->Recv(buffer, sizeof(buffer)).has_value());
+}
+
+// Same peer shutdown observed through the worker (non-blocking socket): the
+// terminal SRT state must surface as `EPOLLHUP` -> `Disconnected` + `OnClosed()`,
+// not as `EPOLLERR` -> `Error`.
+TEST_F(SocketRecvSrtTest, GracefulPeerCloseFiresCloseCallbackAsDisconnected)
+{
+	Watchdog watchdog(std::chrono::seconds(15), "GracefulPeerCloseFiresCloseCallbackAsDisconnected");
+
+	SrtPeer peer;
+	ASSERT_TRUE(peer.Listen());
+	auto events = std::make_shared<SrtAsyncEvents>();
+	auto client = ConnectAsyncClientVia(peer, peer.Port(), events);
+	ASSERT_NE(client, nullptr);
+	ASSERT_EQ(events->ConnectFailed(), 0);
+
+	const char payload[] = "srt-async-graceful-eof";
+	ASSERT_EQ(peer.Send(payload, sizeof(payload)), static_cast<int>(sizeof(payload)));
+	ASSERT_TRUE(WaitUntil([&]() { return events->ReceivedBytes() == sizeof(payload); }));
+
+	peer.CloseConnection();
+
+	ASSERT_TRUE(WaitUntil([&]() { return events->Closed() == 1; }));
+	EXPECT_EQ(client->GetState(), ov::SocketState::Disconnected);
+}
+
+// libsrt declares a silent peer dead only after 16 expiration timer events at
+// least 300 ms apart, so a cut link takes about 5 s to reach `SRTS_BROKEN`
+// regardless of `SRTO_PEERIDLETIMEO`; the waits below allow for that.
+constexpr int SRT_BROKEN_LINK_WAIT_MSEC = 15000;
+
+// A link that dies without any shutdown handshake (the relay drops every
+// datagram) must expire into `SRTS_BROKEN`, which `Recv()` reports as
+// `SRT_ECONNLOST` -> `Disconnected`, not `Error`.
+TEST_F(SocketRecvSrtTest, BrokenLinkReportsDisconnect)
+{
+	Watchdog watchdog(std::chrono::seconds(30), "BrokenLinkReportsDisconnect");
+
+	SrtPeer peer;
+	ASSERT_TRUE(peer.Listen());
+	UdpRelay relay;
+	ASSERT_TRUE(relay.Start(peer.Port()));
+
+	auto client = ConnectClientVia(peer, relay.Port());
+	ASSERT_NE(client, nullptr);
+
+	// Prove the relayed link carries data before cutting it.
+	const char payload[] = "srt-broken-link";
+	ASSERT_EQ(peer.Send(payload, sizeof(payload)), static_cast<int>(sizeof(payload)));
+	char buffer[1500] = {0};
+	size_t received	  = 0;
+	ASSERT_TRUE(RecvSrtMessage(client, buffer, sizeof(buffer), &received));
+	ASSERT_EQ(received, sizeof(payload));
+
+	relay.StopForwarding();
+
+	EXPECT_TRUE(RecvUntilFailure(client, std::chrono::milliseconds(SRT_BROKEN_LINK_WAIT_MSEC)));
+	EXPECT_EQ(client->GetState(), ov::SocketState::Disconnected);
+}
+
+// Same dead link observed through the worker: `SRTS_BROKEN` + `SRT_EPOLL_ERR`
+// must map to `EPOLLHUP` (`Disconnected` + `OnClosed()`), not `EPOLLERR` (`Error`).
+TEST_F(SocketRecvSrtTest, BrokenLinkFiresCloseCallbackAsDisconnected)
+{
+	Watchdog watchdog(std::chrono::seconds(30), "BrokenLinkFiresCloseCallbackAsDisconnected");
+
+	SrtPeer peer;
+	ASSERT_TRUE(peer.Listen());
+	UdpRelay relay;
+	ASSERT_TRUE(relay.Start(peer.Port()));
+
+	auto events = std::make_shared<SrtAsyncEvents>();
+	auto client = ConnectAsyncClientVia(peer, relay.Port(), events);
+	ASSERT_NE(client, nullptr);
+
+	const char payload[] = "srt-async-broken-link";
+	ASSERT_EQ(peer.Send(payload, sizeof(payload)), static_cast<int>(sizeof(payload)));
+	ASSERT_TRUE(WaitUntil([&]() { return events->ReceivedBytes() == sizeof(payload); }));
+
+	relay.StopForwarding();
+
+	ASSERT_TRUE(WaitUntil([&]() { return events->Closed() == 1; }, std::chrono::milliseconds(SRT_BROKEN_LINK_WAIT_MSEC)));
+	EXPECT_EQ(client->GetState(), ov::SocketState::Disconnected);
 }
 
 // ===========================================================================
@@ -963,4 +1554,309 @@ TEST_F(SocketConcurrencyTest, RecvRacesPeerDisconnectStorm)
 			client->Close();
 		}
 	}
+}
+
+// ===========================================================================
+// SRT concurrency / stress
+//
+// SRT ports of the TCP stress tests above, plus a close-vs-epoll storm. OME
+// relies on libsrt's own thread safety for `srt_close()` on one thread racing
+// `srt_epoll_uwait()` on a pool worker, so the pool here has several workers.
+// libsrt itself is not TSan-instrumented; these catch hangs (`Watchdog`),
+// crashes, and misclassified disconnects.
+// ===========================================================================
+class SrtConcurrencyTest : public ::testing::Test
+{
+protected:
+	static constexpr int WORKER_COUNT = 8;
+
+	void SetUp() override
+	{
+		ASSERT_NE(::srt_startup(), -1);
+		_pool = ov::SocketPool::Create("test-srt-conc", ov::SocketType::Srt, false);
+		ASSERT_NE(_pool, nullptr);
+		ASSERT_TRUE(_pool->Initialize(WORKER_COUNT));
+	}
+
+	void TearDown() override
+	{
+		if (_pool != nullptr)
+		{
+			_pool->Uninitialize();
+		}
+		::srt_cleanup();
+	}
+
+	// A blocking-mode OME SRT client with async recv (and async handshake, see
+	// `SocketRecvSrtTest`) connected to `peer`, whose accept thread must already
+	// be running.
+	std::shared_ptr<ov::Socket> ConnectBlocking(SrtPeer &peer)
+	{
+		auto client = _pool->AllocSocket(ov::SocketFamily::Inet);
+		if (client == nullptr)
+		{
+			return nullptr;
+		}
+
+		client->MakeBlocking();
+		client->SetSockOpt<bool>(SRTO_RCVSYN, false);
+		if (Connected(client, client->Connect(LoopbackAddress(peer.Port()), LOOPBACK_TIMEOUT_MSEC)) == false)
+		{
+			client->Close();
+			return nullptr;
+		}
+		return client;
+	}
+
+	// A non-blocking OME SRT client (registered in a worker's SRT epoll) connected to `peer`.
+	std::shared_ptr<ov::Socket> ConnectAsync(SrtPeer &peer, const std::shared_ptr<SrtAsyncEvents> &events)
+	{
+		auto client = _pool->AllocSocket(ov::SocketFamily::Inet);
+		if (client == nullptr)
+		{
+			return nullptr;
+		}
+
+		events->Attach(client);
+		if (client->MakeNonBlocking(events) == false)
+		{
+			return nullptr;
+		}
+		if (Connected(client, client->Connect(LoopbackAddress(peer.Port()), LOOPBACK_TIMEOUT_MSEC)) == false)
+		{
+			client->Close();
+			return nullptr;
+		}
+		return client;
+	}
+
+	// Records why a connect attempt failed (`LastFailure()`), so a storm assertion
+	// can say whether the connect itself was refused or the handshake never completed.
+	bool Connected(const std::shared_ptr<ov::Socket> &client, const std::shared_ptr<const ov::SocketError> &error)
+	{
+		if (error != nullptr)
+		{
+			_last_failure = ov::String::FormatString("connect failed: %s", error->What()).CStr();
+			return false;
+		}
+		if (WaitSrtConnected(client) == false)
+		{
+			_last_failure = ov::String::FormatString("handshake did not complete, srt state %d, reject reason: %s",
+													 ::srt_getsockstate(client->GetNativeHandle()),
+													 ::srt_rejectreason_str(::srt_getrejectreason(client->GetNativeHandle())))
+								.CStr();
+			return false;
+		}
+		return true;
+	}
+
+	const std::string &LastFailure() const
+	{
+		return _last_failure;
+	}
+
+	std::shared_ptr<ov::SocketPool> _pool;
+	std::string _last_failure;
+};
+
+// Many independent SRT sockets each receive on their own thread at the same
+// time. Connections are established serially (an SRT handshake is heavy), the
+// receives run concurrently; every socket must get exactly its message.
+TEST_F(SrtConcurrencyTest, ManyIndependentSocketsReceiveConcurrently)
+{
+	Watchdog watchdog(std::chrono::seconds(30), "SrtManyIndependentSocketsReceiveConcurrently");
+
+	constexpr int SOCKET_COUNT = 48;
+	const char payload[]	   = "srt-concurrent-payload";
+
+	SrtPeer peer;
+	ASSERT_TRUE(peer.Listen(SOCKET_COUNT));
+	peer.AcceptAsync(SOCKET_COUNT);
+
+	std::vector<std::shared_ptr<ov::Socket>> clients;
+	CloseOnExit close_on_exit(clients);
+	for (int i = 0; i < SOCKET_COUNT; i++)
+	{
+		auto client = ConnectBlocking(peer);
+		ASSERT_NE(client, nullptr) << "socket " << i << ": " << LastFailure();
+		clients.push_back(client);
+	}
+	peer.WaitAccepted();
+	ASSERT_EQ(peer.ConnectionCount(), SOCKET_COUNT);
+
+	std::atomic<int> success{0};
+	std::vector<std::thread> threads;
+	threads.reserve(SOCKET_COUNT);
+	for (int i = 0; i < SOCKET_COUNT; i++)
+	{
+		threads.emplace_back([&, i]() {
+			peer.Send(i, payload, sizeof(payload));
+
+			char buffer[1500] = {0};
+			size_t received = 0;
+			if (RecvSrtMessage(clients[i], buffer, sizeof(buffer), &received) &&
+				(received == sizeof(payload)) &&
+				(::memcmp(buffer, payload, sizeof(payload)) == 0))
+			{
+				success.fetch_add(1);
+			}
+		});
+	}
+	for (auto &thread : threads)
+	{
+		thread.join();
+	}
+
+	EXPECT_EQ(success.load(), SOCKET_COUNT);
+}
+
+// Each peer connection is closed concurrently with an in-flight `Recv()` on the
+// OME side. Every `Recv()` must fail, a failed socket must never report a
+// spurious success afterwards, and the storm of simultaneous `srt_close()`
+// calls must not hang or crash.
+//
+// The failure surfaces as `Disconnected` (`SRT_ECONNLOST`) only if `Recv()` runs
+// before libsrt's GC thread moves the broken socket to `SRTS_CLOSED`; every
+// `srt_close()` in the process wakes that GC, and afterwards `srt_recvmsg2()`
+// fails with `SRT_EINVSOCK`, which `Recv()` classifies as `Error`. Both
+// outcomes are therefore accepted and the split is recorded.
+TEST_F(SrtConcurrencyTest, RecvRacesPeerDisconnectStorm)
+{
+	Watchdog watchdog(std::chrono::seconds(30), "SrtRecvRacesPeerDisconnectStorm");
+
+	constexpr int SOCKET_COUNT = 48;
+
+	SrtPeer peer;
+	ASSERT_TRUE(peer.Listen(SOCKET_COUNT));
+	peer.AcceptAsync(SOCKET_COUNT);
+
+	std::vector<std::shared_ptr<ov::Socket>> clients;
+	CloseOnExit close_on_exit(clients);
+	for (int i = 0; i < SOCKET_COUNT; i++)
+	{
+		auto client = ConnectBlocking(peer);
+		ASSERT_NE(client, nullptr) << "socket " << i << ": " << LastFailure();
+		clients.push_back(client);
+	}
+	peer.WaitAccepted();
+	ASSERT_EQ(peer.ConnectionCount(), SOCKET_COUNT);
+
+	std::atomic<int> failed{0};
+	std::atomic<int> disconnected{0};
+	std::atomic<int> errored{0};
+	std::atomic<int> spurious_success{0};
+	std::vector<std::thread> threads;
+	threads.reserve(SOCKET_COUNT);
+	for (int i = 0; i < SOCKET_COUNT; i++)
+	{
+		threads.emplace_back([&, i]() {
+			std::thread peer_closer([&, i]() { peer.CloseConnection(i); });
+
+			if (RecvUntilFailure(clients[i]))
+			{
+				failed.fetch_add(1);
+			}
+
+			peer_closer.join();
+
+			switch (clients[i]->GetState())
+			{
+				case ov::SocketState::Disconnected:
+					disconnected.fetch_add(1);
+					break;
+				case ov::SocketState::Error:
+					errored.fetch_add(1);
+					break;
+				default:
+					break;
+			}
+
+			char buffer[1500];
+			if (clients[i]->Recv(buffer, sizeof(buffer)).has_value())
+			{
+				spurious_success.fetch_add(1);
+			}
+		});
+	}
+	for (auto &thread : threads)
+	{
+		thread.join();
+	}
+
+	EXPECT_EQ(failed.load(), SOCKET_COUNT);
+	EXPECT_EQ(disconnected.load() + errored.load(), SOCKET_COUNT);
+	EXPECT_EQ(spurious_success.load(), 0);
+	RecordProperty("disconnected", disconnected.load());
+	RecordProperty("errored", errored.load());
+}
+
+// Non-blocking sockets spread over several workers are closed from the OME side
+// (`Close()` enqueued to the owning worker, which then calls `srt_close()`) and
+// from the peer side at the same time, round after round, while the other
+// workers sit in `srt_epoll_uwait()`. The test only requires that every socket
+// leaves `Connected` and that no round hangs or crashes.
+TEST_F(SrtConcurrencyTest, CloseRacesEpollStorm)
+{
+	Watchdog watchdog(std::chrono::seconds(120), "SrtCloseRacesEpollStorm");
+
+	constexpr int ROUNDS		= 25;
+	constexpr int SOCKET_COUNT	= 8;
+	constexpr int TOTAL_CLOSES = ROUNDS * SOCKET_COUNT;
+
+	SrtPeer peer;
+	ASSERT_TRUE(peer.Listen(SOCKET_COUNT * 2));
+
+	int closed_from_ome = 0;
+	for (int round = 0; round < ROUNDS; round++)
+	{
+		peer.AcceptAsync(SOCKET_COUNT);
+
+		std::vector<std::shared_ptr<SrtAsyncEvents>> events;
+		std::vector<std::shared_ptr<ov::Socket>> clients;
+		CloseOnExit close_on_exit(clients);
+		for (int i = 0; i < SOCKET_COUNT; i++)
+		{
+			auto e		= std::make_shared<SrtAsyncEvents>();
+			auto client = ConnectAsync(peer, e);
+			ASSERT_NE(client, nullptr) << "round " << round << " socket " << i << ": " << LastFailure();
+			events.push_back(e);
+			clients.push_back(client);
+		}
+		peer.WaitAccepted();
+		ASSERT_EQ(peer.ConnectionCount(), SOCKET_COUNT) << "round " << round;
+
+		// Alternate who closes first per socket so both orders race within a round.
+		std::vector<std::thread> threads;
+		for (int i = 0; i < SOCKET_COUNT; i++)
+		{
+			threads.emplace_back([&, i]() {
+				if ((i + round) % 2 == 0)
+				{
+					clients[i]->Close();
+					peer.CloseConnection(i);
+				}
+				else
+				{
+					peer.CloseConnection(i);
+					clients[i]->Close();
+				}
+			});
+		}
+		for (auto &thread : threads)
+		{
+			thread.join();
+		}
+
+		for (int i = 0; i < SOCKET_COUNT; i++)
+		{
+			ASSERT_TRUE(WaitUntil([&]() { return clients[i]->GetState() != ov::SocketState::Connected; }))
+				<< "round " << round << " socket " << i << " still connected";
+			closed_from_ome++;
+		}
+
+		// Forget this round's peer sockets (all already closed) before the next accept batch.
+		peer.CloseConnection();
+	}
+
+	EXPECT_EQ(closed_from_ome, TOTAL_CLOSES);
 }


### PR DESCRIPTION
## Summary
Updates the pinned libsrt from 1.5.2 to 1.5.6, which includes the fixes for CVE-2026-55869 (heap buffer overflow in KMREQ processing) and CVE-2026-55868 (encryption state machine downgrade).
This also brings in the fix for the `srt_startup()` reference-count regression (Haivision/srt#3098, fixed by #3100 in 1.5.5) that previously forced a rollback from 1.5.4: closing a single FFmpeg-driven SRT connection tore down every SRT socket in the process.

## Changes
- Bump `OME_VER_SRT` to 1.5.6 (`cmake/Versions.cmake`).
- Build libsrt with `-DENABLE_ENCRYPTION=ON` and `-DOPENSSL_ROOT_DIR` pointing at the prerequisite prefix (`cmake/InstallPrerequisites.cmake`). Encryption is already libsrt's default; these flags make the requirement explicit and pin OpenSSL resolution to the bundled OpenSSL, so libsrt links the same library OME ships instead of whatever the build host happens to find.
- Update the libsrt version references in `LICENSE-3RD-PARTY`, `docs/live-source/srt.md`, `docs/streaming/srt.md` and `docs/troubleshooting.md`.
- Add SRT unit tests to `ome_test_base` covering the semantics OME depends on and the failure modes seen with older libsrt versions:
  - `Recv()` disconnect classification for a graceful peer close and for a dead link with no shutdown handshake, on both the blocking path and the worker (epoll) path.
  - Concurrency storms: 48 sockets receiving concurrently, peer disconnects racing in-flight `Recv()`, and OME-side closes racing the epoll workers.
  - `StartupCleanupIsRefCounted`: pins the `srt_startup()`/`srt_cleanup()` reference-count contract (fails on libsrt 1.5.4, passes on 1.5.2/1.5.5/1.5.6).

## Testing
- Unit tests: configure with tests enabled, build the `ome_test_base` target, and run the SRT tests (all green against libsrt 1.5.6):
  ```sh
  cmake -B build/Debug -S . -DCMAKE_BUILD_TYPE=Debug -DOME_BUILD_TESTS=ON -G Ninja
  cmake --build build/Debug --target ome_test_base
  ./build/Debug/bin/ome_test_base --gtest_filter='SocketRecvSrtTest.*:SrtConcurrencyTest.*'
  ```
- Functional smoke with default SRT options (no `<Options>` configured): push to the SRT provider with ffmpeg, confirm the stream appears via the REST API, and play it back from the SRT publisher:
  ```sh
  ffmpeg -re -f lavfi -i testsrc2=size=640x360:rate=30 -f lavfi -i sine -c:v libx264 -c:a aac -f mpegts "srt://127.0.0.1:9999?streamid=srt://127.0.0.1:9999/app/stream"
  ffmpeg -i "srt://127.0.0.1:9998?streamid=srt://127.0.0.1:9998/app/stream" -f null -
  ```
- Encryption check: with `SRTO_PASSPHRASE` configured on the provider, verify a correct passphrase connects and a wrong one is rejected (`BADSECRET`).
- Connect/close churn (approximates the workload that crashed libsrt 1.5.2 and deadlocked 1.5.4; 1.5.6 stays healthy): generate a sample TS once, then run many short-lived remux-only senders, killing half of them hard so both the graceful-close and the silent-death paths are exercised:
  ```sh
  ffmpeg -f lavfi -i testsrc2=size=640x360:rate=30 -f lavfi -i sine -t 600 -c:v libx264 -b:v 400k -c:a aac -f mpegts sample.ts
  for i in $(seq 1 100); do (
    while true; do
      SIG=$([ $((RANDOM % 2)) -eq 0 ] && echo KILL || echo TERM)
      timeout -s $SIG $((RANDOM % 5 + 1)) ffmpeg -re -stream_loop -1 -i sample.ts -c copy -f mpegts "srt://127.0.0.1:9999?streamid=srt://127.0.0.1:9999/app/s$i" 2>/dev/null
    done ) & done
  ```
  While the churn is running, also publish your own stream (e.g. from OBS or a separate ffmpeg push) to a distinct stream id and keep playing it back:
  ```sh
  ffmpeg -re -f lavfi -i testsrc2=size=1280x720:rate=30 -f lavfi -i sine -c:v libx264 -b:v 2M -c:a aac -f mpegts "srt://127.0.0.1:9999?streamid=srt://127.0.0.1:9999/app/live"
  ffplay "srt://127.0.0.1:9998?streamid=srt://127.0.0.1:9998/app/live"
  ```
  Verify that this stream connects promptly, plays without interruption for the whole churn run, and survives stopping and restarting the publisher, and that the server keeps accepting new connections with streams appearing/disappearing normally in the REST API.
