### PR TITLE
fix(transcoder): replace hwupload_cuda with hwupload

### DIFF
--- a/src/modules/ffmpeg/ffmpeg_filter_graph.cpp
+++ b/src/modules/ffmpeg/ffmpeg_filter_graph.cpp
@@ -295,7 +295,7 @@ namespace ffmpeg
 			{
 				is_scale_cuda = true;
 			}
-			else if (strstr(filter->name, "hwupload_cuda") != nullptr)
+			else if (strstr(filter->name, "hwupload") != nullptr)
 			{
 				is_hwupload_cuda = true;
 			}
@@ -310,7 +310,7 @@ namespace ffmpeg
 				continue;
 			}
 
-			if (strstr(filter->name, "scale_cuda") == nullptr && strstr(filter->name, "hwupload_cuda") == nullptr)
+			if (strstr(filter->name, "scale_cuda") == nullptr && strstr(filter->name, "hwupload") == nullptr)
 			{
 				continue;
 			}


### PR DESCRIPTION
## Summary

`ApplyCudaHwContext()` is a helper that gives each hardware filter in a graph the CUDA device to work on.

The helper only knew the `hwupload_cuda` filter, which makes its own CUDA device and ignores the one it is given. The generic `hwupload` filter does use it.

With `hwupload`, the decoder, the filters and the encoder all run on the same CUDA context, so their GPU work stays in order.

## Changes

- Replace `hwupload_cuda` with `hwupload`

## Testing

None.