### PR TITLE
fix(llhls): remove the segment overrun warning

### DIFF
--- a/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.cpp
@@ -38,9 +38,9 @@ namespace bmff
 		_cut_cadence_us = _segment_duration_us;
 		if (config.keyframe_interval_ms > 0)
 		{
-			int64_t keyframe_interval_us = static_cast<int64_t>(config.keyframe_interval_ms * 1000.0 + 0.5);
-			int64_t intervals = (_segment_duration_us + keyframe_interval_us - 1) / keyframe_interval_us;
-			_cut_cadence_us = std::max(_cut_cadence_us, intervals * keyframe_interval_us);
+			_keyframe_interval_us = static_cast<int64_t>(config.keyframe_interval_ms * 1000.0 + 0.5);
+			int64_t intervals = (_segment_duration_us + _keyframe_interval_us - 1) / _keyframe_interval_us;
+			_cut_cadence_us = std::max(_cut_cadence_us, intervals * _keyframe_interval_us);
 		}
 	}
 
@@ -792,8 +792,9 @@ namespace bmff
 			}
 		}
 
-		// A segment that runs well past its plan is worth reporting: the cut
-		// could not land where the cadence wanted it
+		// A cut lands on the first cuttable position at or after the plan, so
+		// overshooting by less than the distance to that position is the cadence
+		// working. Passing one by is what is worth reporting
 		if (decision.completes_segment == true && target_segment_duration_us > 0)
 		{
 			int64_t closed_at_us = last_segment_duration_us;
@@ -802,12 +803,12 @@ namespace bmff
 				closed_at_us += sample_list[index].timing.duration_us;
 			}
 
-			if (closed_at_us > target_segment_duration_us + next_frame.duration_us)
+			int64_t reach_us = std::max(next_frame.duration_us, _keyframe_interval_us);
+			if (closed_at_us > target_segment_duration_us + reach_us)
 			{
-				logtw("%s - Segment closed at %.3f ms, past its %.3f ms plan (buffered %.3f, stored %.3f, frame dts %.3f, start %.3f)",
-					  _log_context.CStr(), closed_at_us / 1000.0, target_segment_duration_us / 1000.0,
-					  buffered_duration_us / 1000.0, last_segment_duration_us / 1000.0,
-					  next_frame.dts_us / 1000.0, segment_start_us / 1000.0);
+				logtw("%s - Segment closed at %.3f ms, %.3f ms past its %.3f ms plan; the next cuttable position was expected within %.3f ms (start %.3f ms)",
+					  _log_context.CStr(), closed_at_us / 1000.0, (closed_at_us - target_segment_duration_us) / 1000.0,
+					  target_segment_duration_us / 1000.0, reach_us / 1000.0, segment_start_us / 1000.0);
 			}
 		}
 

--- a/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.cpp
@@ -36,9 +36,12 @@ namespace bmff
 		// keyframe intervals, so the shortest packageable break follows that
 		// rounded cadence instead of the configured duration
 		_cut_cadence_us = _segment_duration_us;
-		if (config.keyframe_interval_ms > 0)
+		// Judged after the conversion: an interval that rounds away to nothing
+		// cannot divide the duration
+		int64_t keyframe_interval_us = static_cast<int64_t>(config.keyframe_interval_ms * 1000.0 + 0.5);
+		if (keyframe_interval_us > 0)
 		{
-			_keyframe_interval_us = static_cast<int64_t>(config.keyframe_interval_ms * 1000.0 + 0.5);
+			_keyframe_interval_us = keyframe_interval_us;
 			int64_t intervals = (_segment_duration_us + _keyframe_interval_us - 1) / _keyframe_interval_us;
 			_cut_cadence_us = std::max(_cut_cadence_us, intervals * _keyframe_interval_us);
 		}

--- a/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.cpp
+++ b/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.cpp
@@ -41,9 +41,8 @@ namespace bmff
 		int64_t keyframe_interval_us = static_cast<int64_t>(config.keyframe_interval_ms * 1000.0 + 0.5);
 		if (keyframe_interval_us > 0)
 		{
-			_keyframe_interval_us = keyframe_interval_us;
-			int64_t intervals = (_segment_duration_us + _keyframe_interval_us - 1) / _keyframe_interval_us;
-			_cut_cadence_us = std::max(_cut_cadence_us, intervals * _keyframe_interval_us);
+			int64_t intervals = (_segment_duration_us + keyframe_interval_us - 1) / keyframe_interval_us;
+			_cut_cadence_us = std::max(_cut_cadence_us, intervals * keyframe_interval_us);
 		}
 	}
 
@@ -792,26 +791,6 @@ namespace bmff
 				logte("%s - No cuttable position (keyframe or boundary) appeared for %.3f ms, twice the target %.3f ms; the segment is closed here and may not play normally",
 					  _log_context.CStr(), (last_segment_duration_us + emitted_duration_us) / 1000.0, _segment_duration_us / 1000.0);
 				decision.completes_segment = true;
-			}
-		}
-
-		// A cut lands on the first cuttable position at or after the plan, so
-		// overshooting by less than the distance to that position is the cadence
-		// working. Passing one by is what is worth reporting
-		if (decision.completes_segment == true && target_segment_duration_us > 0)
-		{
-			int64_t closed_at_us = last_segment_duration_us;
-			for (size_t index = 0; index < emit_count; index++)
-			{
-				closed_at_us += sample_list[index].timing.duration_us;
-			}
-
-			int64_t reach_us = std::max(next_frame.duration_us, _keyframe_interval_us);
-			if (closed_at_us > target_segment_duration_us + reach_us)
-			{
-				logtw("%s - Segment closed at %.3f ms, %.3f ms past its %.3f ms plan; the next cuttable position was expected within %.3f ms (start %.3f ms)",
-					  _log_context.CStr(), closed_at_us / 1000.0, (closed_at_us - target_segment_duration_us) / 1000.0,
-					  target_segment_duration_us / 1000.0, reach_us / 1000.0, segment_start_us / 1000.0);
 			}
 		}
 

--- a/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.h
+++ b/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.h
@@ -226,9 +226,6 @@ namespace bmff
 		// return from, and a position it has passed by more than one is beyond
 		// saving.
 		int64_t _cut_cadence_us = 0;
-		// The nominal keyframe interval, how far the next cuttable position is
-		// expected to be; zero where every frame can cut
-		int64_t _keyframe_interval_us = 0;
 		LLHlsCueOutCutMode _cue_out_cut_mode = LLHlsCueOutCutMode::Keyframe;
 		ov::String _log_context;
 

--- a/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.h
+++ b/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.h
@@ -226,6 +226,9 @@ namespace bmff
 		// return from, and a position it has passed by more than one is beyond
 		// saving.
 		int64_t _cut_cadence_us = 0;
+		// How far the next cuttable position is on a keyframe-constrained track;
+		// zero where every frame can cut
+		int64_t _keyframe_interval_us = 0;
 		LLHlsCueOutCutMode _cue_out_cut_mode = LLHlsCueOutCutMode::Keyframe;
 		ov::String _log_context;
 

--- a/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.h
+++ b/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.h
@@ -226,8 +226,8 @@ namespace bmff
 		// return from, and a position it has passed by more than one is beyond
 		// saving.
 		int64_t _cut_cadence_us = 0;
-		// The keyframe interval, an upper bound on how far the next cuttable
-		// position is; zero where every frame can cut
+		// The nominal keyframe interval, how far the next cuttable position is
+		// expected to be; zero where every frame can cut
 		int64_t _keyframe_interval_us = 0;
 		LLHlsCueOutCutMode _cue_out_cut_mode = LLHlsCueOutCutMode::Keyframe;
 		ov::String _log_context;

--- a/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.h
+++ b/src/modules/containers/bmff/fmp4_packager/segment_boundary_policy.h
@@ -226,8 +226,8 @@ namespace bmff
 		// return from, and a position it has passed by more than one is beyond
 		// saving.
 		int64_t _cut_cadence_us = 0;
-		// How far the next cuttable position is on a keyframe-constrained track;
-		// zero where every frame can cut
+		// The keyframe interval, an upper bound on how far the next cuttable
+		// position is; zero where every frame can cut
 		int64_t _keyframe_interval_us = 0;
 		LLHlsCueOutCutMode _cue_out_cut_mode = LLHlsCueOutCutMode::Keyframe;
 		ov::String _log_context;


### PR DESCRIPTION
A video segment can only close at a keyframe, so it closes at the first keyframe at or after the pacing plan and comes out longer whenever the plan falls between two of them. That is the cadence working, not a fault, and the warning reported it on every segment for the life of the stream: a stream whose first segment ran long once carries that difference in the pacing ledger and never stops logging.

The warning is removed. A segment that finds no cuttable position for twice the configured duration is still force-closed and reported at error level, and a keyframe interval that does not divide the segment duration is still reported once when the stream is prepared, so nothing an operator can act on is lost. The keyframe interval is also judged after its conversion to microseconds, so a value that rounds away to nothing cannot divide the duration.

Test: publish a stream whose first segment runs longer than the configured duration; a WHIP source reproduces it, since its first frame arrives about two seconds before the rest and stretches the first GOP. Pass conditions: no per-segment warning while segment durations stay at the configured value, and a segment that finds no cuttable position for twice the configured duration still reports the existing error.
