### PR TITLE
docs: describe the connection object in the stream REST API, alert, and transcode webhook docs

### DIFF
--- a/docs/alert.md
+++ b/docs/alert.md
@@ -93,6 +93,7 @@ X-OME-Signature: f871jd991jj1929jsjd91pqa0amm1
 		}
 	],
 	"sourceInfo":{
+		"name":"stream",
 		"createdTime":"2023-04-07T21:15:24.487+09:00",
 		"sourceType":"Rtmp",
 		"sourceUrl":"TCP://192.168.0.220:10639",

--- a/docs/alert.md
+++ b/docs/alert.md
@@ -96,6 +96,14 @@ X-OME-Signature: f871jd991jj1929jsjd91pqa0amm1
 		"createdTime":"2023-04-07T21:15:24.487+09:00",
 		"sourceType":"Rtmp",
 		"sourceUrl":"TCP://192.168.0.220:10639",
+		"connection":{
+			"transport":"TCP",
+			"protocol":"TCP",
+			"localAddress":"192.168.0.160",
+			"localPort":1935,
+			"remoteAddress":"192.168.0.220",
+			"remotePort":10639
+		},
 		"tracks":[
 			{
 				"id":0,
@@ -142,7 +150,7 @@ Here is a detailed explanation of each element of JSON payload:
 | serverInfo | Information identifying the server that sent the notification. This is useful for distinguishing alerts when multiple OvenMediaEngine instances report to the same notification server.<br />`serverID`: Unique ID of the server. It is generated when the server first starts and is persisted in the `Server.id` file in the configuration directory. The configuration directory must be writable for the ID to remain stable across restarts; otherwise (e.g. a read-only ConfigMap mount on Kubernetes) a new ID is generated at every startup.<br />`serverName`: The value of `<Server><Name>` in the configuration. Omitted if not set.<br />`hostname`: The OS hostname of the machine running OvenMediaEngine. On Kubernetes this is the pod name, and on Docker it is the container ID unless `--hostname` is specified. Omitted in the rare case that the hostname cannot be retrieved from the OS.<br />`ipAddresses`: IP addresses of the server, captured at server startup. The public IP addresses resolved from `<StunServer>` (if configured) come first, followed by the local interface addresses (excluding loopback and IPv6 link-local addresses). Omitted when no address is available. |
 | sourceUri  | URI information of the detected source.<br />`INGRESS`: #&#x3C;vhost>#&#x3C;application>/&#x3C;input_stream>                                                                      |
 | messages   | List of messages detected by the Rules.                                                                                                                                           |
-| sourceInfo | Detailed information about the source at the time of detection. It is identical to the response of the REST API's source information query for the detected source.               |
+| sourceInfo | Detailed information about the source, captured when the notification is sent. It is the stream `name` plus the fields of the `input` object in the [Stream REST API](rest-api/v1/virtualhost/application/stream/README.md#get-stream-info) response, at the top level, so it also includes `connection`. For a WebRTC source, `connection` is present only after ICE has selected a candidate pair, so the notification sent when the stream is created normally does not have it yet, while later ones do. A later ICE candidate pair switch changes the value returned by the REST API and is reflected in later notifications, but does not trigger a notification of its own. |
 | type       | It represents the format of the JSON payload. The information of the JSON elements can vary depending on the value of the type.                                                   |
 
 #### Messages

--- a/docs/rest-api/v1/virtualhost/application/stream/README.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/README.md
@@ -320,6 +320,14 @@ Content-Type: application/json
 			"createdTime": "2026-07-29T15:04:21.879+09:00",
 			"sourceType": "Rtmp",
 			"sourceUrl": "tcp://192.168.0.200:41008",
+			"connection": {
+				"transport": "TCP",
+				"protocol": "TCP",
+				"localAddress": "192.168.0.160",
+				"localPort": 1935,
+				"remoteAddress": "192.168.0.200",
+				"remotePort": 41008
+			},
 			"tracks": [
 				{
 					"id": 0,
@@ -475,6 +483,13 @@ Content-Type: application/json
 ```
 keyFrameInterval is GOP size
 ```
+
+Notes on the `connection` object
+
+- `connection` describes the network connection the input stream arrives on. It is present for WebRTC, RTMP, SRT and MPEG-TS inputs and omitted for other source types.
+- `transport` is the transport the sender uses: `UDP`, `TCP`, `SRT` or `TURN`. `protocol` is the protocol of the underlying socket (`UDP`, `TCP` or `SRT`). The two differ only for WebRTC through the built-in TURN server, where `transport` is `TURN` and `protocol` shows whether the sender reached the TURN server over UDP or TCP.
+- `localAddress`/`localPort` are the OvenMediaEngine side of the connection and `remoteAddress`/`remotePort` are the sender side. With TURN they describe the leg between the sender and the TURN server. An address and its port are omitted together when they are not known.
+- For WebRTC, `connection` appears once ICE has selected a candidate pair, so it is absent while the connection is still being set up. When ICE later switches to another pair, the values follow the new pair.
 
 Notes on the track fields
 
@@ -1061,10 +1076,48 @@ components:
         sourceUrl:
           type: string
           description: Omitted when the provider has no source address.
+        connection:
+          $ref: '#/components/schemas/Connection'
         tracks:
           type: array
           items:
             $ref: '#/components/schemas/Track'
+
+    Connection:
+      type: object
+      description: >-
+        Network connection the input stream arrives on. Present only for WebRTC, RTMP, SRT and MPEG-TS
+        sources; for WebRTC, only after ICE has selected a candidate pair.
+      required:
+        - transport
+      properties:
+        transport:
+          type: string
+          description: Transport used by the sender. TURN means a WebRTC sender relayed through the built-in TURN server.
+          enum:
+            - UDP
+            - TCP
+            - SRT
+            - TURN
+        protocol:
+          type: string
+          description: Protocol of the underlying socket. Differs from transport only when transport is TURN.
+          enum:
+            - UDP
+            - TCP
+            - SRT
+        localAddress:
+          type: string
+          description: Address on the OvenMediaEngine side. Omitted when not known.
+        localPort:
+          type: integer
+          description: Port on the OvenMediaEngine side. Omitted when not known.
+        remoteAddress:
+          type: string
+          description: Address on the sender side. Omitted when not known.
+        remotePort:
+          type: integer
+          description: Port on the sender side. Omitted when not known.
 ```
 
 </details>

--- a/docs/rest-api/v1/virtualhost/application/stream/README.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/README.md
@@ -319,7 +319,7 @@ Content-Type: application/json
 		"input": {
 			"createdTime": "2026-07-29T15:04:21.879+09:00",
 			"sourceType": "Rtmp",
-			"sourceUrl": "tcp://192.168.0.200:41008",
+			"sourceUrl": "TCP://192.168.0.200:41008",
 			"connection": {
 				"transport": "TCP",
 				"protocol": "TCP",
@@ -1090,6 +1090,7 @@ components:
         sources; for WebRTC, only after ICE has selected a candidate pair.
       required:
         - transport
+        - protocol
       properties:
         transport:
           type: string

--- a/docs/rest-api/v1/virtualhost/application/stream/README.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/README.md
@@ -1109,16 +1109,16 @@ components:
             - SRT
         localAddress:
           type: string
-          description: Address on the OvenMediaEngine side. Omitted when not known.
+          description: Address on the OvenMediaEngine side. Omitted together with localPort when the local address is not known.
         localPort:
           type: integer
-          description: Port on the OvenMediaEngine side. Omitted when not known.
+          description: Port on the OvenMediaEngine side. Omitted together with localAddress when the local address is not known.
         remoteAddress:
           type: string
-          description: Address on the sender side. Omitted when not known.
+          description: Address on the sender side. Omitted together with remotePort when the remote address is not known.
         remotePort:
           type: integer
-          description: Port on the sender side. Omitted when not known.
+          description: Port on the sender side. Omitted together with remoteAddress when the remote address is not known.
 ```
 
 </details>

--- a/docs/transcoding/transcodewebhook.md
+++ b/docs/transcoding/transcodewebhook.md
@@ -54,6 +54,8 @@ When the Control Server responds with error status codes such as 400 Bad Request
 ### **Request (OME → Control Server)**
 
 OvenMediaEngine sends requests to the Control Server in the following format.
+The `stream` object is the stream `name` plus the fields of the `input` object in the [Stream REST API](../rest-api/v1/virtualhost/application/stream/README.md#get-stream-info) response, including `connection`, with `virtualHost` and `application` added.
+`connection` is the connection in use when the request is sent. OvenMediaEngine sends this request once per input stream, after the input tracks have been parsed, so a later ICE candidate pair switch is not reported through the webhook. For WebRTC the request goes out only after media has started flowing, so `connection` is present.
 
 ```
 POST /configured/target/url/ HTTP/1.1
@@ -69,6 +71,14 @@ X-OME-Signature: f871jd991jj1929jsjd91pqa0amm1
     "application": "app",
     "sourceType": "Rtmp",
     "sourceUrl": "TCP://192.168.0.220:2216",
+    "connection": {
+      "transport": "TCP",
+      "protocol": "TCP",
+      "localAddress": "192.168.0.160",
+      "localPort": 1935,
+      "remoteAddress": "192.168.0.220",
+      "remotePort": 2216
+    },
     "createdTime": "2025-06-05T14:43:54.001+09:00",
     "tracks": [
       {


### PR DESCRIPTION
## Summary

Follow-up docs for #2300, which added a `connection` object (transport, protocol, local and remote address/port) to the ingress stream serialization. This PR describes the object in the three places it appears: the Stream REST API response, Alert notifications, and the TranscodeWebhook request.

## Changes

- `docs/rest-api/v1/virtualhost/application/stream/README.md`
  - Add `connection` to the `input` object in the Get Stream Info response sample.
  - Add a "Notes on the `connection` object" list covering which source types report it (WebRTC, RTMP, SRT, MPEG-TS), the meaning of `transport` vs `protocol` (they differ only for WebRTC through the built-in TURN server), what the local and remote address pairs refer to, and that for WebRTC the object appears once ICE has selected a candidate pair and follows later pair switches.
  - Add a `Connection` schema to the OpenAPI block and reference it from `Input`.
- `docs/alert.md`
  - Add `connection` to the `sourceInfo` sample.
  - Rewrite the `sourceInfo` row to say it is captured when the notification is sent, that it is the stream `name` plus the fields of the REST API `input` object, and that a WebRTC created-notification normally has no `connection` yet while later notifications do. Clarify that an ICE candidate pair switch is reflected in later notifications but does not trigger one of its own.
- `docs/transcoding/transcodewebhook.md`
  - Add `connection` to the `stream` object in the request sample.
  - Note that `stream` is the stream `name` plus the REST API `input` fields with `virtualHost` and `application` added, that `connection` is the connection in use when the request is sent, and that the request goes out once per input stream so a later ICE switch is not reported through the webhook.