### PR TITLE
feat(alert): support multiple webhooks and deprecate single url settings

### DIFF
--- a/docs/alert.md
+++ b/docs/alert.md
@@ -15,9 +15,17 @@ Alert can be set up on `<Server>`, as shown below.
 ```xml
 <Server version="8">
 	<Alert>
-		<Url>http://192.168.0.161:9595/alert/notification</Url>
-		<SecretKey>1234</SecretKey>
-		<Timeout>3000</Timeout>
+		<Webhooks>
+			<Webhook>
+				<Url>http://192.168.0.161:9595/alert/notification</Url>
+				<SecretKey>1234</SecretKey>
+				<Timeout>3000</Timeout>
+			</Webhook>
+			<Webhook>
+				<Url>http://192.168.0.162:9595/alert/notification</Url>
+				<SecretKey>5678</SecretKey>
+			</Webhook>
+		</Webhooks>
 		<Rules>
 			<Ingress>
 				<MinBitrate>2000000</MinBitrate>
@@ -38,12 +46,29 @@ Alert can be set up on `<Server>`, as shown below.
 </Server>
 ```
 
-| Key       | Description                                                                                                                  |
-| --------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| Url       | The HTTP Server to receive the notification. HTTP and HTTPS are available.                                                   |
-| Secretkey | The secret key used when encrypting with HMAC-SHA1<br />For more information, see <a href="alert.md#security">Security</a>.  |
-| Timeout   | Time to wait for a response after request. (in milliseconds)                                                                 |
-| Rules     | Defines anomalies and patterns of interest to be detected.                                                                   |
+| Key      | Description                                                                                       |
+| -------- | --------------------------------------------------------------------------------------------------- |
+| Webhooks | A list of webhooks to receive the notifications. Notifications are sent to every `<Webhook>`.     |
+| Rules    | Defines anomalies and patterns of interest to be detected.                                        |
+
+### Webhook
+
+| Key       | Description                                                                                                                              |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Url       | The HTTP Server to receive the notification. HTTP and HTTPS are available.                                                               |
+| Secretkey | (Optional) The secret key used when encrypting with HMAC-SHA1<br />For more information, see <a href="alert.md#security">Security</a>.   |
+| Timeout   | (Optional, Default: 3000) Time to wait for a response after request. (in milliseconds)                                                   |
+
+:::warning
+`<Url>`, `<SecretKey>` and `<Timeout>` set directly under `<Alert>` are deprecated and will be removed in a future release. During the deprecation period they still work as a single webhook. Please use `<Webhooks>` instead.
+:::
+
+:::info
+Notifications are sent to each webhook sequentially, and a failed request is retried up to 2 times. A webhook that responds slowly or is unreachable therefore delays delivery to the webhooks after it. To keep alert delivery healthy:
+
+* Prefer an IP address for `<Url>`, or a hostname whose DNS server is reliable — the hostname is resolved on every request and DNS resolution is not covered by `<Timeout>`.
+* Do not set `<Timeout>` to `0`, which means waiting for a response indefinitely.
+:::
 
 ### Rules
 

--- a/docs/alert.md
+++ b/docs/alert.md
@@ -56,7 +56,7 @@ Alert can be set up on `<Server>`, as shown below.
 | Key       | Description                                                                                                                              |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | Url       | The HTTP Server to receive the notification. HTTP and HTTPS are available.                                                               |
-| Secretkey | (Optional) The secret key used when encrypting with HMAC-SHA1<br />For more information, see <a href="alert.md#security">Security</a>.   |
+| SecretKey | (Optional) The secret key used when encrypting with HMAC-SHA1<br />For more information, see <a href="alert.md#security">Security</a>.   |
 | Timeout   | (Optional, Default: 3000) Time to wait for a response after request. (in milliseconds)                                                   |
 
 :::warning
@@ -64,7 +64,7 @@ Alert can be set up on `<Server>`, as shown below.
 :::
 
 :::info
-Notifications are sent to each webhook sequentially, and a failed request is retried up to 2 times. A webhook that responds slowly or is unreachable therefore delays delivery to the webhooks after it. To keep alert delivery healthy:
+Notifications are sent to each webhook sequentially, and a request that fails at the connection level (e.g. connection timeout or network error) is retried up to 2 times. An HTTP error response (a status code other than 200) is not retried. A webhook that responds slowly or is unreachable therefore delays delivery to the webhooks after it. To keep alert delivery healthy:
 
 * Prefer an IP address for `<Url>`, or a hostname whose DNS server is reliable — the hostname is resolved on every request and DNS resolution is not covered by `<Timeout>`.
 * Do not set `<Timeout>` to `0`, which means waiting for a response indefinitely.

--- a/misc/conf_examples/Server.xml
+++ b/misc/conf_examples/Server.xml
@@ -191,9 +191,15 @@
 	<!--
 		Refer https://airensoft.gitbook.io/ovenmediaengine/alert
 	<Alert>
-		<Url></Url>
-		<SecretKey></SecretKey>
-		<Timeout>3000</Timeout>
+		Notifications are sent to every <Webhook>.
+		<SecretKey> and <Timeout> of each <Webhook> are optional. (Timeout default: 3000)
+		<Webhooks>
+			<Webhook>
+				<Url></Url>
+				<SecretKey></SecretKey>
+				<Timeout>3000</Timeout>
+			</Webhook>
+		</Webhooks>
 		<Rules>
 			<Ingress>
 				<MinBitrate></MinBitrate>

--- a/src/config/items/alert/alert.h
+++ b/src/config/items/alert/alert.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "rules/rules.h"
+#include "webhooks.h"
 
 namespace cfg
 {
@@ -19,7 +20,9 @@ namespace cfg
 		protected:
 			ov::String _url;
 			ov::String _secret_key;
-			int _timeout_msec;
+			int _timeout_msec = 3000;
+
+			Webhooks _webhooks;
 
 			ov::String _rules_file;
 			rule::Rules _rules;
@@ -28,15 +31,29 @@ namespace cfg
 			CFG_DECLARE_CONST_REF_GETTER_OF(GetUrl, _url)
 			CFG_DECLARE_CONST_REF_GETTER_OF(GetSecretKey, _secret_key)
 			CFG_DECLARE_CONST_REF_GETTER_OF(GetTimeoutMsec, _timeout_msec)
+			CFG_DECLARE_CONST_REF_GETTER_OF(GetWebhooks, _webhooks)
 			CFG_DECLARE_CONST_REF_GETTER_OF(GetRulesFile, _rules_file)
 			CFG_DECLARE_CONST_REF_GETTER_OF(GetRules, _rules)
 
 		protected:
 			void MakeList() override
 			{
-				Register("Url", &_url);
-				Register("SecretKey", &_secret_key);
-				Register("Timeout", &_timeout_msec);
+				// <Webhooks> is the standard way to configure notification destinations.
+				// It is Optional only because the deprecated <Url>/<SecretKey>/<Timeout>
+				// below must still be accepted. At least one webhook must be configured,
+				// which is validated in mon::alrt::Alert::Start().
+				Register<Optional>("Webhooks", &_webhooks);
+
+				// Deprecated. The legacy single webhook settings are kept for backward
+				// compatibility during the deprecation period and will be removed in a
+				// future release.
+				Register<Optional>("Url", &_url, nullptr,
+								   [=]() -> std::shared_ptr<ConfigError> {
+									   logw("Config", "Alert.Url, Alert.SecretKey and Alert.Timeout are deprecated and will be removed in a future release. Please use Alert.Webhooks instead.");
+									   return nullptr;
+								   });
+				Register<Optional>("SecretKey", &_secret_key);
+				Register<Optional>("Timeout", &_timeout_msec);
 				Register<Optional, ResolvePath>("RulesFile", &_rules_file);
 				Register<Optional>("Rules", &_rules);
 			}

--- a/src/config/items/alert/alert.h
+++ b/src/config/items/alert/alert.h
@@ -53,7 +53,14 @@ namespace cfg
 									   return nullptr;
 								   });
 				Register<Optional>("SecretKey", &_secret_key);
-				Register<Optional>("Timeout", &_timeout_msec);
+				Register<Optional>("Timeout", &_timeout_msec, nullptr,
+								   [=]() -> std::shared_ptr<ConfigError> {
+									   if (_timeout_msec < 0)
+									   {
+										   return CreateConfigErrorPtr("Timeout must not be negative: %d", _timeout_msec);
+									   }
+									   return nullptr;
+								   });
 				Register<Optional, ResolvePath>("RulesFile", &_rules_file);
 				Register<Optional>("Rules", &_rules);
 			}

--- a/src/config/items/alert/webhook.h
+++ b/src/config/items/alert/webhook.h
@@ -1,0 +1,36 @@
+//=============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Gilhoon Choi
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+namespace cfg
+{
+	namespace alrt
+	{
+		struct Webhook : public Item
+		{
+		protected:
+			ov::String _url;
+			ov::String _secret_key;
+			int _timeout_msec = 3000;
+
+		public:
+			CFG_DECLARE_CONST_REF_GETTER_OF(GetUrl, _url)
+			CFG_DECLARE_CONST_REF_GETTER_OF(GetSecretKey, _secret_key)
+			CFG_DECLARE_CONST_REF_GETTER_OF(GetTimeoutMsec, _timeout_msec)
+
+		protected:
+			void MakeList() override
+			{
+				Register("Url", &_url);
+				Register<Optional>("SecretKey", &_secret_key);
+				Register<Optional>("Timeout", &_timeout_msec);
+			}
+		};
+	}  // namespace alrt
+}  // namespace cfg

--- a/src/config/items/alert/webhook.h
+++ b/src/config/items/alert/webhook.h
@@ -29,7 +29,14 @@ namespace cfg
 			{
 				Register("Url", &_url);
 				Register<Optional>("SecretKey", &_secret_key);
-				Register<Optional>("Timeout", &_timeout_msec);
+				Register<Optional>("Timeout", &_timeout_msec, nullptr,
+								   [=]() -> std::shared_ptr<ConfigError> {
+									   if (_timeout_msec < 0)
+									   {
+										   return CreateConfigErrorPtr("Timeout must not be negative: %d", _timeout_msec);
+									   }
+									   return nullptr;
+								   });
 			}
 		};
 	}  // namespace alrt

--- a/src/config/items/alert/webhooks.h
+++ b/src/config/items/alert/webhooks.h
@@ -1,0 +1,32 @@
+//=============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Gilhoon Choi
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include "webhook.h"
+
+namespace cfg
+{
+	namespace alrt
+	{
+		struct Webhooks : public Item
+		{
+		protected:
+			std::vector<Webhook> _webhook_list;
+
+		public:
+			CFG_DECLARE_CONST_REF_GETTER_OF(GetWebhookList, _webhook_list)
+
+		protected:
+			void MakeList() override
+			{
+				Register("Webhook", &_webhook_list);
+			}
+		};
+	}  // namespace alrt
+}  // namespace cfg

--- a/src/monitoring/alert/alert.cpp
+++ b/src/monitoring/alert/alert.cpp
@@ -18,6 +18,7 @@
 
 #define LONG_KEY_FRAME_INTERVAL_SIZE 4.0
 #define NOTIFICATION_MAX_RETRY_COUNT 2
+#define WEBHOOK_COUNT_WARNING_THRESHOLD 10
 
 namespace mon::alrt
 {
@@ -91,15 +92,58 @@ namespace mon::alrt
 			return false;
 		}
 
-		auto notification_server_url = ov::Url::Parse(alert.GetUrl());
-		if (notification_server_url == nullptr)
+		// Build the webhook list.
+		std::vector<WebhookInfo> webhook_list;
+
+		for (const auto &webhook_config : alert.GetWebhooks().GetWebhookList())
 		{
-			logte("Could not parse notification url: %s", alert.GetUrl().CStr());
+			WebhookInfo webhook;
+
+			webhook.url = ov::Url::Parse(webhook_config.GetUrl());
+			if (webhook.url == nullptr)
+			{
+				logte("Could not parse notification url: %s", webhook_config.GetUrl().CStr());
+				return false;
+			}
+
+			webhook.secret_key	 = webhook_config.GetSecretKey();
+			webhook.timeout_msec = webhook_config.GetTimeoutMsec();
+
+			webhook_list.push_back(webhook);
+		}
+
+		// Deprecated: the legacy <Url>/<SecretKey>/<Timeout> settings are still
+		// honored as a single webhook during the deprecation period.
+		if (alert.GetUrl().IsEmpty() == false)
+		{
+			WebhookInfo webhook;
+
+			webhook.url = ov::Url::Parse(alert.GetUrl());
+			if (webhook.url == nullptr)
+			{
+				logte("Could not parse notification url: %s", alert.GetUrl().CStr());
+				return false;
+			}
+
+			webhook.secret_key	 = alert.GetSecretKey();
+			webhook.timeout_msec = alert.GetTimeoutMsec();
+
+			webhook_list.push_back(webhook);
+		}
+
+		if (webhook_list.empty())
+		{
+			logte("Alert is enabled but no webhook is configured. Set <Alert><Webhooks>");
 			return false;
 		}
 
-		_server_config = server_config;
-		_server_info   = MakeServerInfo(server_config);
+		if (webhook_list.size() > WEBHOOK_COUNT_WARNING_THRESHOLD)
+		{
+			logtw("%zu webhooks are configured. Notifications are sent to each webhook sequentially, so slow or unreachable webhooks can delay alert delivery to the others.", webhook_list.size());
+		}
+
+		_webhook_list = std::move(webhook_list);
+		_server_info  = MakeServerInfo(server_config);
 
 		_rules_updater = std::make_shared<AlertRulesUpdater>(alert);
 		_rules_updater->UpdateIfNeeded();
@@ -179,6 +223,13 @@ namespace mon::alrt
 
 			for (const auto &[queue_key, queue_metric] : queue_metric_list)
 			{
+				// Bail out mid-pass while stopping, so that Stop() doesn't wait
+				// for a full sweep over every queue and stream.
+				if (_stop_thread_flag)
+				{
+					return;
+				}
+
 				// Build source URI from URN: #VhostName#AppName[/StreamName]
 				ov::String source_uri;
 				auto urn = queue_metric->GetUrn();
@@ -217,6 +268,11 @@ namespace mon::alrt
 			// Fire an alert per source URI (same pattern as stream-metric alerts)
 			for (auto &[source_uri, msgs] : per_source_messages)
 			{
+				if (_stop_thread_flag)
+				{
+					return;
+				}
+
 				messages_key = MakeMessagesKey(type, source_uri);
 				new_messages_keys.push_back(messages_key);
 
@@ -246,6 +302,11 @@ namespace mon::alrt
 				{
 					for (const auto &[stream_key, stream_metric] : app_metric->GetStreamMetricsMap())
 					{
+						if (_stop_thread_flag)
+						{
+							return;
+						}
+
 						message_list.clear();
 
 						if (stream_metric->IsInputStream())
@@ -269,6 +330,12 @@ namespace mon::alrt
 			}
 		}
 
+		if (_stop_thread_flag)
+		{
+			// Skip the cleanup and the rules file check while stopping
+			return;
+		}
+
 		CleanupReleasedMessages(new_messages_keys);
 
 		_rules_updater->UpdateIfNeeded();
@@ -288,8 +355,6 @@ namespace mon::alrt
 				continue;
 			}
 
-			auto alert		  = _server_config->GetAlert();
-
 			auto message_body = notification_data->ToJsonString(_server_info);
 			if (message_body.IsEmpty())
 			{
@@ -297,36 +362,47 @@ namespace mon::alrt
 				continue;
 			}
 
-			int retry_count = 0;
-
-			while (true)
+			// Send the notification to every webhook. Each webhook retries
+			// independently so that a failing server doesn't block the others.
+			for (const auto &webhook : _webhook_list)
 			{
-				// Notification
-				auto notification_server_url = ov::Url::Parse(alert.GetUrl());
-				std::shared_ptr<Notification> notification_response = Notification::Query(notification_server_url, alert.GetTimeoutMsec(), alert.GetSecretKey(), message_body);
-				if (notification_response == nullptr)
+				// Do not start sending to the next webhook while stopping, so that
+				// Stop() doesn't wait for the whole broadcast to complete.
+				if (_stop_thread_flag)
 				{
-					// Probably this doesn't happen
-					logte("Could not load Notification");
 					break;
 				}
 
-				if (notification_response->GetStatusCode() == Notification::StatusCode::INTERNAL_ERROR)
-				{
-					retry_count++;
+				int retry_count = 0;
 
-					if (NOTIFICATION_MAX_RETRY_COUNT < retry_count)
+				while (true)
+				{
+					// Notification
+					std::shared_ptr<Notification> notification_response = Notification::Query(webhook.url, webhook.timeout_msec, webhook.secret_key, message_body);
+					if (notification_response == nullptr)
 					{
+						// Probably this doesn't happen
+						logte("Could not load Notification");
 						break;
 					}
-					else
-					{
-						logte("Notification internal error occurred. Retrying... [%d / %d]", retry_count, NOTIFICATION_MAX_RETRY_COUNT);
-						continue;
-					}
-				}
 
-				break;
+					if (notification_response->GetStatusCode() == Notification::StatusCode::INTERNAL_ERROR)
+					{
+						retry_count++;
+
+						if ((NOTIFICATION_MAX_RETRY_COUNT < retry_count) || _stop_thread_flag)
+						{
+							break;
+						}
+						else
+						{
+							logte("Notification internal error occurred. Retrying... [%d / %d] (webhook: %s)", retry_count, NOTIFICATION_MAX_RETRY_COUNT, webhook.url->ToUrlString(false).CStr());
+							continue;
+						}
+					}
+
+					break;
+				}
 			}
 		}
 	}

--- a/src/monitoring/alert/alert.cpp
+++ b/src/monitoring/alert/alert.cpp
@@ -72,6 +72,30 @@ namespace mon::alrt
 		return server_info;
 	}
 
+	// Validates that the URL is a parsable http(s) URL and fills in the default port,
+	// so that logs based on Host()/Port() always identify the actual endpoint.
+	static std::shared_ptr<ov::Url> ParseWebhookUrl(const ov::String &url_string)
+	{
+		auto url = ov::Url::Parse(url_string);
+		if (url == nullptr)
+		{
+			return nullptr;
+		}
+
+		auto scheme = url->Scheme().UpperCaseString();
+		if ((scheme != "HTTP") && (scheme != "HTTPS"))
+		{
+			return nullptr;
+		}
+
+		if (url->Port() == 0)
+		{
+			url->SetPort((scheme == "HTTPS") ? 443 : 80);
+		}
+
+		return url;
+	}
+
 	bool Alert::Start(const std::shared_ptr<const cfg::Server> &server_config)
 	{
 		if (!_stop_thread_flag)
@@ -93,16 +117,21 @@ namespace mon::alrt
 		}
 
 		// Build the webhook list.
+		// The configured URLs are not logged on error - a webhook URL can carry
+		// credentials or secret path tokens.
 		std::vector<WebhookInfo> webhook_list;
 
+		size_t webhook_index = 0;
 		for (const auto &webhook_config : alert.GetWebhooks().GetWebhookList())
 		{
+			webhook_index++;
+
 			WebhookInfo webhook;
 
-			webhook.url = ov::Url::Parse(webhook_config.GetUrl());
+			webhook.url = ParseWebhookUrl(webhook_config.GetUrl());
 			if (webhook.url == nullptr)
 			{
-				logte("Could not parse notification url: %s", webhook_config.GetUrl().CStr());
+				logte("The url of <Alert><Webhooks><Webhook> #%zu is invalid. It must be a valid http(s) url", webhook_index);
 				return false;
 			}
 
@@ -118,10 +147,10 @@ namespace mon::alrt
 		{
 			WebhookInfo webhook;
 
-			webhook.url = ov::Url::Parse(alert.GetUrl());
+			webhook.url = ParseWebhookUrl(alert.GetUrl());
 			if (webhook.url == nullptr)
 			{
-				logte("Could not parse notification url: %s", alert.GetUrl().CStr());
+				logte("The url of <Alert><Url> is invalid. It must be a valid http(s) url");
 				return false;
 			}
 

--- a/src/monitoring/alert/alert.cpp
+++ b/src/monitoring/alert/alert.cpp
@@ -396,7 +396,8 @@ namespace mon::alrt
 						}
 						else
 						{
-							logte("Notification internal error occurred. Retrying... [%d / %d] (webhook: %s)", retry_count, NOTIFICATION_MAX_RETRY_COUNT, webhook.url->ToUrlString(false).CStr());
+							// Log only host:port - the full URL can contain credentials or secret path tokens
+							logte("Notification internal error occurred. Retrying... [%d / %d] (webhook: %s:%u)", retry_count, NOTIFICATION_MAX_RETRY_COUNT, webhook.url->Host().CStr(), webhook.url->Port());
 							continue;
 						}
 					}

--- a/src/monitoring/alert/alert.h
+++ b/src/monitoring/alert/alert.h
@@ -30,6 +30,13 @@ namespace mon::alrt
 		void SendStreamMessage(Message::Code code, const std::shared_ptr<StreamMetrics> &stream_metric);
 
 	private:
+		struct WebhookInfo
+		{
+			std::shared_ptr<ov::Url> url = nullptr;
+			ov::String secret_key;
+			uint32_t timeout_msec = 0;
+		};
+
 		struct StreamEvent
 		{
 			StreamEvent(Message::Code code, const std::shared_ptr<StreamMetrics> &stream_metric, const std::shared_ptr<StreamMetrics> &parent_stream_metric, const std::shared_ptr<ExtraData> &extra)
@@ -73,12 +80,15 @@ namespace mon::alrt
 		bool PutVerifiedMessages(const ov::String &messages_key, std::vector<std::shared_ptr<Message>> &message_list);
 		std::vector<std::shared_ptr<Message>> GetVerifiedMessages(const ov::String &messages_key);
 
-		std::shared_ptr<const cfg::Server> _server_config = nullptr;
 		std::shared_ptr<AlertRulesUpdater> _rules_updater = nullptr;
 
 		// Identifies which server sent the notification. Built once in Start() and
 		// read-only afterwards, so it is accessed without a lock.
 		Json::Value _server_info;
+
+		// Webhooks to which notifications are sent. Built once in Start() and
+		// read-only afterwards, so it is accessed without a lock.
+		std::vector<WebhookInfo> _webhook_list;
 
 		// Accessed by both the metric worker thread (via _timer) and the threads calling
 		// SendStreamMessage(), so it must be guarded by _last_verified_messages_mutex.

--- a/src/monitoring/alert/notification.cpp
+++ b/src/monitoring/alert/notification.cpp
@@ -107,7 +107,7 @@ namespace mon::alrt
 				}
 				else
 				{
-					SetStatus(StatusCode::INVALID_STATUS_CODE, ov::String::FormatString("Control server responded with %d status code.", static_cast<uint16_t>(status_code)));
+					SetStatus(StatusCode::INVALID_STATUS_CODE, ov::String::FormatString("Webhook server responded with %d status code.", static_cast<uint16_t>(status_code)));
 					return;
 				}
 			}


### PR DESCRIPTION
## Summary

The Alert module can now send notifications to multiple webhooks. `<Alert><Webhooks><Webhook>` becomes the standard way to configure notification destinations, and the legacy `<Url>`/`<SecretKey>`/`<Timeout>` settings are deprecated.

```xml
<Alert>
    <Webhooks>
        <Webhook>
            <Url>http://192.168.0.161:9595/alert/notification</Url>
            <SecretKey>1234</SecretKey>   <!-- optional -->
            <Timeout>3000</Timeout>       <!-- optional, default: 3000 -->
        </Webhook>
        <Webhook>
            <Url>http://192.168.0.162:9595/alert/notification</Url>
        </Webhook>
    </Webhooks>
    <Rules>...</Rules>
</Alert>
```

## Changes

- New config items `cfg::alrt::Webhook` / `Webhooks` — each webhook is self-contained: `<Url>` (required), `<SecretKey>` (optional), `<Timeout>` (optional, default 3000 ms)
- `mon::alrt::Alert` builds a validated webhook list once in `Start()` (fail-fast on unparsable URLs, error when no webhook is configured) and the notification thread sends each notification to every webhook sequentially, with an independent retry loop per webhook
- Shutdown robustness: the send/retry loops and `MetricWorkerThread` now check `_stop_thread_flag`, so `Alert::Stop()` no longer waits for a full broadcast (bounded by a single in-flight HTTP attempt; measured ~3.5 s with two unreachable webhooks, previously ~15 s+)
- A warning is logged when more than 10 webhooks are configured, since sequential delivery means slow webhooks delay the others
- Docs: `docs/alert.md` rewritten around `<Webhooks>`, with a deprecation notice and operational guidance (sequential delivery/retries, prefer IP or reliable DNS since resolution is not covered by `<Timeout>`, do not set `<Timeout>` to 0)

## Backward compatibility

Existing configurations keep working unchanged: the legacy `<Url>`/`<SecretKey>`/`<Timeout>` under `<Alert>` are still accepted during the deprecation period and act as a single webhook. Using them logs:

```
Alert.Url, Alert.SecretKey and Alert.Timeout are deprecated and will be removed in a future release. Please use Alert.Webhooks instead.
```

They can also be combined with `<Webhooks>`, in which case notifications go to all destinations.

## Test plan

- [x] Full build passes
- [x] Legacy config: deprecation warning is logged at config load and notifications still work
- [x] E2E: ingested an RTMP stream that violates an ingress rule — both configured webhooks received the identical JSON payload, and each `X-OME-Signature` matched the HMAC-SHA1 recomputed with that webhook's own `SecretKey`
- [x] Shutdown: with a broadcast in flight to two unreachable webhooks, SIGTERM to exit took ~3.5 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)