### PR TITLE
fix(ovsocket): release the SRT epoll with `srt_epoll_release`, not `srt_close`

### DIFF
--- a/src/base/ovsocket/socket_pool/socket_pool_worker.cpp
+++ b/src/base/ovsocket/socket_pool/socket_pool_worker.cpp
@@ -137,7 +137,7 @@ namespace ov
 		_gc_candidates.clear();
 
 		OV_SAFE_FUNC(_epoll, InvalidSocket, ::close, );
-		OV_SAFE_FUNC(_srt_epoll, InvalidSocket, ::srt_close, );
+		OV_SAFE_FUNC(_srt_epoll, InvalidSocket, ::srt_epoll_release, );
 
 		return true;
 	}


### PR DESCRIPTION
## Summary

`SocketPoolWorker` creates one SRT epoll per worker with `srt_epoll_create()`, but `Uninitialize()` tries to release it with `srt_close()`.
SRT epoll ids and socket ids live in separate id spaces, so this never releases the epoll: `srt_close()` looks the id up in the socket map, does not find it, and returns `0` through its `SRTS_NONEXIST` early return.
The kernel epoll file descriptor that libsrt allocated inside `srt_epoll_create()` is never closed, and nothing is logged because the call reports success.

The leak stays invisible with the default pool, which creates a fixed number of workers that live for the process lifetime. With `ThreadPerSocket=true` on the SRT provider a worker is created per socket, so every SRT session permanently leaks one file descriptor. On a host with the common `nofile` limit of 1024 that exhausts the process after roughly 950 accumulated sessions.

## Changes

- `SocketPoolWorker::Uninitialize()` releases `_srt_epoll` with `::srt_epoll_release()` instead of `::srt_close()`. The TCP and UDP paths already pair `::epoll_create1()` with `::close()` correctly and are untouched.

## Testing

Run the SRT provider with `ThreadPerSocket` enabled:

```xml
<Bind>
  <Providers>
    <SRT>
      <Port>9999</Port>
      <WorkerCount>1</WorkerCount>
      <ThreadPerSocket>true</ThreadPerSocket>
    </SRT>
  </Providers>
</Bind>
```

Push 150 short SRT sessions and count the file descriptors before and after:

```bash
ls /proc/<pid>/fd | wc -l

for r in $(seq 1 15); do
  for k in $(seq 1 10); do
    timeout 6 ffmpeg -loglevel quiet -re -i sample.ts -c copy -t 3 -f mpegts \
      "srt://127.0.0.1:9999?streamid=default/app/z${r}_${k}" &
  done
  wait
done

sleep 300
ls /proc/<pid>/fd | wc -l
ls -l /proc/<pid>/fd | grep -c 'anon_inode:\[eventpoll\]'
```

Before this change the descriptor count grows from 72 to 221 and never drops, and all 149 added entries are `anon_inode:[eventpoll]`.
After this change the count peaks at 81 while the ten concurrent sessions are live and returns to 71 once they end, with the epoll count back at its startup value of 20. SRT ingest, SRT and LLHLS playback, and SIGTERM shutdown were verified on the patched build, and no new error lines appear in the log.

The behavior of `srt_close()` on an epoll id was checked against libsrt 1.5.6 and 1.5.2, and is the same on both. The `SRTS_NONEXIST` early return has been in `srt_close()` since libsrt's first public commit, so this is not a regression from any libsrt update.
