### PR TITLE
fix(bitstream): guard the SPS frame rate division and reject out-of-range ue(v) codes

### DIFF
--- a/src/modules/bitstream/h264/h264_parser.cpp
+++ b/src/modules/bitstream/h264/h264_parser.cpp
@@ -644,9 +644,10 @@ bool H264Parser::ParseVUI(NalUnitBitstreamParser &parser, H264SPS &sps)
 
 				if (fixed_frame_rate_flag)
 				{
-					sps._fps = (num_units_in_tick != 0)
-								   ? (time_scale / (2 * num_units_in_tick))
-								   : 0;
+					// Doubling in 32-bit arithmetic turns `num_units_in_tick` `0x80000000` into a zero divisor.
+					const auto divisor = static_cast<uint64_t>(num_units_in_tick) * 2;
+
+					sps._fps		   = (divisor != 0) ? static_cast<unsigned int>(time_scale / divisor) : 0;
 				}
 			}
 		}

--- a/src/modules/bitstream/h264/h264_parser.cpp
+++ b/src/modules/bitstream/h264/h264_parser.cpp
@@ -622,9 +622,7 @@ bool H264Parser::ParseVUI(NalUnitBitstreamParser &parser, H264SPS &sps)
 
 			if (timing_info_present_flag)
 			{
-				uint32_t num_units_in_tick, time_scale;
-				uint8_t fixed_frame_rate_flag;
-
+				uint32_t num_units_in_tick;
 				// ITU-T H.264 E.1.1: both are u(32), not ue(v). Reading them as Exp-Golomb
 				// desynchronizes the bit position for everything that follows in the VUI.
 				if (!parser.ReadU32(num_units_in_tick))
@@ -632,23 +630,24 @@ bool H264Parser::ParseVUI(NalUnitBitstreamParser &parser, H264SPS &sps)
 					return false;
 				}
 
+				uint32_t time_scale;
 				if (!parser.ReadU32(time_scale))
 				{
 					return false;
 				}
 
+				uint8_t fixed_frame_rate_flag;
 				if (!parser.ReadBit(fixed_frame_rate_flag))
 				{
 					return false;
 				}
 
-				if (fixed_frame_rate_flag)
-				{
-					// Doubling in 32-bit arithmetic turns `num_units_in_tick` `0x80000000` into a zero divisor.
-					const auto divisor = static_cast<uint64_t>(num_units_in_tick) * 2;
+				// ITU-T H.264 E.2.1 derives the clock tick from `num_units_in_tick` and `time_scale` alone.
+				// `fixed_frame_rate_flag` only constrains how evenly the output times are spaced.
+				// Doubling in 32-bit arithmetic turns `num_units_in_tick` `0x80000000` into a zero divisor.
+				const auto divisor = static_cast<uint64_t>(num_units_in_tick) * 2;
 
-					sps._fps		   = (divisor != 0) ? static_cast<unsigned int>(time_scale / divisor) : 0;
-				}
+				sps._fps		   = (divisor != 0) ? static_cast<unsigned int>(time_scale / divisor) : 0;
 			}
 		}
 

--- a/src/modules/bitstream/h264/h264_parser_test.cpp
+++ b/src/modules/bitstream/h264/h264_parser_test.cpp
@@ -1,0 +1,165 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+
+//  Covers: H264Parser VUI timing_info handling, in particular the frame rate
+//          division when num_units_in_tick sits at the edge of u(32).
+//
+//  Bitstreams are hand-built with a BitWriter so the field values under test
+//  are known by construction. Syntax follows ITU-T H.264 (7.3.2.1.1 SPS,
+//  E.1.1 vui_parameters).
+
+// Unit tests
+// ----------
+// cmake -S . -B __temp_build/tests -G Ninja -DOME_BUILD_TESTS=ON
+// ninja -C __temp_build/tests ome_test_modules
+// ./__temp_build/tests/bin/ome_test_modules --gtest_filter='H264Parser.*'
+
+#include <base/ovlibrary/bit_writer.h>
+#include <gtest/gtest.h>
+#include <modules/bitstream/h264/h264_parser.h>
+
+#include <vector>
+
+namespace
+{
+	// ue(v) (ITU-T H.264 9.1)
+	void WriteUE(ov::BitWriter &w, uint32_t value)
+	{
+		uint64_t code_num = static_cast<uint64_t>(value) + 1;
+		int numbits		  = 0;
+		while ((code_num >> (numbits + 1)) != 0)
+		{
+			numbits++;
+		}
+
+		if (numbits > 0)
+		{
+			w.WriteBits(numbits, 0);
+		}
+		w.WriteBits(numbits + 1, code_num);
+	}
+
+	// rbsp_trailing_bits(): stop bit '1' then zero-pad to a byte boundary
+	void WriteTrailing(ov::BitWriter &w)
+	{
+		w.WriteBits(1, 1);
+		while ((w.GetBitCount() % 8) != 0)
+		{
+			w.WriteBits(1, 0);
+		}
+	}
+
+	std::vector<uint8_t> ApplyEmulationPrevention(const std::vector<uint8_t> &rbsp)
+	{
+		std::vector<uint8_t> out;
+		out.reserve(rbsp.size() + 4);
+
+		size_t zeros = 0;
+		for (uint8_t byte : rbsp)
+		{
+			if ((zeros >= 2) && (byte <= 0x03))
+			{
+				out.push_back(0x03);
+				zeros = 0;
+			}
+
+			out.push_back(byte);
+			zeros = (byte == 0x00) ? (zeros + 1) : 0;
+		}
+
+		return out;
+	}
+
+	// A 640x320 Baseline SPS whose VUI carries the given timing_info
+	std::vector<uint8_t> MakeSpsNal(uint32_t num_units_in_tick, uint32_t time_scale)
+	{
+		ov::BitWriter w(64);
+
+		w.WriteBits(8, 66);	 // profile_idc: Baseline, so no chroma_format_idc block
+		w.WriteBits(8, 0);	 // constraint flags + reserved
+		w.WriteBits(8, 31);	 // level_idc
+		WriteUE(w, 0);		 // seq_parameter_set_id
+		WriteUE(w, 4);		 // log2_max_frame_num_minus4
+		WriteUE(w, 0);		 // pic_order_cnt_type
+		WriteUE(w, 4);		 // log2_max_pic_order_cnt_lsb_minus4
+		WriteUE(w, 1);		 // max_num_ref_frames
+		w.WriteBits(1, 0);	 // gaps_in_frame_num_value_allowed_flag
+		WriteUE(w, 39);		 // pic_width_in_mbs_minus1
+		WriteUE(w, 19);		 // pic_height_in_map_units_minus1
+		w.WriteBits(1, 1);	 // frame_mbs_only_flag
+		w.WriteBits(1, 1);	 // direct_8x8_inference_flag
+		w.WriteBits(1, 0);	 // frame_cropping_flag
+
+		w.WriteBits(1, 1);	// vui_parameters_present_flag
+		w.WriteBits(1, 0);	// aspect_ratio_info_present_flag
+		w.WriteBits(1, 0);	// overscan_info_present_flag
+		w.WriteBits(1, 0);	// video_signal_type_present_flag
+		w.WriteBits(1, 0);	// chroma_loc_info_present_flag
+
+		w.WriteBits(1, 1);					 // timing_info_present_flag
+		w.WriteBits(32, num_units_in_tick);	 // num_units_in_tick, u(32)
+		w.WriteBits(32, time_scale);		 // time_scale, u(32)
+		w.WriteBits(1, 1);					 // fixed_frame_rate_flag
+
+		w.WriteBits(1, 0);	// nal_hrd_parameters_present_flag
+		w.WriteBits(1, 0);	// vcl_hrd_parameters_present_flag
+		w.WriteBits(1, 0);	// pic_struct_present_flag
+		w.WriteBits(1, 0);	// bitstream_restriction_flag
+
+		WriteTrailing(w);
+
+		const std::vector<uint8_t> rbsp(w.GetData(), w.GetData() + w.GetDataSize());
+
+		std::vector<uint8_t> nal;
+		nal.push_back(0x67);  // forbidden_zero_bit(0) + nal_ref_idc(3) + nal_unit_type(7, SPS)
+
+		const auto ebsp = ApplyEmulationPrevention(rbsp);
+		nal.insert(nal.end(), ebsp.begin(), ebsp.end());
+
+		return nal;
+	}
+}  // namespace
+
+TEST(H264Parser, DerivesTheFrameRateFromTimingInfo)
+{
+	const auto nal = MakeSpsNal(1, 60);
+
+	H264SPS sps;
+	ASSERT_TRUE(H264Parser::ParseSPS(nal.data(), nal.size(), sps));
+
+	EXPECT_EQ(sps.GetWidth(), 640U);
+	EXPECT_EQ(sps.GetFps(), 30U);
+}
+
+// Doubling 0x80000000 in 32-bit arithmetic wraps the divisor to 0, which used to raise SIGFPE and
+// terminate the process. The value is legal u(32) syntax, so the parser has to survive it.
+TEST(H264Parser, SurvivesANumUnitsInTickThatWrapsTheDoubledDivisor)
+{
+	for (uint32_t time_scale : {0U, 1U, 53U, 60U, 0xFFFFFFFFU})
+	{
+		const auto nal = MakeSpsNal(0x80000000U, time_scale);
+
+		H264SPS sps;
+		ASSERT_TRUE(H264Parser::ParseSPS(nal.data(), nal.size(), sps))
+			<< "time_scale: " << time_scale;
+
+		// Any u(32) time_scale over a divisor of 2^32 truncates to 0
+		EXPECT_EQ(sps.GetFps(), 0U) << "time_scale: " << time_scale;
+	}
+}
+
+TEST(H264Parser, ReportsZeroFpsWhenNumUnitsInTickIsZero)
+{
+	const auto nal = MakeSpsNal(0, 60);
+
+	H264SPS sps;
+	ASSERT_TRUE(H264Parser::ParseSPS(nal.data(), nal.size(), sps));
+
+	EXPECT_EQ(sps.GetFps(), 0U);
+}

--- a/src/modules/bitstream/h264/h264_parser_test.cpp
+++ b/src/modules/bitstream/h264/h264_parser_test.cpp
@@ -77,7 +77,8 @@ namespace
 	}
 
 	// A 640x320 Baseline SPS whose VUI carries the given timing_info
-	std::vector<uint8_t> MakeSpsNal(uint32_t num_units_in_tick, uint32_t time_scale)
+	std::vector<uint8_t> MakeSpsNal(uint32_t num_units_in_tick, uint32_t time_scale,
+									uint8_t fixed_frame_rate_flag = 1)
 	{
 		ov::BitWriter w(64);
 
@@ -102,10 +103,10 @@ namespace
 		w.WriteBits(1, 0);	// video_signal_type_present_flag
 		w.WriteBits(1, 0);	// chroma_loc_info_present_flag
 
-		w.WriteBits(1, 1);					 // timing_info_present_flag
-		w.WriteBits(32, num_units_in_tick);	 // num_units_in_tick, u(32)
-		w.WriteBits(32, time_scale);		 // time_scale, u(32)
-		w.WriteBits(1, 1);					 // fixed_frame_rate_flag
+		w.WriteBits(1, 1);						// timing_info_present_flag
+		w.WriteBits(32, num_units_in_tick);		// num_units_in_tick, u(32)
+		w.WriteBits(32, time_scale);			// time_scale, u(32)
+		w.WriteBits(1, fixed_frame_rate_flag);	// fixed_frame_rate_flag
 
 		w.WriteBits(1, 0);	// nal_hrd_parameters_present_flag
 		w.WriteBits(1, 0);	// vcl_hrd_parameters_present_flag
@@ -162,4 +163,16 @@ TEST(H264Parser, ReportsZeroFpsWhenNumUnitsInTickIsZero)
 	ASSERT_TRUE(H264Parser::ParseSPS(nal.data(), nal.size(), sps));
 
 	EXPECT_EQ(sps.GetFps(), 0U);
+}
+
+// ITU-T H.264 E.2.1 defines the clock tick without reference to `fixed_frame_rate_flag`,
+// so an encoder that will not promise evenly spaced output times still carries a derivable frame rate
+TEST(H264Parser, DerivesTheFrameRateWithoutFixedFrameRateFlag)
+{
+	const auto nal = MakeSpsNal(1001, 60000, 0);
+
+	H264SPS sps;
+	ASSERT_TRUE(H264Parser::ParseSPS(nal.data(), nal.size(), sps));
+
+	EXPECT_EQ(sps.GetFps(), 29U);
 }

--- a/src/modules/bitstream/h264/h264_parser_test.cpp
+++ b/src/modules/bitstream/h264/h264_parser_test.cpp
@@ -21,6 +21,7 @@
 // ./__temp_build/tests/bin/ome_test_modules --gtest_filter='H264Parser.*'
 
 #include <base/ovlibrary/bit_writer.h>
+#include <modules/bitstream/nalu/nal_unit_test_helpers.h>
 #include <gtest/gtest.h>
 #include <modules/bitstream/h264/h264_parser.h>
 
@@ -28,53 +29,9 @@
 
 namespace
 {
-	// ue(v) (ITU-T H.264 9.1)
-	void WriteUE(ov::BitWriter &w, uint32_t value)
-	{
-		uint64_t code_num = static_cast<uint64_t>(value) + 1;
-		int numbits		  = 0;
-		while ((code_num >> (numbits + 1)) != 0)
-		{
-			numbits++;
-		}
-
-		if (numbits > 0)
-		{
-			w.WriteBits(numbits, 0);
-		}
-		w.WriteBits(numbits + 1, code_num);
-	}
-
-	// rbsp_trailing_bits(): stop bit '1' then zero-pad to a byte boundary
-	void WriteTrailing(ov::BitWriter &w)
-	{
-		w.WriteBits(1, 1);
-		while ((w.GetBitCount() % 8) != 0)
-		{
-			w.WriteBits(1, 0);
-		}
-	}
-
-	std::vector<uint8_t> ApplyEmulationPrevention(const std::vector<uint8_t> &rbsp)
-	{
-		std::vector<uint8_t> out;
-		out.reserve(rbsp.size() + 4);
-
-		size_t zeros = 0;
-		for (uint8_t byte : rbsp)
-		{
-			if ((zeros >= 2) && (byte <= 0x03))
-			{
-				out.push_back(0x03);
-				zeros = 0;
-			}
-
-			out.push_back(byte);
-			zeros = (byte == 0x00) ? (zeros + 1) : 0;
-		}
-
-		return out;
-	}
+	using ome_test::ApplyEmulationPrevention;
+	using ome_test::WriteTrailing;
+	using ome_test::WriteUE;
 
 	// A 640x320 Baseline SPS whose VUI carries the given timing_info
 	std::vector<uint8_t> MakeSpsNal(uint32_t num_units_in_tick, uint32_t time_scale,

--- a/src/modules/bitstream/h265/h265_parser.h
+++ b/src/modules/bitstream/h265/h265_parser.h
@@ -159,7 +159,7 @@ public:
 
     float GetFps() const
     {
-		// The tick count stays 0 when the SPS carries no VUI
+		// `timing_info` is optional, so the tick count can still be 0 here
 		if (_vui_parameters._num_units_in_tick == 0)
 		{
 			return 0.0f;

--- a/src/modules/bitstream/h265/h265_parser.h
+++ b/src/modules/bitstream/h265/h265_parser.h
@@ -165,7 +165,7 @@ public:
 			return 0.0f;
 		}
 
-		return _vui_parameters._time_scale / _vui_parameters._num_units_in_tick;
+		return static_cast<float>(_vui_parameters._time_scale) / _vui_parameters._num_units_in_tick;
     }
 
     uint32_t GetId() const

--- a/src/modules/bitstream/h265/h265_parser.h
+++ b/src/modules/bitstream/h265/h265_parser.h
@@ -159,7 +159,13 @@ public:
 
     float GetFps() const
     {
-        return _vui_parameters._time_scale / _vui_parameters._num_units_in_tick;
+		// The tick count stays 0 when the SPS carries no VUI
+		if (_vui_parameters._num_units_in_tick == 0)
+		{
+			return 0.0f;
+		}
+
+		return _vui_parameters._time_scale / _vui_parameters._num_units_in_tick;
     }
 
     uint32_t GetId() const

--- a/src/modules/bitstream/h265/h265_parser_test.cpp
+++ b/src/modules/bitstream/h265/h265_parser_test.cpp
@@ -21,6 +21,7 @@
 
 #include <base/ovlibrary/bit_writer.h>
 #include <base/ovlibrary/data.h>
+#include <modules/bitstream/nalu/nal_unit_test_helpers.h>
 #include <modules/bitstream/h265/h265_decoder_configuration_record.h>
 #include <modules/bitstream/h265/h265_parser.h>
 
@@ -29,62 +30,11 @@
 
 namespace
 {
-	// ---- Exp-Golomb writers (Rec. ITU-T H.265 9.2) ----
-	void WriteUE(ov::BitWriter &w, uint32_t v)
-	{
-		uint64_t n = static_cast<uint64_t>(v) + 1;
-		int numbits = 0;
-		while ((n >> (numbits + 1)) != 0)
-		{
-			numbits++;
-		}
-		if (numbits > 0)
-		{
-			w.WriteBits(numbits, 0);
-		}
-		w.WriteBits(numbits + 1, n);
-	}
-
-	void WriteSE(ov::BitWriter &w, int32_t v)
-	{
-		uint32_t code = (v <= 0) ? static_cast<uint32_t>(-2 * static_cast<int64_t>(v))
-								 : static_cast<uint32_t>(2 * static_cast<int64_t>(v) - 1);
-		WriteUE(w, code);
-	}
-
-	// rbsp_trailing_bits(): stop bit '1' then zero-pad to a byte boundary.
-	void WriteTrailing(ov::BitWriter &w)
-	{
-		w.WriteBits(1, 1);
-		while (w.GetBitCount() % 8 != 0)
-		{
-			w.WriteBits(1, 0);
-		}
-	}
-
-	std::vector<uint8_t> ToBytes(ov::BitWriter &w)
-	{
-		return std::vector<uint8_t>(w.GetData(), w.GetData() + w.GetDataSize());
-	}
-
-	// Insert emulation_prevention_three_byte into an RBSP payload to form an EBSP.
-	std::vector<uint8_t> ApplyEmulationPrevention(const std::vector<uint8_t> &rbsp)
-	{
-		std::vector<uint8_t> out;
-		out.reserve(rbsp.size() + 4);
-		size_t zeros = 0;
-		for (uint8_t b : rbsp)
-		{
-			if (zeros >= 2 && b <= 0x03)
-			{
-				out.push_back(0x03);
-				zeros = 0;
-			}
-			out.push_back(b);
-			zeros = (b == 0x00) ? zeros + 1 : 0;
-		}
-		return out;
-	}
+	using ome_test::ApplyEmulationPrevention;
+	using ome_test::ToBytes;
+	using ome_test::WriteSE;
+	using ome_test::WriteTrailing;
+	using ome_test::WriteUE;
 
 	// Build a NAL unit: 2-byte header (nal_type) + emulation-prevented RBSP.
 	std::vector<uint8_t> MakeNal(uint8_t nal_type, const std::vector<uint8_t> &rbsp)

--- a/src/modules/bitstream/h265/h265_parser_test.cpp
+++ b/src/modules/bitstream/h265/h265_parser_test.cpp
@@ -1248,9 +1248,26 @@ TEST(H265Parser, SliceHeaderRejectsExcessiveOffsetLen)
 // division by it
 TEST(H265Parser, ReportsZeroFpsWhenTheSpsCarriesNoVui)
 {
+	const auto sps_nal = BuildSps(false);
+
 	H265SPS sps;
+	ASSERT_TRUE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
 
 	EXPECT_EQ(sps.GetVuiParameters()._num_units_in_tick, 0U);
+	EXPECT_FLOAT_EQ(sps.GetFps(), 0.0f);
+}
+
+// vui_num_units_in_tick is stored without a range check, so a stream can carry timing_info whose
+// tick count is 0
+TEST(H265Parser, ReportsZeroFpsWhenTheVuiTickCountIsZero)
+{
+	const auto sps_nal = BuildSps(false, 0, 3, {}, 0, 0, 0, {true, true, 0, 60000});
+
+	H265SPS sps;
+	ASSERT_TRUE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+
+	EXPECT_EQ(sps.GetVuiParameters()._num_units_in_tick, 0U);
+	EXPECT_EQ(sps.GetVuiParameters()._time_scale, 60000U);
 	EXPECT_FLOAT_EQ(sps.GetFps(), 0.0f);
 }
 

--- a/src/modules/bitstream/h265/h265_parser_test.cpp
+++ b/src/modules/bitstream/h265/h265_parser_test.cpp
@@ -1183,3 +1183,13 @@ TEST(H265Parser, SliceHeaderRejectsExcessiveOffsetLen)
 	slice = BuildWppIdrSlice(/*num_entry_point_offsets=*/2, /*offset_len_minus1=*/H265_MAX_OFFSET_LEN_MINUS1 + 1);
 	EXPECT_FALSE(H265Parser::ParseSliceHeader(slice.data(), slice.size(), shd, record));
 }
+
+// An SPS with no VUI leaves num_units_in_tick at 0, and the frame rate is a plain integer
+// division by it
+TEST(H265Parser, ReportsZeroFpsWhenTheSpsCarriesNoVui)
+{
+	H265SPS sps;
+
+	EXPECT_EQ(sps.GetVuiParameters()._num_units_in_tick, 0U);
+	EXPECT_FLOAT_EQ(sps.GetFps(), 0.0f);
+}

--- a/src/modules/bitstream/h265/h265_parser_test.cpp
+++ b/src/modules/bitstream/h265/h265_parser_test.cpp
@@ -125,6 +125,16 @@ namespace
 		uint32_t num_long_term_ref_pics_sps = 0;
 	};
 
+	// vui_timing_info (Rec. ITU-T H.265 E.2.1). Absent unless vui_present is set, which is how
+	// an encoder that carries no timing information emits the SPS.
+	struct VuiTimingInfo
+	{
+		bool vui_present		   = false;
+		bool timing_info_present   = false;
+		uint32_t num_units_in_tick = 0;
+		uint32_t time_scale		   = 0;
+	};
+
 	// ---- Minimal VPS (Rec. ITU-T H.265 7.3.2.1). Only needed so a record becomes valid. ----
 	std::vector<uint8_t> BuildVps()
 	{
@@ -168,7 +178,8 @@ namespace
 								  const SpsOverrides &overrides				 = {},
 								  uint32_t log2_max_pic_order_cnt_lsb_minus4 = 0,
 								  uint32_t sps_id							 = 0,
-								  uint32_t max_sub_layers_minus1			 = 0)
+								  uint32_t max_sub_layers_minus1			 = 0,
+								  const VuiTimingInfo &vui					 = {})
 	{
 		ov::BitWriter w(64);
 		w.WriteBits(4, 0);						// sps_video_parameter_set_id
@@ -265,9 +276,32 @@ namespace
 				w.WriteBits(1, 0);	// used_by_curr_pic_lt_sps_flag[i]
 			}
 		}
-		w.WriteBits(1, 0);	// sps_temporal_mvp_enabled_flag
-		w.WriteBits(1, 0);	// strong_intra_smoothing_enabled_flag
-		w.WriteBits(1, 0);	// vui_parameters_present_flag
+		w.WriteBits(1, 0);						  // sps_temporal_mvp_enabled_flag
+		w.WriteBits(1, 0);						  // strong_intra_smoothing_enabled_flag
+		w.WriteBits(1, vui.vui_present ? 1 : 0);  // vui_parameters_present_flag
+		if (vui.vui_present)
+		{
+			w.WriteBits(1, 0);	// aspect_ratio_info_present_flag
+			w.WriteBits(1, 0);	// overscan_info_present_flag
+			w.WriteBits(1, 0);	// video_signal_type_present_flag
+			w.WriteBits(1, 0);	// chroma_loc_info_present_flag
+			w.WriteBits(1, 0);	// neutral_chroma_indication_flag
+			w.WriteBits(1, 0);	// field_seq_flag
+			w.WriteBits(1, 0);	// frame_field_info_present_flag
+			w.WriteBits(1, 0);	// default_display_window_flag
+
+			w.WriteBits(1, vui.timing_info_present ? 1 : 0);  // vui_timing_info_present_flag
+			if (vui.timing_info_present)
+			{
+				w.WriteBits(32, vui.num_units_in_tick);	 // vui_num_units_in_tick
+				w.WriteBits(32, vui.time_scale);		 // vui_time_scale
+				w.WriteBits(1, 0);						 // vui_poc_proportional_to_timing_flag
+				w.WriteBits(1, 0);						 // vui_hrd_parameters_present_flag
+			}
+
+			w.WriteBits(1, 0);	// bitstream_restriction_flag
+		}
+
 		w.WriteBits(1, 0);	// sps_extension_flag
 
 		WriteTrailing(w);
@@ -1232,4 +1266,18 @@ TEST(H265Parser, ParsesAnSpsWithSubLayerProfileTierLevel)
 	EXPECT_EQ(sps.GetWidth(), 320U);
 	EXPECT_EQ(sps.GetHeight(), 240U);
 	EXPECT_EQ(sps.GetMaxSubLayersMinus1(), 1U);
+}
+
+
+// GetFps() returns a float, so the division must not truncate first
+TEST(H265Parser, DerivesANonIntegerFrameRateFromTheVui)
+{
+	const auto sps_nal = BuildSps(false, 0, 3, {}, 0, 0, 0, {true, true, 2002, 60000});
+
+	H265SPS sps;
+	ASSERT_TRUE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+
+	EXPECT_EQ(sps.GetVuiParameters()._num_units_in_tick, 2002U);
+	EXPECT_EQ(sps.GetVuiParameters()._time_scale, 60000U);
+	EXPECT_NEAR(sps.GetFps(), 29.97f, 0.01f);
 }

--- a/src/modules/bitstream/h265/h265_parser_test.cpp
+++ b/src/modules/bitstream/h265/h265_parser_test.cpp
@@ -165,30 +165,56 @@ namespace
 	// (delta_poc_s0_minus1=0, used_by_curr_pic_s0_flag=1), num_positive_pics=0
 	// -> NumDeltaPocs == 1. log2_diff selects CtbLog2SizeY (= 3 + log2_diff).
 	std::vector<uint8_t> BuildSps(bool sao_enabled, uint32_t num_strps = 0, uint32_t log2_diff = 3,
-								  const SpsOverrides &overrides = {},
+								  const SpsOverrides &overrides				 = {},
 								  uint32_t log2_max_pic_order_cnt_lsb_minus4 = 0,
-								  uint32_t sps_id = 0)
+								  uint32_t sps_id							 = 0,
+								  uint32_t max_sub_layers_minus1			 = 0)
 	{
 		ov::BitWriter w(64);
-		w.WriteBits(4, 0);	// sps_video_parameter_set_id
-		w.WriteBits(3, 0);	// sps_max_sub_layers_minus1
-		w.WriteBits(1, 0);	// sps_temporal_id_nesting_flag
+		w.WriteBits(4, 0);						// sps_video_parameter_set_id
+		w.WriteBits(3, max_sub_layers_minus1);	// sps_max_sub_layers_minus1
+		w.WriteBits(1, 0);						// sps_temporal_id_nesting_flag
 
-		// profile_tier_level (max_sub_layers_minus1 == 0 -> 96 bits)
-		w.WriteBits(2, 0);			 // general_profile_space
-		w.WriteBits(1, 0);			 // general_tier_flag
-		w.WriteBits(5, 1);			 // general_profile_idc (Main)
-		w.WriteBits(32, 0x60000000); // general_profile_compatibility_flags
-		w.WriteBits(32, 0);			 // general_constraint_indicator_flags (hi 32)
-		w.WriteBits(16, 0);			 // general_constraint_indicator_flags (lo 16)
-		w.WriteBits(8, 93);			 // general_level_idc (3.1)
+		// profile_tier_level, general part (96 bits)
+		w.WriteBits(2, 0);			  // general_profile_space
+		w.WriteBits(1, 0);			  // general_tier_flag
+		w.WriteBits(5, 1);			  // general_profile_idc (Main)
+		w.WriteBits(32, 0x60000000);  // general_profile_compatibility_flags
+		w.WriteBits(32, 0);			  // general_constraint_indicator_flags (hi 32)
+		w.WriteBits(16, 0);			  // general_constraint_indicator_flags (lo 16)
+		w.WriteBits(8, 93);			  // general_level_idc (3.1)
 
-		WriteUE(w, sps_id);	// sps_seq_parameter_set_id
-		WriteUE(w, 1);	// chroma_format_idc (4:2:0)
+		// profile_tier_level, sub-layer part. The parser skips 88 bits per present profile.
+		for (uint32_t i = 0; i < max_sub_layers_minus1; i++)
+		{
+			w.WriteBits(1, 1);	// sub_layer_profile_present_flag[i]
+			w.WriteBits(1, 1);	// sub_layer_level_present_flag[i]
+		}
+
+		if (max_sub_layers_minus1 > 0)
+		{
+			for (uint32_t i = max_sub_layers_minus1; i < 8; i++)
+			{
+				w.WriteBits(2, 0);	// reserved_zero_2bits[i]
+			}
+		}
+
+		for (uint32_t i = 0; i < max_sub_layers_minus1; i++)
+		{
+			// sub_layer_profile_space(2) + tier_flag(1) + profile_idc(5)
+			// + profile_compatibility_flag(32) + 4 constraint flags + reserved(44)
+			w.WriteBits(44, 0);
+			w.WriteBits(44, 0);
+
+			w.WriteBits(8, 93);	 // sub_layer_level_idc[i]
+		}
+
+		WriteUE(w, sps_id);				   // sps_seq_parameter_set_id
+		WriteUE(w, 1);					   // chroma_format_idc (4:2:0)
 		WriteUE(w, overrides.pic_width);   // pic_width_in_luma_samples
 		WriteUE(w, overrides.pic_height);  // pic_height_in_luma_samples
-		w.WriteBits(1, 0);	// conformance_window_flag
-		WriteUE(w, 0);	// bit_depth_luma_minus8
+		w.WriteBits(1, 0);				   // conformance_window_flag
+		WriteUE(w, 0);					   // bit_depth_luma_minus8
 		WriteUE(w, 0);	// bit_depth_chroma_minus8
 		WriteUE(w, log2_max_pic_order_cnt_lsb_minus4);	// log2_max_pic_order_cnt_lsb_minus4
 
@@ -1192,4 +1218,18 @@ TEST(H265Parser, ReportsZeroFpsWhenTheSpsCarriesNoVui)
 
 	EXPECT_EQ(sps.GetVuiParameters()._num_units_in_tick, 0U);
 	EXPECT_FLOAT_EQ(sps.GetFps(), 0.0f);
+}
+
+// An HEVC profile_tier_level carrying sub-layer profile info makes the parser skip 88 bits at
+// once, which is wider than a single ReadBits() call can take
+TEST(H265Parser, ParsesAnSpsWithSubLayerProfileTierLevel)
+{
+	const auto sps_nal = BuildSps(false, 0, 3, {}, 0, 0, 1);
+
+	H265SPS sps;
+	ASSERT_TRUE(H265Parser::ParseSPS(sps_nal.data(), sps_nal.size(), sps));
+
+	EXPECT_EQ(sps.GetWidth(), 320U);
+	EXPECT_EQ(sps.GetHeight(), 240U);
+	EXPECT_EQ(sps.GetMaxSubLayersMinus1(), 1U);
 }

--- a/src/modules/bitstream/nalu/nal_unit_bitstream_parser.cpp
+++ b/src/modules/bitstream/nalu/nal_unit_bitstream_parser.cpp
@@ -24,36 +24,34 @@ bool NalUnitBitstreamParser::ReadU32(uint32_t &value)
 
 bool NalUnitBitstreamParser::ReadUEV(uint32_t &value)
 {
-	value = 0;
-    int zero_bit_count = 0;
-    uint8_t bit;
-    while (true)
-    {
-        if (ReadBit(bit) == false)
-        {
-            return false;
-        }
-		
-        if (bit == 0)
-        {
-            zero_bit_count++;
-        }
-        else
-        {
-            break;
-        }
-    }
+	value			   = 0;
+	int zero_bit_count = 0;
+	uint8_t bit;
 
-    if (zero_bit_count > 0)
-    {
-		// codeNum tops out at 2^32 - 2 with 31 leading zeros, which is the range every ue(v)
-		// syntax element is defined over. A longer code is out of range, and the shift below
-		// would be undefined.
-		if (zero_bit_count > 31)
+	while (true)
+	{
+		if (ReadBit(bit) == false)
 		{
 			return false;
 		}
 
+		if (bit == 0)
+		{
+			// 31 leading zeros already put codeNum at 2^32 - 2, the maximum any `ue(v)` element takes.
+			// Refusing as the run is counted avoids walking a longer one first.
+			if (++zero_bit_count > 31)
+			{
+				return false;
+			}
+		}
+		else
+		{
+			break;
+		}
+	}
+
+	if (zero_bit_count > 0)
+	{
 		uint32_t rest;
 		if (ReadBits(static_cast<uint8_t>(zero_bit_count), rest) == false)
 		{
@@ -63,11 +61,11 @@ bool NalUnitBitstreamParser::ReadUEV(uint32_t &value)
 		value = (1U << zero_bit_count) - 1 + rest;
 	}
 	else
-    {
-        value = 0;
-    }
+	{
+		value = 0;
+	}
 
-    return true;
+	return true;
 }
 
 bool NalUnitBitstreamParser::ReadSEV(int32_t &value)

--- a/src/modules/bitstream/nalu/nal_unit_bitstream_parser.cpp
+++ b/src/modules/bitstream/nalu/nal_unit_bitstream_parser.cpp
@@ -44,15 +44,22 @@ bool NalUnitBitstreamParser::ReadUEV(uint32_t &value)
 
     if (zero_bit_count > 0)
     {
-        uint32_t rest;
-        if (ReadBits(zero_bit_count, rest) == false)
-        {
-            return false;
-        }
+		// 31 leading zeros already span the whole `uint32_t` range.
+		// A longer code cannot be represented, and the shift itself would be undefined.
+		if (zero_bit_count > 31)
+		{
+			return false;
+		}
 
-        value = (1 << zero_bit_count) - 1 + rest;
-    }
-    else
+		uint32_t rest;
+		if (ReadBits(zero_bit_count, rest) == false)
+		{
+			return false;
+		}
+
+		value = (1U << zero_bit_count) - 1 + rest;
+	}
+	else
     {
         value = 0;
     }

--- a/src/modules/bitstream/nalu/nal_unit_bitstream_parser.cpp
+++ b/src/modules/bitstream/nalu/nal_unit_bitstream_parser.cpp
@@ -1,5 +1,7 @@
 #include "nal_unit_bitstream_parser.h"
 
+#include <algorithm>
+
 NalUnitBitstreamParser::NalUnitBitstreamParser(const uint8_t *bitstream, size_t length)
 	: BitReader(bitstream, length)
 {
@@ -83,8 +85,22 @@ bool NalUnitBitstreamParser::ReadSEV(int32_t &value)
 
 bool NalUnitBitstreamParser::Skip(uint32_t count)
 {
-    uint64_t dummy;
-	return ReadBits(count, dummy);
+	// `ReadBits()` takes the width as a `uint8_t` and rejects a width wider than its output.
+	// Anything larger is consumed in 64 bit steps.
+	while (count > 0)
+	{
+		const auto step = static_cast<uint8_t>(std::min<uint32_t>(count, 64));
+
+		uint64_t dummy;
+		if (ReadBits(step, dummy) == false)
+		{
+			return false;
+		}
+
+		count -= step;
+	}
+
+	return true;
 }
 
 void NalUnitBitstreamParser::NextPosition()

--- a/src/modules/bitstream/nalu/nal_unit_bitstream_parser.cpp
+++ b/src/modules/bitstream/nalu/nal_unit_bitstream_parser.cpp
@@ -60,10 +60,6 @@ bool NalUnitBitstreamParser::ReadUEV(uint32_t &value)
 
 		value = (1U << zero_bit_count) - 1 + rest;
 	}
-	else
-	{
-		value = 0;
-	}
 
 	return true;
 }

--- a/src/modules/bitstream/nalu/nal_unit_bitstream_parser.cpp
+++ b/src/modules/bitstream/nalu/nal_unit_bitstream_parser.cpp
@@ -44,15 +44,16 @@ bool NalUnitBitstreamParser::ReadUEV(uint32_t &value)
 
     if (zero_bit_count > 0)
     {
-		// 31 leading zeros already span the whole `uint32_t` range.
-		// A longer code cannot be represented, and the shift itself would be undefined.
+		// codeNum tops out at 2^32 - 2 with 31 leading zeros, which is the range every ue(v)
+		// syntax element is defined over. A longer code is out of range, and the shift below
+		// would be undefined.
 		if (zero_bit_count > 31)
 		{
 			return false;
 		}
 
 		uint32_t rest;
-		if (ReadBits(zero_bit_count, rest) == false)
+		if (ReadBits(static_cast<uint8_t>(zero_bit_count), rest) == false)
 		{
 			return false;
 		}

--- a/src/modules/bitstream/nalu/nal_unit_bitstream_parser_test.cpp
+++ b/src/modules/bitstream/nalu/nal_unit_bitstream_parser_test.cpp
@@ -43,7 +43,9 @@ namespace
 
 		for (int i = leading_zero_bits - 1; i >= 0; i--)
 		{
-			write_bit(static_cast<int>((rest >> i) & 1));
+			// rest carries the low 64 bits, and shifting a uint64_t by 64 or more is undefined.
+			// Every position above that is zero.
+			write_bit((i < 64) ? static_cast<int>((rest >> i) & 1) : 0);
 		}
 
 		bytes.insert(bytes.end(), 8, 0x00);

--- a/src/modules/bitstream/nalu/nal_unit_bitstream_parser_test.cpp
+++ b/src/modules/bitstream/nalu/nal_unit_bitstream_parser_test.cpp
@@ -95,14 +95,19 @@ TEST(NalUnitBitstreamParser, ReadsTheLargestExpGolombCode)
 	EXPECT_EQ(value, 0xFFFFFFFEU);
 }
 
-// 32 leading zeros put codeNum at 2^32 - 1 + rest, past what the caller can hold
+// 32 leading zeros put codeNum at 2^32 - 1 + rest. 2^32 - 1 still fits a uint32_t, but it is
+// past the 2^32 - 2 that ue(v) is defined over, so the whole length is rejected rather than
+// only the values that overflow.
 TEST(NalUnitBitstreamParser, RejectsAnExpGolombCodeOutOfTheUint32Range)
 {
-	const auto bitstream = MakeUevBitstream(32, 1);
-	NalUnitBitstreamParser parser(bitstream.data(), bitstream.size());
+	for (uint64_t rest : {static_cast<uint64_t>(0), static_cast<uint64_t>(1)})
+	{
+		const auto bitstream = MakeUevBitstream(32, rest);
+		NalUnitBitstreamParser parser(bitstream.data(), bitstream.size());
 
-	uint32_t value = 0;
-	EXPECT_FALSE(parser.ReadUEV(value));
+		uint32_t value = 0;
+		EXPECT_FALSE(parser.ReadUEV(value)) << "rest: " << rest;
+	}
 }
 
 // A zero run this long once wrapped the bit count into the uint8_t width parameter of ReadBits(),

--- a/src/modules/bitstream/nalu/nal_unit_bitstream_parser_test.cpp
+++ b/src/modules/bitstream/nalu/nal_unit_bitstream_parser_test.cpp
@@ -2,11 +2,55 @@
 //
 //  OvenMediaEngine - Unit Tests
 //
-//  Covers: NalUnitBitstreamParser emulation_prevention_three_byte handling
+//  Covers: NalUnitBitstreamParser emulation_prevention_three_byte handling and the
+//          Exp-Golomb range accepted by ReadUEV()
 //
 //==============================================================================
 #include <gtest/gtest.h>
 #include <modules/bitstream/nalu/nal_unit_bitstream_parser.h>
+
+#include <vector>
+
+namespace
+{
+	// Builds a bitstream holding one Exp-Golomb code: leading_zero_bits zero bits, the terminating
+	// 1 bit, then leading_zero_bits bits of rest. Trailing zero bytes keep the reads in bounds.
+	std::vector<uint8_t> MakeUevBitstream(int leading_zero_bits, uint64_t rest)
+	{
+		std::vector<uint8_t> bytes;
+		size_t bit_count = 0;
+
+		auto write_bit	 = [&](int bit) {
+			if ((bit_count % 8) == 0)
+			{
+				bytes.push_back(0x00);
+			}
+
+			if (bit != 0)
+			{
+				bytes.back() |= static_cast<uint8_t>(0x80 >> (bit_count % 8));
+			}
+
+			bit_count++;
+		};
+
+		for (int i = 0; i < leading_zero_bits; i++)
+		{
+			write_bit(0);
+		}
+
+		write_bit(1);
+
+		for (int i = leading_zero_bits - 1; i >= 0; i--)
+		{
+			write_bit(static_cast<int>((rest >> i) & 1));
+		}
+
+		bytes.insert(bytes.end(), 8, 0x00);
+
+		return bytes;
+	}
+}  // namespace
 
 TEST(NalUnitBitstreamParser, SkipsAnEmulationPreventionByte)
 {
@@ -34,5 +78,41 @@ TEST(NalUnitBitstreamParser, KeepsATrailingEmulationPreventionByte)
 		uint8_t value = 0;
 		ASSERT_TRUE(parser.ReadU8(value)) << "byte: " << i;
 		EXPECT_EQ(value, nal[i]) << "byte: " << i;
+	}
+}
+
+// 31 leading zeros put codeNum at 2^31 - 1 + rest, so 0xFFFFFFFE is the largest code that still
+// decodes. It pins the boundary the range check below must not move.
+TEST(NalUnitBitstreamParser, ReadsTheLargestExpGolombCode)
+{
+	const auto bitstream = MakeUevBitstream(31, 0x7FFFFFFF);
+	NalUnitBitstreamParser parser(bitstream.data(), bitstream.size());
+
+	uint32_t value = 0;
+	ASSERT_TRUE(parser.ReadUEV(value));
+	EXPECT_EQ(value, 0xFFFFFFFEU);
+}
+
+// 32 leading zeros put codeNum at 2^32 - 1 + rest, past what the caller can hold
+TEST(NalUnitBitstreamParser, RejectsAnExpGolombCodeOutOfTheUint32Range)
+{
+	const auto bitstream = MakeUevBitstream(32, 1);
+	NalUnitBitstreamParser parser(bitstream.data(), bitstream.size());
+
+	uint32_t value = 0;
+	EXPECT_FALSE(parser.ReadUEV(value));
+}
+
+// A zero run this long once wrapped the bit count into the uint8_t width parameter of ReadBits(),
+// which reported success and left the bit position past the code it never decoded
+TEST(NalUnitBitstreamParser, RejectsALongZeroRunInsteadOfWrappingTheBitCount)
+{
+	for (int leading_zero_bits : {33, 255, 256, 264})
+	{
+		const auto bitstream = MakeUevBitstream(leading_zero_bits, 0);
+		NalUnitBitstreamParser parser(bitstream.data(), bitstream.size());
+
+		uint32_t value = 0;
+		EXPECT_FALSE(parser.ReadUEV(value)) << "leading_zero_bits: " << leading_zero_bits;
 	}
 }

--- a/src/modules/bitstream/nalu/nal_unit_bitstream_parser_test.cpp
+++ b/src/modules/bitstream/nalu/nal_unit_bitstream_parser_test.cpp
@@ -57,8 +57,8 @@ namespace
 TEST(NalUnitBitstreamParser, SkipsAnEmulationPreventionByte)
 {
 	// 00 00 03 01: the 0x03 is an escape, so 0x01 is the byte that follows the two zeros
-	const uint8_t nal[]			   = {0x67, 0x00, 0x00, 0x03, 0x01};
-	const uint8_t unescaped[]	   = {0x67, 0x00, 0x00, 0x01};
+	const uint8_t nal[]		  = {0x67, 0x00, 0x00, 0x03, 0x01};
+	const uint8_t unescaped[] = {0x67, 0x00, 0x00, 0x01};
 	NalUnitBitstreamParser parser(nal, sizeof(nal));
 
 	for (size_t i = 0; i < sizeof(unescaped); i++)
@@ -122,4 +122,26 @@ TEST(NalUnitBitstreamParser, RejectsALongZeroRunInsteadOfWrappingTheBitCount)
 		uint32_t value = 0;
 		EXPECT_FALSE(parser.ReadUEV(value)) << "leading_zero_bits: " << leading_zero_bits;
 	}
+}
+
+// Skip() forwards the count to ReadBits(), whose width parameter is a uint8_t capped at the
+// width of its output. 88 is the count h265_parser.cpp uses for a sub-layer profile_tier_level.
+TEST(NalUnitBitstreamParser, SkipsACountWiderThanOneReadBitsCall)
+{
+	for (uint32_t count : {1U, 8U, 64U, 65U, 88U, 255U, 256U, 264U, 1024U})
+	{
+		std::vector<uint8_t> bytes(256, 0xAA);
+		NalUnitBitstreamParser parser(bytes.data(), bytes.size());
+
+		ASSERT_TRUE(parser.Skip(count)) << "count: " << count;
+		EXPECT_EQ(parser.BitsConsumed(), count) << "count: " << count;
+	}
+}
+
+TEST(NalUnitBitstreamParser, RejectsASkipPastTheEndOfTheBitstream)
+{
+	const uint8_t bytes[] = {0xAA, 0xBB, 0xCC, 0xDD};
+	NalUnitBitstreamParser parser(bytes, sizeof(bytes));
+
+	EXPECT_FALSE(parser.Skip((sizeof(bytes) * 8) + 1));
 }

--- a/src/modules/bitstream/nalu/nal_unit_test_helpers.h
+++ b/src/modules/bitstream/nalu/nal_unit_test_helpers.h
@@ -1,0 +1,80 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 OvenMediaLabs. All rights reserved.
+//
+//==============================================================================
+
+//  Bitstream writers shared by the parser test suites, so that every suite
+//  agrees on what bytes a NAL unit holds. Escaping is not duplicated here:
+//  tests call `NalUnitInsertor::EmulationPreventionBytes()` directly.
+
+#pragma once
+
+#include <base/ovlibrary/bit_writer.h>
+#include <base/ovlibrary/data.h>
+#include <modules/bitstream/nalu/nal_unit_insertor.h>
+
+#include <memory>
+#include <vector>
+
+namespace ome_test
+{
+	// ue(v) (ITU-T H.264 9.1, Rec. ITU-T H.265 9.2)
+	inline void WriteUE(ov::BitWriter &writer, uint32_t value)
+	{
+		uint64_t code_num = static_cast<uint64_t>(value) + 1;
+
+		int numbits		  = 0;
+		while ((code_num >> (numbits + 1)) != 0)
+		{
+			numbits++;
+		}
+
+		if (numbits > 0)
+		{
+			writer.WriteBits(numbits, 0);
+		}
+
+		writer.WriteBits(numbits + 1, code_num);
+	}
+
+	// se(v)
+	inline void WriteSE(ov::BitWriter &writer, int32_t value)
+	{
+		const auto code = (value <= 0)
+							  ? static_cast<uint32_t>(-2 * static_cast<int64_t>(value))
+							  : static_cast<uint32_t>((2 * static_cast<int64_t>(value)) - 1);
+
+		WriteUE(writer, code);
+	}
+
+	// rbsp_trailing_bits(): stop bit '1' then zero-pad to a byte boundary
+	inline void WriteTrailing(ov::BitWriter &writer)
+	{
+		writer.WriteBits(1, 1);
+
+		while ((writer.GetBitCount() % 8) != 0)
+		{
+			writer.WriteBits(1, 0);
+		}
+	}
+
+	inline std::vector<uint8_t> ToBytes(ov::BitWriter &writer)
+	{
+		return std::vector<uint8_t>(writer.GetData(), writer.GetData() + writer.GetDataSize());
+	}
+
+	// Turns an RBSP into an EBSP with the same escaper the encoders use
+	inline std::vector<uint8_t> ApplyEmulationPrevention(const std::vector<uint8_t> &rbsp)
+	{
+		auto ebsp = NalUnitInsertor::EmulationPreventionBytes(
+			std::make_shared<ov::Data>(rbsp.data(), rbsp.size()));
+
+		const auto *bytes = ebsp->GetDataAs<uint8_t>();
+
+		return std::vector<uint8_t>(bytes, bytes + ebsp->GetLength());
+	}
+}  // namespace ome_test

--- a/src/modules/bitstream/nalu/nal_unit_test_helpers.h
+++ b/src/modules/bitstream/nalu/nal_unit_test_helpers.h
@@ -7,9 +7,9 @@
 //
 //==============================================================================
 
-//  Bitstream writers shared by the parser test suites, so that every suite
-//  agrees on what bytes a NAL unit holds. Escaping is not duplicated here:
-//  tests call `NalUnitInsertor::EmulationPreventionBytes()` directly.
+//  Bitstream writers shared by the parser test suites, so that no suite carries its own copy.
+//  `ApplyEmulationPrevention()` is a wrapper over `NalUnitInsertor::EmulationPreventionBytes()`,
+//  not a second implementation of the escaping rule.
 
 #pragma once
 


### PR DESCRIPTION
## Summary

An H.264 SPS whose VUI `timing_info` carries `num_units_in_tick = 0x80000000` terminates the process with SIGFPE.
The frame rate computation guards `num_units_in_tick` against 0, but it divides by `2 * num_units_in_tick`, which wraps to a zero divisor in 32-bit unsigned arithmetic.
The division runs on the MediaRouter inbound worker, reached from `MediaRouterNormalize::ProcessH264AnnexBStream()` and `ProcessH264AVCCStream()` through `AVCDecoderConfigurationRecord::AddSPS()`, so a single SPS from any H.264 ingest takes the whole server down.
The defect dates back to f0665c532 and first shipped in v0.10.8; the `num_units_in_tick != 0` guard added later does not cover the overflow.

Review turned up more defects in the same parsing layer, and this PR takes them as well so the part is stabilized in one go.

## Changes

### The reported crash

- `h264_parser.cpp`: widen `num_units_in_tick` to `uint64_t` before doubling it, so the divisor can no longer wrap to zero. `num_units_in_tick == 0` keeps yielding an fps of 0 as before.

### Shared bitstream reader

- `nal_unit_bitstream_parser.cpp`: reject an Exp-Golomb code with more than 31 leading zero bits, and compute the shift on an unsigned `1`. codeNum tops out at `2^32 - 2` with 31 leading zeros, which is the range every `ue(v)` element is defined over (Rec. ITU-T H.264 clause 9.1 sets no global bound, but `pan_scan_rect_id` and the other widest elements are capped there). The range check also removes the `int` to `uint8_t` narrowing that made a 256-zero code report success with a bogus value while leaving the bit position desynchronized.
- The length check runs inside the leading-zero loop, so a hostile NAL is refused after 32 bits instead of after the whole run. An 8 Mbit zero run cost 24 ms at `-O2` before and returns immediately now.
- `Skip()` consumes its count in 64 bit steps. It forwarded the count to `ReadBits()`, whose width parameter is a `uint8_t` capped at the width of its output, so `Skip(88)` always failed and an HEVC `profile_tier_level()` with `sub_layer_profile_present_flag[i] == 1` never parsed, while `Skip(256)` reported success after consuming nothing.
- Dropped the dead `else` that reassigned `value` to the 0 it already holds.

### Frame rate derivation

- `h264_parser.cpp`: derive the frame rate whenever `timing_info` is present. Rec. ITU-T H.264 E.2.1 defines the clock tick from `num_units_in_tick` and `time_scale` alone, and `fixed_frame_rate_flag` only constrains how evenly the output times are spaced. The flag is clear by default for x264 and openh264, so gating on it left `_fps` at 0 for most streams.
- `h265_parser.h`: return 0 from `H265SPS::GetFps()` when the tick count is 0, which is the case whenever the VUI carries no `timing_info`, and cast the numerator so the division does not truncate before the conversion to `float`. `60000 / 2002` reported 29.00 instead of 29.97.

### Tests

- New `h264_parser_test.cpp` covers the timing_info fields: a sane 30 fps SPS, `num_units_in_tick = 0x80000000` against several `time_scale` values, a zero tick count, and a derivable rate with `fixed_frame_rate_flag` clear.
- `nal_unit_bitstream_parser_test.cpp` covers the `ue(v)` boundary at `0xFFFFFFFE`, the rejected 32-zero length, long zero runs, and `Skip()` counts of 1 through 1024 asserting `BitsConsumed()`.
- `h265_parser_test.cpp` parses an SPS instead of default-constructing one for the fps guard, and adds a sub-layer `profile_tier_level` case that aborts on the pre-fix `Skip()` in a DEBUG build. `BuildSps()` takes an optional VUI so timing_info cases can be built.
- The `ue(v)` writers moved into `nalu/nal_unit_test_helpers.h`, and escaping now goes through `NalUnitInsertor::EmulationPreventionBytes()` instead of a per-suite copy. The two escapers were compared exhaustively over every sequence of length 1..7 from {00,01,02,03,04,FF} plus 200000 random sequences before the swap, with zero mismatches.

## Compatibility

Conformant bitstreams decode to the same values, with one intended change: an SPS that carries `timing_info` with `fixed_frame_rate_flag` clear now reports its derived frame rate instead of 0.
`H264SPS::GetFps()` and `H265SPS::GetFps()` are read only by `GetInfoString()` today, which nothing calls, so no live path changes behavior.