### PR TITLE
refactor(transcoder): rework codec module selection

### DIFF
--- a/src/base/info/codec.h
+++ b/src/base/info/codec.h
@@ -142,15 +142,7 @@ namespace info
 
 		ov::String GetInfoString() const
 		{
-			ov::String supported_codecs;
-			for (const auto &codec : _supported_codecs)
-			{
-				if (supported_codecs.IsEmpty() == false)
-				{
-					supported_codecs.Append(",");
-				}
-				supported_codecs.Append(cmn::GetCodecIdString(codec));
-			}
+			ov::String supported_codecs = cmn::GetCodecIdListString(_supported_codecs);
 
 			ov::String metrics = ov::String::FormatString("dec%2d,enc%2d",
 														  _metrics._active_decoder,

--- a/src/base/info/codec.h
+++ b/src/base/info/codec.h
@@ -115,7 +115,7 @@ namespace info
 			return _metrics;
 		}
 
-		std::vector<cmn::MediaCodecId> GetSupportedCodecs() const
+		const std::vector<cmn::MediaCodecId> &GetSupportedCodecs() const
 		{
 			return _supported_codecs;
 		}

--- a/src/base/mediarouter/media_type.h
+++ b/src/base/mediarouter/media_type.h
@@ -622,6 +622,17 @@ namespace cmn
 		return "Unknown";
 	}
 
+	static ov::String GetCodecIdListString(const std::vector<cmn::MediaCodecId> &codecs)
+	{
+		std::vector<ov::String> names;
+		for (const auto &codec : codecs)
+		{
+			names.push_back(GetCodecIdString(codec));
+		}
+
+		return names.empty() ? ov::String("-") : ov::String::Join(names, ",");
+	}
+
 	static cmn::MediaCodecId GetCodecIdByName(ov::String name)
 	{
 		name.MakeUpper();

--- a/src/transcoder/transcoder_decoder.cpp
+++ b/src/transcoder/transcoder_decoder.cpp
@@ -93,10 +93,22 @@ std::shared_ptr<std::vector<std::shared_ptr<info::CodecCandidate>>> TranscodeDec
 		{
 			for (int device_id = 0; device_id < TranscodeGPU::GetInstance()->GetDeviceCount(module_id); device_id++)
 			{
-				if ((gpu_id == ALL_GPU_ID || gpu_id == device_id) && TranscodeGPU::GetInstance()->IsSupported(module_id, device_id) == true)
+				if (gpu_id != ALL_GPU_ID && gpu_id != device_id)
 				{
-					candidate_modules->push_back(std::make_shared<info::CodecCandidate>(track->GetCodecId(), module_id, device_id));
+					continue;
 				}
+
+				if (tc::TranscodeModules::GetInstance()->GetModule(/*coder_type=*/false, track->GetCodecId(), module_id, device_id) == nullptr)
+				{
+					logtd("%s:%d cannot decode %s. Skip this module",
+						  cmn::GetCodecModuleIdString(module_id),
+						  device_id,
+						  cmn::GetCodecIdString(track->GetCodecId()));
+
+					continue;
+				}
+
+				candidate_modules->push_back(std::make_shared<info::CodecCandidate>(track->GetCodecId(), module_id, device_id));
 			}
 		}
 

--- a/src/transcoder/transcoder_encoder.cpp
+++ b/src/transcoder/transcoder_encoder.cpp
@@ -114,10 +114,22 @@ std::shared_ptr<std::vector<std::shared_ptr<info::CodecCandidate>>> TranscodeEnc
 		{
 			for (int device_id = 0; device_id < TranscodeGPU::GetInstance()->GetDeviceCount(module_id); device_id++)
 			{
-				if ((gpu_id == ALL_GPU_ID || gpu_id == device_id) && TranscodeGPU::GetInstance()->IsSupported(module_id, device_id) == true)
+				if (gpu_id != ALL_GPU_ID && gpu_id != device_id)
 				{
-					candidate_modules->push_back(std::make_shared<info::CodecCandidate>(track->GetCodecId(), module_id, device_id));
+					continue;
 				}
+
+				if (tc::TranscodeModules::GetInstance()->GetModule(/*coder_type=*/true, track->GetCodecId(), module_id, device_id) == nullptr)
+				{
+					logtd("%s:%d cannot encode %s. Skip this module",
+						  cmn::GetCodecModuleIdString(module_id),
+						  device_id,
+						  cmn::GetCodecIdString(track->GetCodecId()));
+
+					continue;
+				}
+
+				candidate_modules->push_back(std::make_shared<info::CodecCandidate>(track->GetCodecId(), module_id, device_id));
 			}
 		}
 		else

--- a/src/transcoder/transcoder_gpu.cpp
+++ b/src/transcoder/transcoder_gpu.cpp
@@ -108,23 +108,6 @@ bool TranscodeGPU::Uninitialize()
 	return true;
 }
 
-bool TranscodeGPU::IsSupported(cmn::MediaCodecModuleId id, cmn::DeviceId gpu_id)
-{
-	switch (id)
-	{
-		case cmn::MediaCodecModuleId::NETINT:
-			return IsSupportedNI(gpu_id);
-		case cmn::MediaCodecModuleId::NVENC:
-			return IsSupportedNV(gpu_id);
-		case cmn::MediaCodecModuleId::XMA:
-			return IsSupportedXMA(gpu_id);
-		default:
-			break;
-	}
-
-	return false;
-}
-
 int32_t TranscodeGPU::GetDeviceCount(cmn::MediaCodecModuleId id)
 {
 	switch (id)
@@ -254,6 +237,15 @@ bool TranscodeGPU::CheckSupportedNV()
 	{
 		logte("Failed to get device count: %s", nvmlErrorString(result));
 		return false;
+	}
+
+	// Every per-device array is MAX_DEVICE_COUNT long, so a host with more GPUs than
+	// that must not be enumerated past the end.
+	if (nvml_device_count > static_cast<unsigned int>(MAX_DEVICE_COUNT))
+	{
+		logtw("NVML reports %u devices, but only %d can be used", nvml_device_count, MAX_DEVICE_COUNT);
+
+		nvml_device_count = MAX_DEVICE_COUNT;
 	}
 
 	// Get CUDA device count
@@ -471,31 +463,4 @@ int32_t TranscodeGPU::GetDeviceIdNV(cmn::DeviceId gpu_id)
 	}
 
 	return _device_cuda_id_nv[gpu_id];
-}
-
-bool TranscodeGPU::IsSupportedNI(cmn::DeviceId gpu_id)
-{
-	if (_device_count_ni == 0 || gpu_id >= _device_count_ni)
-	{
-		return false;
-	}
-
-	return true;
-}
-
-bool TranscodeGPU::IsSupportedNV(cmn::DeviceId gpu_id)
-{
-	// Supported iff this slot was successfully initialized. Indices are sparse
-	// (by NVML device id), so a count comparison is not enough.
-	return gpu_id >= 0 && gpu_id < MAX_DEVICE_COUNT && _device_context_nv[gpu_id] != nullptr;
-}
-
-bool TranscodeGPU::IsSupportedXMA(cmn::DeviceId gpu_id)
-{
-	if (_device_count_xma == 0 || gpu_id >= _device_count_xma)
-	{
-		return false;
-	}
-
-	return true;
 }

--- a/src/transcoder/transcoder_gpu.h
+++ b/src/transcoder/transcoder_gpu.h
@@ -25,8 +25,6 @@ public:
 	bool Initialize();
 	bool Uninitialize();
 
-	bool IsSupported(cmn::MediaCodecModuleId id, cmn::DeviceId gpu_id = 0);
-
 	int32_t GetDeviceCount(cmn::MediaCodecModuleId id);
 
 	std::shared_ptr<HwDeviceContext> GetDeviceContext(cmn::MediaCodecModuleId id, cmn::DeviceId gpu_id = 0);
@@ -44,10 +42,6 @@ protected:
 
 	std::shared_ptr<HwDeviceContext> GetDeviceContextNI(cmn::DeviceId gpu_id = 0);
 	std::shared_ptr<HwDeviceContext> GetDeviceContextNV(cmn::DeviceId gpu_id = 0);
-
-	bool IsSupportedNI(cmn::DeviceId gpu_id = 0);
-	bool IsSupportedNV(cmn::DeviceId gpu_id = 0);
-	bool IsSupportedXMA(cmn::DeviceId gpu_id = 0);
 
 	int32_t GetDeviceCountNI();
 	int32_t GetDeviceCountNV();

--- a/src/transcoder/transcoder_modules.cpp
+++ b/src/transcoder/transcoder_modules.cpp
@@ -47,7 +47,7 @@ namespace tc
 		// Audio Codecs
 		// --------------------------------------------------------------------------
 		Register(info::CodecModule("FFmpeg Audio Codecs", cmn::MediaType::Audio, cmn::MediaCodecModuleId::DEFAULT, 0, "-",
-						   {cmn::MediaCodecId::Aac, cmn::MediaCodecId::Mp2, cmn::MediaCodecId::Opus},
+						   {cmn::MediaCodecId::Aac, cmn::MediaCodecId::Mp2, cmn::MediaCodecId::Mp3, cmn::MediaCodecId::Opus},
 						   true, true, false, false));
 
 		Register(info::CodecModule("Fraunhofer FDK AAC", cmn::MediaType::Audio, cmn::MediaCodecModuleId::FDKAAC, 0, "-",
@@ -56,6 +56,10 @@ namespace tc
 
 		Register(info::CodecModule("Opus Interactive Audio Codec", cmn::MediaType::Audio, cmn::MediaCodecModuleId::LIBOPUS, 0, "-",
 						   {cmn::MediaCodecId::Opus},
+						   true, false, true, false));
+
+		Register(info::CodecModule("Whisper Speech-to-Text", cmn::MediaType::Audio, cmn::MediaCodecModuleId::DEFAULT, 0, "-",
+						   {cmn::MediaCodecId::Whisper},
 						   true, false, true, false));
 
 		// --------------------------------------------------------------------------

--- a/src/transcoder/transcoder_modules.h
+++ b/src/transcoder/transcoder_modules.h
@@ -36,11 +36,16 @@ namespace tc
 
 			for (const auto &codec : _modules)
 			{
-				if (codec->GetMediaType() == media_type &&
-					codec->GetModuleId() == module_id &&
-					codec->GetDeviceId() == device_id &&
-					(coder_type ? codec->isEncoder() : codec->isDecoder()) &&
-					std::find(codec->GetSupportedCodecs().begin(), codec->GetSupportedCodecs().end(), codec_id) != codec->GetSupportedCodecs().end())
+				if (codec->GetMediaType() != media_type ||
+					codec->GetModuleId() != module_id ||
+					codec->GetDeviceId() != device_id ||
+					(coder_type ? codec->isEncoder() : codec->isDecoder()) == false)
+				{
+					continue;
+				}
+
+				const auto &supported_codecs = codec->GetSupportedCodecs();
+				if (std::find(supported_codecs.begin(), supported_codecs.end(), codec_id) != supported_codecs.end())
 				{
 					return codec;
 				}

--- a/src/transcoder/transcoder_test.cpp
+++ b/src/transcoder/transcoder_test.cpp
@@ -2,16 +2,58 @@
 //
 //  OvenMediaEngine - Unit Tests
 //
-//  tests/transcoder/test_transcoder_placeholder.cpp
-//  Covers: TranscoderContext creation, GPU detection, codec mapping
+//  Covers: codec module table lookups
 //
-//  NOTE: Skeleton. Transcoder tests may require FFmpeg initialization.
-//        Tests that do NOT require actual codec instances can be added here.
+//  NOTE: Transcoder tests may require FFmpeg initialization. Tests that do NOT
+//        require actual codec instances can be added here.
 //
 //==============================================================================
 #include <gtest/gtest.h>
 
-TEST(TranscoderPlaceholder, TodoImplementTests)
+#include "transcoder_modules.h"
+
+// The registrations below are the software ones, which are always present; the
+// hardware modules need a device and are not part of these expectations.
+class TranscodeModulesTest : public ::testing::Test
 {
-	GTEST_SKIP() << "Transcoder tests not yet implemented - see tests/transcoder/";
+protected:
+	tc::TranscodeModules *_modules = tc::TranscodeModules::GetInstance();
+};
+
+TEST_F(TranscodeModulesTest, RejectsCodecTheModuleDidNotRegister)
+{
+	// The DEFAULT video decoder registers H264, H265, VP8 and AV1. Media type, module,
+	// device and direction all match for VP9, so only the codec can reject it.
+	EXPECT_EQ(_modules->GetModule(/*coder_type=*/false, cmn::MediaCodecId::Vp9, cmn::MediaCodecModuleId::DEFAULT, 0), nullptr);
+
+	// LIBAOM registers AV1 alone.
+	EXPECT_EQ(_modules->GetModule(/*coder_type=*/true, cmn::MediaCodecId::H264, cmn::MediaCodecModuleId::LIBAOM, 0), nullptr);
+}
+
+TEST_F(TranscodeModulesTest, FindsRegisteredCodec)
+{
+	EXPECT_NE(_modules->GetModule(/*coder_type=*/false, cmn::MediaCodecId::H264, cmn::MediaCodecModuleId::DEFAULT, 0), nullptr);
+	EXPECT_NE(_modules->GetModule(/*coder_type=*/true, cmn::MediaCodecId::Av1, cmn::MediaCodecModuleId::LIBAOM, 0), nullptr);
+	EXPECT_NE(_modules->GetModule(/*coder_type=*/true, cmn::MediaCodecId::Jpeg, cmn::MediaCodecModuleId::DEFAULT, 0), nullptr);
+}
+
+TEST_F(TranscodeModulesTest, KeepsDecoderAndEncoderApart)
+{
+	// The DEFAULT audio module decodes only, the FDKAAC module encodes only.
+	EXPECT_NE(_modules->GetModule(/*coder_type=*/false, cmn::MediaCodecId::Aac, cmn::MediaCodecModuleId::DEFAULT, 0), nullptr);
+	EXPECT_EQ(_modules->GetModule(/*coder_type=*/true, cmn::MediaCodecId::Aac, cmn::MediaCodecModuleId::DEFAULT, 0), nullptr);
+
+	EXPECT_NE(_modules->GetModule(/*coder_type=*/true, cmn::MediaCodecId::Aac, cmn::MediaCodecModuleId::FDKAAC, 0), nullptr);
+	EXPECT_EQ(_modules->GetModule(/*coder_type=*/false, cmn::MediaCodecId::Aac, cmn::MediaCodecModuleId::FDKAAC, 0), nullptr);
+}
+
+TEST_F(TranscodeModulesTest, FindsCodecsRegisteredForTheDefaultModule)
+{
+	EXPECT_NE(_modules->GetModule(/*coder_type=*/false, cmn::MediaCodecId::Mp3, cmn::MediaCodecModuleId::DEFAULT, 0), nullptr);
+	EXPECT_NE(_modules->GetModule(/*coder_type=*/true, cmn::MediaCodecId::Whisper, cmn::MediaCodecModuleId::DEFAULT, 0), nullptr);
+}
+
+TEST_F(TranscodeModulesTest, RejectsUnregisteredDevice)
+{
+	EXPECT_EQ(_modules->GetModule(/*coder_type=*/false, cmn::MediaCodecId::H264, cmn::MediaCodecModuleId::DEFAULT, 1), nullptr);
 }


### PR DESCRIPTION
## Summary

Refactors transcoder codec/module candidate selection to consult the registered module table (instead of only checking device existence), aiming to skip unsupported hardware codec paths earlier and reduce late failures during encoder/decoder creation.

## Changes

- Updates TranscodeModules::GetModule() filtering and uses module-table lookups when building encoder/decoder hardware candidates.
- Extends module registrations (MP3 decode under DEFAULT/FFmpeg audio; Whisper under DEFAULT) and centralizes codec-list formatting via cmn::GetCodecIdListString().
- Removes TranscodeGPU::IsSupported() helpers and clamps NVML-reported device count to MAX_DEVICE_COUNT.

## Testing

`ome_test_transcoder --gtest_filter='TranscodeModulesTest.*'` - 5 cases over `TranscodeModules::GetModule()`:

- Rejects a codec the module never registered, where media type, module, device and direction all match - the case the old lookup accepted
- Rejects a codec registered for the other direction
- Finds a registered codec, the codecs registered for the DEFAULT module, and rejects an unregistered device id

The two codec-only expectations fail against the old lookup.
