### PR TITLE
perf(scheduled): close the item's format context off the releasing thread

### DIFF
--- a/src/modules/task_pool/task_pool.cpp
+++ b/src/modules/task_pool/task_pool.cpp
@@ -53,7 +53,6 @@ namespace ov
 
 		_config = config;
 
-		// A pool that cannot hold a task or run one is not a pool
 		if (_config.thread_count == 0)
 		{
 			_config.thread_count = 1;
@@ -98,8 +97,6 @@ namespace ov
 	{
 		_rejected_count++;
 
-		// A full queue rejects everything that follows, and that is exactly when the log
-		// must not be flooded
 		auto now = std::chrono::steady_clock::now();
 		if ((now - _last_reject_log_time) < std::chrono::seconds(1))
 		{
@@ -129,8 +126,7 @@ namespace ov
 				return false;
 			}
 
-			// The workers are started by the first task and stay until the pool stops, so a
-			// pool nobody uses holds no threads
+			// Started lazily by the first task
 			if (_workers.empty())
 			{
 				AddWorkers(_config.thread_count);
@@ -156,6 +152,79 @@ namespace ov
 		return true;
 	}
 
+	bool TaskPool::PostDedicated(const ov::String &worker_name, Task task, bool keep_alive)
+	{
+		if (task == nullptr)
+		{
+			OV_ASSERT2(task != nullptr);
+			return false;
+		}
+
+		DedicatedWorker *worker = nullptr;
+
+		{
+			std::lock_guard<std::mutex> lock(_mutex);
+
+			if (_stopped)
+			{
+				return false;
+			}
+
+			auto &slot = _dedicated_workers[worker_name];
+			const bool created_now = (slot == nullptr);
+			if (created_now)
+			{
+				slot = std::make_unique<DedicatedWorker>();
+				slot->keep_alive = keep_alive;
+			}
+
+			if (slot->task_queue.size() >= _config.max_tasks)
+			{
+				ReportRejection();
+				return false;
+			}
+
+			if (slot->running == false)
+			{
+				// The previous worker has left for lack of work; joined before a new one starts
+				if (slot->thread.joinable())
+				{
+					slot->thread.join();
+				}
+
+				try
+				{
+					slot->thread = std::thread(&TaskPool::DedicatedWorkerThreadProc, this, slot.get());
+
+					// A thread name holds 15 characters; a longer worker name keeps its front
+					::pthread_setname_np(slot->thread.native_handle(), worker_name.Substring(0, 15).CStr());
+
+					slot->running = true;
+				}
+				catch (const std::system_error &e)
+				{
+					// Post() must not throw at a caller that only expects false back
+					logte("Could not start the dedicated worker '%s': %s", worker_name.CStr(), e.what());
+
+					if (created_now)
+					{
+						_dedicated_workers.erase(worker_name);
+					}
+
+					return false;
+				}
+			}
+
+			slot->task_queue.push(std::move(task));
+			worker = slot.get();
+		}
+
+		// Wakes a keep-alive worker; a no-op otherwise
+		worker->condition.notify_one();
+
+		return true;
+	}
+
 	size_t TaskPool::GetPendingCount() const
 	{
 		std::lock_guard<std::mutex> lock(_mutex);
@@ -172,8 +241,7 @@ namespace ov
 
 	void TaskPool::Stop()
 	{
-		// Held for the whole call so that a second caller waits for the workers to be gone
-		// instead of returning while the first one is still joining them
+		// A second caller waits here until the workers are joined
 		std::lock_guard<std::mutex> stop_lock(_stop_mutex);
 
 		std::vector<std::thread> workers;
@@ -186,8 +254,7 @@ namespace ov
 				return;
 			}
 
-			// Joining its own thread would throw, and the workers left unjoined by that would
-			// take the process down with them
+			// Joining its own thread would throw
 			auto current_thread_id = std::this_thread::get_id();
 			for (const auto &worker : _workers)
 			{
@@ -197,24 +264,103 @@ namespace ov
 					return;
 				}
 			}
+			for (const auto &[name, worker] : _dedicated_workers)
+			{
+				if (worker->thread.get_id() == current_thread_id)
+				{
+					logte("A task tried to stop the pool it runs on, which it cannot do");
+					return;
+				}
+			}
 
 			_stopped = true;
 
-			// Dropped rather than run, because whatever they were going to use may already
-			// be on its way down
+			// Dropped, not run; what they would touch may already be shutting down
 			std::queue<Task> empty_queue;
 			_task_queue.swap(empty_queue);
+
+			for (auto &[name, worker] : _dedicated_workers)
+			{
+				std::queue<Task> empty_worker_queue;
+				worker->task_queue.swap(empty_worker_queue);
+			}
 
 			workers.swap(_workers);
 		}
 
 		_condition.notify_all();
+		for (auto &[name, worker] : _dedicated_workers)
+		{
+			worker->condition.notify_all();
+		}
 
 		for (auto &worker : workers)
 		{
 			if (worker.joinable())
 			{
 				worker.join();
+			}
+		}
+
+		// Joined before the map releases what the workers use
+		for (auto &[name, worker] : _dedicated_workers)
+		{
+			if (worker->thread.joinable())
+			{
+				worker->thread.join();
+			}
+		}
+
+		{
+			std::lock_guard<std::mutex> lock(_mutex);
+			_dedicated_workers.clear();
+		}
+	}
+
+	void TaskPool::DedicatedWorkerThreadProc(DedicatedWorker *worker)
+	{
+		while (true)
+		{
+			Task task;
+
+			{
+				std::unique_lock<std::mutex> lock(_mutex);
+
+				if (worker->keep_alive)
+				{
+					worker->condition.wait(lock, [this, worker]() {
+						return _stopped || (worker->task_queue.empty() == false);
+					});
+				}
+
+				if (_stopped)
+				{
+					break;
+				}
+
+				if (worker->task_queue.empty())
+				{
+					// Only reached without keep_alive: the queue ran dry, the worker leaves
+					worker->running = false;
+					break;
+				}
+
+				task = std::move(worker->task_queue.front());
+				worker->task_queue.pop();
+			}
+
+			// A task of one module must not be able to take down a worker the others share
+			try
+			{
+				task();
+			}
+			catch (const std::exception &e)
+			{
+				logte("A task has thrown an exception: %s", e.what());
+			}
+			catch (...)
+			{
+				logte("A task has thrown an unknown exception");
 			}
 		}
 	}

--- a/src/modules/task_pool/task_pool.cpp
+++ b/src/modules/task_pool/task_pool.cpp
@@ -160,8 +160,6 @@ namespace ov
 			return false;
 		}
 
-		DedicatedWorker *worker = nullptr;
-
 		{
 			std::lock_guard<std::mutex> lock(_mutex);
 
@@ -216,11 +214,11 @@ namespace ov
 			}
 
 			slot->task_queue.push(std::move(task));
-			worker = slot.get();
-		}
 
-		// Wakes a keep-alive worker; a no-op otherwise
-		worker->condition.notify_one();
+			// Notified under the lock: Stop() destroys the worker objects under this same
+			// lock, so a notify after releasing it could hit a destroyed condition
+			slot->condition.notify_one();
+		}
 
 		return true;
 	}

--- a/src/modules/task_pool/task_pool.h
+++ b/src/modules/task_pool/task_pool.h
@@ -14,6 +14,7 @@
 #include <condition_variable>
 #include <functional>
 #include <future>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <queue>
@@ -24,35 +25,12 @@
 
 namespace ov
 {
-	// Runs short tasks on shared worker threads so that modules do not have to own a thread
-	// each. It is meant for work that mostly waits, such as a name lookup or a request to a
-	// remote service, rather than for work that keeps a CPU busy.
+	// Shared worker threads for short tasks that mostly wait (a name lookup, a remote
+	// request). GetInstance() gives the pool the modules share; PostDedicated gives a
+	// module a worker of its own.
 	//
-	// The workers start with the first task and stay until the pool stops.
-	//
-	// GetInstance() gives the pool the modules share. A caller that needs workers of its own,
-	// for work it does not want to leave behind other modules, can construct one instead.
-	//
-	//     // Run it and move on
-	//     ov::TaskPool::GetInstance()->Post([]() { DoWork(); });
-	//
-	//     // Run it and pick the result up later
-	//     auto future = ov::TaskPool::GetInstance()->Submit([]() { return DoWork(); });
-	//     auto result = future.get();
-	//
-	// A task must never wait for another task of this pool to finish, and must never call
-	// Stop(): every worker could end up waiting and none would be left to run what they wait
-	// for, and Stop() from a task would join the thread it runs on.
-	//
-	// A posted task cannot be cancelled and outlives the call that posted it, so it must not
-	// capture a raw `this` of anything that can go away while it waits to run. Capture a
-	// std::weak_ptr and check it instead.
-	//
-	//     std::weak_ptr<Stream> weak_stream = stream;
-	//     ov::TaskPool::GetInstance()->Post([weak_stream]() {
-	//         auto stream = weak_stream.lock();
-	//         if (stream != nullptr) { ... }
-	//     });
+	// A task must not wait for another task of this pool and must not call Stop().
+	// A task outlives the call that posted it, so capture a std::weak_ptr, not a raw this.
 	class TaskPool : public Singleton<TaskPool>
 	{
 	public:
@@ -60,32 +38,33 @@ namespace ov
 
 		struct Config
 		{
-			// Workers the pool runs on. Sized for tasks that wait rather than compute, so it
-			// does not follow the core count.
+			// Sized for tasks that wait, not for the core count
 			size_t thread_count = 4;
-			// Tasks that may wait to start. Reaching this means the producers outrun the
-			// workers, and further tasks are rejected rather than queued without end.
+			// Tasks over this are rejected, not queued without end
 			size_t max_tasks = 128;
 		};
 
 		TaskPool();
 		~TaskPool() override;
 
-		// Applies the <TaskPool> settings of the server configuration. The workers already
-		// running are not resized to a new thread count, so this belongs in the startup path
-		// before any module posts a task.
+		// Applies <Modules><TaskPool> from the server configuration; call before any task is posted
 		bool Initialize();
 
-		// Applies a configuration directly, for callers that do not take it from the server
-		// configuration. The workers already running are left as they are.
+		// Applies a configuration directly; workers already running are not resized
 		void Configure(const Config &config);
 
-		// Hands the task to a worker and returns without waiting for it. Returns false when
-		// the pool is stopped, when the queue is full, or when no worker could be started.
+		// Runs the task on a shared worker. Returns false when stopped or the queue is full
 		bool Post(Task task);
 
-		// Posts a task and hands back its result through a future. When the task cannot be
-		// posted, or the pool stops before it runs, the future reports a broken promise.
+		// Runs the task on a dedicated worker named worker_name, tasks in posted order.
+		// Long-blocking work belongs here, off the shared workers. Callers using the same
+		// name share one worker. The worker leaves once its queue runs dry and the next
+		// post starts a new one; keep_alive keeps it parked instead. The flag of the post
+		// that creates the worker stays.
+		bool PostDedicated(const ov::String &worker_name, Task task, bool keep_alive = false);
+
+		// Posts a task and returns its result as a future; a task that never runs breaks
+		// the promise
 		template <typename Func>
 		auto Submit(Func &&func) -> std::future<std::invoke_result_t<Func>>
 		{
@@ -101,36 +80,46 @@ namespace ov
 			return future;
 		}
 
-		// Tasks waiting to start, not counting the ones already running
+		// Tasks waiting to start
 		size_t GetPendingCount() const;
-		// Workers running right now, which is zero until the first task arrives
+		// Shared workers running now; they start with the first task
 		size_t GetThreadCount() const;
 
-		// Lets the running tasks finish and drops the ones still waiting. The pool does not
-		// take tasks again afterwards, so this belongs in the shutdown path.
+		// Lets running tasks finish and drops the waiting ones; the pool takes no task afterwards
 		void Stop();
 
 	protected:
+		struct DedicatedWorker
+		{
+			std::queue<Task> task_queue;
+			// Only a keep-alive worker waits on this
+			std::condition_variable condition;
+			std::thread thread;
+			bool keep_alive = false;
+			// Cleared by the worker itself when it leaves for lack of work
+			bool running = false;
+		};
+
 		void WorkerThreadProc();
-		// Adds up to `count` workers and returns how many started. The caller holds _mutex.
+		void DedicatedWorkerThreadProc(DedicatedWorker *worker);
+		// Returns how many started. The caller holds _mutex
 		size_t AddWorkers(size_t count);
-		// Counts a rejected task and reports the count at most once a second. The caller
-		// holds _mutex.
+		// Reports rejections at most once a second. The caller holds _mutex
 		void ReportRejection();
 
 		mutable std::mutex _mutex;
 		std::condition_variable _condition;
 
-		// Serializes Stop() itself, so that a caller which finds the pool already stopped
-		// still waits until the workers are joined
+		// A second Stop() waits here until the first has joined the workers
 		std::mutex _stop_mutex;
 
 		Config _config;
 		std::queue<Task> _task_queue;
 		std::vector<std::thread> _workers;
 
-		// A full queue rejects every task that follows, so the rejections are counted and
-		// reported at intervals rather than one log line each
+		// The worker objects must outlive their threads, so Stop() joins before clearing
+		std::map<ov::String, std::unique_ptr<DedicatedWorker>> _dedicated_workers;
+
 		size_t _rejected_count = 0;
 		std::chrono::steady_clock::time_point _last_reject_log_time;
 

--- a/src/modules/task_pool/task_pool_test.cpp
+++ b/src/modules/task_pool/task_pool_test.cpp
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <chrono>
 #include <filesystem>
+#include <optional>
 #include <set>
 #include <vector>
 
@@ -84,12 +85,20 @@ namespace
 		return config;
 	}
 
-	// An exited worker disappears here, unlike one that is merely idle
-	size_t CountProcessThreads()
+	// An exited worker disappears here, unlike one that is merely idle. Nullopt on a
+	// platform without a readable /proc, so the caller can skip instead of aborting
+	std::optional<size_t> CountProcessThreads()
 	{
+		std::error_code error;
+		std::filesystem::directory_iterator entries("/proc/self/task", error);
+		if (error)
+		{
+			return std::nullopt;
+		}
+
 		size_t count = 0;
 
-		for ([[maybe_unused]] const auto &entry : std::filesystem::directory_iterator("/proc/self/task"))
+		for ([[maybe_unused]] const auto &entry : entries)
 		{
 			count++;
 		}
@@ -541,7 +550,12 @@ TEST(TaskPool, ADedicatedWorkerLeavesOnceItsQueueRunsDry)
 {
 	ov::TaskPool pool;
 
-	const auto baseline = CountProcessThreads();
+	const auto counted = CountProcessThreads();
+	if (counted.has_value() == false)
+	{
+		GTEST_SKIP() << "No readable /proc/self/task on this platform";
+	}
+	const size_t baseline = *counted;
 
 	std::promise<void> first_done;
 	auto first_future = first_done.get_future();
@@ -553,11 +567,11 @@ TEST(TaskPool, ADedicatedWorkerLeavesOnceItsQueueRunsDry)
 
 	// Only the worker's exit brings the thread count back down
 	auto deadline = std::chrono::steady_clock::now() + kWaitTimeout;
-	while ((CountProcessThreads() > baseline) && (std::chrono::steady_clock::now() < deadline))
+	while ((CountProcessThreads().value_or(baseline) > baseline) && (std::chrono::steady_clock::now() < deadline))
 	{
 		std::this_thread::sleep_for(std::chrono::milliseconds(10));
 	}
-	EXPECT_EQ(CountProcessThreads(), baseline);
+	EXPECT_EQ(CountProcessThreads().value_or(baseline), baseline);
 
 	// A post after the worker left starts a fresh one and still runs
 	std::promise<void> second_done;

--- a/src/modules/task_pool/task_pool_test.cpp
+++ b/src/modules/task_pool/task_pool_test.cpp
@@ -4,7 +4,7 @@
 //
 //  src/modules/task_pool/task_pool_test.cpp
 //  Covers: TaskPool (posting, results, worker isolation, queue limit, concurrent
-//          posting, stop)
+//          posting, stop, dedicated workers)
 //
 //==============================================================================
 #include <gtest/gtest.h>
@@ -13,14 +13,15 @@
 
 #include <atomic>
 #include <chrono>
+#include <filesystem>
+#include <set>
+#include <vector>
 
 namespace
 {
 	constexpr auto kWaitTimeout = std::chrono::seconds(5);
 
-	// Blocks the workers so that the queue can be observed while they are busy. The wait is
-	// bounded because a failed assertion returns before the gate is opened, and a worker left
-	// waiting for good would hang the whole binary once the pool joins it.
+	// Blocks a worker until opened; the wait is bounded so a failed test cannot hang the binary
 	class TaskGate
 	{
 	public:
@@ -39,9 +40,7 @@ namespace
 		std::shared_future<void> _future{_promise.get_future()};
 	};
 
-	// Leaves every worker blocked on the gate, so that what follows sees a pool that takes
-	// tasks but runs none of them. The counter is shared with the tasks rather than held on
-	// the stack, because a task still counts up after a failed wait gives up on it.
+	// The counter is on the heap because a task may outlive a failed wait
 	struct StartCounter
 	{
 		std::mutex mutex;
@@ -84,6 +83,19 @@ namespace
 
 		return config;
 	}
+
+	// An exited worker disappears here, unlike one that is merely idle
+	size_t CountProcessThreads()
+	{
+		size_t count = 0;
+
+		for ([[maybe_unused]] const auto &entry : std::filesystem::directory_iterator("/proc/self/task"))
+		{
+			count++;
+		}
+
+		return count;
+	}
 }  // namespace
 
 TEST(TaskPool, RunsPostedTask)
@@ -124,8 +136,7 @@ TEST(TaskPool, SubmitReportsAnExceptionThrownByTheTask)
 	EXPECT_THROW(future.get(), std::runtime_error);
 }
 
-// A callable that is not a temporary is deduced as a reference, which the return type has to
-// survive
+// A non-temporary callable is deduced as a reference, which the return type has to survive
 TEST(TaskPool, SubmitTakesACallableThatIsNotATemporary)
 {
 	ov::TaskPool pool;
@@ -159,8 +170,6 @@ TEST(TaskPool, StartsTheWorkersWithTheFirstTask)
 	EXPECT_EQ(pool.GetThreadCount(), 4u);
 }
 
-// Every worker has to be able to run at the same time, otherwise a task that waits would
-// hold up the tasks of every other module
 TEST(TaskPool, RunsTasksOnEveryWorkerAtOnce)
 {
 	// Declared before the pool so that the workers are joined while the gate still exists
@@ -257,8 +266,6 @@ TEST(TaskPool, RunsEveryTaskPostedFromManyThreadsAtOnce)
 	EXPECT_EQ(pool.GetPendingCount(), 0u);
 }
 
-// Whatever a running task is holding must still be valid until it returns, so Stop() cannot
-// come back while one is in the middle of its work
 TEST(TaskPool, StopWaitsForARunningTask)
 {
 	TaskGate gate;
@@ -332,8 +339,7 @@ TEST(TaskPool, TakesNoTaskAfterItIsStopped)
 	EXPECT_THROW(future.get(), std::future_error);
 }
 
-// Stopping from a task would have the pool join the very thread that asks, which takes the
-// process down rather than just failing
+// Stop() from a task would join the very thread that asks
 TEST(TaskPool, RefusesToStopFromItsOwnTask)
 {
 	ov::TaskPool pool;
@@ -366,4 +372,225 @@ TEST(TaskPool, StopIsSafeToCallTwice)
 
 	pool.Stop();
 	pool.Stop();
+}
+
+//------------------------------------------------------------------------------
+// Dedicated workers
+//------------------------------------------------------------------------------
+
+TEST(TaskPool, ADedicatedWorkerRunsTasksInOrderOnOneThread)
+{
+	ov::TaskPool pool;
+	TaskGate gate;
+
+	std::mutex mutex;
+	std::vector<int> order;
+	std::set<std::thread::id> thread_ids;
+	std::promise<void> done_promise;
+	auto done_future = done_promise.get_future();
+
+	// The first task holds the worker so the rest pile up behind it
+	ASSERT_TRUE(pool.PostDedicated("worker-a", [&]() {
+		{
+			std::lock_guard<std::mutex> lock(mutex);
+			thread_ids.insert(std::this_thread::get_id());
+		}
+
+		gate.Wait();
+	}));
+
+	for (int index = 0; index < 5; index++)
+	{
+		ASSERT_TRUE(pool.PostDedicated("worker-a", [&, index]() {
+			std::lock_guard<std::mutex> lock(mutex);
+			order.push_back(index);
+			thread_ids.insert(std::this_thread::get_id());
+
+			if (index == 4)
+			{
+				done_promise.set_value();
+			}
+		}));
+	}
+
+	gate.Open();
+
+	ASSERT_EQ(done_future.wait_for(kWaitTimeout), std::future_status::ready);
+
+	std::lock_guard<std::mutex> lock(mutex);
+	EXPECT_EQ(order, (std::vector<int>{0, 1, 2, 3, 4}));
+	EXPECT_EQ(thread_ids.size(), 1u);
+}
+
+TEST(TaskPool, ABlockedDedicatedWorkerLeavesTheSharedWorkersFree)
+{
+	ov::TaskPool pool;
+	pool.Configure(MakeConfig(1, 8));
+
+	TaskGate gate;
+
+	// The dedicated worker is held on the gate for the whole test
+	ASSERT_TRUE(pool.PostDedicated("worker-b", [&gate]() {
+		gate.Wait();
+	}));
+
+	// The shared worker still takes and runs work
+	std::promise<void> shared_promise;
+	auto shared_future = shared_promise.get_future();
+
+	ASSERT_TRUE(pool.Post([&shared_promise]() {
+		shared_promise.set_value();
+	}));
+	EXPECT_EQ(shared_future.wait_for(kWaitTimeout), std::future_status::ready);
+
+	gate.Open();
+}
+
+TEST(TaskPool, TheSameNameSharesOneDedicatedWorker)
+{
+	ov::TaskPool pool;
+	TaskGate gate;
+
+	std::mutex mutex;
+	std::set<std::thread::id> thread_ids;
+	std::promise<void> done_promise;
+	auto done_future = done_promise.get_future();
+
+	// The first task holds the worker so both land on the same one
+	ASSERT_TRUE(pool.PostDedicated("worker-c", [&]() {
+		{
+			std::lock_guard<std::mutex> lock(mutex);
+			thread_ids.insert(std::this_thread::get_id());
+		}
+
+		gate.Wait();
+	}));
+	ASSERT_TRUE(pool.PostDedicated("worker-c", [&]() {
+		{
+			std::lock_guard<std::mutex> lock(mutex);
+			thread_ids.insert(std::this_thread::get_id());
+		}
+		done_promise.set_value();
+	}));
+
+	gate.Open();
+
+	ASSERT_EQ(done_future.wait_for(kWaitTimeout), std::future_status::ready);
+
+	std::lock_guard<std::mutex> lock(mutex);
+	EXPECT_EQ(thread_ids.size(), 1u);
+}
+
+TEST(TaskPool, ADedicatedWorkerRejectsATaskOnceTooManyAreWaiting)
+{
+	ov::TaskPool pool;
+	pool.Configure(MakeConfig(1, 2));
+
+	TaskGate gate;
+
+	// The queue is filled only after the first task is known to be running, off the queue
+	std::promise<void> started_promise;
+	auto started_future = started_promise.get_future();
+
+	ASSERT_TRUE(pool.PostDedicated("worker-d", [&gate, &started_promise]() {
+		started_promise.set_value();
+		gate.Wait();
+	}));
+	ASSERT_EQ(started_future.wait_for(kWaitTimeout), std::future_status::ready);
+
+	ASSERT_TRUE(pool.PostDedicated("worker-d", []() {}));
+	ASSERT_TRUE(pool.PostDedicated("worker-d", []() {}));
+
+	EXPECT_FALSE(pool.PostDedicated("worker-d", []() {}));
+
+	gate.Open();
+}
+
+TEST(TaskPool, TakesNoDedicatedTaskAfterItIsStopped)
+{
+	ov::TaskPool pool;
+
+	ASSERT_TRUE(pool.PostDedicated("worker-e", []() {}));
+
+	pool.Stop();
+
+	EXPECT_FALSE(pool.PostDedicated("worker-e", []() {}));
+}
+
+TEST(TaskPool, StopWaitsForARunningDedicatedTask)
+{
+	auto pool = std::make_unique<ov::TaskPool>();
+
+	std::atomic<bool> finished{false};
+	std::promise<void> started_promise;
+	auto started_future = started_promise.get_future();
+
+	ASSERT_TRUE(pool->PostDedicated("worker-f", [&]() {
+		started_promise.set_value();
+		std::this_thread::sleep_for(std::chrono::milliseconds(300));
+		finished = true;
+	}));
+
+	ASSERT_EQ(started_future.wait_for(kWaitTimeout), std::future_status::ready);
+
+	pool->Stop();
+	EXPECT_TRUE(finished.load());
+}
+
+TEST(TaskPool, ADedicatedWorkerLeavesOnceItsQueueRunsDry)
+{
+	ov::TaskPool pool;
+
+	const auto baseline = CountProcessThreads();
+
+	std::promise<void> first_done;
+	auto first_future = first_done.get_future();
+
+	ASSERT_TRUE(pool.PostDedicated("worker-g", [&first_done]() {
+		first_done.set_value();
+	}));
+	ASSERT_EQ(first_future.wait_for(kWaitTimeout), std::future_status::ready);
+
+	// Only the worker's exit brings the thread count back down
+	auto deadline = std::chrono::steady_clock::now() + kWaitTimeout;
+	while ((CountProcessThreads() > baseline) && (std::chrono::steady_clock::now() < deadline))
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	}
+	EXPECT_EQ(CountProcessThreads(), baseline);
+
+	// A post after the worker left starts a fresh one and still runs
+	std::promise<void> second_done;
+	auto second_future = second_done.get_future();
+
+	ASSERT_TRUE(pool.PostDedicated("worker-g", [&second_done]() {
+		second_done.set_value();
+	}));
+	EXPECT_EQ(second_future.wait_for(kWaitTimeout), std::future_status::ready);
+}
+
+TEST(TaskPool, AKeepAliveDedicatedWorkerStaysBetweenTasks)
+{
+	ov::TaskPool pool;
+
+	std::promise<std::thread::id> first_id;
+	auto first_future = first_id.get_future();
+
+	ASSERT_TRUE(pool.PostDedicated("worker-h", [&first_id]() {
+		first_id.set_value(std::this_thread::get_id());
+	}, true));
+	ASSERT_EQ(first_future.wait_for(kWaitTimeout), std::future_status::ready);
+
+	// Long enough that a worker which leaves when idle would be gone by now
+	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+	std::promise<std::thread::id> second_id;
+	auto second_future = second_id.get_future();
+
+	ASSERT_TRUE(pool.PostDedicated("worker-h", [&second_id]() {
+		second_id.set_value(std::this_thread::get_id());
+	}, true));
+	ASSERT_EQ(second_future.wait_for(kWaitTimeout), std::future_status::ready);
+
+	EXPECT_EQ(first_future.get(), second_future.get());
 }

--- a/src/providers/scheduled/CMakeLists.txt
+++ b/src/providers/scheduled/CMakeLists.txt
@@ -5,6 +5,7 @@ ome_add_static_library(scheduled_provider
         mediarouter
         orchestrator
         ovlibrary
+        task_pool
 )
 
 if(OME_BUILD_TESTS)

--- a/src/providers/scheduled/schedule.cpp
+++ b/src/providers/scheduled/schedule.cpp
@@ -65,15 +65,15 @@ namespace pvd
 				return;
 			}
 
-			// Closing can block on the storage the file lives on, so it must not
-			// run on whichever thread happens to drop the last reference (the
-			// playback thread swapping schedules, or the API thread updating one)
+			// Closing can block on the storage the file lives on, so it goes to a dedicated
+			// worker instead of the releasing thread (normally the playback thread) or the
+			// shared workers. When the pool cannot take it, the close runs right here.
 			auto close = [ctx, file_path_copy]() mutable {
 				logti("LoadContext: Closing format context : %s", file_path_copy.CStr());
 				::avformat_close_input(&ctx);
 			};
 
-			if (ov::TaskPool::GetInstance()->Post(close) == false)
+			if (ov::TaskPool::GetInstance()->PostDedicated("SchedCtxClose", close) == false)
 			{
 				close();
 			}

--- a/src/providers/scheduled/schedule.cpp
+++ b/src/providers/scheduled/schedule.cpp
@@ -10,6 +10,7 @@
 #include "schedule.h"
 #include "schedule_private.h"
 #include <base/ovlibrary/files.h>
+#include <modules/task_pool/task_pool.h>
 
 namespace pvd
 {
@@ -59,10 +60,22 @@ namespace pvd
 
 		ov::String file_path_copy = _file_path;
 		_format_context.reset(ctx, [file_path_copy](AVFormatContext *ctx) {
-			if (ctx)
+			if (ctx == nullptr)
 			{
+				return;
+			}
+
+			// Closing can block on the storage the file lives on, so it must not
+			// run on whichever thread happens to drop the last reference (the
+			// playback thread swapping schedules, or the API thread updating one)
+			auto close = [ctx, file_path_copy]() mutable {
 				logti("LoadContext: Closing format context : %s", file_path_copy.CStr());
 				::avformat_close_input(&ctx);
+			};
+
+			if (ov::TaskPool::GetInstance()->Post(close) == false)
+			{
+				close();
 			}
 		});
 


### PR DESCRIPTION
A scheduled channel keeps an ffmpeg format context open for every file item in its schedule. When a schedule is replaced, the files of the old schedule are closed on whichever thread releases them last, and that is the playback thread, at the exact moment it starts the next program. On a storage that responds slowly, such as a network mount, closing a single file can take hundreds of milliseconds, so the program starts late by the total of those closes. And when the start is more than one second late, the channel also seeks the first item forward by the lost time to stay on schedule; that seek lands on the next keyframe, so the item can reach the end of its file before its configured duration and end early.

The files are now closed on a dedicated worker of the task pool named `SchedCtxClose`. The thread that releases a file only hands it over and moves on, so a slow storage no longer delays the program start, and the late-start seek is not triggered in the first place. The dedicated worker runs its closes one at a time without occupying the pool's shared workers, so however long a close blocks, work of other modules such as the DRM key prefetch is unaffected. The worker lives only while it has work: it exits once its queue runs dry and is created again by the next close.

**Test**

Play a scheduled channel with a fallback and a scheduled program, update the schedule file while the fallback is on air, and let the program start.

1. Read the log around the program start: `Start ... program` and `GetFirstItem`.
2. Find the `Closing format context` lines and read the thread name in front of them.
3. Let the program run through its items and switch back to the fallback.

Pass conditions: the program starts at its scheduled time with `GetFirstItem` reporting an elapsed time under a second, the `Closing format context` lines carry the `SchedCtxClose` thread name instead of the `Scheduled` thread, and the items play and switch as before.

Measured on this branch with a one second delay added to each close: across 19 schedule replacements the program start was at most 17 ms late, all 81 closes ran on the `SchedCtxClose` worker one at a time, the worker thread disappeared between bursts and returned for the next one, and the process thread count stayed constant throughout. The same build with the closes kept synchronous started 4,009 ms late.
