### PR TITLE
build(deps): fetch x264 from the GitHub mirror instead of official repo

### DIFF
--- a/cmake/InstallPrerequisites.cmake
+++ b/cmake/InstallPrerequisites.cmake
@@ -180,7 +180,8 @@ set(PCRE2_SOURCE_URL "https://github.com/PCRE2Project/pcre2/releases/download/pc
 set(OPENH264_SOURCE_URL "https://github.com/cisco/openh264/archive/${OPENH264_ARCHIVE_REF}.tar.gz")
 set(HIREDIS_SOURCE_URL "https://github.com/redis/hiredis/archive/${HIREDIS_ARCHIVE_REF}.tar.gz")
 set(NVCC_HDR_SOURCE_URL "https://github.com/FFmpeg/nv-codec-headers/releases/download/n${NVCC_HDR_SOURCE_REF}/nv-codec-headers-${NVCC_HDR_SOURCE_REF}.tar.gz")
-set(X264_SOURCE_URL "https://code.videolan.org/videolan/x264/-/archive/${X264_ARCHIVE_REF}.tar.bz2")
+# TODO: restore the official https://code.videolan.org/videolan/x264/-/archive/${X264_ARCHIVE_REF}.tar.bz2
+set(X264_SOURCE_URL "https://github.com/mirror/x264/archive/${X264_SOURCE_REF}.tar.gz")
 set(WEBP_SOURCE_URL "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${WEBP_SOURCE_REF}.tar.gz")
 set(SPDLOG_SOURCE_URL "https://github.com/gabime/spdlog/archive/${SPDLOG_ARCHIVE_REF}.tar.gz")
 set(WHISPER_SOURCE_URL "https://github.com/ggml-org/whisper.cpp/archive/${WHISPER_ARCHIVE_REF}.tar.gz")


### PR DESCRIPTION
## Summary

`code.videolan.org` has been unreliable, and a failed x264 download aborts the whole `InstallPrerequisites` run. **As a temporary workaround, x264 is fetched from the `github.com/mirror/x264` mirror repository** (the same commit) until the official host is dependable again.

- `X264_SOURCE_URL` now points at `github.com/mirror/x264/archive/${X264_SOURCE_REF}.tar.gz`.
  `ome_fetch` auto-detects the compression, so `.tar.gz` needs no other change.
- Built from `X264_SOURCE_REF` directly, so the tarball is always the commit
  pinned in `Versions.cmake` instead of the `master` snapshot the GitLab pattern
  resolved to by default.
- A `TODO` keeps the original URL so it can be restored once the mirror is no
  longer needed.

## Test

- `cmake -DOME_ENABLE_X264=ON -P cmake/InstallPrerequisites.cmake` on Ubuntu 22.04: x264 downloads, builds, and installs.