### PR TITLE
refactor(mediarouter): record per-track readiness on shared track stats

### DIFF
--- a/src/base/info/track_stats.cpp
+++ b/src/base/info/track_stats.cpp
@@ -223,6 +223,16 @@ void TrackStats::SetQualityMeasured()
 	_quality_measured = true;
 }
 
+bool TrackStats::IsReady() const
+{
+	return _ready;
+}
+
+void TrackStats::SetReady()
+{
+	_ready = true;
+}
+
 void TrackStats::SetHasBframes(bool has_bframe)
 {
 	_has_bframe = has_bframe;

--- a/src/base/info/track_stats.h
+++ b/src/base/info/track_stats.h
@@ -63,6 +63,11 @@ public:
 	bool IsQualityMeasured() const;
 	void SetQualityMeasured();
 
+	// Set to true by the mediarouter once the track becomes ready (valid and
+	// quality-measured, see MediaRouteStream::IsStreamReady); never goes back to false
+	bool IsReady() const;
+	void SetReady();
+
 	// B-frames detected in the bitstream by the config author
 	void SetHasBframes(bool has_bframe);
 	bool HasBframes() const;
@@ -113,6 +118,8 @@ private:
 	std::atomic<int64_t> _last_received_timestamp = -1;
 
 	std::atomic<bool> _quality_measured = false;
+
+	std::atomic<bool> _ready = false;
 
 	std::atomic<bool> _has_bframe = false;
 

--- a/src/mediarouter/mediarouter_stream.cpp
+++ b/src/mediarouter/mediarouter_stream.cpp
@@ -131,22 +131,35 @@ bool MediaRouteStream::IsStreamReady()
 
 	auto tracks = _stream->GetTracks();
 
+	bool all_tracks_ready = true;
+
+	// Evaluate every track (no early return) so each ready track is recorded even
+	// while another track still blocks the stream
 	for (const auto &track_it : tracks)
 	{
 		auto track = track_it.second;
 
 		// The map entry is the latest published version of this track; while a
 		// track stays undescribed no version has been published yet
-		if (track->IsValid() == false)
+		if ((track->IsValid() == false) ||
+			(_stream->HasTrackQualityMeasured(track->GetId()) == false))
 		{
-			return false;
+			all_tracks_ready = false;
+			continue;
 		}
 
-		// If the track is an outbound track, it is necessary to check the quality.
-		if (_stream->HasTrackQualityMeasured(track->GetId()) == false)
+		// Record readiness on the shared stats; modules holding setup-time track
+		// versions (e.g. the provider) read this fact instead of judging validity
+		auto stats = _stream->GetTrackStats(track->GetId());
+		if (stats != nullptr)
 		{
-			return false;
+			stats->SetReady();
 		}
+	}
+
+	if (all_tracks_ready == false)
+	{
+		return false;
 	}
 
 	_is_all_tracks_parsed = true;
@@ -185,8 +198,9 @@ void MediaRouteStream::CheckUnpreparedTrackTimeout()
 	{
 		auto track = track_it.second;
 
-		// Mirror IsStreamReady(): a track blocks prepare until it is both valid and quality-measured
-		if (track->IsValid() == true && _stream->HasTrackQualityMeasured(track->GetId()) == true)
+		// Readiness is recorded by IsStreamReady(), which always runs before this check
+		auto stats = _stream->GetTrackStats(track->GetId());
+		if (stats != nullptr && stats->IsReady() == true)
 		{
 			continue;
 		}


### PR DESCRIPTION
Track readiness (valid and quality-measured) is evaluated in multiple places, and the result is visible only inside the mediarouter's own copy of the stream info because parsed track properties are published into that copy only.

IsStreamReady() now evaluates every track without early return and records per-track readiness on the shared TrackStats, and CheckUnpreparedTrackTimeout() reuses the recorded fact instead of duplicating the judgment. Stream preparation behavior is unchanged.

## Test
- Full unit test suite passed (846/846).
- WHIP ingest with VP8+OPUS and H264+OPUS: both streams prepared normally within about 1 second, no unprepared-track warnings for healthy input, and WebRTC/LLHLS playback was unaffected.