### PR TITLE
feat(api): add startOffset to sendEvent for scheduling events ahead of the media

### DIFF
--- a/docs/rest-api/v1/virtualhost/application/stream/send-event.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/send-event.md
@@ -27,6 +27,7 @@ Authorization: Basic {credentials}
 {
   "eventFormat": "id3v2",
   "eventType": "video",
+  "startOffset": 0,
   "events":[
       {
         "frameType": "TXXX",
@@ -46,6 +47,9 @@ Authorization: Basic {credentials}
   Select one of event, video, and audio. event inserts an event into every track. 
   video inserts events only on tracks of video type. 
   audio inserts events only on tracks of audio type.
+# startOffset (Optional, Default : 0)
+  How long (in ms) from the current stream position to delay the event. 
+  Negative values are not allowed, and the maximum is 300000.
 # events
   It accepts only Json array format and can contain multiple events.
  
@@ -135,6 +139,23 @@ The given vhost name or app name could not be found.
 {
     "statusCode": 404,
     "message": "Could not find the application: [default/non-exists] (404)"
+}
+```
+
+</details>
+
+<details>
+
+<summary><span class="http-method http-method-409">409</span> Conflict</summary>
+
+The stream has not started sending media yet, so there is no position to place the event at.
+
+#### **Body**
+
+```json
+{
+    "statusCode": 409,
+    "message": "Media is not started yet: [default/app/stream] (409)"
 }
 ```
 

--- a/docs/rest-api/v1/virtualhost/application/stream/send-event.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/send-event.md
@@ -49,7 +49,9 @@ Authorization: Basic {credentials}
   audio inserts events only on tracks of audio type.
 # startOffset (Optional, Default : 0)
   How long (in ms) from the current stream position to delay the event. 
-  Negative values are not allowed, and the maximum is 300000.
+  Negative values are not allowed, and the maximum is 300000. 
+  Events are placed in the order they are sent, so an event that would land 
+  at or before the previous one is refused.
 # events
   It accepts only Json array format and can contain multiple events.
  
@@ -148,7 +150,7 @@ The given vhost name or app name could not be found.
 
 <summary><span class="http-method http-method-409">409</span> Conflict</summary>
 
-The stream has not started sending media yet, so there is no position to place the event at.
+The stream has not started sending media yet, so there is no position to place the event at, or the event would land at or before one already sent.
 
 #### **Body**
 
@@ -156,6 +158,13 @@ The stream has not started sending media yet, so there is no position to place t
 {
     "statusCode": 409,
     "message": "Media has not started yet: [default/app/stream] (409)"
+}
+```
+
+```json
+{
+    "statusCode": 409,
+    "message": "An event is already placed at or after this position, so events must be sent in order: [default/app/stream] (409)"
 }
 ```
 

--- a/docs/rest-api/v1/virtualhost/application/stream/send-event.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/send-event.md
@@ -155,7 +155,7 @@ The stream has not started sending media yet, so there is no position to place t
 ```json
 {
     "statusCode": 409,
-    "message": "Media is not started yet: [default/app/stream] (409)"
+    "message": "Media has not started yet: [default/app/stream] (409)"
 }
 ```
 

--- a/src/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.cpp
+++ b/src/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.cpp
@@ -26,6 +26,10 @@ namespace api
 {
 	namespace v1
 	{
+		// An event scheduled ahead of the media holds the stream's event channel
+		// until it is reached, so the reservation is bounded
+		static constexpr int64_t kMaxEventStartOffsetMs = 300000;
+
 		void StreamActionsController::PrepareHandlers()
 		{
 			RegisterPost(R"((hlsDumps))", &StreamActionsController::OnPostHLSDumps);
@@ -283,6 +287,7 @@ namespace api
 			//   "eventFormat": "id3v2",
 			//   "eventType": "video",
 			//	 "urgent": false,
+			//	 "startOffset": 3000,
 			//   "events":[
 			//       {
 			//         "frameType": "TXXX",
@@ -329,10 +334,42 @@ namespace api
 				throw http::HttpError(http::StatusCode::BadRequest, "eventFormat(string) and events(array) are required");
 			}
 
+			// startOffset (Optional, milliseconds) - schedules the event that far
+			// ahead of the position the media has reached now
+			int64_t start_offset_ms = 0;
+			if (request_body.isMember("startOffset") == true)
+			{
+				if (request_body["startOffset"].isInt64() == false)
+				{
+					throw http::HttpError(http::StatusCode::BadRequest, "startOffset must be an integer in milliseconds");
+				}
+
+				start_offset_ms = request_body["startOffset"].asInt64();
+				if (start_offset_ms < 0)
+				{
+					throw http::HttpError(http::StatusCode::BadRequest, "startOffset must not be negative");
+				}
+
+				if (start_offset_ms > kMaxEventStartOffsetMs)
+				{
+					throw http::HttpError(http::StatusCode::BadRequest, "startOffset must not exceed %" PRId64 " ms", kMaxEventStartOffsetMs);
+				}
+			}
+
+			// Every format shares one position, so an event carries the same time
+			// wherever it ends up
+			int64_t timestamp = source_stream->GetCurrentTimestampMs();
+			if (timestamp < 0)
+			{
+				throw http::HttpError(http::StatusCode::Conflict,
+									  "Media is not started yet: [%s/%s/%s]",
+									  vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr(), stream->GetName().CStr());
+			}
+			timestamp += start_offset_ms;
+
 			cmn::BitstreamFormat event_format	  = cmn::BitstreamFormat::Unknown;
 			ov::String event_format_string		  = request_body["eventFormat"].asString().c_str();
 			std::shared_ptr<ov::Data> events_data = nullptr;
-			int64_t timestamp					  = -1;
 
 			if (event_format_string.UpperCaseString() == "ID3V2")
 			{

--- a/src/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.cpp
+++ b/src/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.cpp
@@ -422,6 +422,16 @@ namespace api
 				urgent = request_body["urgent"].asBool();
 			}
 
+			// Events are consumed in the order they are sent, so one must not be
+			// placed before an event already on its way. Claimed only once the
+			// request is known to be sound, so a refused request leaves no mark
+			if (source_stream->ClaimEventTimestampMs(timestamp) == false)
+			{
+				throw http::HttpError(http::StatusCode::Conflict,
+									  "An event is already placed at or after this position, so events must be sent in order: [%s/%s/%s]",
+									  vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr(), stream->GetName().CStr());
+			}
+
 			if (source_stream->SendDataFrame(timestamp, event_format, event_type, events_data, urgent, true) == false)
 			{
 				throw http::HttpError(http::StatusCode::InternalServerError,

--- a/src/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.cpp
+++ b/src/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.cpp
@@ -362,7 +362,7 @@ namespace api
 			if (timestamp < 0)
 			{
 				throw http::HttpError(http::StatusCode::Conflict,
-									  "Media is not started yet: [%s/%s/%s]",
+									  "Media has not started yet: [%s/%s/%s]",
 									  vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr(), stream->GetName().CStr());
 			}
 			timestamp += start_offset_ms;

--- a/src/base/provider/stream.cpp
+++ b/src/base/provider/stream.cpp
@@ -205,16 +205,23 @@ namespace pvd
 			ov::LockGuard lock(_timestamp_mutex);
 
 			// The clock is the newest position over every media track, so a
-			// lagging track cannot pull it backward. A track that restarted lower
-			// re-anchors it: holding the old maximum would stamp every event and
-			// marker far ahead of the media for the life of the stream.
+			// lagging track cannot pull it backward. A track that restarted
+			// lower re-anchors it instead.
 			if (media_timestamp_ms > _last_media_timestamp_ms || track_restarted == true)
 			{
 				previous_ms = _last_media_timestamp_ms;
 				_last_media_timestamp_ms = media_timestamp_ms;
 				_last_media_timestamp_ms_hint.store(media_timestamp_ms, std::memory_order_relaxed);
 				_elapsed_from_last_media_timestamp.Restart();
+			}
+
+			// A re-anchor discards the timeline, and the positions handed out on
+			// it go with it: keeping them would stamp every event far ahead of
+			// the media for the life of the stream.
+			if (track_restarted == true)
+			{
 				_max_generated_timestamp_ms = -1LL;
+				_last_event_timestamp_ms = -1LL;
 			}
 		}
 

--- a/src/base/provider/stream.cpp
+++ b/src/base/provider/stream.cpp
@@ -142,6 +142,20 @@ namespace pvd
 		return _max_generated_timestamp_ms;
 	}
 
+	bool Stream::ClaimEventTimestampMs(int64_t timestamp_ms)
+	{
+		ov::LockGuard lock(_timestamp_mutex);
+
+		if (timestamp_ms <= _last_event_timestamp_ms)
+		{
+			return false;
+		}
+
+		_last_event_timestamp_ms = timestamp_ms;
+
+		return true;
+	}
+
 	void Stream::UpdateLastTimestampStat(const std::shared_ptr<const MediaTrack> &track, const std::shared_ptr<const MediaPacket> &packet)
 	{
 		if (track == nullptr ||

--- a/src/base/provider/stream.h
+++ b/src/base/provider/stream.h
@@ -86,6 +86,11 @@ namespace pvd
 
 		int64_t GetCurrentTimestampMs();
 
+		// Claims the position an event is placed at. Events are consumed in the
+		// order they are sent, so a position at or before the one already claimed
+		// is refused instead of being placed out of order
+		bool ClaimEventTimestampMs(int64_t timestamp_ms);
+
 
 	protected:
 		// Record the newest media position from a passing packet;
@@ -111,6 +116,9 @@ namespace pvd
 		std::atomic<int64_t> _last_media_timestamp_ms_hint{-1LL};
 		ov::StopWatch _elapsed_from_last_media_timestamp OV_GUARDED_BY(_timestamp_mutex);
 		int64_t _max_generated_timestamp_ms OV_GUARDED_BY(_timestamp_mutex) = -1LL;
+		// The furthest position an event has been placed at, so a later event
+		// never lands before it (see ClaimEventTimestampMs)
+		int64_t _last_event_timestamp_ms OV_GUARDED_BY(_timestamp_mutex) = -1LL;
 
 		Stream(const std::shared_ptr<pvd::Application> &application, StreamSourceType source_type);
 		Stream(const std::shared_ptr<pvd::Application> &application, info::stream_id_t stream_id, StreamSourceType source_type);


### PR DESCRIPTION
`sendEvent` places an event at the position the stream has reached when the request arrives, so an event can only be marked at the moment of the call. A sender that knows the moment in advance, or that cannot call at that exact instant, has no way to express it.

This adds `startOffset`, an optional millisecond value that delays the event by that much from that position. It is resolved once for the request, before the event format is handled, so it applies to every format the API accepts. Negative values are refused and the maximum is 300000. A request that arrives before the stream has sent any media now answers 409 rather than 500, because there is no position to place the event at.

**Test**

Publish an RTMP stream and play LL-HLS.

1. Send an event with `startOffset` omitted and another with it set, back to back. Download the segment that carries them and read the `emsg` boxes.
2. Send `-1`, `300001`, `300000`, `"3000"`, and `1.5`.
3. Send an event to a stream that has not started publishing.

Pass conditions: the two `emsg` presentation times differ by exactly the offset, measured against each request's own base position, and the event with no offset lands where it did before. `-1`, `300001`, `"3000"`, and `1.5` are refused with 400, and `300000` is accepted. The stream that has not started answers 409.

Measured on this branch: presentation times 18.571s and 21.580s against base positions 18571 and 18580, an exact 3000 ms gap. Unit tests 840 pass.
