### PR TITLE
feat(scheduled): add MaxFallbackDurationMs and PreserveRemovedScheduleFile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ intermediates
 logs
 build
 run
+.work
 
 # Ignore local temporary build trees (e.g. compile_commands / test builds)
 __temp_build/

--- a/docs/live-source/scheduled-channel.md
+++ b/docs/live-source/scheduled-channel.md
@@ -26,7 +26,7 @@ To use this feature, activate Schedule Provider as follows.
 `<MediaRootDir>`\
 Root path where media files are located. If you specify a relative path, the directory where the config file is located is root.
 
-`<ScheduleFileDir>`\
+`<ScheduleFilesDir>`\
 Root path where the schedule file is located. If you specify a relative path, the directory where the config file is located is root.
 
 `<PreserveRemovedScheduleFile> (optional, default: false)`\
@@ -34,7 +34,7 @@ When OvenMediaEngine removes a schedule file, such as when the channel is delete
 
 ## Schedule Files
 
-Scheduled Channel creates/updates/deletes streams by creating/editing/deleting files with the .sch extension in the ScheduleFileDir path. Schedule files (`.sch`) use the following XML format. When a `{Stream Name}.sch` file is created in ScheduleFileDir, OvenMediaEngine analyzes the file and creates a Schedule Channel with `{Stream Name}`. If the contents of `{Stream Name}.sch` are changed, the Schedule Channel is updated, and if the file is deleted, the stream is deleted.
+Scheduled Channel creates/updates/deletes streams by creating/editing/deleting files with the .sch extension in the ScheduleFilesDir path. Schedule files (`.sch`) use the following XML format. When a `{Stream Name}.sch` file is created in ScheduleFilesDir, OvenMediaEngine analyzes the file and creates a Schedule Channel with `{Stream Name}`. If the contents of `{Stream Name}.sch` are changed, the Schedule Channel is updated, and if the file is deleted, the stream is deleted.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/docs/live-source/scheduled-channel.md
+++ b/docs/live-source/scheduled-channel.md
@@ -17,6 +17,7 @@ To use this feature, activate Schedule Provider as follows.
     <Schedule>
         <MediaRootDir>/opt/ovenmediaengine/media</MediaRootDir>
         <ScheduleFilesDir>/opt/ovenmediaengine/media</ScheduleFilesDir>
+        <PreserveRemovedScheduleFile>false</PreserveRemovedScheduleFile> <!-- optional, default: false -->
     </Schedule>
     ...
 </Providers>
@@ -27,6 +28,9 @@ Root path where media files are located. If you specify a relative path, the dir
 
 `<ScheduleFileDir>`\
 Root path where the schedule file is located. If you specify a relative path, the directory where the config file is located is root.
+
+`<PreserveRemovedScheduleFile> (optional, default: false)`\
+When OvenMediaEngine removes a schedule file, such as when the channel is deleted with the DELETE API or by `<MaxFallbackDurationMs>`, setting this to true renames the file by appending the removal time, for example `today.sch.20260831T204512`, instead of deleting it. A renamed file is not loaded as a channel. Renaming it back to the original .sch name recreates the channel.
 
 ## Schedule Files
 
@@ -54,9 +58,10 @@ Scheduled Channel creates/updates/deletes streams by creating/editing/deleting f
                 <Language>ja</Language>
             </Item>
         </AudioMap>
+        <MaxFallbackDurationMs>60000</MaxFallbackDurationMs> <!-- optional, default: 0 (unlimited) -->
     </Stream>
 
-    <FallbackProgram> <!-- Not yet supported -->
+    <FallbackProgram>
         <Item url="file://sample.mp4" start="0" duration="60000" />
     </FallbackProgram>
 
@@ -65,7 +70,7 @@ Scheduled Channel creates/updates/deletes streams by creating/editing/deleting f
     </Program>
     <Program name="2" scheduled="2022-03-14T15:10:0.0+09:00" repeat="true">
         <Item url="file://sample.mp4" start="0" duration="60000" />
-        <Item url="stream://default/app/stream1" duration="60000" /> <!-- Not yet supported -->
+        <Item url="stream://default/app/stream1" duration="60000" />
         <Item url="file://sample.mp4" start="60000" duration="120000" />
     </Program>
 </Schedule>
@@ -88,6 +93,9 @@ Determines whether to use the audio track. If `AudioTrack` is set to true and th
 
 `<Stream>/<AudioMap> (optional, default: false)`\
 To enable multiple audio tracks (multilingual audio) in Scheduled Channel, enable `AudioMap`. It is important that all scheduled live sources and file sources provide audio tracks equal to or greater than the number of audio tracks defined in `AudioMap`. If you define 3 `AudioMaps`, but the file source or live source provides less than 3 audio tracks, the Program will generate an error. If you provide more audio tracks than the defined `AudioMaps`, they will be mapped in order and the rest will be ignored.
+
+`<Stream>/<MaxFallbackDurationMs> (optional, default: 0)`\
+Automatically deletes the channel when fallback lasts longer than this duration, in milliseconds. The result is the same as deleting the channel with the DELETE API, so the schedule file is also removed according to `<PreserveRemovedScheduleFile>`. The duration is measured while no scheduled program item is playing, which includes the time before the first program starts, and it starts over whenever a scheduled item plays again. Changing the value while fallback is running also restarts the count. If set to 0 or not set, the channel is never deleted automatically.
 
 `<FallbackProgram> (optional)`\
 It is a program that switches automatically when there is no program scheduled at the current time or an error occurs in an item. If the program is updated at the current time or the item returns to normal, it will fail back to the original program. Both files and live can be used for items in FallbackProgram. However, it is recommended to use a stable file.
@@ -174,6 +182,8 @@ This function is a scheduling channel, but it can be used for applications such 
 ```
 
 This channel normally plays `default/app/input`, but when live input is stopped, it plays the file in `<FallbackProgram>`. This will last forever until the .sch file is deleted. One trick was to set the origin program's schedule time to year 2000 so that this stream would play unconditionally.
+
+If the channel should end by itself when the live input stops for a long time, such as when the broadcast is over, set `<Stream>/<MaxFallbackDurationMs>`. The channel is then deleted automatically, together with its schedule file, once fallback lasts longer than the set duration.
 
 
 :::warning

--- a/src/api_server/controllers/v1/vhosts/apps/scheduled_channels/scheduled_channels_controller.cpp
+++ b/src/api_server/controllers/v1/vhosts/apps/scheduled_channels/scheduled_channels_controller.cpp
@@ -267,9 +267,9 @@ namespace api
 			auto schedule_file_path = ov::String::FormatString("%s/%s.%s", schedule_files_dir.CStr(), stream->GetName().CStr(), pvd::ScheduleFileExtension);
 
 			// Delete schedule file
-			if (ov::DeleteFile(schedule_file_path) == false)
+			if (pvd::RemoveScheduleFile(schedule_file_path, schedule_config.IsPreserveRemovedScheduleFile()) == false)
 			{
-				throw http::HttpError(http::StatusCode::InternalServerError, "Could not delete the schedule file %s", schedule_file_path.CStr());
+				throw http::HttpError(http::StatusCode::InternalServerError, "Could not remove the schedule file %s", schedule_file_path.CStr());
 			}
 
 			return {http::StatusCode::OK};

--- a/src/api_server/controllers/v1/vhosts/apps/scheduled_channels/scheduled_channels_controller.cpp
+++ b/src/api_server/controllers/v1/vhosts/apps/scheduled_channels/scheduled_channels_controller.cpp
@@ -272,6 +272,8 @@ namespace api
 				throw http::HttpError(http::StatusCode::InternalServerError, "Could not remove the schedule file %s", schedule_file_path.CStr());
 			}
 
+			logti("Scheduled channel is requested to be deleted by the REST API : %s/%s", app->GetVHostAppName().CStr(), stream->GetName().CStr());
+
 			return {http::StatusCode::OK};
 		}
 	}  // namespace v1

--- a/src/config/items/virtual_hosts/applications/providers/scheduled_provider.h
+++ b/src/config/items/virtual_hosts/applications/providers/scheduled_provider.h
@@ -23,6 +23,8 @@ namespace cfg
 				protected:
 					ov::String _media_root_dir;
 					ov::String _schedule_files_dir;
+					// Rename removed schedule files with a timestamp instead of deleting them
+					bool _preserve_removed_schedule_file = false;
 
 				public:
 					ProviderType GetType() const override
@@ -32,6 +34,7 @@ namespace cfg
 
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetMediaRootDir, _media_root_dir)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetScheduleFilesDir, _schedule_files_dir)
+					CFG_DECLARE_CONST_REF_GETTER_OF(IsPreserveRemovedScheduleFile, _preserve_removed_schedule_file)
 
 				protected:
 					void MakeList() override
@@ -40,6 +43,7 @@ namespace cfg
 
 						Register("MediaRootDir", &_media_root_dir);
 						Register("ScheduleFilesDir", &_schedule_files_dir);
+						Register<Optional>("PreserveRemovedScheduleFile", &_preserve_removed_schedule_file);
 					}
 				};
 			}  // namespace pvd

--- a/src/modules/json_serdes/dump.cpp
+++ b/src/modules/json_serdes/dump.cpp
@@ -45,7 +45,7 @@ namespace serdes
 
 		// playlist
 		auto json_playlist = json_body["playlist"];
-		if (json_playlist.empty() == false || json_playlist.isArray() == true)
+		if (json_playlist.empty() == false && json_playlist.isArray() == true)
 		{
 			for (uint32_t i = 0; i < json_playlist.size(); i++)
 			{

--- a/src/modules/json_serdes/record.cpp
+++ b/src/modules/json_serdes/record.cpp
@@ -93,7 +93,7 @@ namespace serdes
 
 		// <Required>
 		auto json_stream = json_body["stream"];
-		if (json_stream.empty() == false || json_stream.isObject() == true)
+		if (json_stream.empty() == false && json_stream.isObject() == true)
 		{
 			// <Required>
 			auto json_stream_name = json_stream["name"];

--- a/src/providers/scheduled/schedule.cpp
+++ b/src/providers/scheduled/schedule.cpp
@@ -11,6 +11,9 @@
 #include "schedule_private.h"
 #include <base/ovlibrary/files.h>
 
+#include <chrono>
+#include <cstdio>
+#include <ctime>
 #include <unistd.h>
 
 namespace pvd
@@ -399,20 +402,38 @@ namespace pvd
 				ov::String characteristics;
 				
 				auto public_name_object = audio_map_item_object["name"];
-				if (public_name_object.isNull() == false || public_name_object.isString() == true)
+				if (public_name_object.isNull() == false)
 				{
+					if (public_name_object.isString() == false)
+					{
+						_last_error = "audioMap name must be a string";
+						return false;
+					}
+
 					public_name = public_name_object.asString().c_str();
 				}
 
 				auto language_object = audio_map_item_object["language"];
-				if (language_object.isNull() == false || language_object.isString() == true)
+				if (language_object.isNull() == false)
 				{
+					if (language_object.isString() == false)
+					{
+						_last_error = "audioMap language must be a string";
+						return false;
+					}
+
 					language = language_object.asString().c_str();
 				}
 
 				auto characteristics_object = audio_map_item_object["characteristics"];
-				if (characteristics_object.isNull() == false || characteristics_object.isString() == true)
+				if (characteristics_object.isNull() == false)
 				{
+					if (characteristics_object.isString() == false)
+					{
+						_last_error = "audioMap characteristics must be a string";
+						return false;
+					}
+
 					characteristics = characteristics_object.asString().c_str();
 				}
 
@@ -422,15 +443,27 @@ namespace pvd
 
 		// error_tolerance_duration_ms
 		auto error_tolerance_duration_ms_object = stream_object["errorToleranceDurationMs"];
-		if (error_tolerance_duration_ms_object.isNull() == false || error_tolerance_duration_ms_object.isInt() == true)
+		if (error_tolerance_duration_ms_object.isNull() == false)
 		{
-			_stream._error_tolerance_duration_ms = error_tolerance_duration_ms_object.asInt();
+			if (error_tolerance_duration_ms_object.isIntegral() == false)
+			{
+				_last_error = "errorToleranceDurationMs must be an integer";
+				return false;
+			}
+
+			_stream._error_tolerance_duration_ms = error_tolerance_duration_ms_object.asInt64();
 		}
 
 		// max_fallback_duration_ms
 		auto max_fallback_duration_ms_object = stream_object["maxFallbackDurationMs"];
-		if (max_fallback_duration_ms_object.isNull() == false || max_fallback_duration_ms_object.isInt() == true)
+		if (max_fallback_duration_ms_object.isNull() == false)
 		{
+			if (max_fallback_duration_ms_object.isIntegral() == false)
+			{
+				_last_error = "maxFallbackDurationMs must be an integer";
+				return false;
+			}
+
 			_stream._max_fallback_duration_ms = max_fallback_duration_ms_object.asInt64();
 		}
 
@@ -510,8 +543,14 @@ namespace pvd
 			}
 
 			auto repeat_object = program_object["repeat"];
-			if (repeat_object.isNull() == false || repeat_object.isBool() == true)
+			if (repeat_object.isNull() == false)
 			{
+				if (repeat_object.isBool() == false)
+				{
+					_last_error = "repeat must be a boolean";
+					return false;
+				}
+
 				repeat = repeat_object.asBool();
 			}
 
@@ -597,22 +636,40 @@ namespace pvd
 
 			// start
 			auto start_object = item_object["start"];
-			if (start_object.isNull() == false || start_object.isInt() == true)
+			if (start_object.isNull() == false)
 			{
-				start_time_ms_conf = start_object.asInt();
+				if (start_object.isIntegral() == false)
+				{
+					_last_error = "start must be an integer";
+					return false;
+				}
+
+				start_time_ms_conf = start_object.asInt64();
 			}
 
 			// duration
 			auto duration_object = item_object["duration"];
-			if (duration_object.isNull() == false || duration_object.isInt() == true)
+			if (duration_object.isNull() == false)
 			{
-				duration_ms_conf = duration_object.asInt();
+				if (duration_object.isIntegral() == false)
+				{
+					_last_error = "duration must be an integer";
+					return false;
+				}
+
+				duration_ms_conf = duration_object.asInt64();
 			}
 
 			// fallbackOnErr
 			auto fallback_on_err_object = item_object["fallbackOnErr"];
-			if (fallback_on_err_object.isNull() == false || fallback_on_err_object.isBool() == true)
+			if (fallback_on_err_object.isNull() == false)
 			{
+				if (fallback_on_err_object.isBool() == false)
+				{
+					_last_error = "fallbackOnErr must be a boolean";
+					return false;
+				}
+
 				fallback_on_err = fallback_on_err_object.asBool();
 			}
 

--- a/src/providers/scheduled/schedule.cpp
+++ b/src/providers/scheduled/schedule.cpp
@@ -19,7 +19,13 @@ namespace pvd
 	{
 		if (preserve == false)
 		{
-			return ov::DeleteFile(file_path);
+			if (ov::DeleteFile(file_path) == false)
+			{
+				return false;
+			}
+
+			logti("Schedule file deleted : %s", file_path.CStr());
+			return true;
 		}
 
 		auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
@@ -40,7 +46,13 @@ namespace pvd
 			target_path = ov::String::FormatString("%s.%s_%d", file_path.CStr(), timestamp, suffix);
 		}
 
-		return ::rename(file_path.CStr(), target_path.CStr()) == 0;
+		if (::rename(file_path.CStr(), target_path.CStr()) != 0)
+		{
+			return false;
+		}
+
+		logti("Schedule file preserved : %s -> %s", file_path.CStr(), target_path.CStr());
+		return true;
 	}
 
 	std::shared_ptr<AVFormatContext> Schedule::Item::LoadContext()

--- a/src/providers/scheduled/schedule.cpp
+++ b/src/providers/scheduled/schedule.cpp
@@ -11,6 +11,7 @@
 #include "schedule_private.h"
 #include <base/ovlibrary/files.h>
 
+#include <cerrno>
 #include <chrono>
 #include <cstdio>
 #include <ctime>
@@ -20,6 +21,12 @@ namespace pvd
 {
 	bool RemoveScheduleFile(const ov::String &file_path, bool preserve)
 	{
+		// Already removed elsewhere, the goal state is reached
+		if (::access(file_path.CStr(), F_OK) != 0 && errno == ENOENT)
+		{
+			return true;
+		}
+
 		if (preserve == false)
 		{
 			if (ov::DeleteFile(file_path) == false)

--- a/src/providers/scheduled/schedule.cpp
+++ b/src/providers/scheduled/schedule.cpp
@@ -21,8 +21,12 @@ namespace pvd
 {
 	bool RemoveScheduleFile(const ov::String &file_path, bool preserve)
 	{
-		// Already removed elsewhere, the goal state is reached
-		if (::access(file_path.CStr(), F_OK) != 0 && errno == ENOENT)
+		// Removed elsewhere also reaches the goal state, including losing a removal race
+		auto file_gone = [&file_path]() -> bool {
+			return ::access(file_path.CStr(), F_OK) != 0 && errno == ENOENT;
+		};
+
+		if (file_gone())
 		{
 			return true;
 		}
@@ -31,7 +35,7 @@ namespace pvd
 		{
 			if (ov::DeleteFile(file_path) == false)
 			{
-				return false;
+				return file_gone();
 			}
 
 			logti("Schedule file deleted : %s", file_path.CStr());
@@ -58,7 +62,7 @@ namespace pvd
 
 		if (::rename(file_path.CStr(), target_path.CStr()) != 0)
 		{
-			return false;
+			return file_gone();
 		}
 
 		logti("Schedule file preserved : %s -> %s", file_path.CStr(), target_path.CStr());

--- a/src/providers/scheduled/schedule.cpp
+++ b/src/providers/scheduled/schedule.cpp
@@ -11,8 +11,38 @@
 #include "schedule_private.h"
 #include <base/ovlibrary/files.h>
 
+#include <unistd.h>
+
 namespace pvd
 {
+	bool RemoveScheduleFile(const ov::String &file_path, bool preserve)
+	{
+		if (preserve == false)
+		{
+			return ov::DeleteFile(file_path);
+		}
+
+		auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+		struct tm local_time;
+		::localtime_r(&now, &local_time);
+
+		char timestamp[32];
+		::strftime(timestamp, sizeof(timestamp), "%Y%m%dT%H%M%S", &local_time);
+
+		auto target_path = ov::String::FormatString("%s.%s", file_path.CStr(), timestamp);
+		for (int suffix = 1; ::access(target_path.CStr(), F_OK) == 0; suffix++)
+		{
+			if (suffix > 100)
+			{
+				return false;
+			}
+
+			target_path = ov::String::FormatString("%s.%s_%d", file_path.CStr(), timestamp, suffix);
+		}
+
+		return ::rename(file_path.CStr(), target_path.CStr()) == 0;
+	}
+
 	std::shared_ptr<AVFormatContext> Schedule::Item::LoadContext()
 	{
 		ov::StopWatch sw;
@@ -385,6 +415,13 @@ namespace pvd
 			_stream._error_tolerance_duration_ms = error_tolerance_duration_ms_object.asInt();
 		}
 
+		// max_fallback_duration_ms
+		auto max_fallback_duration_ms_object = stream_object["maxFallbackDurationMs"];
+		if (max_fallback_duration_ms_object.isNull() == false || max_fallback_duration_ms_object.isInt() == true)
+		{
+			_stream._max_fallback_duration_ms = max_fallback_duration_ms_object.asInt64();
+		}
+
 		return true;
 	}
 
@@ -722,6 +759,13 @@ namespace pvd
 		if (error_tolerance_duration_ms_node)
 		{
 			_stream._error_tolerance_duration_ms = error_tolerance_duration_ms_node.text().as_llong();
+		}
+
+		// max_fallback_duration_ms
+		auto max_fallback_duration_ms_node = stream_node.child("MaxFallbackDurationMs");
+		if (max_fallback_duration_ms_node)
+		{
+			_stream._max_fallback_duration_ms = max_fallback_duration_ms_node.text().as_llong();
 		}
 
 		return true;
@@ -1085,6 +1129,9 @@ namespace pvd
 		// ErrorToleranceDurationMs
 		stream_node.append_child("ErrorToleranceDurationMs").text().set(_stream._error_tolerance_duration_ms);
 
+		// MaxFallbackDurationMs
+		stream_node.append_child("MaxFallbackDurationMs").text().set(_stream._max_fallback_duration_ms);
+
 		// FallbackProgram
 		if (_fallback_program != nullptr)
 		{
@@ -1155,6 +1202,9 @@ namespace pvd
 
 		// error_tolerance_duration_ms
 		stream_object["errorToleranceDurationMs"] = _stream._error_tolerance_duration_ms;
+
+		// max_fallback_duration_ms
+		stream_object["maxFallbackDurationMs"] = _stream._max_fallback_duration_ms;
 
 		root_object["stream"] = stream_object;
 

--- a/src/providers/scheduled/schedule.h
+++ b/src/providers/scheduled/schedule.h
@@ -25,6 +25,7 @@
         <AudioTrack>true</AudioTrack> <!-- optional, default : true -->
 
 		<ErrorToleranceDurationMs>1000</ErrorToleranceDurationMs>
+		<MaxFallbackDurationMs>60000</MaxFallbackDurationMs> <!-- optional, delete the channel if fallback lasts longer than this, <= 0 : unlimited -->
     </Stream>
 
     <FallbackProgram>
@@ -47,6 +48,9 @@
 namespace pvd
 {
 	constexpr const char *ScheduleFileExtension = "sch";
+
+	// Deletes a schedule file, or renames it to <path>.<timestamp> when preserve is true
+	bool RemoveScheduleFile(const ov::String &file_path, bool preserve);
 
 	class Schedule
 	{
@@ -131,6 +135,9 @@ namespace pvd
 			std::vector<info::AudioMapItem> _audio_map;
 
 			int64_t _error_tolerance_duration_ms = 500;
+
+			// Delete the channel if fallback lasts longer than this, <= 0 : unlimited
+			int64_t _max_fallback_duration_ms = 0;
 		};
 
 		class Program

--- a/src/providers/scheduled/scheduled_application.cpp
+++ b/src/providers/scheduled/scheduled_application.cpp
@@ -130,10 +130,12 @@ namespace pvd
                 continue;
             }
 
-            // Same as deleting the channel via the DELETE API. If the file is left as is, the channel will be recreated on the next tick
+            // Same as deleting the channel via the DELETE API. If the file were left as is, the channel would be recreated on the next tick, so remove the channel only when its file is removed
             if (RemoveScheduleFile(schedule_file_info._file_path, _preserve_removed_schedule_file) == false)
             {
-                logtw("Failed to remove schedule file : %s", schedule_file_info._file_path.CStr());
+                logtw("Failed to remove schedule file, will retry on the next tick : %s", schedule_file_info._file_path.CStr());
+                ++it;
+                continue;
             }
 
             if (RemoveSchedule(schedule_file_info) == true)

--- a/src/providers/scheduled/scheduled_application.cpp
+++ b/src/providers/scheduled/scheduled_application.cpp
@@ -38,6 +38,7 @@ namespace pvd
         auto config = GetConfig().GetProviders().GetScheduledProvider();
         _media_root_dir = ov::GetDirPath(config.GetMediaRootDir(), cfg::ConfigManager::GetInstance()->GetConfigPath());
         _schedule_files_path = ov::GetDirPath(config.GetScheduleFilesDir(), cfg::ConfigManager::GetInstance()->GetConfigPath());
+        _preserve_removed_schedule_file = config.IsPreserveRemovedScheduleFile();
 
         _schedule_file_name_regex = ov::Regex::CompiledRegex(ov::Regex::WildCardRegex(ov::String::FormatString("*.%s", ScheduleFileExtension)));
         
@@ -111,6 +112,35 @@ namespace pvd
 				{
 					++it;
 				}
+            }
+            else
+            {
+                ++it;
+            }
+        }
+
+        // Remove channels that stayed in fallback longer than MaxFallbackDurationMs
+        for (auto it = _schedule_file_info_db.begin(); it != _schedule_file_info_db.end();)
+        {
+            auto &schedule_file_info = it->second;
+            auto stream = std::static_pointer_cast<ScheduledStream>(GetStreamByName(schedule_file_info._schedule->GetStream()._name));
+            if (stream == nullptr || stream->IsMaxFallbackDurationExceeded() == false)
+            {
+                ++it;
+                continue;
+            }
+
+            // Same as deleting the channel via the DELETE API. If the file is left as is, the channel will be recreated on the next tick
+            if (RemoveScheduleFile(schedule_file_info._file_path, _preserve_removed_schedule_file) == false)
+            {
+                logtw("Failed to remove schedule file : %s", schedule_file_info._file_path.CStr());
+            }
+
+            if (RemoveSchedule(schedule_file_info) == true)
+            {
+                logti("Removed schedule channel : %s/%s (%s) - fallback lasted longer than MaxFallbackDurationMs", GetVHostAppName().CStr(), schedule_file_info._schedule->GetStream()._name.CStr(), schedule_file_info._file_path.CStr());
+
+                it = _schedule_file_info_db.erase(it);
             }
             else
             {

--- a/src/providers/scheduled/scheduled_application.cpp
+++ b/src/providers/scheduled/scheduled_application.cpp
@@ -104,7 +104,7 @@ namespace pvd
                 std::shared_ptr<info::Stream> deleted_stream_info;
 				if (RemoveSchedule(schedule_file_info, &deleted_stream_info) == true)
 				{
-					logti("Removed schedule channel : %s/%s (%s)", GetVHostAppName().CStr(), schedule_file_info._schedule->GetStream()._name.CStr(), schedule_file_info._file_path.CStr());
+					logti("Removed schedule channel : %s/%s (%s) - the schedule file has been removed", GetVHostAppName().CStr(), schedule_file_info._schedule->GetStream()._name.CStr(), schedule_file_info._file_path.CStr());
 
 					it = _schedule_file_info_db.erase(it);
 				}

--- a/src/providers/scheduled/scheduled_application.h
+++ b/src/providers/scheduled/scheduled_application.h
@@ -54,6 +54,7 @@ namespace pvd
         ov::String _media_root_dir;
         ov::String _schedule_files_path;
         ov::Regex _schedule_file_name_regex;
+        bool _preserve_removed_schedule_file = false;
 
         // File name hash -> ScheduleFileInfo
         std::map<size_t, ScheduleFileInfo> _schedule_file_info_db;

--- a/src/providers/scheduled/scheduled_stream.cpp
+++ b/src/providers/scheduled/scheduled_stream.cpp
@@ -88,9 +88,41 @@ namespace pvd
         return true;
     }
 
+    bool ScheduledStream::IsMaxFallbackDurationExceeded() const
+    {
+        auto schedule = PeekSchedule();
+        if (schedule == nullptr)
+        {
+            return false;
+        }
+
+        auto max_fallback_duration_ms = schedule->GetStream()._max_fallback_duration_ms;
+        if (max_fallback_duration_ms <= 0)
+        {
+            return false;
+        }
+
+        auto fallback_entered_at_ms = _fallback_entered_at_ms.load();
+        if (fallback_entered_at_ms == -1)
+        {
+            return false;
+        }
+
+        return (ov::Time::GetMonotonicTimestamp() - fallback_entered_at_ms) >= max_fallback_duration_ms;
+    }
+
     bool ScheduledStream::UpdateSchedule(const std::shared_ptr<Schedule> &schedule)
     {
         std::lock_guard<std::shared_mutex> lock(_schedule_mutex);
+
+        // If MaxFallbackDurationMs is changed while in fallback, count from now
+        if (_schedule != nullptr && schedule != nullptr &&
+            _schedule->GetStream()._max_fallback_duration_ms != schedule->GetStream()._max_fallback_duration_ms &&
+            _fallback_entered_at_ms.load() != -1)
+        {
+            _fallback_entered_at_ms.store(ov::Time::GetMonotonicTimestamp());
+        }
+
         _schedule = schedule;
 
         _schedule_updated.SetEvent();
@@ -349,6 +381,12 @@ namespace pvd
     ScheduledStream::PlaybackResult ScheduledStream::PlayFallbackOrWait()
     {
         logti("Scheduled Channel %s/%s: Start fallback program", GetApplicationName(), GetName().CStr());
+
+        // Keeps running until a scheduled item actually plays again
+        if (_fallback_entered_at_ms.load() == -1)
+        {
+            _fallback_entered_at_ms.store(ov::Time::GetMonotonicTimestamp());
+        }
 
         PlaybackResult result = PlaybackResult::PLAY_NEXT_ITEM;
 
@@ -638,6 +676,12 @@ namespace pvd
             logtt("Scheduled Channel Send Packet : %s/%s: Track %d, origin dts : %" PRId64 ", pts %" PRId64 ", dts %" PRId64 ", duration %" PRId64 ", tb %f, dts_ms %f, dts_gap %" PRId64 "", GetApplicationName(), GetName().CStr(), track_id, single_file_dts, pts, dts, duration, track->GetTimeBase().GetExpr(), time_ms, dts_gap);
 
             SendFrame(media_packet);
+
+            if (fallback_item == false)
+            {
+                // A scheduled item is playing, fallback is over
+                _fallback_entered_at_ms.store(-1);
+            }
 
             _last_packet_map[track_id] = media_packet;
 
@@ -1087,6 +1131,12 @@ namespace pvd
             logtt("Scheduled Channel Send Packet : %s/%s: Track %d, origin dts : %" PRId64 ", pts %" PRId64 ", dts %" PRId64 ", tb %f, dts_ms %f", GetApplicationName(), GetName().CStr(), track_id, single_file_dts, pts, dts, track->GetTimeBase().GetExpr(), time_ms);
 
             SendFrame(media_packet);
+
+            if (fallback_item == false)
+            {
+                // A scheduled item is playing, fallback is over
+                _fallback_entered_at_ms.store(-1);
+            }
 
             // dts to real time (ms)
             auto single_file_dts_ms = static_cast<double>(single_file_dts) * track->GetTimeBase().GetExpr() * static_cast<double>(1000);

--- a/src/providers/scheduled/scheduled_stream.h
+++ b/src/providers/scheduled/scheduled_stream.h
@@ -43,6 +43,9 @@ namespace pvd
         // Get current program
         bool GetCurrentProgram(std::shared_ptr<Schedule::Program> &curr_program, std::shared_ptr<Schedule::Item> &curr_item, int64_t &curr_item_pos) const;
 
+        // Checked by the schedule watcher to remove the channel when MaxFallbackDurationMs is exceeded
+        bool IsMaxFallbackDurationExceeded() const;
+
     private:
         void WorkerThread();
 
@@ -109,6 +112,9 @@ namespace pvd
 
         // Fallback
         std::shared_ptr<Schedule::Program> _fallback_program;
+
+        // Monotonic time (ms) when fallback started, -1 : not in fallback
+        std::atomic<int64_t> _fallback_entered_at_ms{-1};
 
         std::map<int, int> _origin_id_track_id_map;
 


### PR DESCRIPTION
**Problem**

Once a scheduled channel enters fallback it stays alive indefinitely, so when a live input ends permanently the channel keeps serving and recording the fallback until someone deletes it manually.

**Solution**

Adds `<Stream><MaxFallbackDurationMs>` to the schedule file, which deletes the channel together with its schedule file when fallback lasts longer than the set duration, the same result as deleting it via the DELETE API. Also adds `<Providers><Schedule><PreserveRemovedScheduleFile>`, which renames a removed schedule file with a timestamp instead of deleting it, applied to both the automatic removal and the DELETE API.

**Test**

- Off air fallback with `MaxFallbackDurationMs` set to 15000: the channel and its schedule file are removed 15 seconds after fallback starts.
- A program playing normally: the channel stays alive well past the configured duration.
- Live input loss and recovery: fallback starts, the input returns after 8 seconds and the count resets, the channel survives past the configured duration, and stopping the input again removes the channel 15 seconds later.
- Changing `MaxFallbackDurationMs` while fallback is running: the count restarts from the moment of the change.
- `PreserveRemovedScheduleFile` set to true: the schedule file is renamed with a timestamp on removal, for both the automatic removal and the DELETE API, and the renamed file is not loaded as a channel.
