### PR TITLE
fix(llhls): anchor synced segment boundaries on the stream's first segment

### DIFF
--- a/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.h
+++ b/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.h
@@ -24,7 +24,9 @@ namespace bmff
 	// All positions are integer microseconds on the shared media clock.
 	struct SegmentBoundary
 	{
-		// Where the segment ends
+		// Where the segment ends. Meaningful only when the plan was asked with a
+		// segment start; without one it carries no position, and a stream whose
+		// timeline runs below zero ends its segments there too
 		int64_t end_us = -1;
 
 		// Whether end_us is the exact end or the aim to cut at or after

--- a/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy.cpp
@@ -160,18 +160,23 @@ namespace bmff
 		// (within half a frame) belongs to that boundary, not before it
 		const int64_t tolerance_us = (_video_frame_rate > 0) ? std::llround(500000.0 / _video_frame_rate) : 500;
 
-		int64_t multiple = std::max(static_cast<int64_t>(1), position_us / _segment_duration_us);
+		const int64_t origin_us = (_grid_origin_us >= 0) ? _grid_origin_us : 0;
+
+		// The origin itself is a boundary, so the search starts at it; the check
+		// below rejects it when the segment already starts there
+		int64_t multiple = std::max(static_cast<int64_t>(0), (position_us - origin_us) / _segment_duration_us);
 
 		while (true)
 		{
-			int64_t boundary_us = multiple * _segment_duration_us;
+			int64_t boundary_us = origin_us + (multiple * _segment_duration_us);
 
 			// The aimed position must be a real frame position, so the realized
-			// cut can land exactly on it when the keyframe cadence allows
+			// cut can land exactly on it when the keyframe cadence allows. The
+			// cadence is counted from the origin, where this stream's frames are
 			if (_video_frame_rate > 0)
 			{
-				double frame_index = std::round(static_cast<double>(boundary_us) * _video_frame_rate / 1000000.0);
-				boundary_us = std::llround(frame_index * 1000000.0 / _video_frame_rate);
+				double frame_index = std::round(static_cast<double>(boundary_us - origin_us) * _video_frame_rate / 1000000.0);
+				boundary_us = origin_us + std::llround(frame_index * 1000000.0 / _video_frame_rate);
 			}
 
 			if (boundary_us > position_us + tolerance_us)
@@ -192,6 +197,13 @@ namespace bmff
 		{
 			plan.end_us = -1;
 			return plan;
+		}
+
+		// The first start this reference sees fixes where the aimed positions
+		// begin for the stream
+		if (_grid_origin_us < 0)
+		{
+			_grid_origin_us = *segment_start_us;
 		}
 
 		plan.end_us = NextBoundaryUs(*segment_start_us) - kBoundaryBiasUs;

--- a/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy.cpp
@@ -171,8 +171,9 @@ namespace bmff
 			int64_t boundary_us = origin_us + (multiple * _segment_duration_us);
 
 			// The aimed position must be a real frame position, so the realized
-			// cut can land exactly on it when the keyframe cadence allows. The
-			// cadence is counted from the origin, where this stream's frames are
+			// cut can land exactly on it when the keyframe cadence allows.
+			// Frames are counted from the origin, which is itself a frame of
+			// this stream
 			if (_video_frame_rate > 0)
 			{
 				double frame_index = std::round(static_cast<double>(boundary_us - origin_us) * _video_frame_rate / 1000000.0);

--- a/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy.cpp
@@ -160,7 +160,7 @@ namespace bmff
 		// (within half a frame) belongs to that boundary, not before it
 		const int64_t tolerance_us = (_video_frame_rate > 0) ? std::llround(500000.0 / _video_frame_rate) : 500;
 
-		const int64_t origin_us = (_grid_origin_us >= 0) ? _grid_origin_us : 0;
+		const int64_t origin_us = _origin_us.value_or(0);
 
 		// The origin itself is a boundary, so the search starts at it; the check
 		// below rejects it when the segment already starts there
@@ -201,10 +201,10 @@ namespace bmff
 		}
 
 		// The first start this reference sees fixes where the aimed positions
-		// begin for the stream
-		if (_grid_origin_us < 0)
+		// begin for the stream, whatever its sign
+		if (_origin_us.has_value() == false)
 		{
-			_grid_origin_us = *segment_start_us;
+			_origin_us = *segment_start_us;
 		}
 
 		plan.end_us = NextBoundaryUs(*segment_start_us) - kBoundaryBiasUs;

--- a/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy.h
+++ b/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy.h
@@ -80,18 +80,19 @@ namespace bmff
 	};
 
 	// The reference track's policy in synced segmentation. It aims each cut at
-	// fixed timeline positions (multiples of the configured duration snapped to
-	// its own frame cadence), lands on the first cuttable frame at or after
-	// them, and publishes every realized boundary to the feed every synced
-	// track follows. The fixed positions make the grid deterministic, and a
-	// marker cut re-anchors simply by the next segment starting where it starts.
+	// fixed timeline positions (the segment duration apart, counted from where
+	// the stream's first segment started and snapped to its own frame cadence),
+	// lands on the first cuttable frame at or after them, and publishes every
+	// realized boundary to the feed every synced track follows. The fixed
+	// spacing makes the positions deterministic, and a marker cut re-anchors
+	// simply by the next segment starting where it starts.
 	class ReferenceBoundaryPolicy : public SegmentBoundaryPolicy
 	{
 	public:
 		// video_frame_rate: the cadence the aimed positions snap to, so every
-		// position is a real frame (0 keeps plain multiples). The feed the
-		// realized boundaries are published to is created and owned here; the
-		// synced tracks read it through GetBoundaryFeed().
+		// position is a real frame (0 keeps them a plain segment duration
+		// apart). The feed the realized boundaries are published to is created
+		// and owned here; the synced tracks read it through GetBoundaryFeed().
 		ReferenceBoundaryPolicy(const Config &config, double video_frame_rate);
 
 		SegmentBoundary GetSegmentBoundary(std::optional<int64_t> segment_start_us) override;
@@ -106,8 +107,9 @@ namespace bmff
 		// by this reference
 		std::shared_ptr<const BoundaryFeed> GetBoundaryFeed() const;
 
-		// The first aimed position at or after the given one (µs), snapped to
-		// the frame cadence. Public for tests.
+		// The first aimed position past the given one (µs), snapped to the frame
+		// cadence. A position within half a frame of one belongs to it, so that
+		// one is not returned. Public for tests.
 		int64_t NextBoundaryUs(int64_t position_us) const;
 
 	protected:
@@ -125,9 +127,10 @@ namespace bmff
 		// Where the aimed positions start counting. The frames of a stream sit
 		// at their own offset, and counting from zero would aim between two of
 		// them on every segment; taking the first segment start as the origin
-		// puts every aimed position on a frame this stream actually has.
-		// Negative until the first start is known, which counts from zero.
-		int64_t _grid_origin_us = -1;
+		// puts every aimed position on a frame this stream actually has. Unset
+		// until that start is known, which counts from zero. A first start can
+		// be negative, so the unset state cannot be a value of its own.
+		std::optional<int64_t> _origin_us;
 	};
 
 	// A synced track's policy: computes no boundaries of its own. Each segment

--- a/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy.h
+++ b/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy.h
@@ -121,6 +121,13 @@ namespace bmff
 		// Whether the opening anchor went out with the first stored chunk; the
 		// reference's media thread is the only writer
 		bool _opening_anchor_published = false;
+
+		// Where the aimed positions start counting. The frames of a stream sit
+		// at their own offset, and counting from zero would aim between two of
+		// them on every segment; taking the first segment start as the origin
+		// puts every aimed position on a frame this stream actually has.
+		// Negative until the first start is known, which counts from zero.
+		int64_t _grid_origin_us = -1;
 	};
 
 	// A synced track's policy: computes no boundaries of its own. Each segment

--- a/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy_test.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy_test.cpp
@@ -460,6 +460,16 @@ TEST(ReferenceBoundaryPolicyTest, BoundariesStartWhereTheStreamDid)
 	EXPECT_NEAR(PlanAt(policy, 6000.0).end_us, 8500000.0, 10.0);
 }
 
+TEST(ReferenceBoundaryPolicyTest, ATimelineBelowZeroFixesTheOriginToo)
+{
+	auto policy = MakeReference(30.0);
+
+	// A first start below zero is a position like any other, so the aimed
+	// positions follow it instead of counting from zero
+	EXPECT_NEAR(PlanAt(policy, -500.0).end_us, 3500000.0, 10.0);
+	EXPECT_NEAR(PlanAt(policy, 4000.0).end_us, 7500000.0, 10.0);
+}
+
 TEST(ReferenceBoundaryPolicyTest, PublishesRealizedBoundaries)
 {
 	auto policy = MakeReference();

--- a/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy_test.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy_test.cpp
@@ -420,6 +420,10 @@ TEST(ReferenceBoundaryPolicyTest, BoundaryFollowsTheSegmentStart)
 {
 	auto policy = MakeReference(30.0, 7);
 
+	// The aimed positions start where the stream's first segment did; this one
+	// opened at zero, so they fall on plain multiples of the segment duration
+	PlanAt(policy, 0.0);
+
 	// Unknown start: only the numbering is planned. The planned boundaries sit
 	// a microsecond under the true position so a rounding ulp cannot push the
 	// cut past the intended frame.
@@ -442,6 +446,9 @@ TEST(ReferenceBoundaryPolicyTest, BoundaryFollowsTheSegmentStart)
 TEST(ReferenceBoundaryPolicyTest, PublishesRealizedBoundaries)
 {
 	auto policy = MakeReference();
+
+	// The stream's first segment opened at zero, so the aimed positions start there
+	PlanAt(policy, 0.0);
 
 	// A marker cut completed the segment early, at 1400
 	Complete(policy, 5, 0.0, 1400.0);

--- a/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy_test.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/synced_boundary_policy_test.cpp
@@ -443,6 +443,23 @@ TEST(ReferenceBoundaryPolicyTest, BoundaryFollowsTheSegmentStart)
 	EXPECT_NEAR(PlanAt(policy, 3900.0).end_us, 4000000.0, 10.0);
 }
 
+TEST(ReferenceBoundaryPolicyTest, BoundariesStartWhereTheStreamDid)
+{
+	auto policy = MakeReference(30.0);
+
+	// A stream whose timeline opens away from zero: its frames sit at that
+	// offset, so the aimed positions start there instead of on multiples of
+	// the segment duration
+	EXPECT_NEAR(PlanAt(policy, 500.0).end_us, 4500000.0, 10.0);
+
+	// and keep the segment duration between them
+	EXPECT_NEAR(PlanAt(policy, 5000.0).end_us, 8500000.0, 10.0);
+
+	// A segment starting at a marker cut targets the same one, so the track
+	// returns to the cadence by itself here too
+	EXPECT_NEAR(PlanAt(policy, 6000.0).end_us, 8500000.0, 10.0);
+}
+
 TEST(ReferenceBoundaryPolicyTest, PublishesRealizedBoundaries)
 {
 	auto policy = MakeReference();

--- a/src/publishers/llhls/llhls_stream.cpp
+++ b/src/publishers/llhls/llhls_stream.cpp
@@ -1903,9 +1903,10 @@ bool LLHlsStream::AddPackager(const std::shared_ptr<const MediaTrack> &media_tra
 	auto reference_track = (GetSegmentationMode() == LLHlsSegmentationMode::Synced) ? GetReferenceTrack() : nullptr;
 	if (reference_track != nullptr)
 	{
-		// The reference aims at multiples of the segment duration on its own
-		// frame cadence; the realized cuts land on its keyframes and every other
-		// track follows them. Created on the first track, whichever it is.
+		// The reference aims a segment duration apart from where its first
+		// segment started, on its own frame cadence; the realized cuts land on
+		// its keyframes and every other track follows them. Created on the
+		// first track, whichever it is.
 		if (_reference_boundary_policy == nullptr)
 		{
 			if (server_time_based_segment_numbering == true)


### PR DESCRIPTION
In synced segmentation the reference track aims each cut at positions counted from zero. A stream whose timeline does not start there has its frames at their own offset, so every aimed position falls between two of them and the cut lands on the following frame instead. The stream then reports every segment as closing past its plan, for as long as it runs. `TimestampMode` `SystemClock` puts every stream in that state, and any source that opens away from zero reaches it as well.

The first segment start now fixes where those positions begin, so each one is a frame the stream actually has and the cut lands on it. The spacing between them is unchanged, so a segment cut short by a marker still returns to the cadence at the next one.

**Test**

Publish a stream whose timeline does not start at zero, with synced segmentation, and play LL-HLS.

1. Watch the log for `Segment closed at ... past its ... plan`.
2. Read EXTINF and the part durations from the chunklist.

Pass conditions: the warning does not appear, EXTINF equals the configured segment duration, and the parts equal the configured chunk duration.

Measured on this branch with a scheduled channel on `SystemClock`: ten minutes and three item switches with no such warning, EXTINF 2.000 on every segment, and parts of 1.000. The same build before the change logged the warning on every segment.

Unit tests: 840 pass, including the boundary tests that cover a segment cut short returning to the cadence.
