### PR TITLE
fix: improve the error log when codec creation fails

### DIFF
--- a/src/transcoder/transcoder_stream.cpp
+++ b/src/transcoder/transcoder_stream.cpp
@@ -2276,3 +2276,21 @@ void TranscoderStream::NotifyDeleteStreams()
 	}
 }
 
+void TranscoderStream::SetState(State state)
+{
+	auto prev_state = _state.exchange(state);
+	if (prev_state == state)
+	{
+		return;
+	}
+
+	auto message = ov::String::FormatString("%s stream state changed: %s -> %s", _log_prefix.CStr(), GetStateString(prev_state), GetStateString(state));
+	if (state == State::ERROR)
+	{
+		logte("%s", message.CStr());
+	}
+	else
+	{
+		logti("%s", message.CStr());
+	}
+}

--- a/src/transcoder/transcoder_stream.h
+++ b/src/transcoder/transcoder_stream.h
@@ -87,11 +87,7 @@ private:
 	}
 
 	// Set the stream state
-	void SetState(State state)
-	{
-		logt("Transcoder", "%s stream state changed: %s -> %s", _log_prefix.CStr(), GetStateString(_state), GetStateString(state));
-		_state.exchange(state);
-	}
+	void SetState(State state);
 
 	State GetState() const
 	{


### PR DESCRIPTION
## Summary

When a transcoder stream fails to build its encoders or filters, the failure has to be visible in the log. `SetState()` reported the transition with `logt()`, which is a no-op in a release build, so a stream falling into `ERROR` left no record of it. And because the "from" state was read separately from `_state.exchange()`, the message could name a transition that never happened.

The transition is now logged at info, at error when the stream enters `ERROR`, and built from the state `exchange()` actually replaced.

## Changes

- `SetState()` moves out of the header into `transcoder_stream.cpp`.
- The previous state comes from `exchange()`'s return value.
- A transition to the state the stream is already in returns without logging. `ChangeOutputFormat()`   sets `ERROR` on every failed encoder/filter rebuild, so a stream that keeps changing format would   otherwise repeat the same line.
- The message is logged at info, and at error for a transition into `ERROR`, so it survives a release build.

## Testing

Build only - the change adds no behaviour beyond what it logs.

```bash
cmake --build build/DebugGpu --target transcoder
```
