### PR TITLE
fix(api): report a failed application creation instead of crashing

### DIFF
--- a/src/api_server/controllers/v1/vhosts/apps/apps_controller.cpp
+++ b/src/api_server/controllers/v1/vhosts/apps/apps_controller.cpp
@@ -79,7 +79,15 @@ namespace api
 						"application",
 						ov::String::FormatString("%s/%s", vhost->GetName().CStr(), app_config.GetName().CStr()));
 
-					auto app	  = GetApplication(vhost, app_config.GetName().CStr());
+					auto app = GetApplication(vhost, app_config.GetName().CStr());
+
+					if (app == nullptr)
+					{
+						throw http::HttpError(http::StatusCode::InternalServerError,
+											  "Could not find the application after creating it: [%s/%s]",
+											  vhost->GetName().CStr(), app_config.GetName().CStr());
+					}
+
 					auto app_json = ::serdes::JsonFromApplication(app);
 
 					Json::Value response;
@@ -185,6 +193,12 @@ namespace api
 				ov::String::FormatString("%s/%s", vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr()));
 
 			auto app_metrics = GetApplication(vhost, app_config.GetName().CStr());
+
+			if (app_metrics == nullptr)
+			{
+				throw http::HttpError(http::StatusCode::InternalServerError, "Could not find the application after recreating it: [%s/%s]",
+									  vhost->GetName().CStr(), app_config.GetName().CStr());
+			}
 
 			return ::serdes::JsonFromApplication(app_metrics);
 		}

--- a/src/api_server/controllers/v1/vhosts/apps/output_profiles/output_profiles_controller.cpp
+++ b/src/api_server/controllers/v1/vhosts/apps/output_profiles/output_profiles_controller.cpp
@@ -137,7 +137,15 @@ namespace api
 			std::shared_ptr<mon::ApplicationMetrics> new_app;
 			Json::Value new_app_json;
 
-			new_app		 = GetApplication(vhost, app->GetVHostAppName().GetAppName().CStr());
+			new_app = GetApplication(vhost, app->GetVHostAppName().GetAppName().CStr());
+
+			if (new_app == nullptr)
+			{
+				throw http::HttpError(http::StatusCode::InternalServerError,
+									  "Could not find the application after recreating it: [%s/%s]",
+									  vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr());
+			}
+
 			new_app_json = new_app->GetConfig().ToJson();
 
 			for (auto &response_profile : response)
@@ -253,11 +261,17 @@ namespace api
 
 			auto new_app = GetApplication(vhost, app->GetVHostAppName().GetAppName().CStr());
 
+			if (new_app == nullptr)
+			{
+				throw http::HttpError(http::StatusCode::InternalServerError, "Could not find the application after recreating it: [%s/%s]",
+									  vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr());
+			}
+
 			Json::Value value;
 
 			if (FindOutputProfile(new_app, profile_name, &value) < 0)
 			{
-				http::HttpError(http::StatusCode::InternalServerError, "Output profile is modified, but not found");
+				throw http::HttpError(http::StatusCode::InternalServerError, "Output profile is modified, but not found");
 			}
 
 			return value;

--- a/src/api_server/helpers/helpers.cpp
+++ b/src/api_server/helpers/helpers.cpp
@@ -376,7 +376,7 @@ namespace api
 		auto orchestrator = ocst::Orchestrator::GetInstance();
 		auto result		  = orchestrator->CreateApplication(*vhost, app_config);
 
-		if (result != ocst::Result::Succeeded)
+		if (result == ocst::Result::Failed)
 		{
 			// The old application is already deleted, so bring it back with its previous config
 			if (orchestrator->CreateApplication(*vhost, app->GetConfig(), app->IsDynamicApp()) != ocst::Result::Succeeded)

--- a/src/api_server/helpers/helpers.cpp
+++ b/src/api_server/helpers/helpers.cpp
@@ -11,6 +11,8 @@
 #include <modules/http/http.h>
 #include <modules/json_serdes/converters.h>
 
+#include "../api_private.h"
+
 namespace api
 {
 	std::map<uint32_t, std::shared_ptr<mon::HostMetrics>> GetVirtualHostList()
@@ -371,8 +373,21 @@ namespace api
 			"application",
 			ov::String::FormatString("%s/%s", vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr()));
 
+		auto orchestrator = ocst::Orchestrator::GetInstance();
+		auto result		  = orchestrator->CreateApplication(*vhost, app_config);
+
+		if (result != ocst::Result::Succeeded)
+		{
+			// The old application is already deleted, so bring it back with its previous config
+			if (orchestrator->CreateApplication(*vhost, app->GetConfig(), app->IsDynamicApp()) != ocst::Result::Succeeded)
+			{
+				logte("Could not restore the application after a failed recreation: [%s/%s]",
+					  vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr());
+			}
+		}
+
 		ThrowIfOrchestratorNotSucceeded(
-			ocst::Orchestrator::GetInstance()->CreateApplication(*vhost, app_config),
+			result,
 			"create",
 			"application",
 			ov::String::FormatString("%s/%s", vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr()));

--- a/src/api_server/helpers/helpers.cpp
+++ b/src/api_server/helpers/helpers.cpp
@@ -11,8 +11,6 @@
 #include <modules/http/http.h>
 #include <modules/json_serdes/converters.h>
 
-#include "../api_private.h"
-
 namespace api
 {
 	std::map<uint32_t, std::shared_ptr<mon::HostMetrics>> GetVirtualHostList()
@@ -373,21 +371,8 @@ namespace api
 			"application",
 			ov::String::FormatString("%s/%s", vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr()));
 
-		auto orchestrator = ocst::Orchestrator::GetInstance();
-		auto result		  = orchestrator->CreateApplication(*vhost, app_config);
-
-		if (result == ocst::Result::Failed)
-		{
-			// The old application is already deleted, so bring it back with its previous config
-			if (orchestrator->CreateApplication(*vhost, app->GetConfig(), app->IsDynamicApp()) != ocst::Result::Succeeded)
-			{
-				logte("Could not restore the application after a failed recreation: [%s/%s]",
-					  vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr());
-			}
-		}
-
 		ThrowIfOrchestratorNotSucceeded(
-			result,
+			ocst::Orchestrator::GetInstance()->CreateApplication(*vhost, app_config),
 			"create",
 			"application",
 			ov::String::FormatString("%s/%s", vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr()));

--- a/src/orchestrator/orchestrator.cpp
+++ b/src/orchestrator/orchestrator.cpp
@@ -1555,7 +1555,9 @@ namespace ocst
 		}
 
 		logte("Trying to rollback for the application [%s]", app_info.GetVHostAppName().CStr());
-		return DeleteApplication(app_info);
+		DeleteApplication(app_info);
+
+		return Result::Failed;
 	}
 
 	std::shared_ptr<Application> Orchestrator::GetApplication(const info::VHostAppName &vhost_app_name) const


### PR DESCRIPTION
## Summary

A single REST call could kill the server.
`Orchestrator::CreateApplication()` returned the result of its rollback `DeleteApplication()` after a module rejected the application, so a failed creation was reported as `Succeeded`.
The output profile and app controllers then dereferenced the null application returned by `GetApplication()` and the process died with SIGSEGV.
Any configuration that Transcoder rejects triggers it: an empty or duplicated output profile name, or an empty or duplicated output stream name.

## Changes

- `Orchestrator::CreateApplication()` returns `Failed` after the rollback instead of the rollback result.
- `RecreateApplication()` throws 500 when the new configuration cannot be created. The application stays deleted in that case, same as `AppsController::OnPatchApp()`; validating the configuration before the delete is a follow-up.
- `OutputProfilesController` POST/PATCH and `AppsController` POST/PATCH check the application returned by `GetApplication()` after creation and throw 500 instead of dereferencing null.
- `OutputProfilesController::OnPatchOutputProfile()` now actually throws the `HttpError` it built when the modified profile is not found.

### Behavior change

Because a rejected application is now reported as a failure, the callers that were already prepared for it take their existing failure paths:

- Startup: an application rejected by a module (for example a duplicated `OutputStreamName` in `Server.xml`) used to be dropped silently while the server kept running. `CreateVirtualHost()` now rolls back the virtual host and the server refuses to start, logging which application failed.
- `POST /v1/vhosts` with applications in the body returns 400 and rolls back the virtual host instead of returning 200 with the rejected application missing.
- `POST /v1/vhosts/{vhost}/apps` returns 500 instead of crashing.
- Pull-based dynamic application creation already failed on the follow-up lookup, so its result is unchanged.

## Testing

Verified with a debug build (clang, thread-safety analysis on) and `ac57f5568` as the before/after pair.

1. Create a vhost and an app through the API, then POST an output profile whose `outputStreamName` duplicates the default profile:

   ```bash
   TOKEN=$(printf 'ome-access-token' | base64)
   curl -s -X POST -H "Authorization: Basic $TOKEN" -H 'Content-Type: application/json' -d '[{"name":"apitest","host":{"names":["*"]}}]' http://127.0.0.1:8081/v1/vhosts
   curl -s -X POST -H "Authorization: Basic $TOKEN" -H 'Content-Type: application/json' -d '[{"name":"app","type":"live"}]' http://127.0.0.1:8081/v1/vhosts/apitest/apps
   curl -s -X POST -H "Authorization: Basic $TOKEN" -H 'Content-Type: application/json' -d '[{"name":"dup","outputStreamName":"${OriginStreamName}","encodes":{"videos":[{"name":"v","codec":"h264","width":320,"height":180,"bitrate":"200000","framerate":15}]}}]' http://127.0.0.1:8081/v1/vhosts/apitest/apps/app/outputProfiles
   ```

   Before: no response, `received signal 11 (SIGSEGV)` in the log.
   After: `500 Failed to create the application: [apitest/app]`, the server stays up, and `GET /v1/vhosts/apitest/apps/app/outputProfiles` still lists only `default`.

2. Same with PATCH: create a profile `p2` with `${OriginStreamName}_p2`, then PATCH its `outputStreamName` to `${OriginStreamName}`.
   Before: SIGSEGV.
   After: `500 Failed to create the application: [apitest/app]` and the server stays up. The application is deleted, so `GET /v1/vhosts/apitest/apps/app` returns 404.

3. `POST /v1/vhosts/apitest/apps` with two profiles sharing an `outputStreamName` in the body.
   Before: SIGSEGV. After: 500, the server stays up, and the application is deleted.

4. Start the server with a `Server.xml` whose application has two `<OutputProfile>` entries with the same `<OutputStreamName>`.
   Before: the server starts with that application silently missing. After: `Could not create VirtualHost(default)` and the server exits.

5. Non-duplicated POST/PATCH/DELETE of output profiles and PATCH of an app still return 200.
   Unit tests: 854 passed, 0 failed.
