### PR TITLE
fix(websocket): use minimal payload length encoding at the boundaries

### DIFF
--- a/src/modules/http/server/web_socket/web_socket_response.cpp
+++ b/src/modules/http/server/web_socket/web_socket_response.cpp
@@ -43,7 +43,7 @@ namespace http
 
 				size_t length = (data == nullptr) ? 0LL : data->GetLength();
 
-				if (length < 0x7D)
+				if (length <= 0x7D)
 				{
 					// frame-payload-length    = ( %x00-7D )
 					//                         / ( %x7E frame-payload-length-16 )
@@ -52,7 +52,7 @@ namespace http
 					//                         ; respectively
 					header.payload_length = static_cast<uint8_t>(length);
 				}
-				else if (length < 0xFFFF)
+				else if (length <= 0xFFFF)
 				{
 					// frame-payload-length-16 = %x0000-FFFF ; 16 bits in length
 					header.payload_length = 126;


### PR DESCRIPTION
### Problem

[RFC 6455 §5.2](https://datatracker.ietf.org/doc/html/rfc6455#section-5.2)  requires that "the minimal number of bytes MUST be used to encode the length" of a frame payload. `WebSocketResponse::Send()` encodes the two boundary values one form too large:

- a **125-byte (0x7D)** payload fits the 7-bit field (`frame-payload-length = %x00-7D`) but is sent as `126` + a 16-bit extended length;
- a **65535-byte (0xFFFF)** payload fits the 16-bit field (`frame-payload-length-16 = %x0000-FFFF`) but is sent as `127` + a 64-bit extended length.

Strict client implementations reject non-minimal frames. Chrome is one of them: when it receives such a frame, it fails the connection and **the whole signalling WebSocket goes down**. We hit this in production — a JSON signalling message of exactly 125 bytes was enough to disconnect the client.

### Fix

Use `<=` at both boundaries so each length is encoded in the smallest form the grammar allows. No behavior change for any other length.